### PR TITLE
aot: 6 AOT codegen optimizations for x86-64 (#95)

### DIFF
--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -299,6 +299,14 @@ const CallPatch = struct {
     target_func_idx: u32,
 };
 
+/// Patches one 4-byte entry in a br_table jump table. After final layout is
+/// known, `entry_offset` is overwritten with `block_offsets[target_block] - base_offset`.
+const TablePatch = struct {
+    entry_offset: usize,
+    base_offset: usize,
+    target_block: ir.BlockId,
+};
+
 fn compileInst(
     code: *emit.CodeBuffer,
     inst: ir.Inst,
@@ -612,6 +620,11 @@ fn compileInst(
             const else_patch = code.len();
             try code.emitI32(0);
             try patches.append(code.allocator, .{ .patch_offset = else_patch, .target_block = br.else_block });
+        },
+        .br_table => {
+            // br_table is only used through compileFunctionRA path in production.
+            // The legacy stack-based compileInst path does not support it.
+            return error.Unsupported;
         },
 
         // ── Function calls ────────────────────────────────────────────
@@ -1067,13 +1080,15 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
     defer branch_patches.deinit(allocator);
     var call_patches: std.ArrayList(CallPatch) = .empty;
     defer call_patches.deinit(allocator);
+    var table_patches: std.ArrayList(TablePatch) = .empty;
+    defer table_patches.deinit(allocator);
 
     var last_was_ret = false;
     for (func.blocks.items, 0..) |block, idx| {
         try block_offsets.put(@intCast(idx), code.len());
         for (block.instructions.items) |inst| {
             last_was_ret = isRet(inst.op);
-            try compileInstRA(&code, inst, &alloc_result, &const_vals, &branch_patches, &call_patches, import_count, &used_caller_saved, &used_callee_saved);
+            try compileInstRA(&code, inst, &alloc_result, &const_vals, &branch_patches, &call_patches, &table_patches, import_count, &used_caller_saved, &used_callee_saved);
         }
     }
 
@@ -1081,6 +1096,13 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
         if (block_offsets.get(patch.target_block)) |target_off| {
             const rel: i32 = @intCast(@as(i64, @intCast(target_off)) - @as(i64, @intCast(patch.patch_offset + 4)));
             code.patchI32(patch.patch_offset, rel);
+        }
+    }
+
+    for (table_patches.items) |patch| {
+        if (block_offsets.get(patch.target_block)) |target_off| {
+            const rel: i32 = @intCast(@as(i64, @intCast(target_off)) - @as(i64, @intCast(patch.base_offset)));
+            code.patchI32(patch.entry_offset, rel);
         }
     }
 
@@ -1189,6 +1211,7 @@ fn compileInstRA(
     const_vals: *const std.AutoHashMap(ir.VReg, i64),
     patches: *std.ArrayList(BranchPatch),
     call_patches: *std.ArrayList(CallPatch),
+    table_patches: *std.ArrayList(TablePatch),
     import_count: u32,
     used_caller_saved: *const [caller_saved_alloc.len]bool,
     used_callee_saved: *const [callee_saved_alloc.len]bool,
@@ -1360,6 +1383,57 @@ fn compileInstRA(
             const else_patch = code.len();
             try code.emitI32(0);
             try patches.append(code.allocator, .{ .patch_offset = else_patch, .target_block = br.else_block });
+        },
+        .br_table => |bt| {
+            // Load index into r11 (scratch) and canonicalize upper 32 bits to zero.
+            const idx_reg = try useVReg(code, alloc_result, bt.index, .r11);
+            if (idx_reg != .r11) try code.movRegReg(.r11, idx_reg);
+            try code.zeroExtend32(.r11);
+
+            // cmp r11, targets.len ; jae default  (unsigned out-of-range goes to default)
+            try code.cmpRegImm32(.r11, @intCast(bt.targets.len));
+            try code.emitByte(0x0F);
+            try code.emitByte(0x83);
+            const default_patch = code.len();
+            try code.emitI32(0);
+            try patches.append(code.allocator, .{ .patch_offset = default_patch, .target_block = bt.default });
+
+            // lea r10, [rip + table]       ; 4C 8D 15 disp32
+            try code.emitByte(0x4C);
+            try code.emitByte(0x8D);
+            try code.emitByte(0x15);
+            const lea_disp_off = code.len();
+            try code.emitI32(0);
+
+            // movsxd r11, dword ptr [r10 + r11*4]
+            // REX.WRXB = 0x4F, opcode 0x63, ModR/M=00_011_100 (0x1C), SIB=10_011_010 (0x9A)
+            try code.emitByte(0x4F);
+            try code.emitByte(0x63);
+            try code.emitByte(0x1C);
+            try code.emitByte(0x9A);
+
+            // add r10, r11
+            try code.addRegReg(.r10, .r11);
+
+            // jmp r10                     ; 41 FF E2
+            try code.emitByte(0x41);
+            try code.emitByte(0xFF);
+            try code.emitByte(0xE2);
+
+            // Emit the jump table inline (no fallthrough from the indirect jmp).
+            const table_off = code.len();
+            const lea_rel: i32 = @intCast(@as(i64, @intCast(table_off)) - @as(i64, @intCast(lea_disp_off + 4)));
+            code.patchI32(lea_disp_off, lea_rel);
+
+            for (bt.targets) |target| {
+                const entry_off = code.len();
+                try code.emitI32(0);
+                try table_patches.append(code.allocator, .{
+                    .entry_offset = entry_off,
+                    .base_offset = table_off,
+                    .target_block = target,
+                });
+            }
         },
 
         // ── Function calls ────────────────────────────────────────────
@@ -2726,4 +2800,54 @@ test "compileFunctionRA: local_get and local_set" {
 
     try std.testing.expect(code.len > 10);
     try std.testing.expectEqual(@as(u8, 0xC3), code[code.len - 1]);
+}
+
+test "compileFunctionRA: br_table emits jump table + indirect jmp" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+
+    // Param 0 is the switch index. 2 targets + default.
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+
+    const idx = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = idx, .type = .i32 });
+
+    const targets = try allocator.alloc(ir.BlockId, 2);
+    targets[0] = b1;
+    targets[1] = b2;
+    try func.getBlock(b0).append(.{ .op = .{ .br_table = .{
+        .index = idx,
+        .targets = targets,
+        .default = b3,
+    } } });
+
+    const r1 = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = r1 });
+    try func.getBlock(b1).append(.{ .op = .{ .ret = r1 } });
+    const r2 = func.newVReg();
+    try func.getBlock(b2).append(.{ .op = .{ .iconst_32 = 2 }, .dest = r2 });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = r2 } });
+    const r3 = func.newVReg();
+    try func.getBlock(b3).append(.{ .op = .{ .iconst_32 = 3 }, .dest = r3 });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = r3 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+    // targets slice is leaked by IR (same pattern as call.args); free explicitly.
+    allocator.free(targets);
+
+    // lea r10, [rip+disp32]
+    try std.testing.expect(containsBytes(code, &.{ 0x4C, 0x8D, 0x15 }));
+    // movsxd r11, [r10 + r11*4]
+    try std.testing.expect(containsBytes(code, &.{ 0x4F, 0x63, 0x1C, 0x9A }));
+    // jmp r10
+    try std.testing.expect(containsBytes(code, &.{ 0x41, 0xFF, 0xE2 }));
+    // jae rel32 (bounds check)
+    try std.testing.expect(containsBytes(code, &.{ 0x0F, 0x83 }));
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -905,7 +905,48 @@ const regalloc = @import("../../ir/regalloc.zig");
 /// VRegs are assigned to physical registers; instructions operate directly
 /// on assigned registers without push/pop through a CachedStack.
 pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocator: std.mem.Allocator) !FuncCompileResult {
-    var alloc_result = try regalloc.allocate(func, allocator);
+    // Collect clobber points: instructions that destroy specific registers.
+    // Uses the same sequential numbering as computeLiveRanges in analysis.zig.
+    var clobber_points: std.ArrayList(regalloc.ClobberPoint) = .empty;
+    defer clobber_points.deinit(allocator);
+    {
+        var pos: u32 = 0;
+        for (func.blocks.items) |block| {
+            for (block.instructions.items) |ci| {
+                switch (ci.op) {
+                    .call, .call_indirect => {
+                        // Calls clobber caller-saved allocatable regs.
+                        // alloc_regs = [rdx(2), rsi(6), rdi(7), r8(8), r9(9)]
+                        // On Win64: rdx, r8, r9 are volatile (indices 0, 3, 4)
+                        // On SysV: all 5 are volatile
+                        const mask = if (comptime builtin.os.tag == .windows)
+                            [_]bool{ true, false, false, true, true }
+                        else
+                            [_]bool{ true, true, true, true, true };
+                        try clobber_points.append(allocator, .{ .pos = pos, .regs_clobbered = mask });
+                    },
+                    .memory_copy => {
+                        // REP MOVSB clobbers rsi(6) and rdi(7) → indices 1, 2
+                        try clobber_points.append(allocator, .{
+                            .pos = pos,
+                            .regs_clobbered = .{ false, true, true, false, false },
+                        });
+                    },
+                    .memory_fill => {
+                        // REP STOSB clobbers rdi(7) → index 2
+                        try clobber_points.append(allocator, .{
+                            .pos = pos,
+                            .regs_clobbered = .{ false, false, true, false, false },
+                        });
+                    },
+                    else => {},
+                }
+                pos += 1;
+            }
+        }
+    }
+
+    var alloc_result = try regalloc.allocate(func, allocator, clobber_points.items);
     defer alloc_result.deinit();
 
     // Compute which caller-saved registers are actually used by this function.
@@ -966,13 +1007,15 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
     }
 
     // Frame: locals + spill slots + 1 vmctx slot, aligned to 16 bytes.
