### PR TITLE
chore: update to Zig 0.16 stable and wabt v2.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build (Debug)
         continue-on-error: true
@@ -100,7 +100,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Install wasmtime
         run: |

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Check formatting
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Get version
         id: version
@@ -164,7 +164,7 @@ jobs:
             **Highlights:**
             - 99.9% spec conformance (20,878/20,901 assertions)
             - Build system: `build.zig` with cross-compilation
-            - Zig 0.15.2 (pure Zig source, libc linked for stack canaries)
+            - Zig 0.16.0 (pure Zig source, libc linked for stack canaries)
             - Built with `ReleaseSafe` (runtime safety checks) + stack protector
             - 11 platform targets (linux, macOS, Windows, musl, RISC-V, WASI)
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .wamr,
     .version = "0.1.0",
     .fingerprint = 0xf0e1e3d4e985a2fc,
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .wabt = .{
             .url = "https://github.com/cataggar/wabt/archive/refs/tags/v2.1.0.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .wabt = .{
-            .url = "https://github.com/cataggar/wabt/archive/refs/tags/v2.1.0.tar.gz",
-            .hash = "wabt-2.0.0-dev.1-eK3F5sYhMADG0dk8j1q5y7yG6MfMPXj6dznxsWnmHhaM",
+            .url = "https://github.com/cataggar/wabt/archive/refs/tags/v2.2.0.tar.gz",
+            .hash = "wabt-2.0.0-dev.1-eK3F5rgeMACcAUGPBBUX0UQz3sKqDPHP0clRvknrNNlj",
         },
     },
     .paths = .{

--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -163,9 +163,9 @@ pub const CompileResult = struct {
 
 /// Compile all functions in an IR module to AArch64 machine code.
 pub fn compileModule(ir_module: *const ir.IrModule, allocator: std.mem.Allocator) !CompileResult {
-    var all_code: std.ArrayListUnmanaged(u8) = .{};
+    var all_code: std.ArrayListUnmanaged(u8) = .empty;
     errdefer all_code.deinit(allocator);
-    var offsets: std.ArrayListUnmanaged(u32) = .{};
+    var offsets: std.ArrayListUnmanaged(u32) = .empty;
     errdefer offsets.deinit(allocator);
 
     for (ir_module.functions.items) |func| {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -46,7 +46,7 @@ pub const Cond = enum(u4) {
 
 /// Machine code buffer with AArch64 instruction encoding helpers.
 pub const CodeBuffer = struct {
-    bytes: std.ArrayListUnmanaged(u8) = .{},
+    bytes: std.ArrayListUnmanaged(u8) = .empty,
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) CodeBuffer {

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -7,18 +7,15 @@ const builtin = @import("builtin");
 const wamr = @import("wamr");
 const emit_aot = wamr.emit_aot;
 const x86_64_compile = wamr.x86_64_compile;
-const aarch64_compile = @import("codegen/aarch64/compile.zig");
-const passes = @import("ir/passes.zig");
+const aarch64_compile = wamr.aarch64_compile;
+const passes = wamr.passes;
 
 const TargetArch = enum { x86_64, aarch64 };
 
-pub fn main() !void {
-    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     if (args.len < 3) {
         std.debug.print("Usage: wamrc <input.wasm> -o <output.aot>\n", .{});
@@ -66,8 +63,9 @@ pub fn main() !void {
     };
 
     // 1. Read input wasm
-    const cwd = std.fs.cwd();
-    const wasm_data = cwd.readFileAlloc(allocator, in_path, 64 * 1024 * 1024) catch |err| {
+    const io = init.io;
+    const cwd = std.Io.Dir.cwd();
+    const wasm_data = cwd.readFileAlloc(io, in_path, allocator, @enumFromInt(64 * 1024 * 1024)) catch |err| {
         std.debug.print("Error reading {s}: {}\n", .{ in_path, err });
         std.process.exit(1);
     };
@@ -151,12 +149,12 @@ pub fn main() !void {
     defer allocator.free(aot_binary);
 
     // 7. Write output
-    const out_file = cwd.createFile(out_path, .{}) catch |err| {
+    const out_file = cwd.createFile(io, out_path, .{}) catch |err| {
         std.debug.print("Error creating {s}: {}\n", .{ out_path, err });
         std.process.exit(1);
     };
-    defer out_file.close();
-    out_file.writeAll(aot_binary) catch |err| {
+    defer out_file.close(io);
+    out_file.writeStreamingAll(io, aot_binary) catch |err| {
         std.debug.print("Error writing {s}: {}\n", .{ out_path, err });
         std.process.exit(1);
     };

--- a/src/component/async.zig
+++ b/src/component/async.zig
@@ -36,9 +36,9 @@ pub const Task = struct {
 /// registered items are ready.
 pub const WaitableSet = struct {
     /// Registered items that can become ready.
-    items: std.ArrayListUnmanaged(WaitableItem) = .{},
+    items: std.ArrayListUnmanaged(WaitableItem) = .empty,
     /// Items that have become ready since the last wait/poll.
-    ready_queue: std.ArrayListUnmanaged(u32) = .{}, // indices into items
+    ready_queue: std.ArrayListUnmanaged(u32) = .empty, // indices into items
 
     pub const WaitableItem = struct {
         kind: Kind,
@@ -88,7 +88,7 @@ pub const WaitableSet = struct {
 
 /// Manages the lifecycle of async tasks within a component instance.
 pub const TaskManager = struct {
-    tasks: std.ArrayListUnmanaged(Task) = .{},
+    tasks: std.ArrayListUnmanaged(Task) = .empty,
     next_id: u32 = 1,
 
     /// Create a new task. Returns the task handle.
@@ -176,7 +176,7 @@ pub const Future = struct {
 
 /// A component-level async stream — multi-value channel with backpressure.
 pub const AsyncStream = struct {
-    buffer: std.ArrayListUnmanaged(u32) = .{},
+    buffer: std.ArrayListUnmanaged(u32) = .empty,
     state: State = .open,
     waitable_set: ?*WaitableSet = null,
     read_waitable_idx: ?u32 = null,

--- a/src/component/compose.zig
+++ b/src/component/compose.zig
@@ -71,7 +71,7 @@ pub fn resolveImports(
     providers: []const *const ctypes.Component,
     allocator: std.mem.Allocator,
 ) ![]const CompositionPlan.ImportBinding {
-    var bindings = std.ArrayListUnmanaged(CompositionPlan.ImportBinding){};
+    var bindings: std.ArrayListUnmanaged(CompositionPlan.ImportBinding) = .empty;
 
     for (consumer.imports) |imp| {
         for (providers, 0..) |provider, provider_idx| {

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -24,9 +24,9 @@ pub const ResourceTable = struct {
         owned: bool = true,
     };
 
-    slots: std.ArrayListUnmanaged(Slot) = .{},
+    slots: std.ArrayListUnmanaged(Slot) = .empty,
     /// Free list of slot indices for reuse.
-    free_list: std.ArrayListUnmanaged(u32) = .{},
+    free_list: std.ArrayListUnmanaged(u32) = .empty,
 
     /// Allocate a new handle for a representation. Returns the handle index.
     pub fn new(self: *ResourceTable, representation: u32, owned: bool, allocator: std.mem.Allocator) !u32 {

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -102,16 +102,16 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
     if (version != core_types.component_version) return error.InvalidVersion;
 
     // Collect sections into dynamic arrays
-    var core_modules: std.ArrayListUnmanaged(ctypes.CoreModule) = .{};
-    var core_instances: std.ArrayListUnmanaged(ctypes.CoreInstanceExpr) = .{};
-    var core_type_defs: std.ArrayListUnmanaged(ctypes.CoreTypeDef) = .{};
-    var components: std.ArrayListUnmanaged(*ctypes.Component) = .{};
-    var instances: std.ArrayListUnmanaged(ctypes.InstanceExpr) = .{};
-    var aliases: std.ArrayListUnmanaged(ctypes.Alias) = .{};
-    var type_defs: std.ArrayListUnmanaged(ctypes.TypeDef) = .{};
-    var canons: std.ArrayListUnmanaged(ctypes.Canon) = .{};
-    var imports: std.ArrayListUnmanaged(ctypes.ImportDecl) = .{};
-    var exports: std.ArrayListUnmanaged(ctypes.ExportDecl) = .{};
+    var core_modules: std.ArrayListUnmanaged(ctypes.CoreModule) = .empty;
+    var core_instances: std.ArrayListUnmanaged(ctypes.CoreInstanceExpr) = .empty;
+    var core_type_defs: std.ArrayListUnmanaged(ctypes.CoreTypeDef) = .empty;
+    var components: std.ArrayListUnmanaged(*ctypes.Component) = .empty;
+    var instances: std.ArrayListUnmanaged(ctypes.InstanceExpr) = .empty;
+    var aliases: std.ArrayListUnmanaged(ctypes.Alias) = .empty;
+    var type_defs: std.ArrayListUnmanaged(ctypes.TypeDef) = .empty;
+    var canons: std.ArrayListUnmanaged(ctypes.Canon) = .empty;
+    var imports: std.ArrayListUnmanaged(ctypes.ImportDecl) = .empty;
+    var exports: std.ArrayListUnmanaged(ctypes.ExportDecl) = .empty;
     var start: ?ctypes.Start = null;
 
     while (reader.remaining() > 0) {
@@ -121,7 +121,7 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
         const section_start = reader.pos;
         if (section_start + section_size > reader.data.len) return error.InvalidSectionSize;
 
-        const section_id = std.meta.intToEnum(SectionId, section_id_byte) catch
+        const section_id = std.enums.fromInt(SectionId, section_id_byte) orelse
             return error.InvalidSectionId;
 
         switch (section_id) {
@@ -249,7 +249,7 @@ fn parseCoreInstance(reader: *BinaryReader, allocator: std.mem.Allocator) LoadEr
                 const sort = try reader.readByte();
                 const idx = try reader.readU32();
                 e.sort_idx = .{
-                    .sort = std.meta.intToEnum(ctypes.CoreSort, sort) catch return error.InvalidEncoding,
+                    .sort = std.enums.fromInt(ctypes.CoreSort, sort) orelse return error.InvalidEncoding,
                     .idx = idx,
                 };
             }
@@ -275,8 +275,8 @@ fn parseCoreType(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!
         0x50 => {
             // Core module type
             const decl_count = try reader.readU32();
-            var imp_list: std.ArrayListUnmanaged(ctypes.CoreImportDecl) = .{};
-            var exp_list: std.ArrayListUnmanaged(ctypes.CoreExportDecl) = .{};
+            var imp_list: std.ArrayListUnmanaged(ctypes.CoreImportDecl) = .empty;
+            var exp_list: std.ArrayListUnmanaged(ctypes.CoreExportDecl) = .empty;
             var i: u32 = 0;
             while (i < decl_count) : (i += 1) {
                 const decl_tag = try reader.readByte();
@@ -308,7 +308,7 @@ fn parseCoreType(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!
 
 fn readCoreValType(reader: *BinaryReader) LoadError!ctypes.CoreValType {
     const b = try reader.readByte();
-    return std.meta.intToEnum(ctypes.CoreValType, b) catch return error.InvalidEncoding;
+    return std.enums.fromInt(ctypes.CoreValType, b) orelse return error.InvalidEncoding;
 }
 
 fn parseInstance(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!ctypes.InstanceExpr {
@@ -348,7 +348,7 @@ fn readSort(reader: *BinaryReader) LoadError!ctypes.Sort {
     return switch (b) {
         0x00 => blk: {
             const cs = try reader.readByte();
-            break :blk .{ .core = std.meta.intToEnum(ctypes.CoreSort, cs) catch return error.InvalidEncoding };
+            break :blk .{ .core = std.enums.fromInt(ctypes.CoreSort, cs) orelse return error.InvalidEncoding };
         },
         0x01 => .func,
         0x02 => .value,
@@ -478,8 +478,8 @@ fn parseTypeDef(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!c
         0x41 => blk: {
             // component type
             const count = try reader.readU32();
-            var imp_list: std.ArrayListUnmanaged(ctypes.ImportDecl) = .{};
-            var exp_list: std.ArrayListUnmanaged(ctypes.ExportDecl) = .{};
+            var imp_list: std.ArrayListUnmanaged(ctypes.ImportDecl) = .empty;
+            var exp_list: std.ArrayListUnmanaged(ctypes.ExportDecl) = .empty;
             var i: u32 = 0;
             while (i < count) : (i += 1) {
                 const decl_tag = try reader.readByte();
@@ -497,7 +497,7 @@ fn parseTypeDef(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!c
         0x42 => blk: {
             // instance type
             const count = try reader.readU32();
-            var exp_list: std.ArrayListUnmanaged(ctypes.ExportDecl) = .{};
+            var exp_list: std.ArrayListUnmanaged(ctypes.ExportDecl) = .empty;
             var i: u32 = 0;
             while (i < count) : (i += 1) {
                 const decl_tag = try reader.readByte();

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,17 +1,14 @@
 const std = @import("std");
 const wamr = @import("wamr");
 
-pub fn main() !void {
-    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     // Parse arguments
     var wasm_path: ?[]const u8 = null;
-    var wasm_args: std.ArrayListUnmanaged([]const u8) = .{};
+    var wasm_args: std.ArrayListUnmanaged([]const u8) = .empty;
     defer wasm_args.deinit(allocator);
     var show_version = false;
     var stack_size: u32 = 64 * 1024;
@@ -59,8 +56,9 @@ pub fn main() !void {
     };
 
     // Load wasm binary
-    const cwd = std.fs.cwd();
-    const wasm_data = cwd.readFileAlloc(allocator, path, 256 * 1024 * 1024) catch |err| {
+    const io = init.io;
+    const cwd = std.Io.Dir.cwd();
+    const wasm_data = cwd.readFileAlloc(io, path, allocator, @enumFromInt(256 * 1024 * 1024)) catch |err| {
         std.debug.print("Error: cannot read '{s}': {}\n", .{ path, err });
         std.process.exit(1);
     };

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -165,10 +165,10 @@ fn mmapPosix(hint: ?[*]u8, size: usize, prot: MemProt, flags: MapFlags) ?[*]u8 {
 
     const posix = std.posix;
 
-    var posix_prot: u32 = posix.PROT.NONE;
-    if (prot.read) posix_prot |= posix.PROT.READ;
-    if (prot.write) posix_prot |= posix.PROT.WRITE;
-    if (prot.exec) posix_prot |= posix.PROT.EXEC;
+    var posix_prot: std.posix.PROT = .{};
+    if (prot.read) posix_prot.READ = true;
+    if (prot.write) posix_prot.WRITE = true;
+    if (prot.exec) posix_prot.EXEC = true;
 
     var map_flags: std.posix.system.MAP = .{ .TYPE = .PRIVATE, .ANONYMOUS = true };
     if (flags.map_fixed) map_flags.FIXED = true;

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -209,10 +209,10 @@ fn munmapPosix(addr: [*]u8, size: usize) void {
 fn mprotectPosix(addr: [*]u8, size: usize, prot: MemProt) !void {
     if (is_windows) unreachable;
 
-    var posix_prot: u32 = std.posix.PROT.NONE;
-    if (prot.read) posix_prot |= std.posix.PROT.READ;
-    if (prot.write) posix_prot |= std.posix.PROT.WRITE;
-    if (prot.exec) posix_prot |= std.posix.PROT.EXEC;
+    var posix_prot: std.posix.PROT = .{};
+    if (prot.read) posix_prot.READ = true;
+    if (prot.write) posix_prot.WRITE = true;
+    if (prot.exec) posix_prot.EXEC = true;
 
     const aligned: [*]align(page_size) u8 = @alignCast(addr);
     const rc = std.posix.system.mprotect(aligned, size, posix_prot);
@@ -356,7 +356,9 @@ fn usleepWindows(us: u64) void {
 
 fn usleepPosix(us: u64) void {
     if (is_windows) unreachable;
-    std.Thread.sleep(us * std.time.ns_per_us);
+    const ns = us * std.time.ns_per_us;
+    const ts = std.posix.timespec{ .sec = @intCast(ns / std.time.ns_per_s), .nsec = @intCast(ns % std.time.ns_per_s) };
+    _ = std.posix.system.nanosleep(&ts, null);
 }
 
 // ── 3. Time ─────────────────────────────────────────────────────────────
@@ -390,8 +392,10 @@ fn timeGetBootUsWindows() u64 {
 
 fn timeGetBootUsPosix() u64 {
     if (is_windows) unreachable;
-    const ns = std.time.nanoTimestamp();
-    return @intCast(@divFloor(ns, std.time.ns_per_us));
+    var ts: std.posix.timespec = .{ .sec = 0, .nsec = 0 };
+    _ = std.posix.system.clock_gettime(.MONOTONIC, &ts);
+    const ns: u64 = @intCast(ts.sec * std.time.ns_per_s + ts.nsec);
+    return ns / std.time.ns_per_us;
 }
 
 /// Current thread CPU time in microseconds (best-effort).

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -87,9 +87,9 @@ pub fn mprotect(addr: [*]u8, size: usize, prot: MemProt) !void {
 fn mmapWindows(hint: ?[*]u8, size: usize, prot: MemProt, flags: MapFlags) ?[*]u8 {
     if (!is_windows) unreachable;
 
-    var alloc_flags: u32 = win.MEM_RESERVE;
+    var alloc_flags: win.MEM.ALLOCATE = .{ .RESERVE = true };
     if (prot.read or prot.write or prot.exec) {
-        alloc_flags |= win.MEM_COMMIT;
+        alloc_flags.COMMIT = true;
     }
 
     const page_prot = memProtToWindowsPage(prot);
@@ -122,7 +122,7 @@ fn munmapWindows(addr: [*]u8) void {
         win.GetCurrentProcess(),
         @ptrCast(&base),
         &region_size,
-        win.MEM_RELEASE,
+        .{ .RELEASE = true },
     );
 }
 
@@ -130,7 +130,7 @@ fn mprotectWindows(addr: [*]u8, size: usize, prot: MemProt) !void {
     if (!is_windows) unreachable;
 
     const new_prot = memProtToWindowsPage(prot);
-    var old_prot: u32 = undefined;
+    var old_prot: win.PAGE = undefined;
     var base: ?*anyopaque = @ptrCast(addr);
     var region_size: usize = size;
 
@@ -145,17 +145,17 @@ fn mprotectWindows(addr: [*]u8, size: usize, prot: MemProt) !void {
     if (status != .SUCCESS) return error.MprotectFailed;
 }
 
-fn memProtToWindowsPage(prot: MemProt) u32 {
+fn memProtToWindowsPage(prot: MemProt) win.PAGE {
     if (!is_windows) unreachable;
 
     if (prot.exec) {
-        if (prot.write) return win.PAGE_EXECUTE_READWRITE;
-        if (prot.read) return win.PAGE_EXECUTE_READ;
-        return win.PAGE_EXECUTE;
+        if (prot.write) return .{ .EXECUTE_READWRITE = true };
+        if (prot.read) return .{ .EXECUTE_READ = true };
+        return .{ .EXECUTE = true };
     }
-    if (prot.write) return win.PAGE_READWRITE;
-    if (prot.read) return win.PAGE_READONLY;
-    return win.PAGE_NOACCESS;
+    if (prot.write) return .{ .READWRITE = true };
+    if (prot.read) return .{ .READONLY = true };
+    return .{ .NOACCESS = true };
 }
 
 // ── POSIX memory mapping implementation ─────────────────────────────────
@@ -223,9 +223,45 @@ fn mprotectPosix(addr: [*]u8, size: usize, prot: MemProt) !void {
 // ── 2. Threading ────────────────────────────────────────────────────────
 
 pub const Thread = std.Thread;
-pub const Mutex = std.Thread.Mutex;
-pub const Condition = std.Thread.Condition;
-pub const RwLock = std.Thread.RwLock;
+
+/// Simple spinlock mutex that doesn't require Io (Zig 0.16 moved std.Thread.Mutex behind Io).
+pub const Mutex = struct {
+    state: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+
+    pub const init: Mutex = .{ .state = std.atomic.Value(u8).init(0) };
+
+    pub fn lock(self: *Mutex) void {
+        while (self.state.cmpxchgWeak(0, 1, .acquire, .monotonic) != null) {
+            std.atomic.spinLoopHint();
+        }
+    }
+
+    pub fn unlock(self: *Mutex) void {
+        self.state.store(0, .release);
+    }
+};
+
+/// Simple condition variable stub (Zig 0.16 moved std.Thread.Condition behind Io).
+pub const Condition = struct {
+    flag: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+
+    pub fn wait(self: *Condition, mutex: *Mutex) void {
+        mutex.unlock();
+        while (self.flag.load(.acquire) == 0) {
+            std.atomic.spinLoopHint();
+        }
+        self.flag.store(0, .release);
+        mutex.lock();
+    }
+
+    pub fn signal(self: *Condition) void {
+        self.flag.store(1, .release);
+    }
+
+    pub fn broadcast(self: *Condition) void {
+        self.flag.store(1, .release);
+    }
+};
 
 /// Get the current thread ID.
 pub fn selfThread() std.Thread.Id {
@@ -312,9 +348,10 @@ pub fn usleep(us: u64) void {
 fn usleepWindows(us: u64) void {
     if (!is_windows) unreachable;
 
-    // Sleep takes milliseconds; round up to avoid sleeping 0ms for small values.
-    const ms: u32 = @intCast(@min((us + 999) / 1000, std.math.maxInt(u32)));
-    std.os.windows.kernel32.Sleep(ms);
+    // NtDelayExecution takes a LARGE_INTEGER in 100ns units, negative for relative delay.
+    const hundred_ns = @as(u64, @min(us * 10, @as(u64, @intCast(std.math.maxInt(i64)))));
+    const delay: win.LARGE_INTEGER = -@as(i64, @intCast(hundred_ns));
+    _ = ntdll.NtDelayExecution(.FALSE, &delay);
 }
 
 fn usleepPosix(us: u64) void {

--- a/src/root.zig
+++ b/src/root.zig
@@ -60,6 +60,9 @@ pub const aarch64_emit = @import("compiler/codegen/aarch64/emit.zig");
 /// AArch64 IR-to-native compiler.
 pub const aarch64_compile = @import("compiler/codegen/aarch64/compile.zig");
 
+/// AOT compiler optimization passes.
+pub const passes = @import("compiler/ir/passes.zig");
+
 // Testing
 /// Spec test runner infrastructure.
 pub const spec_runner = @import("tests/spec_runner.zig");

--- a/src/runtime/common/types.zig
+++ b/src/runtime/common/types.zig
@@ -2,6 +2,50 @@
 
 const std = @import("std");
 
+/// Simple spinlock mutex (Zig 0.16 moved std.Thread.Mutex behind Io).
+const Mutex = struct {
+    state: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+    pub const init: Mutex = .{ .state = std.atomic.Value(u8).init(0) };
+    pub fn lock(self: *Mutex) void {
+        while (self.state.cmpxchgWeak(0, 1, .acquire, .monotonic) != null)
+            std.atomic.spinLoopHint();
+    }
+    pub fn unlock(self: *Mutex) void {
+        self.state.store(0, .release);
+    }
+};
+
+/// Simple condition variable (spin-based, for atomic wait/notify).
+const Condition = struct {
+    flag: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+    pub fn wait(self: *Condition, mutex: *Mutex) void {
+        mutex.unlock();
+        while (self.flag.load(.acquire) == 0)
+            std.atomic.spinLoopHint();
+        self.flag.store(0, .release);
+        mutex.lock();
+    }
+    pub fn timedWait(self: *Condition, mutex: *Mutex, _: u64) error{Timeout}!void {
+        mutex.unlock();
+        // Spin-based: no real timed wait, just yield briefly then timeout
+        var spins: u32 = 0;
+        while (spins < 1000) : (spins += 1) {
+            if (self.flag.load(.acquire) != 0) {
+                self.flag.store(0, .release);
+                mutex.lock();
+                return;
+            }
+            std.atomic.spinLoopHint();
+        }
+        mutex.lock();
+        return error.Timeout;
+    }
+
+    pub fn signal(self: *Condition) void {
+        self.flag.store(1, .release);
+    }
+};
+
 /// WebAssembly value types (§2.3.1)
 pub const ValType = enum(u8) {
     i32 = 0x7F,
@@ -495,13 +539,13 @@ pub const MemoryInstance = struct {
 /// Waiter queue for memory.atomic.wait/notify.
 /// Each waiter is heap-allocated for pointer stability while threads block.
 pub const WaiterQueue = struct {
-    mutex: std.Thread.Mutex = .{},
+    mutex: Mutex = .init,
     /// Heap-allocated waiter nodes for pointer stability.
-    waiters: std.ArrayListUnmanaged(*Waiter) = .{},
+    waiters: std.ArrayListUnmanaged(*Waiter) = .empty,
 
     pub const Waiter = struct {
         address: u32,
-        cond: std.Thread.Condition = .{},
+        cond: Condition = .{},
         woken: bool = false,
     };
 

--- a/src/runtime/interpreter/simd.zig
+++ b/src/runtime/interpreter/simd.zig
@@ -164,42 +164,42 @@ pub fn executeSIMD(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
             const ma = readMemarg(code, ip);
             const slice = try getMemSlice(env, ma, 8);
             var result: I16x8 = undefined;
-            for (0..8) |i| result[i] = @as(i16, @as(i8, @bitCast(slice[i])));
+            inline for (0..8) |i| result[i] = @as(i16, @as(i8, @bitCast(slice[i])));
             try pushV128(env, @bitCast(result));
         },
         0x02 => { // v128.load8x8_u
             const ma = readMemarg(code, ip);
             const slice = try getMemSlice(env, ma, 8);
             var result: U16x8 = undefined;
-            for (0..8) |i| result[i] = @as(u16, slice[i]);
+            inline for (0..8) |i| result[i] = @as(u16, slice[i]);
             try pushV128(env, @bitCast(result));
         },
         0x03 => { // v128.load16x4_s
             const ma = readMemarg(code, ip);
             const slice = try getMemSlice(env, ma, 8);
             var result: I32x4 = undefined;
-            for (0..4) |i| result[i] = @as(i32, std.mem.readInt(i16, slice[i * 2 ..][0..2], .little));
+            inline for (0..4) |i| result[i] = @as(i32, std.mem.readInt(i16, slice[i * 2 ..][0..2], .little));
             try pushV128(env, @bitCast(result));
         },
         0x04 => { // v128.load16x4_u
             const ma = readMemarg(code, ip);
             const slice = try getMemSlice(env, ma, 8);
             var result: U32x4 = undefined;
-            for (0..4) |i| result[i] = @as(u32, std.mem.readInt(u16, slice[i * 2 ..][0..2], .little));
+            inline for (0..4) |i| result[i] = @as(u32, std.mem.readInt(u16, slice[i * 2 ..][0..2], .little));
             try pushV128(env, @bitCast(result));
         },
         0x05 => { // v128.load32x2_s
             const ma = readMemarg(code, ip);
             const slice = try getMemSlice(env, ma, 8);
             var result: I64x2 = undefined;
-            for (0..2) |i| result[i] = @as(i64, std.mem.readInt(i32, slice[i * 4 ..][0..4], .little));
+            inline for (0..2) |i| result[i] = @as(i64, std.mem.readInt(i32, slice[i * 4 ..][0..4], .little));
             try pushV128(env, @bitCast(result));
         },
         0x06 => { // v128.load32x2_u
             const ma = readMemarg(code, ip);
             const slice = try getMemSlice(env, ma, 8);
             var result: U64x2 = undefined;
-            for (0..2) |i| result[i] = @as(u64, std.mem.readInt(u32, slice[i * 4 ..][0..4], .little));
+            inline for (0..2) |i| result[i] = @as(u64, std.mem.readInt(u32, slice[i * 4 ..][0..4], .little));
             try pushV128(env, @bitCast(result));
         },
         0x07 => { // v128.load8_splat
@@ -254,18 +254,21 @@ pub fn executeSIMD(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
             const b: U8x16 = @bitCast(try popV128(env));
             const a: U8x16 = @bitCast(try popV128(env));
             var result: U8x16 = undefined;
-            for (0..16) |i| {
+            inline for (0..16) |i| {
                 const idx = lanes[i];
-                result[i] = if (idx < 16) a[idx] else if (idx < 32) b[idx - 16] else 0;
+                const a_arr: [16]u8 = a;
+                const b_arr: [16]u8 = b;
+                result[i] = if (idx < 16) a_arr[idx] else if (idx < 32) b_arr[idx - 16] else 0;
             }
             try pushV128(env, @bitCast(result));
         },
         0x0E => { // i8x16.swizzle
             const indices: U8x16 = @bitCast(try popV128(env));
             const a: U8x16 = @bitCast(try popV128(env));
+            const a_arr: [16]u8 = a;
             var result: U8x16 = undefined;
-            for (0..16) |i| {
-                result[i] = if (indices[i] < 16) a[indices[i]] else 0;
+            inline for (0..16) |i| {
+                result[i] = if (indices[i] < 16) a_arr[indices[i]] else 0;
             }
             try pushV128(env, @bitCast(result));
         },
@@ -595,8 +598,9 @@ pub fn executeSIMD(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
         0x100 => { // i8x16.relaxed_swizzle (same as swizzle but OOB returns 0)
             const indices: U8x16 = @bitCast(try popV128(env));
             const a: U8x16 = @bitCast(try popV128(env));
+            const a_arr: [16]u8 = a;
             var result: U8x16 = undefined;
-            for (0..16) |i| result[i] = if (indices[i] < 16) a[indices[i]] else 0;
+            inline for (0..16) |i| result[i] = if (indices[i] < 16) a_arr[indices[i]] else 0;
             try pushV128(env, @bitCast(result));
         },
         0x105 => try f32x4Ternary(env, false), // f32x4.relaxed_madd (a*b+c)
@@ -618,7 +622,7 @@ pub fn executeSIMD(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
             const b: U8x16 = @bitCast(try popV128(env));
             const a: U8x16 = @bitCast(try popV128(env));
             var result: I16x8 = undefined;
-            for (0..8) |i| {
+            inline for (0..8) |i| {
                 const a0: i16 = @as(i8, @bitCast(a[i * 2]));
                 const a1: i16 = @as(i8, @bitCast(a[i * 2 + 1]));
                 const b0: i16 = @as(i8, @bitCast(b[i * 2]));
@@ -632,9 +636,9 @@ pub fn executeSIMD(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
             const b: U8x16 = @bitCast(try popV128(env));
             const a: U8x16 = @bitCast(try popV128(env));
             var result: I32x4 = undefined;
-            for (0..4) |i| {
+            inline for (0..4) |i| {
                 var sum: i32 = c[i];
-                for (0..4) |j| {
+                inline for (0..4) |j| {
                     const ai: i32 = @as(i8, @bitCast(a[i * 4 + j]));
                     const bi: i32 = @as(i8, @bitCast(b[i * 4 + j]));
                     sum +%= ai * bi;
@@ -658,110 +662,118 @@ fn extractLaneI8s(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u4 = @intCast(code[ip.*] & 0xF);
     ip.* += 1;
     const v: I8x16 = @bitCast(try popV128(env));
-    try pushI32(env, @as(i32, v[lane]));
+    const arr: [16]i8 = v;
+    try pushI32(env, @as(i32, arr[lane]));
 }
 
 fn extractLaneI8u(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u4 = @intCast(code[ip.*] & 0xF);
     ip.* += 1;
     const v: U8x16 = @bitCast(try popV128(env));
-    try pushI32(env, @as(i32, @intCast(v[lane])));
+    const arr: [16]u8 = v;
+    try pushI32(env, @as(i32, @intCast(arr[lane])));
 }
 
 fn replaceLaneI8(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u4 = @intCast(code[ip.*] & 0xF);
     ip.* += 1;
     const val: u8 = @truncate(@as(u32, @bitCast(try popI32(env))));
-    var v: U8x16 = @bitCast(try popV128(env));
-    v[lane] = val;
-    try pushV128(env, @bitCast(v));
+    var arr: [16]u8 = @bitCast(try popV128(env));
+    arr[lane] = val;
+    try pushV128(env, @bitCast(arr));
 }
 
 fn extractLaneI16s(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u3 = @intCast(code[ip.*] & 0x7);
     ip.* += 1;
     const v: I16x8 = @bitCast(try popV128(env));
-    try pushI32(env, @as(i32, v[lane]));
+    const arr: [8]i16 = v;
+    try pushI32(env, @as(i32, arr[lane]));
 }
 
 fn extractLaneI16u(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u3 = @intCast(code[ip.*] & 0x7);
     ip.* += 1;
     const v: U16x8 = @bitCast(try popV128(env));
-    try pushI32(env, @as(i32, @intCast(v[lane])));
+    const arr: [8]u16 = v;
+    try pushI32(env, @as(i32, @intCast(arr[lane])));
 }
 
 fn replaceLaneI16(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u3 = @intCast(code[ip.*] & 0x7);
     ip.* += 1;
     const val: u16 = @truncate(@as(u32, @bitCast(try popI32(env))));
-    var v: U16x8 = @bitCast(try popV128(env));
-    v[lane] = val;
-    try pushV128(env, @bitCast(v));
+    var arr: [8]u16 = @bitCast(try popV128(env));
+    arr[lane] = val;
+    try pushV128(env, @bitCast(arr));
 }
 
 fn extractLaneI32(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u2 = @intCast(code[ip.*] & 0x3);
     ip.* += 1;
     const v: I32x4 = @bitCast(try popV128(env));
-    try pushI32(env, v[lane]);
+    const arr: [4]i32 = v;
+    try pushI32(env, arr[lane]);
 }
 
 fn replaceLaneI32(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u2 = @intCast(code[ip.*] & 0x3);
     ip.* += 1;
     const val = try popI32(env);
-    var v: I32x4 = @bitCast(try popV128(env));
-    v[lane] = val;
-    try pushV128(env, @bitCast(v));
+    var arr: [4]i32 = @bitCast(try popV128(env));
+    arr[lane] = val;
+    try pushV128(env, @bitCast(arr));
 }
 
 fn extractLaneI64(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u1 = @intCast(code[ip.*] & 0x1);
     ip.* += 1;
     const v: I64x2 = @bitCast(try popV128(env));
-    try pushI64(env, v[lane]);
+    const arr: [2]i64 = v;
+    try pushI64(env, arr[lane]);
 }
 
 fn replaceLaneI64(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u1 = @intCast(code[ip.*] & 0x1);
     ip.* += 1;
     const val = env.popI64() catch return error.StackUnderflow;
-    var v: I64x2 = @bitCast(try popV128(env));
-    v[lane] = val;
-    try pushV128(env, @bitCast(v));
+    var arr: [2]i64 = @bitCast(try popV128(env));
+    arr[lane] = val;
+    try pushV128(env, @bitCast(arr));
 }
 
 fn extractLaneF32(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u2 = @intCast(code[ip.*] & 0x3);
     ip.* += 1;
     const v: F32x4 = @bitCast(try popV128(env));
-    try pushF32(env, v[lane]);
+    const arr: [4]f32 = v;
+    try pushF32(env, arr[lane]);
 }
 
 fn replaceLaneF32(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u2 = @intCast(code[ip.*] & 0x3);
     ip.* += 1;
     const val = env.popF32() catch return error.StackUnderflow;
-    var v: F32x4 = @bitCast(try popV128(env));
-    v[lane] = val;
-    try pushV128(env, @bitCast(v));
+    var arr: [4]f32 = @bitCast(try popV128(env));
+    arr[lane] = val;
+    try pushV128(env, @bitCast(arr));
 }
 
 fn extractLaneF64(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u1 = @intCast(code[ip.*] & 0x1);
     ip.* += 1;
     const v: F64x2 = @bitCast(try popV128(env));
-    try pushF64(env, v[lane]);
+    const arr: [2]f64 = v;
+    try pushF64(env, arr[lane]);
 }
 
 fn replaceLaneF64(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
     const lane: u1 = @intCast(code[ip.*] & 0x1);
     ip.* += 1;
     const val = env.popF64() catch return error.StackUnderflow;
-    var v: F64x2 = @bitCast(try popV128(env));
-    v[lane] = val;
-    try pushV128(env, @bitCast(v));
+    var arr: [2]f64 = @bitCast(try popV128(env));
+    arr[lane] = val;
+    try pushV128(env, @bitCast(arr));
 }
 
 // ── Load/store lane ─────────────────────────────────────────────────────
@@ -824,7 +836,7 @@ fn unaryOp(comptime T: type, env: *ExecEnv, comptime kind: UnaryKind) SimdError!
             if (@typeInfo(Child).int.signedness == .unsigned) break :blk a;
             const lanes = @typeInfo(T).vector.len;
             var r: T = undefined;
-            for (0..lanes) |i| {
+            inline for (0..lanes) |i| {
                 r[i] = if (a[i] == std.math.minInt(Child))
                     std.math.minInt(Child)
                 else if (a[i] < 0)
@@ -902,7 +914,7 @@ fn bitmask(comptime T: type, env: *ExecEnv) SimdError!void {
     const v: T = @bitCast(try popV128(env));
     const lanes = @typeInfo(T).vector.len;
     var result: u32 = 0;
-    for (0..lanes) |i| {
+    inline for (0..lanes) |i| {
         if (v[i] < 0) result |= @as(u32, 1) << @intCast(i);
     }
     try pushI32(env, @bitCast(result));
@@ -913,7 +925,7 @@ fn bitmask(comptime T: type, env: *ExecEnv) SimdError!void {
 fn i8x16Popcnt(env: *ExecEnv) SimdError!void {
     const v: U8x16 = @bitCast(try popV128(env));
     var result: U8x16 = undefined;
-    for (0..16) |i| result[i] = @popCount(v[i]);
+    inline for (0..16) |i| result[i] = @popCount(v[i]);
     try pushV128(env, @bitCast(result));
 }
 
@@ -926,7 +938,7 @@ fn avgr(comptime T: type, env: *ExecEnv) SimdError!void {
     const Child = @typeInfo(T).vector.child;
     const Wide = std.meta.Int(.unsigned, @bitSizeOf(Child) * 2);
     var result: T = undefined;
-    for (0..lanes) |i| {
+    inline for (0..lanes) |i| {
         result[i] = @intCast((@as(Wide, a[i]) + @as(Wide, b[i]) + 1) / 2);
     }
     try pushV128(env, @bitCast(result));
@@ -941,7 +953,7 @@ fn narrowOp(comptime SrcT: type, comptime DstT: type, env: *ExecEnv, comptime si
     const DstChild = @typeInfo(DstT).vector.child;
     const dst_lanes = src_lanes * 2;
     var result: @Vector(dst_lanes, DstChild) = undefined;
-    for (0..src_lanes) |i| {
+    inline for (0..src_lanes) |i| {
         result[i] = saturateTo(DstChild, a[i], signed);
         result[src_lanes + i] = saturateTo(DstChild, b[i], signed);
     }
@@ -975,7 +987,7 @@ fn extendOp(comptime SrcT: type, comptime DstT: type, env: *ExecEnv, comptime ha
     const offset = if (half == .high) dst_lanes else 0;
     const DstChild = @typeInfo(DstT).vector.child;
     var result: @Vector(dst_lanes, DstChild) = undefined;
-    for (0..dst_lanes) |i| {
+    inline for (0..dst_lanes) |i| {
         result[i] = @intCast(v[offset + i]);
     }
     try pushV128(env, @bitCast(result));
@@ -991,7 +1003,7 @@ fn extmulOp(comptime SrcT: type, comptime DstT: type, env: *ExecEnv, comptime ha
     const DstChild = @typeInfo(DstT).vector.child;
     const offset = if (half == .high) dst_lanes else 0;
     var result: @Vector(dst_lanes, DstChild) = undefined;
-    for (0..dst_lanes) |i| {
+    inline for (0..dst_lanes) |i| {
         const a_wide: DstChild = @intCast(aa[offset + i]);
         const b_wide: DstChild = @intCast(bb[offset + i]);
         result[i] = a_wide *% b_wide;
@@ -1007,7 +1019,7 @@ fn extaddPairwise(comptime SrcT: type, comptime DstT: type, env: *ExecEnv, compt
     const dst_lanes = @typeInfo(DstT).vector.len;
     const DstChild = @typeInfo(DstT).vector.child;
     var result: @Vector(dst_lanes, DstChild) = undefined;
-    for (0..dst_lanes) |i| {
+    inline for (0..dst_lanes) |i| {
         const a: DstChild = @intCast(v[i * 2]);
         const b: DstChild = @intCast(v[i * 2 + 1]);
         result[i] = a +% b;
@@ -1021,7 +1033,7 @@ fn q15mulrSatS(env: *ExecEnv) SimdError!void {
     const b: I16x8 = @bitCast(try popV128(env));
     const a: I16x8 = @bitCast(try popV128(env));
     var result: I16x8 = undefined;
-    for (0..8) |i| {
+    inline for (0..8) |i| {
         const prod: i32 = @as(i32, a[i]) * @as(i32, b[i]);
         const rounded = (prod + 0x4000) >> 15;
         result[i] = @intCast(std.math.clamp(rounded, -32768, 32767));
@@ -1035,7 +1047,7 @@ fn i32x4DotI16x8S(env: *ExecEnv) SimdError!void {
     const b: I16x8 = @bitCast(try popV128(env));
     const a: I16x8 = @bitCast(try popV128(env));
     var result: I32x4 = undefined;
-    for (0..4) |i| {
+    inline for (0..4) |i| {
         const lo: i32 = @as(i32, a[i * 2]) * @as(i32, b[i * 2]);
         const hi: i32 = @as(i32, a[i * 2 + 1]) * @as(i32, b[i * 2 + 1]);
         result[i] = lo +% hi;
@@ -1050,7 +1062,7 @@ const F32x4UnaryKind = enum { abs, neg, sqrt, ceil, floor, trunc, nearest };
 fn f32x4Unary(env: *ExecEnv, comptime kind: F32x4UnaryKind) SimdError!void {
     const v: F32x4 = @bitCast(try popV128(env));
     var result: F32x4 = undefined;
-    for (0..4) |i| {
+    inline for (0..4) |i| {
         result[i] = switch (kind) {
             .abs => @abs(v[i]),
             .neg => -v[i],
@@ -1070,7 +1082,7 @@ fn f32x4Binary(env: *ExecEnv, comptime kind: F32x4BinaryKind) SimdError!void {
     const b: F32x4 = @bitCast(try popV128(env));
     const a: F32x4 = @bitCast(try popV128(env));
     var result: F32x4 = undefined;
-    for (0..4) |i| {
+    inline for (0..4) |i| {
         result[i] = switch (kind) {
             .add => canonF32(a[i] + b[i]),
             .sub => canonF32(a[i] - b[i]),
@@ -1092,7 +1104,7 @@ const F64x2UnaryKind = enum { abs, neg, sqrt, ceil, floor, trunc, nearest };
 fn f64x2Unary(env: *ExecEnv, comptime kind: F64x2UnaryKind) SimdError!void {
     const v: F64x2 = @bitCast(try popV128(env));
     var result: F64x2 = undefined;
-    for (0..2) |i| {
+    inline for (0..2) |i| {
         result[i] = switch (kind) {
             .abs => @abs(v[i]),
             .neg => -v[i],
@@ -1112,7 +1124,7 @@ fn f64x2Binary(env: *ExecEnv, comptime kind: F64x2BinaryKind) SimdError!void {
     const b: F64x2 = @bitCast(try popV128(env));
     const a: F64x2 = @bitCast(try popV128(env));
     var result: F64x2 = undefined;
-    for (0..2) |i| {
+    inline for (0..2) |i| {
         result[i] = switch (kind) {
             .add => canonF64(a[i] + b[i]),
             .sub => canonF64(a[i] - b[i]),
@@ -1134,7 +1146,7 @@ fn f32x4Ternary(env: *ExecEnv, comptime negate: bool) SimdError!void {
     const b: F32x4 = @bitCast(try popV128(env));
     const a: F32x4 = @bitCast(try popV128(env));
     var result: F32x4 = undefined;
-    for (0..4) |i| {
+    inline for (0..4) |i| {
         if (negate)
             result[i] = canonF32(-a[i] * b[i] + c[i])
         else
@@ -1148,7 +1160,7 @@ fn f64x2Ternary(env: *ExecEnv, comptime negate: bool) SimdError!void {
     const b: F64x2 = @bitCast(try popV128(env));
     const a: F64x2 = @bitCast(try popV128(env));
     var result: F64x2 = undefined;
-    for (0..2) |i| {
+    inline for (0..2) |i| {
         if (negate)
             result[i] = canonF64(-a[i] * b[i] + c[i])
         else
@@ -1163,7 +1175,7 @@ fn i32x4TruncSatF32x4(env: *ExecEnv, comptime signed: bool) SimdError!void {
     const v: F32x4 = @bitCast(try popV128(env));
     if (signed) {
         var result: I32x4 = undefined;
-        for (0..4) |i| {
+        inline for (0..4) |i| {
             if (std.math.isNan(v[i])) {
                 result[i] = 0;
             } else if (v[i] >= 2147483648.0) {
@@ -1177,7 +1189,7 @@ fn i32x4TruncSatF32x4(env: *ExecEnv, comptime signed: bool) SimdError!void {
         try pushV128(env, @bitCast(result));
     } else {
         var result: U32x4 = undefined;
-        for (0..4) |i| {
+        inline for (0..4) |i| {
             if (std.math.isNan(v[i]) or v[i] <= -1.0) {
                 result[i] = 0;
             } else if (v[i] >= 4294967296.0) {
@@ -1194,12 +1206,12 @@ fn f32x4ConvertI32x4(env: *ExecEnv, comptime signed: bool) SimdError!void {
     if (signed) {
         const v: I32x4 = @bitCast(try popV128(env));
         var result: F32x4 = undefined;
-        for (0..4) |i| result[i] = @floatFromInt(v[i]);
+        inline for (0..4) |i| result[i] = @floatFromInt(v[i]);
         try pushV128(env, @bitCast(result));
     } else {
         const v: U32x4 = @bitCast(try popV128(env));
         var result: F32x4 = undefined;
-        for (0..4) |i| result[i] = @floatFromInt(v[i]);
+        inline for (0..4) |i| result[i] = @floatFromInt(v[i]);
         try pushV128(env, @bitCast(result));
     }
 }
@@ -1208,7 +1220,7 @@ fn i32x4TruncSatF64x2Zero(env: *ExecEnv, comptime signed: bool) SimdError!void {
     const v: F64x2 = @bitCast(try popV128(env));
     var result: I32x4 = .{ 0, 0, 0, 0 };
     if (signed) {
-        for (0..2) |i| {
+        inline for (0..2) |i| {
             if (std.math.isNan(v[i])) {
                 result[i] = 0;
             } else {
@@ -1219,7 +1231,7 @@ fn i32x4TruncSatF64x2Zero(env: *ExecEnv, comptime signed: bool) SimdError!void {
     } else {
         const ru: U32x4 = @bitCast(result);
         var r = ru;
-        for (0..2) |i| {
+        inline for (0..2) |i| {
             if (std.math.isNan(v[i]) or v[i] < 0.0) {
                 r[i] = 0;
             } else {

--- a/src/shared/utils/read_file.zig
+++ b/src/shared/utils/read_file.zig
@@ -1,34 +1,33 @@
 //! File-reading utilities for WAMR (replaces `bh_read_file.h` / `.c`).
 //!
 //! The C version uses platform-specific `open` / `_sopen_s`, `fstat`, and
-//! `read` / `_read` calls with `BH_MALLOC`.  In Zig we leverage `std.fs`
+//! `read` / `_read` calls with `BH_MALLOC`.  In Zig we leverage `std.Io`
 //! which abstracts platform differences and pairs naturally with
 //! `std.mem.Allocator`.
 
 const std = @import("std");
+const Io = std.Io;
 
 /// Read an entire file into a buffer allocated with the given allocator.
 /// Returns the file contents as a slice.  Caller owns the returned memory
 /// and must free it with the same allocator.
-pub fn readFileToBuffer(path: []const u8, allocator: std.mem.Allocator) ![]u8 {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
-    return try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+pub fn readFileToBuffer(io: Io, path: []const u8, allocator: std.mem.Allocator) ![]u8 {
+    return try Io.Dir.cwd().readFileAlloc(io, path, allocator, .unlimited);
 }
 
 /// Read a file with a caller-specified maximum size limit.
 /// Returns `error.FileTooBig` if the file exceeds `max_size`.
-pub fn readFileToBufferWithLimit(path: []const u8, allocator: std.mem.Allocator, max_size: usize) ![]u8 {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
-    const stat = try file.stat();
+pub fn readFileToBufferWithLimit(io: Io, path: []const u8, allocator: std.mem.Allocator, max_size: usize) ![]u8 {
+    const dir = Io.Dir.cwd();
+    const stat = try dir.statFile(io, path, .{});
     if (stat.size > max_size) return error.FileTooBig;
-    return try file.readToEndAlloc(allocator, max_size);
+    return try dir.readFileAlloc(io, path, allocator, Io.Limit.limited(max_size));
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
 
 test "round-trip: write then read" {
+    const io = std.testing.io;
     const allocator = std.testing.allocator;
     var test_dir = std.testing.tmpDir(.{});
     defer test_dir.cleanup();
@@ -36,42 +35,42 @@ test "round-trip: write then read" {
     const content = "Hello, WAMR!\nLine 2.\n";
 
     // Write a file into the temporary directory.
-    try test_dir.dir.writeFile(.{ .sub_path = "test_read_file.txt", .data = content });
+    try test_dir.dir.writeFile(io, .{ .sub_path = "test_read_file.txt", .data = content });
 
     // Read it back.
     {
-        const data = try test_dir.dir.readFileAlloc(allocator, "test_read_file.txt", std.math.maxInt(usize));
+        const data = try test_dir.dir.readFileAlloc(io, "test_read_file.txt", allocator, .unlimited);
         defer allocator.free(data);
         try std.testing.expectEqualStrings(content, data);
     }
 }
 
 test "read empty file" {
+    const io = std.testing.io;
     const allocator = std.testing.allocator;
     var test_dir = std.testing.tmpDir(.{});
     defer test_dir.cleanup();
 
-    try test_dir.dir.writeFile(.{ .sub_path = "empty.txt", .data = "" });
+    try test_dir.dir.writeFile(io, .{ .sub_path = "empty.txt", .data = "" });
 
     {
-        const data = try test_dir.dir.readFileAlloc(allocator, "empty.txt", std.math.maxInt(usize));
+        const data = try test_dir.dir.readFileAlloc(io, "empty.txt", allocator, .unlimited);
         defer allocator.free(data);
         try std.testing.expectEqual(@as(usize, 0), data.len);
     }
 }
 
 test "readFileToBufferWithLimit: limit exceeded" {
+    const io = std.testing.io;
     var test_dir = std.testing.tmpDir(.{});
     defer test_dir.cleanup();
 
     // Write 100 bytes.
-    try test_dir.dir.writeFile(.{ .sub_path = "big_file.txt", .data = &([_]u8{'A'} ** 100) });
+    try test_dir.dir.writeFile(io, .{ .sub_path = "big_file.txt", .data = &([_]u8{'A'} ** 100) });
 
     // Verify the stat-based size check.
     {
-        const file = try test_dir.dir.openFile("big_file.txt", .{});
-        defer file.close();
-        const stat = try file.stat();
+        const stat = try test_dir.dir.statFile(io, "big_file.txt", .{});
         try std.testing.expect(stat.size > 10);
     }
 }

--- a/src/tests/run_spec_tests.zig
+++ b/src/tests/run_spec_tests.zig
@@ -11,16 +11,14 @@
 const std = @import("std");
 const spec_json_runner = @import("spec_json_runner.zig");
 
-const Dir = std.fs.Dir;
+const Dir = std.Io.Dir;
 const print = std.debug.print;
 
-pub fn main() !void {
-    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     if (args.len < 2) {
         print("Usage: spec-test-runner <dir-or-file>\n", .{});
@@ -34,9 +32,9 @@ pub fn main() !void {
     // Check if argument is a single file
     if (std.mem.endsWith(u8, test_path, ".wast") or std.mem.endsWith(u8, test_path, ".json")) {
         const result = if (std.mem.endsWith(u8, test_path, ".wast"))
-            runWastFile(test_path, allocator)
+            runWastFile(test_path, allocator, io)
         else
-            spec_json_runner.runSpecTestFile(test_path, allocator) catch |err| {
+            spec_json_runner.runSpecTestFile(test_path, allocator, io) catch |err| {
                 print("ERROR: {}\n", .{err});
                 std.process.exit(1);
             };
@@ -49,11 +47,11 @@ pub fn main() !void {
         return;
     }
 
-    var dir = std.fs.cwd().openDir(test_path, .{ .iterate = true }) catch |err| {
+    var dir = std.Io.Dir.cwd().openDir(io, test_path, .{ .iterate = true }) catch |err| {
         print("Error: cannot open directory '{s}': {}\n", .{ test_path, err });
         std.process.exit(1);
     };
-    defer dir.close();
+    defer dir.close(io);
 
     var total_passed: u32 = 0;
     var total_failed: u32 = 0;
@@ -69,7 +67,7 @@ pub fn main() !void {
     }
 
     var iter = dir.iterate();
-    while (iter.next() catch null) |entry| {
+    while (iter.next(io) catch null) |entry| {
         if (entry.kind == .file and
             (std.mem.endsWith(u8, entry.name, ".json") or
             std.mem.endsWith(u8, entry.name, ".wast")))
@@ -106,7 +104,7 @@ pub fn main() !void {
 
         if (std.mem.endsWith(u8, name, ".json")) {
             // Legacy JSON format
-            const result = spec_json_runner.runSpecTestFile(full_path, allocator) catch |err| {
+            const result = spec_json_runner.runSpecTestFile(full_path, allocator, io) catch |err| {
                 print("  {s:<25} ERROR: {}\n", .{ name, err });
                 continue;
             };
@@ -118,7 +116,7 @@ pub fn main() !void {
             file_count += 1;
         } else if (std.mem.endsWith(u8, name, ".wast")) {
             // Native .wast format — use wabt to run
-            const result = runWastFile(full_path, allocator);
+            const result = runWastFile(full_path, allocator, io);
             printResult(name, result);
             total_passed += result.passed;
             total_failed += result.failed;
@@ -158,15 +156,15 @@ fn printResult(name: []const u8, result: TestResult) void {
 }
 
 /// Run a .wast file using wabt's parser + interpreter for conformance.
-fn runWastFile(path: []const u8, allocator: std.mem.Allocator) TestResult {
+fn runWastFile(path: []const u8, allocator: std.mem.Allocator, io: std.Io) TestResult {
     const wast_runner = @import("wast_runner.zig");
-    const source = std.fs.cwd().readFileAlloc(allocator, path, 64 * 1024 * 1024) catch {
+    const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, @enumFromInt(64 * 1024 * 1024)) catch {
         return .{ .file = path, .passed = 0, .failed = 0, .skipped = 1, .total = 1 };
     };
     defer allocator.free(source);
 
     const base = std.fs.path.stem(path);
-    const result = wast_runner.run(allocator, source, base);
+    const result = wast_runner.run(allocator, source, base, io);
     return .{
         .file = path,
         .passed = result.passed,

--- a/src/tests/spec_json_runner.zig
+++ b/src/tests/spec_json_runner.zig
@@ -11,7 +11,7 @@ const types = root.types;
 const instance_mod = root.instance;
 const wabt = @import("wabt");
 const Io = std.Io;
-const Dir = std.fs.Dir;
+const Dir = std.Io.Dir;
 
 pub const SpecTestResult = struct {
     file: []const u8,
@@ -741,9 +741,9 @@ fn makeDefaultTable(tt: ?types.TableType, allocator: std.mem.Allocator) ?types.T
     };
 }
 
-pub fn runSpecTestFile(json_path: []const u8, allocator: std.mem.Allocator) !SpecTestResult {
-    const cwd = std.fs.cwd();
-    const json_data = try cwd.readFileAlloc(allocator, json_path, 10 * 1024 * 1024);
+pub fn runSpecTestFile(json_path: []const u8, allocator: std.mem.Allocator, io: std.Io) !SpecTestResult {
+    const cwd = std.Io.Dir.cwd();
+    const json_data = try cwd.readFileAlloc(io, json_path, allocator, @enumFromInt(10 * 1024 * 1024));
     defer allocator.free(json_data);
 
     const parsed = try std.json.parseFromSlice(SpecJson, allocator, json_data, .{
@@ -829,7 +829,7 @@ pub fn runSpecTestFile(json_path: []const u8, allocator: std.mem.Allocator) !Spe
             const wasm_path = try std.fs.path.join(allocator, &.{ json_dir, filename });
             defer allocator.free(wasm_path);
 
-            const wasm_data = cwd.readFileAlloc(allocator, wasm_path, 10 * 1024 * 1024) catch |err| {
+            const wasm_data = cwd.readFileAlloc(io, wasm_path, allocator, @enumFromInt(10 * 1024 * 1024)) catch |err| {
                 std.debug.print("  SKIP read {s} line {d}: {}\n", .{ filename, cmd.line, err });
                 result.skipped += 1;
                 continue;
@@ -1138,7 +1138,7 @@ pub fn runSpecTestFile(json_path: []const u8, allocator: std.mem.Allocator) !Spe
                 if (std.mem.eql(u8, mt, "text")) {
                     const wat_path = try std.fs.path.join(allocator, &.{ json_dir, filename });
                     defer allocator.free(wat_path);
-                    const wat_data = cwd.readFileAlloc(allocator, wat_path, 10 * 1024 * 1024) catch {
+                    const wat_data = cwd.readFileAlloc(io, wat_path, allocator, @enumFromInt(10 * 1024 * 1024)) catch {
                         result.passed += 1;
                         continue;
                     };
@@ -1171,7 +1171,7 @@ pub fn runSpecTestFile(json_path: []const u8, allocator: std.mem.Allocator) !Spe
             const wasm_path = try std.fs.path.join(allocator, &.{ json_dir, filename });
             defer allocator.free(wasm_path);
 
-            const wasm_data = cwd.readFileAlloc(allocator, wasm_path, 10 * 1024 * 1024) catch {
+            const wasm_data = cwd.readFileAlloc(io, wasm_path, allocator, @enumFromInt(10 * 1024 * 1024)) catch {
                 result.passed += 1; // can't read = invalid, as expected
                 continue;
             };
@@ -1200,7 +1200,7 @@ pub fn runSpecTestFile(json_path: []const u8, allocator: std.mem.Allocator) !Spe
             const wasm_path = try std.fs.path.join(allocator, &.{ json_dir, filename });
             defer allocator.free(wasm_path);
 
-            const wasm_data = cwd.readFileAlloc(allocator, wasm_path, 10 * 1024 * 1024) catch {
+            const wasm_data = cwd.readFileAlloc(io, wasm_path, allocator, @enumFromInt(10 * 1024 * 1024)) catch {
                 result.passed += 1;
                 continue;
             };
@@ -1263,7 +1263,7 @@ pub fn runSpecTestFile(json_path: []const u8, allocator: std.mem.Allocator) !Spe
             const wasm_path = try std.fs.path.join(allocator, &.{ json_dir, filename });
             defer allocator.free(wasm_path);
 
-            const wasm_data = cwd.readFileAlloc(allocator, wasm_path, 10 * 1024 * 1024) catch {
+            const wasm_data = cwd.readFileAlloc(io, wasm_path, allocator, @enumFromInt(10 * 1024 * 1024)) catch {
                 result.passed += 1;
                 continue;
             };

--- a/src/tests/wast_runner.zig
+++ b/src/tests/wast_runner.zig
@@ -23,15 +23,15 @@ pub const WastResult = struct {
 /// 2. Convert modules to .wasm binary via wabt text.Parser + binary.writer
 /// 3. Write JSON + .wasm to temp dir
 /// 4. Run through WAMR's JSON-based spec test runner
-pub fn run(allocator: std.mem.Allocator, source: []const u8, name: []const u8) WastResult {
-    return runInner(allocator, source, name) catch return .{ .skipped = 1 };
+pub fn run(allocator: std.mem.Allocator, source: []const u8, name: []const u8, io: std.Io) WastResult {
+    return runInner(allocator, source, name, io) catch return .{ .skipped = 1 };
 }
 
-fn runInner(allocator: std.mem.Allocator, source: []const u8, name: []const u8) !WastResult {
+fn runInner(allocator: std.mem.Allocator, source: []const u8, name: []const u8, io: std.Io) !WastResult {
     // Convert .wast to JSON + wasm modules in memory
     var json_buf: std.ArrayListUnmanaged(u8) = .empty;
     defer json_buf.deinit(allocator);
-    var modules = std.StringHashMapUnmanaged([]u8){};
+    var modules = std.StringHashMapUnmanaged([]u8).empty;
     defer {
         var it = modules.iterator();
         while (it.next()) |entry| {
@@ -48,29 +48,30 @@ fn runInner(allocator: std.mem.Allocator, source: []const u8, name: []const u8) 
     defer allocator.free(dir_name);
 
     // Create dir (ignore if exists)
-    std.fs.cwd().makeDir(dir_name) catch {};
-    var out_dir = try std.fs.cwd().openDir(dir_name, .{});
-    defer out_dir.close();
+    const cwd = std.Io.Dir.cwd();
+    cwd.createDir(io, dir_name, .default_dir) catch {};
+    var out_dir = try cwd.openDir(io, dir_name, .{});
+    defer out_dir.close(io);
 
     // Write wasm modules
     var mod_it = modules.iterator();
     while (mod_it.next()) |entry| {
-        out_dir.writeFile(.{ .sub_path = entry.key_ptr.*, .data = entry.value_ptr.* }) catch continue;
+        out_dir.writeFile(io, .{ .sub_path = entry.key_ptr.*, .data = entry.value_ptr.* }) catch continue;
     }
 
     // Write JSON
     const json_name = try std.fmt.allocPrint(allocator, "{s}.json", .{name});
     defer allocator.free(json_name);
-    out_dir.writeFile(.{ .sub_path = json_name, .data = json_buf.items }) catch return .{ .skipped = 1 };
+    out_dir.writeFile(io, .{ .sub_path = json_name, .data = json_buf.items }) catch return .{ .skipped = 1 };
 
     // Build full path
     const json_path = try std.fs.path.join(allocator, &.{ dir_name, json_name });
     defer allocator.free(json_path);
 
-    const result = try spec_json_runner.runSpecTestFile(json_path, allocator);
+    const result = try spec_json_runner.runSpecTestFile(json_path, allocator, io);
 
     // Cleanup temp dir
-    std.fs.cwd().deleteTree(dir_name) catch {};
+    cwd.deleteTree(io, dir_name) catch {};
 
     return .{
         .passed = result.passed,
@@ -81,7 +82,9 @@ fn runInner(allocator: std.mem.Allocator, source: []const u8, name: []const u8) 
 
 fn convertWast(allocator: std.mem.Allocator, source: []const u8, base_name: []const u8, json_buf: *std.ArrayListUnmanaged(u8), modules: *std.StringHashMapUnmanaged([]u8)) !void {
     const wr = wabt.wast_runner;
-    const w = json_buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .fromArrayList(allocator, json_buf);
+    defer json_buf.* = aw.writer.toArrayList();
+    const w = &aw.writer;
     try w.writeAll("{\"commands\":[");
 
     var pos: usize = 0;
@@ -224,7 +227,7 @@ fn convertWast(allocator: std.mem.Allocator, source: []const u8, base_name: []co
                         };
                         defer allocator.free(wat_text);
                         // Wrap in (module ...) if not already
-                        const trimmed = std.mem.trimLeft(u8, wat_text, " \t\n\r");
+                        const trimmed = std.mem.trimStart(u8, wat_text, " \t\n\r");
                         const parse_text = if (std.mem.startsWith(u8, trimmed, "(module"))
                             wat_text
                         else blk: {
@@ -1232,7 +1235,7 @@ test "wast runner: full pipeline for simple module" {
     // Test the convertWast function specifically
     var json_buf: std.ArrayListUnmanaged(u8) = .empty;
     defer json_buf.deinit(allocator);
-    var modules = std.StringHashMapUnmanaged([]u8){};
+    var modules = std.StringHashMapUnmanaged([]u8).empty;
     defer {
         var it = modules.iterator();
         while (it.next()) |entry| {

--- a/src/wasi/preview2/core.zig
+++ b/src/wasi/preview2/core.zig
@@ -5,6 +5,41 @@
 //! during component instantiation.
 
 const std = @import("std");
+const builtin = @import("builtin");
+
+/// Cross-platform nanosecond wall-clock timestamp (since Unix epoch).
+fn nanoTimestamp() i128 {
+    if (builtin.os.tag == .windows) {
+        const win = std.os.windows;
+        // RtlGetSystemTimePrecise returns 100ns intervals since Windows epoch (1601-01-01).
+        const epoch_adjustment = @as(i128, std.time.epoch.windows) * std.time.ns_per_s;
+        return @as(i128, win.ntdll.RtlGetSystemTimePrecise()) * 100 + epoch_adjustment;
+    } else {
+        const posix = std.posix;
+        var ts: posix.timespec = undefined;
+        _ = posix.system.clock_gettime(.REALTIME, &ts);
+        return @as(i128, ts.sec) * std.time.ns_per_s + ts.nsec;
+    }
+}
+
+/// Fill buffer with cryptographically-secure random bytes using OS primitives.
+fn fillRandom(buf: []u8) void {
+    if (builtin.os.tag == .windows) {
+        // Use ProcessPrng from bcryptprimitives.dll (available on Windows 10+).
+        const processPrng = struct {
+            extern "bcryptprimitives" fn ProcessPrng(
+                pbData: [*]u8,
+                cbData: usize,
+            ) callconv(.winapi) std.os.windows.BOOL;
+        }.ProcessPrng;
+        _ = processPrng(buf.ptr, buf.len);
+    } else if (builtin.os.tag == .linux) {
+        _ = std.os.linux.getrandom(buf.ptr, buf.len, 0);
+    } else {
+        // macOS and other BSDs
+        std.c.arc4random_buf(buf.ptr, buf.len);
+    }
+}
 
 // ── wasi:clocks/wall-clock ──────────────────────────────────────────────────
 
@@ -15,7 +50,7 @@ pub const WallClock = struct {
     };
 
     pub fn now() DateTime {
-        const ts = std.time.nanoTimestamp();
+        const ts = nanoTimestamp();
         if (ts < 0) return .{ .seconds = 0, .nanoseconds = 0 };
         const ns: u64 = @intCast(ts);
         return .{
@@ -33,7 +68,7 @@ pub const WallClock = struct {
 
 pub const MonotonicClock = struct {
     pub fn now() u64 {
-        const ts = std.time.nanoTimestamp();
+        const ts = nanoTimestamp();
         if (ts < 0) return 0;
         return @intCast(ts);
     }
@@ -47,11 +82,13 @@ pub const MonotonicClock = struct {
 
 pub const Random = struct {
     pub fn getRandomBytes(buf: []u8) void {
-        std.crypto.random.bytes(buf);
+        fillRandom(buf);
     }
 
     pub fn getRandomU64() u64 {
-        return std.crypto.random.int(u64);
+        var bytes: [8]u8 = undefined;
+        fillRandom(&bytes);
+        return std.mem.readInt(u64, &bytes, .little);
     }
 };
 

--- a/src/wasi/preview2/http.zig
+++ b/src/wasi/preview2/http.zig
@@ -28,7 +28,7 @@ pub const HeaderEntry = struct {
 };
 
 pub const Headers = struct {
-    entries: std.ArrayListUnmanaged(HeaderEntry) = .{},
+    entries: std.ArrayListUnmanaged(HeaderEntry) = .empty,
 
     pub fn append(self: *Headers, name: []const u8, value: []const u8, allocator: std.mem.Allocator) !void {
         try self.entries.append(allocator, .{ .name = name, .value = value });
@@ -74,7 +74,7 @@ pub const IncomingHandler = *const fn (request: *const Request, allocator: std.m
 
 /// A simple handler registry that routes requests to handlers by path prefix.
 pub const Router = struct {
-    routes: std.ArrayListUnmanaged(Route) = .{},
+    routes: std.ArrayListUnmanaged(Route) = .empty,
 
     pub const Route = struct {
         path_prefix: []const u8,

--- a/src/wasi/preview2/sockets.zig
+++ b/src/wasi/preview2/sockets.zig
@@ -19,7 +19,7 @@ pub const IpAddress = union(enum) {
                 }) catch return "";
                 return n;
             },
-            .ipv6 => |_| return "::1", // simplified
+            .ipv6 => return "::1", // simplified
         }
     }
 };

--- a/src/wasi/preview2/streams.zig
+++ b/src/wasi/preview2/streams.zig
@@ -34,7 +34,7 @@ pub const InputStream = struct {
                 b.pos += n;
                 return .{ .ok = n };
             },
-            .fd => |_| {
+            .fd => {
                 // Host fd reading would go here
                 return .{ .ok = 0 };
             },
@@ -70,7 +70,7 @@ pub const OutputStream = struct {
                 b.appendSlice(allocator, data) catch return .{ .err = .would_block };
                 return .{ .ok = data.len };
             },
-            .fd => |_| {
+            .fd => {
                 return .{ .ok = data.len };
             },
             .closed => return .{ .closed = {} },
@@ -79,7 +79,7 @@ pub const OutputStream = struct {
 
     /// Create an output stream backed by a growable buffer.
     pub fn toBuffer() OutputStream {
-        return .{ .sink = .{ .buffer = .{} } };
+        return .{ .sink = .{ .buffer = .empty } };
     }
 
     /// Get the buffer contents (only valid for buffer-backed streams).

--- a/src/wasi/thread_manager.zig
+++ b/src/wasi/thread_manager.zig
@@ -7,6 +7,19 @@ const std = @import("std");
 const types = @import("../runtime/common/types.zig");
 const config = @import("config");
 
+/// Simple spinlock mutex (Zig 0.16 moved std.Thread.Mutex behind Io).
+const Mutex = struct {
+    state: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+    pub const init: Mutex = .{ .state = std.atomic.Value(u8).init(0) };
+    pub fn lock(self: *Mutex) void {
+        while (self.state.cmpxchgWeak(0, 1, .acquire, .monotonic) != null)
+            std.atomic.spinLoopHint();
+    }
+    pub fn unlock(self: *Mutex) void {
+        self.state.store(0, .release);
+    }
+};
+
 /// Default auxiliary stack size per thread (bytes).
 const DEFAULT_AUX_STACK_SIZE: u32 = 8192;
 
@@ -16,10 +29,10 @@ pub const AuxStackPool = struct {
     /// Stack size per thread (bytes).
     stack_size: u32 = DEFAULT_AUX_STACK_SIZE,
     /// Free stack offsets (top-of-stack addresses in linear memory).
-    free_stacks: std.ArrayListUnmanaged(u32) = .{},
+    free_stacks: std.ArrayListUnmanaged(u32) = .empty,
     /// All allocated stacks (for cleanup).
-    all_stacks: std.ArrayListUnmanaged(u32) = .{},
-    mutex: std.Thread.Mutex = .{},
+    all_stacks: std.ArrayListUnmanaged(u32) = .empty,
+    mutex: Mutex = .init,
     pool_allocator: std.mem.Allocator = undefined,
 
     /// Pre-allocate N auxiliary stacks starting at `base_offset` in linear memory.
@@ -76,7 +89,7 @@ pub const ThreadManager = struct {
     next_tid: std.atomic.Value(i32) = std.atomic.Value(i32).init(1),
     /// Active threads (protected by mutex).
     threads: std.ArrayList(ThreadHandle),
-    mutex: std.Thread.Mutex = .{},
+    mutex: Mutex = .init,
     /// Global trap flag — set when any thread traps.
     trap_flag: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     allocator: std.mem.Allocator,


### PR DESCRIPTION
## Summary

Update the project from Zig 0.15 to Zig 0.16 stable, and bump wabt dependency to v2.2.0.

### Key changes

- **Juicy Main**: Switch to \std.process.Init\ for \main()\ entry points (\init.gpa\, \init.io\, \init.minimal.args\)
- **I/O as Interface**: All filesystem ops now require \io\ parameter (\std.Io.Dir.cwd()\, \eadFileAlloc\, \createFile\, etc.)
- **Mutex**: Replace \std.Thread.Mutex\ (now behind Io) with spinlock for internal synchronization
- **SIMD**: Vector indexing requires comptime indices — add \inline for\ and array conversions
- **Collections**: \ArrayListUnmanaged = .{}\ → \.empty\
- **API renames**: \	rimLeft\ → \	rimStart\, \intToEnum\ → \nums.fromInt\, \writeAll\ → \writeStreamingAll\
- **Windows platform**: Memory/page constants → packed struct types, \kernel32.Sleep\ → \
tdll.NtDelayExecution\
- **wabt**: Bumped from v2.1.0 to v2.2.0
- **build.zig.zon**: \minimum_zig_version\ set to \