-    // After push rbp (rsp=0 mod 16), sub rsp + callee-save pushes must
-    // leave rsp ≡ 8 mod 16, so that an odd number of caller-saved pushes
-    // at call sites aligns rsp to 16 for the CALL instruction.
+    // No push/pop at call sites (allocator handles clobbering), so after
+    // push rbp (rsp=0 mod 16) + sub rsp + callee-save pushes, rsp must
+    // be 0 mod 16 for direct CALL alignment.
     const spill_slots = alloc_result.spill_count;
     const raw_size: u32 = (func.local_count + 64 + spill_slots + 1) * 8;
     const aligned: u32 = (raw_size + 15) & ~@as(u32, 15);
-    const frame_size: u32 = if (callee_save_count % 2 == 0) aligned | 8 else aligned;
+    // After push rbp: rsp=0 mod 16. After sub rsp,frame_size + N callee pushes:
+    // want (frame_size + 8*N) ≡ 0 mod 16 → rsp ≡ 0 mod 16 at CALL sites.
+    const frame_size: u32 = if (callee_save_count % 2 == 0) aligned else aligned | 8;
     try code.emitPrologue(frame_size);
 
     // Save memory base (VMContext) from first ABI register to [rbp - 8]
@@ -1317,8 +1360,8 @@ fn compileInstRA(
 
         // ── Function calls ────────────────────────────────────────────
         .call => |cl| {
-            // Save caller-saved allocatable registers across the call
-            for (caller_saved_alloc, 0..) |reg, cs_i| { if (used_caller_saved[cs_i]) try code.pushReg(reg); }
+            // No push/pop: the allocator ensures no live vreg in a
+            // caller-saved register spans this call instruction.
 
             if (cl.func_idx < import_count) {
                 // Import call: indirect call via host function pointer table in VmCtx.
@@ -1365,13 +1408,6 @@ fn compileInstRA(
                 });
             }
 
-            // Restore caller-saved registers (reverse order)
-            var ri: usize = caller_saved_alloc.len;
-            while (ri > 0) {
-                ri -= 1;
-                if (used_caller_saved[ri]) try code.popReg(caller_saved_alloc[ri]);
-            }
-
             if (inst.dest) |dest| {
                 try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
             }
@@ -1379,8 +1415,8 @@ fn compileInstRA(
 
         // ── Indirect function calls ───────────────────────────────────
         .call_indirect => |ci| {
-            // Save caller-saved allocatable registers across the call
-            for (caller_saved_alloc, 0..) |reg, cs_i| { if (used_caller_saved[cs_i]) try code.pushReg(reg); }
+            // No push/pop: the allocator ensures no live vreg in a
+            // clobbered register spans this call instruction.
 
             // Load table element index
             const idx_reg = try useVReg(code, alloc_result, ci.elem_idx, .rax);
@@ -1416,13 +1452,6 @@ fn compileInstRA(
             try code.callReg(.rax);
             if (comptime builtin.os.tag == .windows) {
                 try code.addRegImm32(.rsp, 32);
-            }
-
-            // Restore caller-saved registers (reverse order)
-            var ri: usize = caller_saved_alloc.len;
-            while (ri > 0) {
-                ri -= 1;
-                if (used_caller_saved[ri]) try code.popReg(caller_saved_alloc[ri]);
             }
 
             if (inst.dest) |dest| {

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1203,7 +1203,8 @@ fn compileInstRA(
             } else {
                 try code.movRegImm32(dr, val);
             }
-            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
+            // 32-bit write already zero-extends upper bits — skip zeroExtend32
+            try writeDef(code, alloc_result, dest, dr);
         },
         .iconst_64 => |val| {
             const dest = inst.dest orelse return;
@@ -1215,7 +1216,8 @@ fn compileInstRA(
             const dest = inst.dest orelse return;
             const dr = destReg(alloc_result, dest);
             try code.movRegImm32(dr, @bitCast(val));
-            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
+            // 32-bit write already zero-extends
+            try writeDef(code, alloc_result, dest, dr);
         },
         .fconst_64 => |val| {
             const dest = inst.dest orelse return;
@@ -1294,7 +1296,8 @@ fn compileInstRA(
             };
             try code.setcc(cc, .rax);
             try code.movzxByte(.rax, .rax);
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            // setcc+movzx produces clean 0/1 — skip zeroExtend32
+            try writeDef(code, alloc_result, dest, .rax);
         },
 
         .eqz => |vreg| {
@@ -1304,7 +1307,8 @@ fn compileInstRA(
             try code.testRegReg(.rax, .rax);
             try code.setcc(0x4, .rax);
             try code.movzxByte(.rax, .rax);
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            // setcc+movzx produces clean 0/1 — skip zeroExtend32
+            try writeDef(code, alloc_result, dest, .rax);
         },
 
         // ── Local variable access ─────────────────────────────────────
@@ -1485,7 +1489,14 @@ fn compileInstRA(
                 }
                 if (dr != .rax) try code.movRegReg(dr, .rax);
             }
-            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
+            // For non-sign-extended loads ≤ 4 bytes, movRegMemSized already
+            // produces a zero-extended (clean) i32 — skip redundant zeroExtend32.
+            const load_is_clean = !ld.sign_extend and ld.size <= 4;
+            if (load_is_clean) {
+                try writeDef(code, alloc_result, dest, dr);
+            } else {
+                try writeDefTyped(code, alloc_result, dest, dr, inst.type);
+            }
         },
         .store => |st| {
             // Load base FIRST to avoid register clobbering if both operands
@@ -1542,7 +1553,8 @@ fn compileInstRA(
             // Read current page count from VmCtx
             try code.movRegMem(.r10, .rbp, vmctx_offset);
             try code.movRegMemNoRex(.rax, .r10, vmctx_mem_pages_field);
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            // 32-bit load already zero-extends
+            try writeDef(code, alloc_result, dest, .rax);
         },
         .memory_grow => |pages_vreg| {
             const dest = inst.dest orelse return;
@@ -1766,7 +1778,8 @@ fn compileInstRA(
             if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
             // Truncate to 32-bit: writing to eax zero-extends to rax
             try code.emitSlice(&.{ 0x89, 0xC0 }); // mov eax, eax
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            // Already zero-extended by the 32-bit write
+            try writeDef(code, alloc_result, dest, .rax);
         },
         .extend_i32_s => |vreg| {
             const dest = inst.dest orelse return;

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -24,6 +24,12 @@ else
 /// prologues, ALL allocatable registers must be treated as caller-saved.
 const caller_saved_alloc = [_]emit.Reg{ .rdx, .rsi, .rdi, .r8, .r9 };
 
+/// Callee-saved allocatable registers preserved in prologue/epilogue.
+/// On Win64, rsi and rdi are callee-saved per the ABI; compiled functions
+/// must save/restore them if used. On SysV they're caller-saved (handled
+/// at call sites via caller_saved_alloc), so no prologue work is needed.
+const callee_saved_alloc = [_]emit.Reg{ .rsi, .rdi };
+
 /// Fixed frame offset for the VMContext pointer.
 /// Stored at [rbp - 8] by compileFunctionRA at function entry.
 /// Points to a VmCtx struct with memory_base at +0, globals_base at +16.
@@ -905,6 +911,8 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
     // Compute which caller-saved registers are actually used by this function.
     // Only these need to be saved/restored around call sites.
     var used_caller_saved: [caller_saved_alloc.len]bool = .{false} ** caller_saved_alloc.len;
+    // Track which callee-saved registers are used (for prologue/epilogue preservation).
+    var used_callee_saved: [callee_saved_alloc.len]bool = .{false} ** callee_saved_alloc.len;
     {
         var it = alloc_result.assignments.iterator();
         while (it.next()) |entry| {
@@ -914,8 +922,34 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
                     for (caller_saved_alloc, 0..) |cs_reg, i| {
                         if (reg == cs_reg) used_caller_saved[i] = true;
                     }
+                    if (comptime builtin.os.tag == .windows) {
+                        for (callee_saved_alloc, 0..) |cs_reg, i| {
+                            if (reg == cs_reg) used_callee_saved[i] = true;
+                        }
+                    }
                 },
                 .stack => {},
+            }
+        }
+    }
+    // Mark callee-saved regs clobbered by fixed-register instructions:
+    // memory_copy (REP MOVSB) hard-uses rsi+rdi, memory_fill (REP STOSB) uses rdi.
+    if (comptime builtin.os.tag == .windows) {
+        for (func.blocks.items) |block| {
+            for (block.instructions.items) |blk_inst| {
+                switch (blk_inst.op) {
+                    .memory_copy => {
+                        for (callee_saved_alloc, 0..) |cs_reg, i| {
+                            if (cs_reg == .rsi or cs_reg == .rdi) used_callee_saved[i] = true;
+                        }
+                    },
+                    .memory_fill => {
+                        for (callee_saved_alloc, 0..) |cs_reg, i| {
+                            if (cs_reg == .rdi) used_callee_saved[i] = true;
+                        }
+                    },
+                    else => {},
+                }
             }
         }
     }
@@ -923,10 +957,22 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
     var code = emit.CodeBuffer.init(allocator);
     errdefer code.deinit();
 
-    // Frame: locals + spill slots + 1 vmctx slot, aligned to 16 bytes
+    // Count callee-saved pushes for stack alignment calculation.
+    var callee_save_count: u32 = 0;
+    if (comptime builtin.os.tag == .windows) {
+        for (used_callee_saved) |used| {
+            if (used) callee_save_count += 1;
+        }
+    }
+
+    // Frame: locals + spill slots + 1 vmctx slot, aligned to 16 bytes.
+    // After push rbp (rsp=0 mod 16), sub rsp + callee-save pushes must
+    // leave rsp ≡ 8 mod 16, so that an odd number of caller-saved pushes
+    // at call sites aligns rsp to 16 for the CALL instruction.
     const spill_slots = alloc_result.spill_count;
     const raw_size: u32 = (func.local_count + 64 + spill_slots + 1) * 8;
-    const frame_size: u32 = (raw_size + 15) & ~@as(u32, 15) | 8;
+    const aligned: u32 = (raw_size + 15) & ~@as(u32, 15);
+    const frame_size: u32 = if (callee_save_count % 2 == 0) aligned | 8 else aligned;
     try code.emitPrologue(frame_size);
 
     // Save memory base (VMContext) from first ABI register to [rbp - 8]
@@ -947,6 +993,13 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
         try code.xorReg32(.rax);
         for (func.param_count..func.local_count) |i| {
             try code.movMemReg(.rbp, -@as(i32, @intCast((i + 2) * 8)), .rax);
+        }
+    }
+
+    // Save callee-saved registers used by this function (Win64 ABI: rsi/rdi).
+    if (comptime builtin.os.tag == .windows) {
+        for (callee_saved_alloc, 0..) |reg, i| {
+            if (used_callee_saved[i]) try code.pushReg(reg);
         }
     }
 
@@ -977,7 +1030,7 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
         try block_offsets.put(@intCast(idx), code.len());
         for (block.instructions.items) |inst| {
             last_was_ret = isRet(inst.op);
-            try compileInstRA(&code, inst, &alloc_result, &const_vals, &branch_patches, &call_patches, import_count, &used_caller_saved);
+            try compileInstRA(&code, inst, &alloc_result, &const_vals, &branch_patches, &call_patches, import_count, &used_caller_saved, &used_callee_saved);
         }
     }
 
@@ -989,6 +1042,14 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
     }
 
     if (!last_was_ret) {
+        // Restore callee-saved registers before epilogue (reverse order).
+        if (comptime builtin.os.tag == .windows) {
+            var ci: usize = callee_saved_alloc.len;
+            while (ci > 0) {
+                ci -= 1;
+                if (used_callee_saved[ci]) try code.popReg(callee_saved_alloc[ci]);
+            }
+        }
         try code.emitEpilogue();
     }
 
@@ -1079,6 +1140,7 @@ fn compileInstRA(
     call_patches: *std.ArrayList(CallPatch),
     import_count: u32,
     used_caller_saved: *const [caller_saved_alloc.len]bool,
+    used_callee_saved: *const [callee_saved_alloc.len]bool,
 ) !void {
     switch (inst.op) {
         // ── Constants ─────────────────────────────────────────────────
@@ -1220,6 +1282,14 @@ fn compileInstRA(
                 const src_reg = try useVReg(code, alloc_result, val, .rax);
                 if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
             }
+            // Restore callee-saved registers before epilogue (reverse order).
+            if (comptime builtin.os.tag == .windows) {
+                var ci: usize = callee_saved_alloc.len;
+                while (ci > 0) {
+                    ci -= 1;
+                    if (used_callee_saved[ci]) try code.popReg(callee_saved_alloc[ci]);
+                }
+            }
             try code.emitEpilogue();
         },
 
@@ -1299,7 +1369,7 @@ fn compileInstRA(
             var ri: usize = caller_saved_alloc.len;
             while (ri > 0) {
                 ri -= 1;
-                try code.popReg(caller_saved_alloc[ri]);
+                if (used_caller_saved[ri]) try code.popReg(caller_saved_alloc[ri]);
             }
 
             if (inst.dest) |dest| {
@@ -1352,7 +1422,7 @@ fn compileInstRA(
             var ri: usize = caller_saved_alloc.len;
             while (ri > 0) {
                 ri -= 1;
-                try code.popReg(caller_saved_alloc[ri]);
+                if (used_caller_saved[ri]) try code.popReg(caller_saved_alloc[ri]);
             }
 
             if (inst.dest) |dest| {
@@ -1533,7 +1603,7 @@ fn compileInstRA(
             var ri: usize = caller_saved_alloc.len;
             while (ri > 0) {
                 ri -= 1;
-                try code.popReg(caller_saved_alloc[ri]);
+                if (used_caller_saved[ri]) try code.popReg(caller_saved_alloc[ri]);
             }
             try code.movRegReg(.rax, .r11);
 

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1131,6 +1131,14 @@ fn regOf(alloc_result: *const regalloc.AllocResult, vreg: ir.VReg) ?emit.Reg {
     };
 }
 
+/// Return the physical register for a destination VReg, or a default scratch
+/// register for stack-spilled destinations. This enables register-flexible
+/// codegen: instructions operate directly on the allocated register instead
+/// of always routing through rax.
+fn destReg(alloc_result: *const regalloc.AllocResult, dest: ir.VReg) emit.Reg {
+    return regOf(alloc_result, dest) orelse .rax;
+}
+
 fn compileInstRA(
     code: *emit.CodeBuffer,
     inst: ir.Inst,
@@ -1146,104 +1154,95 @@ fn compileInstRA(
         // ── Constants ─────────────────────────────────────────────────
         .iconst_32 => |val| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             if (val == 0) {
-                try code.xorReg32(.rax);
+                try code.xorReg32(dr);
             } else {
-                try code.movRegImm32(.rax, val);
+                try code.movRegImm32(dr, val);
             }
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .iconst_64 => |val| {
             const dest = inst.dest orelse return;
-            try code.movRegImm64(.rax, @bitCast(val));
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            const dr = destReg(alloc_result, dest);
+            try code.movRegImm64(dr, @bitCast(val));
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .fconst_32 => |val| {
             const dest = inst.dest orelse return;
-            try code.movRegImm32(.rax, @bitCast(val));
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            const dr = destReg(alloc_result, dest);
+            try code.movRegImm32(dr, @bitCast(val));
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .fconst_64 => |val| {
             const dest = inst.dest orelse return;
-            try code.movRegImm64(.rax, @bitCast(val));
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            const dr = destReg(alloc_result, dest);
+            try code.movRegImm64(dr, @bitCast(val));
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
 
         // ── Binary arithmetic ─────────────────────────────────────────
         .add, .sub, .mul, .@"and", .@"or", .xor => {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const bin = switch (inst.op) {
                 .add => |b| b, .sub => |b| b, .mul => |b| b,
                 .@"and" => |b| b, .@"or" => |b| b, .xor => |b| b,
                 else => unreachable,
             };
+            const scratch: emit.Reg = if (dr == .rax) .rcx else .rax;
             // Check if RHS is a constant for immediate form
             if (const_vals.get(bin.rhs)) |imm| {
                 if (imm >= std.math.minInt(i32) and imm <= std.math.maxInt(i32)) {
-                    const lhs_reg = try useVReg(code, alloc_result, bin.lhs, .rax);
-                    if (lhs_reg != .rax) try code.movRegReg(.rax, lhs_reg);
+                    const lhs_reg = try useVReg(code, alloc_result, bin.lhs, dr);
+                    if (lhs_reg != dr) try code.movRegReg(dr, lhs_reg);
                     const imm32: i32 = @intCast(imm);
                     switch (inst.op) {
-                        .add => if (imm32 != 0) try code.addRegImm32(.rax, imm32),
-                        .sub => if (imm32 != 0) try code.subRegImm32(.rax, imm32),
-                        .@"and" => try code.andRegImm32(.rax, imm32),
-                        .@"or" => if (imm32 != 0) try code.orRegImm32(.rax, imm32),
-                        .xor => if (imm32 != 0) try code.xorRegImm32(.rax, imm32),
+                        .add => if (imm32 != 0) try code.addRegImm32(dr, imm32),
+                        .sub => if (imm32 != 0) try code.subRegImm32(dr, imm32),
+                        .@"and" => try code.andRegImm32(dr, imm32),
+                        .@"or" => if (imm32 != 0) try code.orRegImm32(dr, imm32),
+                        .xor => if (imm32 != 0) try code.xorRegImm32(dr, imm32),
                         .mul => {
-                            try code.movRegImm32(.rcx, imm32);
-                            try code.imulRegReg(.rax, .rcx);
+                            try code.movRegImm32(scratch, imm32);
+                            try code.imulRegReg(dr, scratch);
                         },
                         else => unreachable,
                     }
-                    if (inst.type == .i32) try code.zeroExtend32(.rax);
-                    try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+                    if (inst.type == .i32) try code.zeroExtend32(dr);
+                    try writeDefTyped(code, alloc_result, dest, dr, inst.type);
                     return;
                 }
             }
-            // General case: load LHS first, save to r11 only if RHS might clobber it
-            const lhs_reg = try useVReg(code, alloc_result, bin.lhs, .rax);
-            if (lhs_reg != .rax) try code.movRegReg(.rax, lhs_reg);
-            // Check if RHS vreg is assigned to rax (would clobber LHS)
-            const rhs_alloc = alloc_result.get(bin.rhs);
-            const rhs_in_rax = if (rhs_alloc) |a| switch (a) {
-                .reg => |p| @as(emit.Reg, @enumFromInt(p)) == .rax,
-                .stack => false,
-            } else false;
-            if (rhs_in_rax) try code.movRegReg(.r11, .rax);
-            const rhs_reg = try useVReg(code, alloc_result, bin.rhs, .rcx);
-            if (rhs_reg != .rcx) try code.movRegReg(.rcx, rhs_reg);
-            if (rhs_in_rax) try code.movRegReg(.rax, .r11);
+            // General case: load LHS into dest register, RHS into scratch
+            const lhs_reg = try useVReg(code, alloc_result, bin.lhs, dr);
+            if (lhs_reg != dr) try code.movRegReg(dr, lhs_reg);
+            const rhs_reg = try useVReg(code, alloc_result, bin.rhs, scratch);
             switch (inst.op) {
-                .add => try code.addRegReg(.rax, .rcx),
-                .sub => try code.subRegReg(.rax, .rcx),
-                .mul => try code.imulRegReg(.rax, .rcx),
-                .@"and" => try code.andRegReg(.rax, .rcx),
-                .@"or" => try code.orRegReg(.rax, .rcx),
-                .xor => try code.xorRegReg(.rax, .rcx),
+                .add => try code.addRegReg(dr, rhs_reg),
+                .sub => try code.subRegReg(dr, rhs_reg),
+                .mul => try code.imulRegReg(dr, rhs_reg),
+                .@"and" => try code.andRegReg(dr, rhs_reg),
+                .@"or" => try code.orRegReg(dr, rhs_reg),
+                .xor => try code.xorRegReg(dr, rhs_reg),
                 else => unreachable,
             }
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
 
         // ── Comparisons ───────────────────────────────────────────────
         inline .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u => |bin, tag| {
             const dest = inst.dest orelse return;
+            // setcc writes a byte register; on x86-64, sil/dil need a mandatory
+            // REX prefix that our emitter doesn't force. Use rax (al) to be safe.
             const lhs_reg = try useVReg(code, alloc_result, bin.lhs, .rax);
             if (lhs_reg != .rax) try code.movRegReg(.rax, lhs_reg);
-            const rhs_alloc_cmp = alloc_result.get(bin.rhs);
-            const rhs_in_rax_cmp = if (rhs_alloc_cmp) |a| switch (a) {
-                .reg => |p| @as(emit.Reg, @enumFromInt(p)) == .rax,
-                .stack => false,
-            } else false;
-            if (rhs_in_rax_cmp) try code.movRegReg(.r11, .rax);
             const rhs_reg = try useVReg(code, alloc_result, bin.rhs, .rcx);
-            if (rhs_reg != .rcx) try code.movRegReg(.rcx, rhs_reg);
-            if (rhs_in_rax_cmp) try code.movRegReg(.rax, .r11);
             // Use 32-bit compare for i32 to get correct signed semantics
             if (inst.type == .i32) {
-                try code.cmpRegReg32(.rax, .rcx);
+                try code.cmpRegReg32(.rax, rhs_reg);
             } else {
-                try code.cmpRegReg(.rax, .rcx);
+                try code.cmpRegReg(.rax, rhs_reg);
             }
             const cc: u4 = comptime switch (tag) {
                 .eq => 0x4, .ne => 0x5, .lt_s => 0xC, .lt_u => 0x2,
@@ -1268,8 +1267,9 @@ fn compileInstRA(
         // ── Local variable access ─────────────────────────────────────
         .local_get => |idx| {
             const dest = inst.dest orelse return;
-            try code.movRegMem(.rax, .rbp, -@as(i32, @intCast((idx + 2) * 8)));
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            const dr = destReg(alloc_result, dest);
+            try code.movRegMem(dr, .rbp, -@as(i32, @intCast((idx + 2) * 8)));
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .local_set => |ls| {
             const src_reg = try useVReg(code, alloc_result, ls.val, .rax);
@@ -1441,17 +1441,22 @@ fn compileInstRA(
             try code.zeroExtend32(.rax); // wasm addresses are i32
             try code.addRegReg(.rax, .r10); // rax = mem_base + wasm_addr
             if (ld.offset > 0) try code.addRegImm32(.rax, @intCast(ld.offset));
-            try code.movRegMemSized(.rax, .rax, 0, ld.size);
+            // Load value into dest register (address is in rax)
+            const dr = destReg(alloc_result, dest);
+            try code.movRegMemSized(dr, .rax, 0, ld.size);
             if (ld.sign_extend and ld.size < 8) {
-                // Sign-extend for smaller loads
+                // Sign-extend for smaller loads — uses hardcoded rax encodings,
+                // so move to rax if needed, sign-extend, move back.
+                if (dr != .rax) try code.movRegReg(.rax, dr);
                 switch (ld.size) {
                     1 => try code.emitSlice(&.{ 0x48, 0x0F, 0xBE, 0xC0 }), // movsx rax, al
                     2 => try code.emitSlice(&.{ 0x48, 0x0F, 0xBF, 0xC0 }), // movsx rax, ax
                     4 => try code.emitSlice(&.{ 0x48, 0x63, 0xC0 }),       // movsxd rax, eax
                     else => {},
                 }
+                if (dr != .rax) try code.movRegReg(dr, .rax);
             }
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .store => |st| {
             // Load base FIRST to avoid register clobbering if both operands
@@ -1698,11 +1703,12 @@ fn compileInstRA(
 
         .global_get => |idx| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             // Load globals_base from VmCtx, then load global value
             try code.movRegMem(.r10, .rbp, vmctx_offset); // VmCtx*
             try code.movRegMem(.r10, .r10, vmctx_globals_field); // globals_base
-            try code.movRegMem(.rax, .r10, @as(i32, @intCast(idx * 8))); // global[idx]
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try code.movRegMem(dr, .r10, @as(i32, @intCast(idx * 8))); // global[idx]
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .global_set => |gs| {
             const val_reg = try useVReg(code, alloc_result, gs.val, .rax);

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1557,8 +1557,12 @@ fn compileInstRA(
         // ── Division ──────────────────────────────────────────────────
         .div_s, .div_u, .rem_s, .rem_u => |bin| {
             const dest = inst.dest orelse return;
-            // Save caller-saved regs since idiv clobbers rax and rdx
-            for (caller_saved_alloc, 0..) |reg, cs_i| { if (used_caller_saved[cs_i]) try code.pushReg(reg); }
+            // idiv clobbers rax+rdx. rax is not allocatable, so only rdx
+            // (which IS allocatable) needs saving if it holds a live value.
+            const rdx_in_use = for (caller_saved_alloc, 0..) |reg, i| {
+                if (reg == .rdx and used_caller_saved[i]) break true;
+            } else false;
+            if (rdx_in_use) try code.pushReg(.rdx);
 
             const lhs_reg = try useVReg(code, alloc_result, bin.lhs, .rax);
             if (lhs_reg != .rax) try code.movRegReg(.rax, lhs_reg);
@@ -1602,15 +1606,19 @@ fn compileInstRA(
                 else => unreachable,
             };
 
-            // Restore caller-saved regs (reverse order)
-            // But first save result to r11 so it survives the pops
-            try code.movRegReg(.r11, result_reg);
-            var ri: usize = caller_saved_alloc.len;
-            while (ri > 0) {
-                ri -= 1;
-                if (used_caller_saved[ri]) try code.popReg(caller_saved_alloc[ri]);
+            // Restore rdx if it was saved
+            if (rdx_in_use) {
+                if (result_reg == .rdx) {
+                    // Remainder result is in rdx — save before restoring
+                    try code.movRegReg(.r11, .rdx);
+                    try code.popReg(.rdx);
+                    try code.movRegReg(.rax, .r11);
+                } else {
+                    try code.popReg(.rdx);
+                }
+            } else {
+                if (result_reg != .rax) try code.movRegReg(.rax, result_reg);
             }
-            try code.movRegReg(.rax, .r11);
 
             try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
         },

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -491,48 +491,50 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
             .br_table => {
                 const count = readU32(code, &ip);
                 // Read all targets (count entries + 1 default)
-                var targets = try allocator.alloc(u32, count + 1);
-                defer allocator.free(targets);
-                for (0..count + 1) |i| targets[i] = readU32(code, &ip);
+                const raw_targets = try allocator.alloc(u32, count + 1);
+                defer allocator.free(raw_targets);
+                for (0..count + 1) |i| raw_targets[i] = readU32(code, &ip);
 
                 const index = safePop(&vreg_stack);
 
-                // Lower to if-else chain: for each target, compare index and branch
+                // Resolve depths to target block IDs.
+                // Entries whose depth is out of range are skipped (matches
+                // previous if-else behavior which silently dropped them).
+                const ir_targets = try allocator.alloc(ir.BlockId, count);
+                var resolved_count: u32 = 0;
+                var default_target: ir.BlockId = 0;
+                var have_default = false;
+
                 for (0..count) |i| {
-                    const depth = targets[i];
+                    const depth = raw_targets[i];
                     if (depth < block_stack.items.len) {
                         const target_frame = block_stack.items[block_stack.items.len - 1 - depth];
-
-                        // Compare index == i
-                        const cmp_const = ir_func.newVReg();
-                        try ir_func.getBlock(current_block).append(.{
-                            .op = .{ .iconst_32 = @intCast(i) },
-                            .dest = cmp_const,
-                            .type = .i32,
-                        });
-                        const cmp_result = ir_func.newVReg();
-                        try ir_func.getBlock(current_block).append(.{
-                            .op = .{ .eq = .{ .lhs = index, .rhs = cmp_const } },
-                            .dest = cmp_result,
-                            .type = .i32,
-                        });
-
-                        // Branch if equal
-                        const fallthrough = try ir_func.newBlock();
-                        try ir_func.getBlock(current_block).append(.{ .op = .{ .br_if = .{
-                            .cond = cmp_result,
-                            .then_block = target_frame.target_block,
-                            .else_block = fallthrough,
-                        } } });
-                        current_block = fallthrough;
+                        ir_targets[resolved_count] = target_frame.target_block;
+                        resolved_count += 1;
                     }
                 }
 
-                // Default target (last entry)
-                const default_depth = targets[count];
+                const default_depth = raw_targets[count];
                 if (default_depth < block_stack.items.len) {
-                    const default_frame = block_stack.items[block_stack.items.len - 1 - default_depth];
-                    try ir_func.getBlock(current_block).append(.{ .op = .{ .br = default_frame.target_block } });
+                    default_target = block_stack.items[block_stack.items.len - 1 - default_depth].target_block;
+                    have_default = true;
+                }
+
+                if (have_default and resolved_count > 0) {
+                    // Shrink slice ownership to actually-resolved entries.
+                    const final_targets = ir_targets[0..resolved_count];
+                    try ir_func.getBlock(current_block).append(.{ .op = .{ .br_table = .{
+                        .index = index,
+                        .targets = final_targets,
+                        .default = default_target,
+                    } } });
+                } else if (have_default) {
+                    allocator.free(ir_targets);
+                    try ir_func.getBlock(current_block).append(.{ .op = .{ .br = default_target } });
+                } else {
+                    // No valid target — fall through as unreachable.
+                    allocator.free(ir_targets);
+                    try ir_func.getBlock(current_block).append(.{ .op = .{ .@"unreachable" = {} } });
                 }
                 dead_code = true;
             },

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -24,6 +24,10 @@ pub fn buildSuccessors(
                     try succs.append(allocator, bi.then_block);
                     try succs.append(allocator, bi.else_block);
                 },
+                .br_table => |bt| {
+                    for (bt.targets) |t| try succs.append(allocator, t);
+                    try succs.append(allocator, bt.default);
+                },
                 else => {},
             }
         }
@@ -158,6 +162,7 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
             live.put(st.val, {}) catch {};
         },
         .br_if => |bi| live.put(bi.cond, {}) catch {},
+        .br_table => |bt| live.put(bt.index, {}) catch {},
         .ret => |maybe_vreg| if (maybe_vreg) |v| live.put(v, {}) catch {},
         .call => |cl| {
             for (cl.args) |arg| live.put(arg, {}) catch {};
@@ -338,6 +343,7 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
             last_use.put(st.val, pos) catch {};
         },
         .br_if => |bi| last_use.put(bi.cond, pos) catch {},
+        .br_table => |bt| last_use.put(bt.index, pos) catch {},
         .ret => |maybe_vreg| if (maybe_vreg) |v| last_use.put(v, pos) catch {},
         .call => |cl| {
             for (cl.args) |arg| last_use.put(arg, pos) catch {};

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -80,6 +80,7 @@ pub const Inst = struct {
         // Control flow
         br: BlockId,
         br_if: struct { cond: VReg, then_block: BlockId, else_block: BlockId },
+        br_table: struct { index: VReg, targets: []const BlockId, default: BlockId },
         ret: ?VReg,
         @"unreachable": void,
 

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -84,6 +84,7 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
             list.append(st.val);
         },
         .br_if => |bi| list.append(bi.cond),
+        .br_table => |bt| list.append(bt.index),
         .ret => |maybe_vreg| if (maybe_vreg) |v| list.append(v),
         .call => {}, // call args handled separately in buildUseDef (unbounded)
         .call_indirect => {}, // same
@@ -198,6 +199,7 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
             if (st.val == old) st.val = new;
         },
         .br_if => |*bi| if (bi.cond == old) { bi.cond = new; },
+        .br_table => |*bt| if (bt.index == old) { bt.index = new; },
         .ret => |*maybe_vreg| if (maybe_vreg.*) |v| { if (v == old) maybe_vreg.* = new; },
         .call => |cl| {
             for (@constCast(cl.args)) |*arg| {
@@ -366,7 +368,7 @@ pub fn deadCodeElimination(func: *ir.IrFunction, allocator: std.mem.Allocator) !
 
 fn hasSideEffect(inst: ir.Inst) bool {
     return switch (inst.op) {
-        .store, .local_set, .global_set, .call, .call_indirect, .ret, .br, .br_if, .@"unreachable",
+        .store, .local_set, .global_set, .call, .call_indirect, .ret, .br, .br_if, .br_table, .@"unreachable",
         .atomic_fence, .atomic_load, .atomic_store, .atomic_rmw, .atomic_cmpxchg,
         .atomic_notify, .atomic_wait, .memory_copy, .memory_fill, .memory_grow,
         .memory_init, .data_drop,

--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -3,6 +3,11 @@
 //! Assigns physical x86-64 registers to VRegs based on live range intervals.
 //! Uses the Poletto & Sarkar algorithm: sort intervals by start, walk in order,
 //! assign from free pool, spill the longest-remaining interval when exhausted.
+//!
+//! Clobber-aware: instructions that destroy register contents (calls,
+//! memory_copy, etc.) are modeled as ClobberPoints. The allocator ensures
+//! no VReg assigned to a clobbered register has its live range span the
+//! clobber, eliminating the need for push/pop at those sites.
 
 const std = @import("std");
 const ir = @import("ir.zig");
@@ -43,10 +48,20 @@ const alloc_regs = [_]PhysReg{ 2, 6, 7, 8, 9 };
 pub const scratch1: PhysReg = 10; // r10
 pub const scratch2: PhysReg = 11; // r11
 
+/// A point in the instruction stream where specific registers are destroyed.
+/// Used to model calls (clobber caller-saved), memory_copy (clobber rsi+rdi), etc.
+pub const ClobberPoint = struct {
+    pos: u32,
+    /// Which alloc_regs indices are clobbered at this position.
+    regs_clobbered: [alloc_regs.len]bool,
+};
+
 /// Run linear scan register allocation on a function.
+/// `clobbers` lists positions where specific registers are destroyed.
 pub fn allocate(
     func: *const ir.IrFunction,
     allocator: std.mem.Allocator,
+    clobbers: []const ClobberPoint,
 ) !AllocResult {
     // Compute live ranges (sorted by start position)
     const ranges = try analysis.computeLiveRanges(func, allocator);
@@ -66,8 +81,8 @@ pub fn allocate(
         // Expire old intervals that ended before this one starts
         expireOldIntervals(&active, range.start, &reg_free);
 
-        // Try to find a free register
-        if (findFreeReg(&reg_free)) |reg_idx| {
+        // Try to find a free register that is safe (not clobbered during this range)
+        if (findSafeReg(&reg_free, range.start, range.end, clobbers)) |reg_idx| {
             reg_free[reg_idx] = false;
             try assignments.put(range.vreg, .{ .reg = alloc_regs[reg_idx] });
             try insertActive(&active, allocator, .{
@@ -76,34 +91,33 @@ pub fn allocate(
                 .reg_idx = reg_idx,
             });
         } else {
-            // No free register — spill the interval with the longest remaining range
-            if (active.items.len > 0) {
-                const last = active.items.len - 1;
-                const spill_candidate = active.items[last];
-                if (spill_candidate.end > range.end) {
-                    // Spill the active interval, assign its register to the new one
-                    const stolen_reg = spill_candidate.reg_idx;
-                    // Move spilled VReg to stack
-                    const spill_offset = computeSpillOffset(spill_count);
-                    try assignments.put(spill_candidate.vreg, .{ .stack = spill_offset });
-                    spill_count += 1;
-                    // Remove spilled from active
-                    _ = active.orderedRemove(last);
-                    // Assign stolen register to new interval
-                    try assignments.put(range.vreg, .{ .reg = alloc_regs[stolen_reg] });
-                    try insertActive(&active, allocator, .{
-                        .vreg = range.vreg,
-                        .end = range.end,
-                        .reg_idx = stolen_reg,
-                    });
-                } else {
-                    // New interval is shorter — spill the new one
-                    const spill_offset = computeSpillOffset(spill_count);
-                    try assignments.put(range.vreg, .{ .stack = spill_offset });
-                    spill_count += 1;
+            // No safe free register — try to evict an active interval
+            // whose register IS safe for this range.
+            var best_evict: ?usize = null;
+            for (active.items, 0..) |ai, idx| {
+                if (ai.end > range.end and
+                    regSafeForRange(ai.reg_idx, range.start, range.end, clobbers))
+                {
+                    if (best_evict == null or ai.end > active.items[best_evict.?].end) {
+                        best_evict = idx;
+                    }
                 }
+            }
+
+            if (best_evict) |evict_idx| {
+                const evicted = active.orderedRemove(evict_idx);
+                const stolen_reg = evicted.reg_idx;
+                const spill_offset = computeSpillOffset(spill_count);
+                try assignments.put(evicted.vreg, .{ .stack = spill_offset });
+                spill_count += 1;
+                try assignments.put(range.vreg, .{ .reg = alloc_regs[stolen_reg] });
+                try insertActive(&active, allocator, .{
+                    .vreg = range.vreg,
+                    .end = range.end,
+                    .reg_idx = stolen_reg,
+                });
             } else {
-                // No active intervals — spill the new one
+                // No safe eviction candidate — spill the new interval
                 const spill_offset = computeSpillOffset(spill_count);
                 try assignments.put(range.vreg, .{ .stack = spill_offset });
                 spill_count += 1;
@@ -136,10 +150,24 @@ fn expireOldIntervals(
     }
 }
 
-/// Find the first free register, or null if all are occupied.
-fn findFreeReg(reg_free: *const [alloc_regs.len]bool) ?usize {
+/// Check if register at `reg_idx` is safe for a live range [start, end].
+/// A register is unsafe if it's clobbered at any point strictly inside the range.
+fn regSafeForRange(reg_idx: usize, start: u32, end: u32, clobbers: []const ClobberPoint) bool {
+    for (clobbers) |cp| {
+        if (cp.pos > start and cp.pos < end and cp.regs_clobbered[reg_idx]) return false;
+    }
+    return true;
+}
+
+/// Find a free register that is not clobbered during [start, end].
+fn findSafeReg(
+    reg_free: *const [alloc_regs.len]bool,
+    start: u32,
+    end: u32,
+    clobbers: []const ClobberPoint,
+) ?usize {
     for (reg_free, 0..) |free, i| {
-        if (free) return i;
+        if (free and regSafeForRange(i, start, end, clobbers)) return i;
     }
     return null;
 }
@@ -185,7 +213,7 @@ test "allocate: simple function gets registers" {
     try block0.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v2 });
     try block0.append(.{ .op = .{ .ret = v2 } });
 
-    var result = try allocate(&func, allocator);
+    var result = try allocate(&func, allocator, &.{});
     defer result.deinit();
 
     // All 3 VRegs should get registers (only 3 needed, 9 available)
@@ -220,7 +248,7 @@ test "allocate: no spills with few live values" {
     }
     try block0.append(.{ .op = .{ .ret = prev } });
 
-    var result = try allocate(&func, allocator);
+    var result = try allocate(&func, allocator, &.{});
     defer result.deinit();
 
     // Low register pressure — no spills expected
@@ -250,7 +278,7 @@ test "allocate: spills when pressure exceeds registers" {
     }
     try block0.append(.{ .op = .{ .ret = sum } });
 
-    var result = try allocate(&func, allocator);
+    var result = try allocate(&func, allocator, &.{});
     defer result.deinit();
 
     // Should have some spills (15 values alive > 9 registers)


### PR DESCRIPTION
Fixes #95.

Implements 6 AOT codegen optimizations for the x86-64 backend. All 538 unit tests pass; wasm spec `br_table.wast` (186/186), `switch.wast` (28/28), `labels.wast` (29/29), `block.wast` (223/223), `br.wast`, `br_if.wast`, `loop.wast` all clean.

## Commits

| Commit | Change |
|---|---|
| callee-saved preservation | Win64 prologue/epilogue push/pop for `rsi`/`rdi` (fixes a pre-existing pop bug). |
| register-flexible codegen | `destReg()` helper: constants, arithmetic, loads, `global_get` now write directly to the allocated register instead of routing through `rax`. |
| division rdx-only save | `idiv` now saves only `rdx` (when live) instead of blanket push/pop of all caller-saved regs. |
| clobber-aware register allocator | Models call/`memory_copy`/`memory_fill` sites as clobber points. Allocator guarantees no live vreg spans a clobber in a clobbered register. **Eliminates all call-site push/pop**. Stack alignment fixed (`rsp` is now 0 mod 16 at call). |
| skip redundant `zeroExtend32` | Tracks which operations already produce clean i32 (`iconst_32`, comparisons, `eqz`, `wrap_i64`, `memory_size`, unsigned loads ≤4 bytes) and skips the trailing `mov eax,eax`. |
| br_table jump table | New `br_table` IR op replaces the O(N) if-else cascade. Codegen emits a computed jump via `lea r10,[rip+table]` → `movsxd r11,[r10+idx*4]` → `add r10,r11` → `jmp r10` with a 4-byte relative jump table patched after layout. Index is canonicalized with `zeroExtend32` before the bounds check. Matches Cranelift's lowering. |

## Addresses each P0–P2 in #95

- **P0 #1 (5-reg pool)** — partially via flexible-codegen (`destReg`) eliminating hardcoded `rax` usage. Expanding the pool further is deferred.
- **P0 #2 (push/pop per call)** — eliminated by clobber-aware allocator.
- **P1 #3 (push/pop per div)** — now only `rdx` is saved when live across the division.
- **P1 #4 (redundant zeroExtend32)** — skipped for known-clean producers.
- **P2 #5 (br_table as if-else)** — replaced with O(1) computed jump table.

## Testing

`zig build test` → 538/538.  
`zig-out/bin/spec-test-runner.exe tests/spec/test/core/br_table.wast` → 186/186.  
Plus: `block.wast`, `br.wast`, `br_if.wast`, `labels.wast`, `loop.wast`, `switch.wast`, `unwind.wast`, `return.wast` — all pass.
