### PR TITLE
AOT x86-64: phase-2 codegen optimizations (issue #100)

### DIFF
--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1541,10 +1541,9 @@ fn compileInstRA(
             if (base_reg != .rax) try code.movRegReg(.rax, base_reg);
             try code.zeroExtend32(.rax); // wasm addresses are i32
             try code.addRegReg(.rax, .r10); // rax = mem_base + wasm_addr
-            if (ld.offset > 0) try code.addRegImm32(.rax, @intCast(ld.offset));
-            // Load value into dest register (address is in rax)
+            // Load value into dest register (address is in rax); fold offset into disp.
             const dr = destReg(alloc_result, dest);
-            try code.movRegMemSized(dr, .rax, 0, ld.size);
+            try code.movRegMemSized(dr, .rax, @intCast(ld.offset), ld.size);
             if (ld.sign_extend and ld.size < 8) {
                 switch (ld.size) {
                     1 => try code.movsxByteToReg(dr, dr),
@@ -1563,22 +1562,20 @@ fn compileInstRA(
             }
         },
         .store => |st| {
-            // Load base FIRST to avoid register clobbering if both operands
-            // are assigned to the same register by the allocator
+            // Load memory base from VMContext frame slot into r10.
+            try code.movRegMem(.r10, .rbp, vmctx_offset); // load VmCtx*
+            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base
+            // Compute final address in rax (not allocatable — safe to clobber).
             const base_reg = try useVReg(code, alloc_result, st.base, .rax);
             if (base_reg != .rax) try code.movRegReg(.rax, base_reg);
             try code.zeroExtend32(.rax); // wasm addresses are i32
-            // Save base address to r11 (scratch, not allocatable)
-            try code.movRegReg(.r11, .rax);
-            // Now load value — may clobber rax if both operands share a register
+            try code.addRegReg(.rax, .r10); // rax = mem_base + wasm_addr
+            // Load value into rcx (not allocatable — safe to clobber).
+            // useVReg writes spill loads into scratch=.rcx, so rax is preserved.
             const val_reg = try useVReg(code, alloc_result, st.val, .rcx);
             if (val_reg != .rcx) try code.movRegReg(.rcx, val_reg);
-            // Compute final address using saved base in r11
-            try code.movRegMem(.r10, .rbp, vmctx_offset); // load VmCtx*
-            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base
-            try code.addRegReg(.r11, .r10); // r11 = mem_base + wasm_addr
-            if (st.offset > 0) try code.addRegImm32(.r11, @intCast(st.offset));
-            try code.movMemRegSized(.r11, 0, .rcx, st.size);
+            // Fold wasm offset into the mov displacement.
+            try code.movMemRegSized(.rax, @intCast(st.offset), .rcx, st.size);
         },
         .memory_copy => |mc| {
             // REP MOVSB: rdi=dst, rsi=src, rcx=len
@@ -3057,4 +3054,61 @@ test "compileFunctionRA: div does not emit dead r11 save around operand load" {
     // rdx-restore path (only when rdx-in-use AND op is rem), so it must NOT
     // appear here because no vreg got rdx (low pressure).
     try std.testing.expect(!containsBytes(code, &.{ 0x4C, 0x89, 0xD8 }));
+}
+
+
+test "compileFunctionRA: load folds wasm offset into mov disp" {
+    // Verifies B2: i32.load with offset=8 no longer emits `add rax, 8`
+    // then `mov dst, [rax]`; instead a single `mov dst, [rax+8]`.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .load = .{ .base = v0, .offset = 8, .size = 4, .sign_extend = false } }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v1 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // `add rax, 8` = 48 83 C0 08 (with REX.W). It must no longer appear.
+    try std.testing.expect(!containsBytes(code, &.{ 0x48, 0x83, 0xC0, 0x08 }));
+    // `add rax, imm32` form = 48 05 ...  also must not appear.
+    try std.testing.expect(!containsBytes(code, &.{ 0x48, 0x05 }));
+}
+
+test "compileFunctionRA: store folds wasm offset into mov disp and omits r11 save" {
+    // Verifies B2: i32.store with offset=16 emits a single
+    // `mov [rax+16], ecx` and no longer stashes the base into r11.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 42 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .store = .{ .base = v0, .val = v1, .offset = 16, .size = 4 } } });
+    try block.append(.{ .op = .{ .ret = null } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // No `mov r11, rax` (49 89 C3) — the base is kept in rax directly.
+    try std.testing.expect(!containsBytes(code, &.{ 0x49, 0x89, 0xC3 }));
+    // No `add r11, imm32` (49 81 C3 ... or 49 83 C3 ...) — offset is folded.
+    try std.testing.expect(!containsBytes(code, &.{ 0x49, 0x81, 0xC3 }));
+    try std.testing.expect(!containsBytes(code, &.{ 0x49, 0x83, 0xC3 }));
+    // 32-bit store `mov [rax+16], ecx` with disp32 encoding = 89 88 10 00 00 00.
+    try std.testing.expect(containsBytes(code, &.{ 0x89, 0x88, 0x10, 0x00, 0x00, 0x00 }));
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1085,9 +1085,23 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
     var last_was_ret = false;
     for (func.blocks.items, 0..) |block, idx| {
         try block_offsets.put(@intCast(idx), code.len());
+        const next_block_id: ?ir.BlockId = if (idx + 1 < func.blocks.items.len) @intCast(idx + 1) else null;
         for (block.instructions.items) |inst| {
             last_was_ret = isRet(inst.op);
             try compileInstRA(&code, inst, &alloc_result, &const_vals, &branch_patches, &call_patches, &table_patches, import_count, &used_caller_saved, &used_callee_saved);
+        }
+        // C3 fall-through peephole: if the block's terminator emitted a
+        // trailing `E9 disp32` (br, or br_if's unconditional else) whose
+        // target is the next block, drop those 5 bytes and the stale patch.
+        // Works for br_if because the else branch is emitted last.
+        if (next_block_id) |nb| {
+            if (branch_patches.items.len > 0) {
+                const last = branch_patches.items[branch_patches.items.len - 1];
+                if (last.target_block == nb and last.patch_offset + 4 == code.len()) {
+                    code.truncate(code.len() - 5);
+                    _ = branch_patches.pop();
+                }
+            }
         }
     }
 
@@ -3160,4 +3174,79 @@ test "compileFunctionRA: add of two non-constant values emits LEA" {
     // ADD reg,reg (01 /r with REX.W) must NOT appear for this add — the
     // LEA replaced it. The 64-bit add encoding is `48 01 ...`.
     try std.testing.expect(!containsBytes(code, &.{ 0x48, 0x01 }));
+}
+
+
+test "compileFunctionRA: br to next block is elided (C3 fallthrough)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const block0 = func.getBlock(b0);
+    const block1 = func.getBlock(b1);
+
+    const v0 = func.newVReg();
+    // b0: br b1   (b1 is the immediately-following block → fall through)
+    try block0.append(.{ .op = .{ .br = b1 } });
+    // b1: return 7
+    try block1.append(.{ .op = .{ .iconst_32 = 7 }, .dest = v0, .type = .i32 });
+    try block1.append(.{ .op = .{ .ret = v0 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // No unconditional E9-relative jump should appear: the only br was
+    // to the next block and must have been elided. Scan for 0xE9.
+    for (code) |b| {
+        try std.testing.expect(b != 0xE9);
+    }
+}
+
+test "compileFunctionRA: br_if else==next drops trailing jmp (C3)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 1);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const block0 = func.getBlock(b0);
+    const block1 = func.getBlock(b1);
+    const block2 = func.getBlock(b2);
+
+    const cond = func.newVReg();
+    const r = func.newVReg();
+    // b0: br_if cond, then=b2, else=b1  (b1 is next → else falls through)
+    try block0.append(.{ .op = .{ .local_get = 0 }, .dest = cond, .type = .i32 });
+    try block0.append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = b2, .else_block = b1 } } });
+    // b1: return 0
+    try block1.append(.{ .op = .{ .iconst_32 = 0 }, .dest = r, .type = .i32 });
+    try block1.append(.{ .op = .{ .ret = r } });
+    // b2: return 1
+    try block2.append(.{ .op = .{ .iconst_32 = 1 }, .dest = r, .type = .i32 });
+    try block2.append(.{ .op = .{ .ret = r } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // The conditional jump 0F 85 must still be present.
+    try std.testing.expect(containsBytes(code, &.{ 0x0F, 0x85 }));
+    // The unconditional E9 that would jump to the else block (b1) must
+    // have been elided: search for 0F 85 rel32 (6 bytes) immediately
+    // followed by 0xE9 — that would be the un-elided pattern.
+    var has_trailing_e9 = false;
+    var i: usize = 0;
+    while (i + 6 < code.len) : (i += 1) {
+        if (code[i] == 0x0F and code[i + 1] == 0x85 and code[i + 6] == 0xE9) {
+            has_trailing_e9 = true;
+            break;
+        }
+    }
+    try std.testing.expect(!has_trailing_e9);
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1279,7 +1279,22 @@ fn compileInstRA(
                     return;
                 }
             }
-            // General case: load LHS into dest register, RHS into scratch
+            // General case. For add specifically, if lhs is in a different
+            // register than dst, use LEA dst, [lhs + rhs] to fuse the mov
+            // and add into one instruction (C2). LEA requires both operands
+            // to be in real registers (not spilled) and neither to be rsp.
+            if (inst.op == .add) {
+                const lhs_reg_raw = regOf(alloc_result, bin.lhs);
+                const rhs_reg_raw = regOf(alloc_result, bin.rhs);
+                if (lhs_reg_raw != null and rhs_reg_raw != null and
+                    lhs_reg_raw.? != dr and lhs_reg_raw.? != .rsp and rhs_reg_raw.? != .rsp)
+                {
+                    try code.leaRegBaseIndex64(dr, lhs_reg_raw.?, rhs_reg_raw.?);
+                    try writeDefTyped(code, alloc_result, dest, dr, inst.type);
+                    return;
+                }
+            }
+            // Fallback: load LHS into dest register, RHS into scratch.
             const lhs_reg = try useVReg(code, alloc_result, bin.lhs, dr);
             if (lhs_reg != dr) try code.movRegReg(dr, lhs_reg);
             const rhs_reg = try useVReg(code, alloc_result, bin.rhs, scratch);
@@ -3112,4 +3127,37 @@ test "compileFunctionRA: store folds wasm offset into mov disp and omits r11 sav
     try std.testing.expect(!containsBytes(code, &.{ 0x49, 0x83, 0xC3 }));
     // 32-bit store `mov [rax+16], ecx` with disp32 encoding = 89 88 10 00 00 00.
     try std.testing.expect(containsBytes(code, &.{ 0x89, 0x88, 0x10, 0x00, 0x00, 0x00 }));
+}
+
+
+test "compileFunctionRA: add of two non-constant values emits LEA" {
+    // Two local_get results then add — neither is in const_vals so the LEA
+    // path should fire, producing a single `lea dst, [lhs + rhs]` instead
+    // of `mov dst, lhs; add dst, rhs`.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 2, 3, 0); // 2 params so 2 locals
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .local_get = 1 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v2, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v2 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // Expect a 64-bit LEA (REX.W, opcode 0x8D, SIB form). The 0x8D opcode
+    // only appears for LEA in this function, so checking its presence is
+    // sufficient.
+    try std.testing.expect(containsBytes(code, &.{ 0x48, 0x8D }));
+    // ADD reg,reg (01 /r with REX.W) must NOT appear for this add — the
+    // LEA replaced it. The 64-bit add encoding is `48 01 ...`.
+    try std.testing.expect(!containsBytes(code, &.{ 0x48, 0x01 }));
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -2503,7 +2503,7 @@ test "compileFunction: iconst_32(0) emits xor (zero idiom)" {
     try std.testing.expect(!containsBytes(code, &.{ 0xC7, 0xC0, 0x00, 0x00, 0x00, 0x00 }));
 }
 
-test "compileFunction: iconst + add uses ADD imm32" {
+test "compileFunction: iconst + add uses ADD imm8 form" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -2521,9 +2521,10 @@ test "compileFunction: iconst + add uses ADD imm32" {
     const code = try compileFunction(&func, allocator);
     defer allocator.free(code);
 
-    // Should contain ADD reg, imm32 (81 /0) with value 5
-    try std.testing.expect(containsBytes(code, &.{0x81}));
-    try std.testing.expect(containsBytes(code, &.{ 0x05, 0x00, 0x00, 0x00 }));
+    // 5 fits in i8 → ADD reg, imm8 (opcode 0x83 /0, imm8=0x05).
+    try std.testing.expect(containsBytes(code, &.{ 0x83, 0xC0, 0x05 }));
+    // The 7-byte imm32 form (0x81 /0) must NOT appear for this small imm.
+    try std.testing.expect(!containsBytes(code, &.{ 0x81, 0xC0, 0x05, 0x00, 0x00, 0x00 }));
 }
 
 test "compileFunction: cmp + br_if fuses to Jcc (no setcc)" {

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -25,10 +25,14 @@ else
 const caller_saved_alloc = [_]emit.Reg{ .rdx, .rsi, .rdi, .r8, .r9 };
 
 /// Callee-saved allocatable registers preserved in prologue/epilogue.
-/// On Win64, rsi and rdi are callee-saved per the ABI; compiled functions
+/// r12, r13 are callee-saved on both Win64 and SysV.
+/// On Win64, rsi and rdi are also callee-saved per the ABI; compiled functions
 /// must save/restore them if used. On SysV they're caller-saved (handled
-/// at call sites via caller_saved_alloc), so no prologue work is needed.
-const callee_saved_alloc = [_]emit.Reg{ .rsi, .rdi };
+/// at call sites via caller_saved_alloc), so no prologue work is needed for them.
+const callee_saved_alloc = if (builtin.os.tag == .windows)
+    [_]emit.Reg{ .rsi, .rdi, .r12, .r13 }
+else
+    [_]emit.Reg{ .r12, .r13 };
 
 /// Fixed frame offset for the VMContext pointer.
 /// Stored at [rbp - 8] by compileFunctionRA at function entry.
@@ -929,27 +933,27 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
                 switch (ci.op) {
                     .call, .call_indirect => {
                         // Calls clobber caller-saved allocatable regs.
-                        // alloc_regs = [rdx(2), rsi(6), rdi(7), r8(8), r9(9)]
-                        // On Win64: rdx, r8, r9 are volatile (indices 0, 3, 4)
-                        // On SysV: all 5 are volatile
+                        // alloc_regs = [rdx(2), rsi(6), rdi(7), r8(8), r9(9), r12(12), r13(13)]
+                        // On Win64: rdx, r8, r9 are volatile (indices 0, 3, 4); rsi/rdi/r12/r13 callee-saved.
+                        // On SysV: rdx, rsi, rdi, r8, r9 are volatile; r12, r13 callee-saved.
                         const mask = if (comptime builtin.os.tag == .windows)
-                            [_]bool{ true, false, false, true, true }
+                            [_]bool{ true, false, false, true, true, false, false }
                         else
-                            [_]bool{ true, true, true, true, true };
+                            [_]bool{ true, true, true, true, true, false, false };
                         try clobber_points.append(allocator, .{ .pos = pos, .regs_clobbered = mask });
                     },
                     .memory_copy => {
                         // REP MOVSB clobbers rsi(6) and rdi(7) → indices 1, 2
                         try clobber_points.append(allocator, .{
                             .pos = pos,
-                            .regs_clobbered = .{ false, true, true, false, false },
+                            .regs_clobbered = .{ false, true, true, false, false, false, false },
                         });
                     },
                     .memory_fill => {
                         // REP STOSB clobbers rdi(7) → index 2
                         try clobber_points.append(allocator, .{
                             .pos = pos,
-                            .regs_clobbered = .{ false, false, true, false, false },
+                            .regs_clobbered = .{ false, false, true, false, false, false, false },
                         });
                     },
                     else => {},
@@ -976,10 +980,8 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
                     for (caller_saved_alloc, 0..) |cs_reg, i| {
                         if (reg == cs_reg) used_caller_saved[i] = true;
                     }
-                    if (comptime builtin.os.tag == .windows) {
-                        for (callee_saved_alloc, 0..) |cs_reg, i| {
-                            if (reg == cs_reg) used_callee_saved[i] = true;
-                        }
+                    for (callee_saved_alloc, 0..) |cs_reg, i| {
+                        if (reg == cs_reg) used_callee_saved[i] = true;
                     }
                 },
                 .stack => {},
@@ -1013,10 +1015,8 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
 
     // Count callee-saved pushes for stack alignment calculation.
     var callee_save_count: u32 = 0;
-    if (comptime builtin.os.tag == .windows) {
-        for (used_callee_saved) |used| {
-            if (used) callee_save_count += 1;
-        }
+    for (used_callee_saved) |used| {
+        if (used) callee_save_count += 1;
     }
 
     // Frame: locals + spill slots + 1 vmctx slot, aligned to 16 bytes.
@@ -1052,11 +1052,10 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
         }
     }
 
-    // Save callee-saved registers used by this function (Win64 ABI: rsi/rdi).
-    if (comptime builtin.os.tag == .windows) {
-        for (callee_saved_alloc, 0..) |reg, i| {
-            if (used_callee_saved[i]) try code.pushReg(reg);
-        }
+    // Save callee-saved registers used by this function.
+    // Win64: rsi, rdi, r12, r13. SysV: r12, r13.
+    for (callee_saved_alloc, 0..) |reg, i| {
+        if (used_callee_saved[i]) try code.pushReg(reg);
     }
 
     // Build constant value table for immediate folding
@@ -1108,12 +1107,10 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
 
     if (!last_was_ret) {
         // Restore callee-saved registers before epilogue (reverse order).
-        if (comptime builtin.os.tag == .windows) {
-            var ci: usize = callee_saved_alloc.len;
-            while (ci > 0) {
-                ci -= 1;
-                if (used_callee_saved[ci]) try code.popReg(callee_saved_alloc[ci]);
-            }
+        var ci: usize = callee_saved_alloc.len;
+        while (ci > 0) {
+            ci -= 1;
+            if (used_callee_saved[ci]) try code.popReg(callee_saved_alloc[ci]);
         }
         try code.emitEpilogue();
     }
@@ -1353,12 +1350,10 @@ fn compileInstRA(
                 if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
             }
             // Restore callee-saved registers before epilogue (reverse order).
-            if (comptime builtin.os.tag == .windows) {
-                var ci: usize = callee_saved_alloc.len;
-                while (ci > 0) {
-                    ci -= 1;
-                    if (used_callee_saved[ci]) try code.popReg(callee_saved_alloc[ci]);
-                }
+            var ci: usize = callee_saved_alloc.len;
+            while (ci > 0) {
+                ci -= 1;
+                if (used_callee_saved[ci]) try code.popReg(callee_saved_alloc[ci]);
             }
             try code.emitEpilogue();
         },
@@ -2929,4 +2924,76 @@ test "compileFunctionRA: memory_size loads into allocated dest register" {
     // Opcode 0x8B, REX.B=0x41 (because base is r10). ModR/M = 10_010_010 (0x92),
     // then disp32 = 0x38 00 00 00 (vmctx_mem_pages_field = 56).
     try std.testing.expect(containsBytes(code, &.{ 0x41, 0x8B, 0x92, 0x38, 0x00, 0x00, 0x00 }));
+}
+
+
+test "compileFunctionRA: r12 allocated under register pressure" {
+    // Seven simultaneously-live values (6 constants + one op) overflow the
+    // first 5 alloc_regs (rdx, rsi, rdi, r8, r9). The 6th and 7th must go to
+    // r12 and r13 (newly added to alloc_regs). We also verify that r12 is
+    // preserved via push/pop in the prologue/epilogue.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    const v3 = func.newVReg();
+    const v4 = func.newVReg();
+    const v5 = func.newVReg();
+    const v6 = func.newVReg();
+    const v7 = func.newVReg();
+    // Produce 7 constants that are all live through an add chain.
+    try block.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 3 }, .dest = v2, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 4 }, .dest = v3, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 5 }, .dest = v4, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 6 }, .dest = v5, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 7 }, .dest = v6, .type = .i32 });
+    // Consume all of them so their ranges extend here.
+    try block.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v7, .type = .i32 });
+    // Use the rest (prevents range expiry) by re-summing.
+    const v8 = func.newVReg();
+    try block.append(.{ .op = .{ .add = .{ .lhs = v2, .rhs = v3 } }, .dest = v8, .type = .i32 });
+    const v9 = func.newVReg();
+    try block.append(.{ .op = .{ .add = .{ .lhs = v4, .rhs = v5 } }, .dest = v9, .type = .i32 });
+    const v10 = func.newVReg();
+    try block.append(.{ .op = .{ .add = .{ .lhs = v6, .rhs = v7 } }, .dest = v10, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v10 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // Prologue should push r12 (41 54) because it is callee-saved and used.
+    try std.testing.expect(containsBytes(code, &.{ 0x41, 0x54 }));
+    // Epilogue should pop r12 (41 5C).
+    try std.testing.expect(containsBytes(code, &.{ 0x41, 0x5C }));
+}
+
+test "compileFunctionRA: low-pressure function does not save r12" {
+    // A function that only needs one allocatable register must not touch r12.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 42 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v0 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // No push r12 (41 54) and no pop r12 (41 5C).
+    try std.testing.expect(!containsBytes(code, &.{ 0x41, 0x54 }));
+    try std.testing.expect(!containsBytes(code, &.{ 0x41, 0x5C }));
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1301,37 +1301,37 @@ fn compileInstRA(
         // ── Comparisons ───────────────────────────────────────────────
         inline .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u => |bin, tag| {
             const dest = inst.dest orelse return;
-            // setcc writes a byte register; on x86-64, sil/dil need a mandatory
-            // REX prefix that our emitter doesn't force. Use rax (al) to be safe.
-            const lhs_reg = try useVReg(code, alloc_result, bin.lhs, .rax);
-            if (lhs_reg != .rax) try code.movRegReg(.rax, lhs_reg);
-            const rhs_reg = try useVReg(code, alloc_result, bin.rhs, .rcx);
-            // Use 32-bit compare for i32 to get correct signed semantics
+            const dr = destReg(alloc_result, dest);
+            // Load lhs and rhs using different spill scratches so spilled
+            // operands don't clobber each other.
+            const lhs_reg = try useVReg(code, alloc_result, bin.lhs, .r11);
+            const rhs_reg = try useVReg(code, alloc_result, bin.rhs, .rax);
+            // Use 32-bit compare for i32 to get correct signed semantics.
             if (inst.type == .i32) {
-                try code.cmpRegReg32(.rax, rhs_reg);
+                try code.cmpRegReg32(lhs_reg, rhs_reg);
             } else {
-                try code.cmpRegReg(.rax, rhs_reg);
+                try code.cmpRegReg(lhs_reg, rhs_reg);
             }
             const cc: u4 = comptime switch (tag) {
                 .eq => 0x4, .ne => 0x5, .lt_s => 0xC, .lt_u => 0x2,
                 .gt_s => 0xF, .gt_u => 0x7, .le_s => 0xE, .le_u => 0x6,
                 .ge_s => 0xD, .ge_u => 0x3, else => unreachable,
             };
-            try code.setcc(cc, .rax);
-            try code.movzxByte(.rax, .rax);
+            try code.setcc(cc, dr);
+            try code.movzxByte(dr, dr);
             // setcc+movzx produces clean 0/1 — skip zeroExtend32
-            try writeDef(code, alloc_result, dest, .rax);
+            try writeDef(code, alloc_result, dest, dr);
         },
 
         .eqz => |vreg| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const src_reg = try useVReg(code, alloc_result, vreg, .rax);
-            if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
-            try code.testRegReg(.rax, .rax);
-            try code.setcc(0x4, .rax);
-            try code.movzxByte(.rax, .rax);
+            try code.testRegReg(src_reg, src_reg);
+            try code.setcc(0x4, dr);
+            try code.movzxByte(dr, dr);
             // setcc+movzx produces clean 0/1 — skip zeroExtend32
-            try writeDef(code, alloc_result, dest, .rax);
+            try writeDef(code, alloc_result, dest, dr);
         },
 
         // ── Local variable access ─────────────────────────────────────
@@ -1372,8 +1372,7 @@ fn compileInstRA(
         },
         .br_if => |br| {
             const cond_reg = try useVReg(code, alloc_result, br.cond, .rax);
-            if (cond_reg != .rax) try code.movRegReg(.rax, cond_reg);
-            try code.testRegReg(.rax, .rax);
+            try code.testRegReg(cond_reg, cond_reg);
             try code.emitByte(0x0F);
             try code.emitByte(0x85);
             const then_patch = code.len();
@@ -1552,16 +1551,12 @@ fn compileInstRA(
             const dr = destReg(alloc_result, dest);
             try code.movRegMemSized(dr, .rax, 0, ld.size);
             if (ld.sign_extend and ld.size < 8) {
-                // Sign-extend for smaller loads — uses hardcoded rax encodings,
-                // so move to rax if needed, sign-extend, move back.
-                if (dr != .rax) try code.movRegReg(.rax, dr);
                 switch (ld.size) {
-                    1 => try code.emitSlice(&.{ 0x48, 0x0F, 0xBE, 0xC0 }), // movsx rax, al
-                    2 => try code.emitSlice(&.{ 0x48, 0x0F, 0xBF, 0xC0 }), // movsx rax, ax
-                    4 => try code.emitSlice(&.{ 0x48, 0x63, 0xC0 }),       // movsxd rax, eax
+                    1 => try code.movsxByteToReg(dr, dr),
+                    2 => try code.movsxWordToReg(dr, dr),
+                    4 => try code.movsxd(dr, dr),
                     else => {},
                 }
-                if (dr != .rax) try code.movRegReg(dr, .rax);
             }
             // For non-sign-extended loads ≤ 4 bytes, movRegMemSized already
             // produces a zero-extended (clean) i32 — skip redundant zeroExtend32.
@@ -1624,11 +1619,12 @@ fn compileInstRA(
         // ── Memory management ─────────────────────────────────────────
         .memory_size => {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             // Read current page count from VmCtx
             try code.movRegMem(.r10, .rbp, vmctx_offset);
-            try code.movRegMemNoRex(.rax, .r10, vmctx_mem_pages_field);
+            try code.movRegMemNoRex(dr, .r10, vmctx_mem_pages_field);
             // 32-bit load already zero-extends
-            try writeDef(code, alloc_result, dest, .rax);
+            try writeDef(code, alloc_result, dest, dr);
         },
         .memory_grow => |pages_vreg| {
             const dest = inst.dest orelse return;
@@ -1777,37 +1773,36 @@ fn compileInstRA(
         // ── Unary ops ─────────────────────────────────────────────────
         .clz => |vreg| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const src_reg = try useVReg(code, alloc_result, vreg, .rax);
-            if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
             if (inst.type == .i32) {
-                // Use 32-bit LZCNT to count only within the low 32 bits
-                try code.emitSlice(&.{ 0xF3, 0x0F, 0xBD, 0xC0 }); // lzcnt eax, eax
+                try code.lzcnt32(dr, src_reg);
             } else {
-                try code.lzcnt(.rax, .rax);
+                try code.lzcnt(dr, src_reg);
             }
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .ctz => |vreg| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const src_reg = try useVReg(code, alloc_result, vreg, .rax);
-            if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
             if (inst.type == .i32) {
-                try code.emitSlice(&.{ 0xF3, 0x0F, 0xBC, 0xC0 }); // tzcnt eax, eax
+                try code.tzcnt32(dr, src_reg);
             } else {
-                try code.tzcnt(.rax, .rax);
+                try code.tzcnt(dr, src_reg);
             }
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .popcnt => |vreg| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const src_reg = try useVReg(code, alloc_result, vreg, .rax);
-            if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
             if (inst.type == .i32) {
-                try code.emitSlice(&.{ 0xF3, 0x0F, 0xB8, 0xC0 }); // popcnt eax, eax
+                try code.popcnt32(dr, src_reg);
             } else {
-                try code.popcntReg(.rax, .rax);
+                try code.popcntReg(dr, src_reg);
             }
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
 
         // ── Select ────────────────────────────────────────────────────
@@ -1835,10 +1830,9 @@ fn compileInstRA(
         },
         .global_set => |gs| {
             const val_reg = try useVReg(code, alloc_result, gs.val, .rax);
-            if (val_reg != .rax) try code.movRegReg(.rax, val_reg);
             try code.movRegMem(.r10, .rbp, vmctx_offset); // VmCtx*
             try code.movRegMem(.r10, .r10, vmctx_globals_field); // globals_base
-            try code.movMemReg(.r10, @as(i32, @intCast(gs.idx * 8)), .rax); // global[idx] = val
+            try code.movMemReg(.r10, @as(i32, @intCast(gs.idx * 8)), val_reg); // global[idx] = val
         },
 
         .@"unreachable" => {
@@ -1848,52 +1842,47 @@ fn compileInstRA(
         // ── Type conversions ──────────────────────────────────────────
         .wrap_i64 => |vreg| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const src_reg = try useVReg(code, alloc_result, vreg, .rax);
-            if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
-            // Truncate to 32-bit: writing to eax zero-extends to rax
-            try code.emitSlice(&.{ 0x89, 0xC0 }); // mov eax, eax
-            // Already zero-extended by the 32-bit write
-            try writeDef(code, alloc_result, dest, .rax);
+            // 32-bit reg-reg move truncates to 32 bits and zero-extends.
+            try code.movRegReg32(dr, src_reg);
+            try writeDef(code, alloc_result, dest, dr);
         },
         .extend_i32_s => |vreg| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const src_reg = try useVReg(code, alloc_result, vreg, .rax);
-            if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
-            // MOVSXD rax, eax: sign-extend 32→64
-            try code.emitSlice(&.{ 0x48, 0x63, 0xC0 });
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try code.movsxd(dr, src_reg);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .extend_i32_u => |vreg| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const src_reg = try useVReg(code, alloc_result, vreg, .rax);
-            if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
-            // mov eax, eax: zero-extend 32→64 (implicit on x86-64)
-            try code.emitSlice(&.{ 0x89, 0xC0 });
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            // 32-bit mov zero-extends to 64.
+            try code.movRegReg32(dr, src_reg);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .extend8_s => |vreg| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const src_reg = try useVReg(code, alloc_result, vreg, .rax);
-            if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
-            // MOVSX rax, al: REX.W 0F BE C0
-            try code.emitSlice(&.{ 0x48, 0x0F, 0xBE, 0xC0 });
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try code.movsxByteToReg(dr, src_reg);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .extend16_s => |vreg| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const src_reg = try useVReg(code, alloc_result, vreg, .rax);
-            if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
-            // MOVSX rax, ax: REX.W 0F BF C0
-            try code.emitSlice(&.{ 0x48, 0x0F, 0xBF, 0xC0 });
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try code.movsxWordToReg(dr, src_reg);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .extend32_s => |vreg| {
             const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
             const src_reg = try useVReg(code, alloc_result, vreg, .rax);
-            if (src_reg != .rax) try code.movRegReg(.rax, src_reg);
-            // MOVSXD rax, eax
-            try code.emitSlice(&.{ 0x48, 0x63, 0xC0 });
-            try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
+            try code.movsxd(dr, src_reg);
+            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .reinterpret => |vreg| {
             const dest = inst.dest orelse return;
@@ -2677,8 +2666,10 @@ test "compileFunctionRA: wrap_i64 emits mov eax,eax" {
     defer allocator.free(compile_result.call_patches);
     defer allocator.free(code);
 
-    // Should contain mov eax, eax (89 C0) for wrap_i64
-    try std.testing.expect(containsBytes(code, &.{ 0x89, 0xC0 }));
+    // Allocator keeps v0 in rdx and puts v1 in rsi (v0's range doesn't end
+    // strictly before v1 begins). wrap_i64 emits `mov esi, edx` = 89 D6
+    // (ModR/M 11_010_110, reg=rdx=2, rm=rsi=6), which zero-extends to rsi.
+    try std.testing.expect(containsBytes(code, &.{ 0x89, 0xD6 }));
     try std.testing.expectEqual(@as(u8, 0xC3), code[code.len - 1]);
 }
 
@@ -2700,8 +2691,8 @@ test "compileFunctionRA: extend_i32_s emits MOVSXD" {
     defer allocator.free(compile_result.call_patches);
     defer allocator.free(code);
 
-    // Should contain MOVSXD rax, eax (48 63 C0)
-    try std.testing.expect(containsBytes(code, &.{ 0x48, 0x63, 0xC0 }));
+    // MOVSXD rsi, edx (sign-extend v0→v1; v0 in rdx, v1 in rsi): 48 63 F2
+    try std.testing.expect(containsBytes(code, &.{ 0x48, 0x63, 0xF2 }));
 }
 
 test "compileFunctionRA: memory_copy emits REP MOVSB" {
@@ -2850,4 +2841,92 @@ test "compileFunctionRA: br_table emits jump table + indirect jmp" {
     try std.testing.expect(containsBytes(code, &.{ 0x41, 0xFF, 0xE2 }));
     // jae rel32 (bounds check)
     try std.testing.expect(containsBytes(code, &.{ 0x0F, 0x83 }));
+}
+
+test "compileFunctionRA: eqz targets allocated dest register (rdx)" {
+    // eqz result should use the destReg directly, not funnel through rax.
+    // For a simple function the first allocatable reg is rdx (alloc_regs[0]),
+    // so we expect `setcc dl` (0F 94 C2) and `movzx rdx, dl` (48 0F B6 D2).
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .eqz = v0 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v1 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // Allocator expires v0 after v1 starts (live-range end==start), so v0 gets
+    // rdx and v1 gets rsi. The setcc result therefore lands in sil, which
+    // requires the mandatory REX prefix to distinguish it from DH.
+    // setcc sil: 40 0F 94 C6  (REX=0x40, opcode 0F 94, ModR/M 11_000_110)
+    try std.testing.expect(containsBytes(code, &.{ 0x40, 0x0F, 0x94, 0xC6 }));
+    // movzx rsi, sil: 48 0F B6 F6  (REX.W, ModR/M 11_110_110)
+    try std.testing.expect(containsBytes(code, &.{ 0x48, 0x0F, 0xB6, 0xF6 }));
+    // Must NOT emit the old rax-centric `setcc al` (0F 94 C0).
+    try std.testing.expect(!containsBytes(code, &.{ 0x0F, 0x94, 0xC0 }));
+}
+
+test "compileFunctionRA: comparison targets allocated dest register" {
+    // eq should use destReg for setcc instead of hardcoded rax. The first
+    // allocatable reg is rdx, so verify `setcc dl` is present.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .eq = .{ .lhs = v0, .rhs = v1 } }, .dest = v2, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v2 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // Two constants are live simultaneously at the eq, so v0→rdx, v1→rsi,
+    // v2→rdi. The setcc writes dil with mandatory REX.
+    // setcc dil: 40 0F 94 C7  (REX=0x40, opcode 0F 94, ModR/M 11_000_111)
+    try std.testing.expect(containsBytes(code, &.{ 0x40, 0x0F, 0x94, 0xC7 }));
+    // movzx rdi, dil: 48 0F B6 FF  (REX.W, ModR/M 11_111_111)
+    try std.testing.expect(containsBytes(code, &.{ 0x48, 0x0F, 0xB6, 0xFF }));
+    // No legacy `setcc al`.
+    try std.testing.expect(!containsBytes(code, &.{ 0x0F, 0x94, 0xC0 }));
+}
+
+test "compileFunctionRA: memory_size loads into allocated dest register" {
+    // memory_size should emit `mov dr, [r10 + mem_pages_field]` with
+    // dr being the allocated destination register rather than forced rax.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    try block.append(.{ .op = .memory_size, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v0 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // mov edx, [r10 + 56] — 32-bit load, no REX.W.
+    // Opcode 0x8B, REX.B=0x41 (because base is r10). ModR/M = 10_010_010 (0x92),
+    // then disp32 = 0x38 00 00 00 (vmctx_mem_pages_field = 56).
+    try std.testing.expect(containsBytes(code, &.{ 0x41, 0x8B, 0x92, 0x38, 0x00, 0x00, 0x00 }));
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1672,10 +1672,10 @@ fn compileInstRA(
 
             const lhs_reg = try useVReg(code, alloc_result, bin.lhs, .rax);
             if (lhs_reg != .rax) try code.movRegReg(.rax, lhs_reg);
-            try code.movRegReg(.r11, .rax); // save LHS
+            // useVReg loads spilled rhs into its scratch (.rcx), so it cannot
+            // clobber rax; no need to stash LHS in r11.
             const rhs_reg = try useVReg(code, alloc_result, bin.rhs, .rcx);
             if (rhs_reg != .rcx) try code.movRegReg(.rcx, rhs_reg);
-            try code.movRegReg(.rax, .r11); // restore LHS
 
             // Zero divisor check
             try code.testRegReg(.rcx, .rcx);
@@ -1735,10 +1735,10 @@ fn compileInstRA(
             // Load val first to avoid clobbering if both share a register
             const val_reg = try useVReg(code, alloc_result, bin.lhs, .rax);
             if (val_reg != .rax) try code.movRegReg(.rax, val_reg);
-            try code.movRegReg(.r11, .rax); // save val
+            // useVReg loads spilled cnt into its scratch (.rcx), so it cannot
+            // clobber rax; no need to stash val in r11.
             const cnt_reg = try useVReg(code, alloc_result, bin.rhs, .rcx);
             if (cnt_reg != .rcx) try code.movRegReg(.rcx, cnt_reg);
-            try code.movRegReg(.rax, .r11); // restore val
             switch (inst.op) {
                 .shl => {
                     try code.rexW(.rax, .rax);
@@ -2996,4 +2996,65 @@ test "compileFunctionRA: low-pressure function does not save r12" {
     // No push r12 (41 54) and no pop r12 (41 5C).
     try std.testing.expect(!containsBytes(code, &.{ 0x41, 0x54 }));
     try std.testing.expect(!containsBytes(code, &.{ 0x41, 0x5C }));
+}
+
+
+test "compileFunctionRA: shift does not emit dead r11 save" {
+    // Before B1, every shl emitted `mov r11, rax; ...; mov rax, r11` around
+    // the rhs load. Since useVReg loads spilled rhs into its scratch (.rcx),
+    // rax is never clobbered, so the save is dead. Verify it's gone.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 10 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .shl = .{ .lhs = v0, .rhs = v1 } }, .dest = v2, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v2 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // `mov r11, rax` = 49 89 C3. `mov rax, r11` = 4C 89 D8. Neither should appear.
+    try std.testing.expect(!containsBytes(code, &.{ 0x49, 0x89, 0xC3 }));
+    try std.testing.expect(!containsBytes(code, &.{ 0x4C, 0x89, 0xD8 }));
+    // Shift opcode D3 E0 (shl rax, cl with REX.W) must still appear.
+    try std.testing.expect(containsBytes(code, &.{ 0xD3, 0xE0 }));
+}
+
+test "compileFunctionRA: div does not emit dead r11 save around operand load" {
+    // Before B1, div emitted `mov r11, rax; mov rcx, rhs; mov rax, r11` to
+    // preserve LHS. With distinct scratches the save is dead.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 100 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 5 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .div_u = .{ .lhs = v0, .rhs = v1 } }, .dest = v2, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v2 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // `mov r11, rax` = 49 89 C3 must not appear before the idiv/div.
+    try std.testing.expect(!containsBytes(code, &.{ 0x49, 0x89, 0xC3 }));
+    // `mov rax, r11` = 4C 89 D8: this sequence also appears in div's rem
+    // rdx-restore path (only when rdx-in-use AND op is rem), so it must NOT
+    // appear here because no vreg got rdx (low pressure).
+    try std.testing.expect(!containsBytes(code, &.{ 0x4C, 0x89, 0xD8 }));
 }

--- a/src/compiler/codegen/x86_64/emit.zig
+++ b/src/compiler/codegen/x86_64/emit.zig
@@ -433,6 +433,30 @@ pub const CodeBuffer = struct {
         try self.modrm(0b11, dst.low3(), src.low3());
     }
 
+    /// LEA dst, [base + index] — 3-operand 64-bit add without touching flags.
+    /// Used for non-destructive `dst = base + index` when dst != base, saving
+    /// a `mov dst, base` compared to the mov+add sequence.
+    /// Precondition: index must not be RSP (SIB encodes rsp as "no index").
+    pub fn leaRegBaseIndex64(self: *CodeBuffer, dst: Reg, base: Reg, index: Reg) !void {
+        std.debug.assert(index != .rsp);
+        // REX.W + R (dst) + X (index) + B (base).
+        const rex_byte: u8 = 0x48 |
+            (@as(u8, @intFromEnum(dst) >> 3) << 2) |
+            (@as(u8, @intFromEnum(index) >> 3) << 1) |
+            (@as(u8, @intFromEnum(base) >> 3));
+        try self.emitByte(rex_byte);
+        try self.emitByte(0x8D); // LEA
+        // If base.low3 == 5 (rbp/r13), mod=00 would mean RIP-relative, so use
+        // mod=01 with disp8=0 to encode a plain [base + index] form.
+        const needs_disp8 = base.low3() == 5;
+        const mod: u2 = if (needs_disp8) 0b01 else 0b00;
+        try self.modrm(mod, dst.low3(), 0b100); // rm=100 → SIB follows
+        // SIB: scale=00, index=index.low3, base=base.low3
+        const sib: u8 = (@as(u8, 0) << 6) | (@as(u8, index.low3()) << 3) | @as(u8, base.low3());
+        try self.emitByte(sib);
+        if (needs_disp8) try self.emitByte(0x00);
+    }
+
     /// ADD reg, imm32 (64-bit).
     /// ADD reg, imm (64-bit). Uses the imm8 form (opcode 0x83) when imm fits
     /// in a signed byte, saving 3 bytes vs the imm32 form (opcode 0x81).
@@ -1526,3 +1550,35 @@ test "xorReg32 r8 (extended, 3 bytes)" {
     try hexEqual(buf.getCode(), &.{ 0x45, 0x31, 0xC0 });
 }
 
+
+
+test "leaRegBaseIndex64 rdx, rsi, rdi" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.leaRegBaseIndex64(.rdx, .rsi, .rdi);
+    // REX.W=0x48 (no extension), opcode 0x8D, ModR/M 00_010_100=0x14,
+    // SIB 00_111_110=0x3E (scale=0, index=rdi=7, base=rsi=6).
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x8D, 0x14, 0x3E });
+}
+
+test "leaRegBaseIndex64 r12, r13, rdx (base r13 needs disp8=0)" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.leaRegBaseIndex64(.r12, .r13, .rdx);
+    // REX: W=1, R=1 (r12), X=0 (rdx low), B=1 (r13) → 0x4D.
+    // Opcode 0x8D.
+    // ModR/M: mod=01 (disp8), reg=r12.low3=4, rm=100 → 01_100_100 = 0x64.
+    // SIB: scale=0, index=rdx=2, base=r13.low3=5 → 00_010_101 = 0x15.
+    // disp8: 0x00.
+    try hexEqual(buf.getCode(), &.{ 0x4D, 0x8D, 0x64, 0x15, 0x00 });
+}
+
+test "leaRegBaseIndex64 rax, r8, r9" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.leaRegBaseIndex64(.rax, .r8, .r9);
+    // REX: W=1, R=0, X=1 (r9), B=1 (r8) → 0x4B.
+    // Opcode 0x8D. ModR/M mod=00, reg=0, rm=100 → 0x04.
+    // SIB scale=0, index=r9.low3=1, base=r8.low3=0 → 00_001_000 = 0x08.
+    try hexEqual(buf.getCode(), &.{ 0x4B, 0x8D, 0x04, 0x08 });
+}

--- a/src/compiler/codegen/x86_64/emit.zig
+++ b/src/compiler/codegen/x86_64/emit.zig
@@ -124,6 +124,11 @@ pub const CodeBuffer = struct {
 
     /// MOV dst, src (64-bit register-to-register).
     pub fn movRegReg(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        // Post-allocation peephole (B3): a self-move is a semantic no-op —
+        // the 64-bit mov doesn't even clear upper bits (that's the 32-bit
+        // form). Skip emission so allocator-introduced identity moves
+        // vanish.
+        if (dst == src) return;
         try self.rexW(src, dst);
         try self.emitByte(0x89);
         try self.modrm(0b11, src.low3(), dst.low3());
@@ -1581,4 +1586,22 @@ test "leaRegBaseIndex64 rax, r8, r9" {
     // Opcode 0x8D. ModR/M mod=00, reg=0, rm=100 → 0x04.
     // SIB scale=0, index=r9.low3=1, base=r8.low3=0 → 00_001_000 = 0x08.
     try hexEqual(buf.getCode(), &.{ 0x4B, 0x8D, 0x04, 0x08 });
+}
+
+
+test "movRegReg elides self-move" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.movRegReg(.rax, .rax);
+    try buf.movRegReg(.r12, .r12);
+    // Both self-moves must produce zero bytes.
+    try std.testing.expectEqual(@as(usize, 0), buf.getCode().len);
+}
+
+test "movRegReg still emits for distinct regs" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.movRegReg(.rax, .rdx);
+    // REX.W 89 /r: 48 89 D0 (mov rax, rdx)
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x89, 0xD0 });
 }

--- a/src/compiler/codegen/x86_64/emit.zig
+++ b/src/compiler/codegen/x86_64/emit.zig
@@ -434,51 +434,89 @@ pub const CodeBuffer = struct {
     }
 
     /// ADD reg, imm32 (64-bit).
+    /// ADD reg, imm (64-bit). Uses the imm8 form (opcode 0x83) when imm fits
+    /// in a signed byte, saving 3 bytes vs the imm32 form (opcode 0x81).
     pub fn addRegImm32(self: *CodeBuffer, dst: Reg, imm: i32) !void {
         try self.rexW(.rax, dst);
-        try self.emitByte(0x81);
-        try self.modrm(0b11, 0, dst.low3());
-        try self.emitI32(imm);
+        if (imm >= -128 and imm <= 127) {
+            try self.emitByte(0x83);
+            try self.modrm(0b11, 0, dst.low3());
+            try self.emitByte(@bitCast(@as(i8, @intCast(imm))));
+        } else {
+            try self.emitByte(0x81);
+            try self.modrm(0b11, 0, dst.low3());
+            try self.emitI32(imm);
+        }
     }
 
-    /// SUB reg, imm32 (64-bit).
+    /// SUB reg, imm (64-bit). Uses imm8 form when possible.
     pub fn subRegImm32(self: *CodeBuffer, dst: Reg, imm: i32) !void {
         try self.rexW(.rax, dst);
-        try self.emitByte(0x81);
-        try self.modrm(0b11, 5, dst.low3());
-        try self.emitI32(imm);
+        if (imm >= -128 and imm <= 127) {
+            try self.emitByte(0x83);
+            try self.modrm(0b11, 5, dst.low3());
+            try self.emitByte(@bitCast(@as(i8, @intCast(imm))));
+        } else {
+            try self.emitByte(0x81);
+            try self.modrm(0b11, 5, dst.low3());
+            try self.emitI32(imm);
+        }
     }
 
-    /// AND reg, imm32 (64-bit, sign-extended).
+    /// AND reg, imm (64-bit, sign-extended). Uses imm8 form when possible.
     pub fn andRegImm32(self: *CodeBuffer, dst: Reg, imm: i32) !void {
         try self.rexW(.rax, dst);
-        try self.emitByte(0x81);
-        try self.modrm(0b11, 4, dst.low3());
-        try self.emitI32(imm);
+        if (imm >= -128 and imm <= 127) {
+            try self.emitByte(0x83);
+            try self.modrm(0b11, 4, dst.low3());
+            try self.emitByte(@bitCast(@as(i8, @intCast(imm))));
+        } else {
+            try self.emitByte(0x81);
+            try self.modrm(0b11, 4, dst.low3());
+            try self.emitI32(imm);
+        }
     }
 
-    /// OR reg, imm32 (64-bit, sign-extended).
+    /// OR reg, imm (64-bit, sign-extended). Uses imm8 form when possible.
     pub fn orRegImm32(self: *CodeBuffer, dst: Reg, imm: i32) !void {
         try self.rexW(.rax, dst);
-        try self.emitByte(0x81);
-        try self.modrm(0b11, 1, dst.low3());
-        try self.emitI32(imm);
+        if (imm >= -128 and imm <= 127) {
+            try self.emitByte(0x83);
+            try self.modrm(0b11, 1, dst.low3());
+            try self.emitByte(@bitCast(@as(i8, @intCast(imm))));
+        } else {
+            try self.emitByte(0x81);
+            try self.modrm(0b11, 1, dst.low3());
+            try self.emitI32(imm);
+        }
     }
 
-    /// XOR reg, imm32 (64-bit, sign-extended).
+    /// XOR reg, imm (64-bit, sign-extended). Uses imm8 form when possible.
     pub fn xorRegImm32(self: *CodeBuffer, dst: Reg, imm: i32) !void {
         try self.rexW(.rax, dst);
-        try self.emitByte(0x81);
-        try self.modrm(0b11, 6, dst.low3());
-        try self.emitI32(imm);
+        if (imm >= -128 and imm <= 127) {
+            try self.emitByte(0x83);
+            try self.modrm(0b11, 6, dst.low3());
+            try self.emitByte(@bitCast(@as(i8, @intCast(imm))));
+        } else {
+            try self.emitByte(0x81);
+            try self.modrm(0b11, 6, dst.low3());
+            try self.emitI32(imm);
+        }
     }
 
-    /// CMP reg, imm32 (64-bit, sign-extended).
+    /// CMP reg, imm (64-bit, sign-extended). Uses imm8 form when possible.
     pub fn cmpRegImm32(self: *CodeBuffer, dst: Reg, imm: i32) !void {
         try self.rexW(.rax, dst);
-        try self.emitByte(0x81);
-        try self.modrm(0b11, 7, dst.low3());
-        try self.emitI32(imm);
+        if (imm >= -128 and imm <= 127) {
+            try self.emitByte(0x83);
+            try self.modrm(0b11, 7, dst.low3());
+            try self.emitByte(@bitCast(@as(i8, @intCast(imm))));
+        } else {
+            try self.emitByte(0x81);
+            try self.modrm(0b11, 7, dst.low3());
+            try self.emitI32(imm);
+        }
     }
 
     /// XOR r32, r32 — zero register without REX.W (2 bytes, zero idiom).
@@ -1400,44 +1438,76 @@ test "zeroExtendReg 64-bit (no-op)" {
 // Immediate-form instruction tests
 // ═══════════════════════════════════════════════════════════════════════
 
-test "subRegImm32 rax, 10" {
+test "subRegImm32 rax, 10 uses imm8 form" {
     var buf = CodeBuffer.init(std.testing.allocator);
     defer buf.deinit();
     try buf.subRegImm32(.rax, 10);
-    // REX.W 81 /5 rax, 0A000000: 48 81 E8 0A 00 00 00
-    try hexEqual(buf.getCode(), &.{ 0x48, 0x81, 0xE8, 0x0A, 0x00, 0x00, 0x00 });
+    // REX.W 83 /5 rax, imm8: 48 83 E8 0A
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x83, 0xE8, 0x0A });
 }
 
-test "andRegImm32 rax, 0xFF" {
+test "subRegImm32 rax, 1000 uses imm32 form" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.subRegImm32(.rax, 1000);
+    // REX.W 81 /5 rax, imm32: 48 81 E8 E8 03 00 00
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x81, 0xE8, 0xE8, 0x03, 0x00, 0x00 });
+}
+
+test "andRegImm32 rax, 0xFF uses imm32 form (0xFF > i8 max)" {
     var buf = CodeBuffer.init(std.testing.allocator);
     defer buf.deinit();
     try buf.andRegImm32(.rax, 0xFF);
-    // REX.W 81 /4 rax: 48 81 E0 FF 00 00 00
+    // REX.W 81 /4 rax: 48 81 E0 FF 00 00 00 (0xFF doesn't fit in i8)
     try hexEqual(buf.getCode(), &.{ 0x48, 0x81, 0xE0, 0xFF, 0x00, 0x00, 0x00 });
 }
 
-test "orRegImm32 rax, 1" {
+test "andRegImm32 rax, 0x0F uses imm8 form" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.andRegImm32(.rax, 0x0F);
+    // REX.W 83 /4 rax, imm8: 48 83 E0 0F
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x83, 0xE0, 0x0F });
+}
+
+test "orRegImm32 rax, 1 uses imm8 form" {
     var buf = CodeBuffer.init(std.testing.allocator);
     defer buf.deinit();
     try buf.orRegImm32(.rax, 1);
-    // REX.W 81 /1 rax: 48 81 C8 01 00 00 00
-    try hexEqual(buf.getCode(), &.{ 0x48, 0x81, 0xC8, 0x01, 0x00, 0x00, 0x00 });
+    // REX.W 83 /1 rax, imm8: 48 83 C8 01
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x83, 0xC8, 0x01 });
 }
 
-test "xorRegImm32 rax, 0x55" {
+test "xorRegImm32 rax, 0x55 uses imm8 form" {
     var buf = CodeBuffer.init(std.testing.allocator);
     defer buf.deinit();
     try buf.xorRegImm32(.rax, 0x55);
-    // REX.W 81 /6 rax: 48 81 F0 55 00 00 00
-    try hexEqual(buf.getCode(), &.{ 0x48, 0x81, 0xF0, 0x55, 0x00, 0x00, 0x00 });
+    // REX.W 83 /6 rax, imm8: 48 83 F0 55
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x83, 0xF0, 0x55 });
 }
 
-test "cmpRegImm32 rax, 42" {
+test "cmpRegImm32 rax, 42 uses imm8 form" {
     var buf = CodeBuffer.init(std.testing.allocator);
     defer buf.deinit();
     try buf.cmpRegImm32(.rax, 42);
-    // REX.W 81 /7 rax: 48 81 F8 2A 00 00 00
-    try hexEqual(buf.getCode(), &.{ 0x48, 0x81, 0xF8, 0x2A, 0x00, 0x00, 0x00 });
+    // REX.W 83 /7 rax, imm8: 48 83 F8 2A
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x83, 0xF8, 0x2A });
+}
+
+test "addRegImm32 rax, -1 uses imm8 form (sign-extended)" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.addRegImm32(.rax, -1);
+    // REX.W 83 /0 rax, imm8=0xFF: 48 83 C0 FF
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x83, 0xC0, 0xFF });
+}
+
+test "addRegImm32 rax, 128 uses imm32 form (boundary)" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.addRegImm32(.rax, 128);
+    // 128 doesn't fit in i8 — must use imm32: 48 81 C0 80 00 00 00
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x81, 0xC0, 0x80, 0x00, 0x00, 0x00 });
 }
 
 test "xorReg32 rax (zero idiom, 2 bytes)" {

--- a/src/compiler/codegen/x86_64/emit.zig
+++ b/src/compiler/codegen/x86_64/emit.zig
@@ -291,8 +291,16 @@ pub const CodeBuffer = struct {
     // ── SETcc / MOVZX / TEST / CQO / DIV / CMOV ──────────────────────
 
     /// SETcc r/m8 — set byte based on condition code.
+    /// Byte-register access requires a REX prefix for SPL/BPL/SIL/DIL
+    /// (encodings 4–7) to distinguish them from AH/CH/DH/BH. We force
+    /// the REX emission in that case even when no extension bits are set.
     pub fn setcc(self: *CodeBuffer, cc: u4, dst: Reg) !void {
-        try self.rex(false, .rax, dst);
+        const idx = @intFromEnum(dst);
+        if (idx >= 4 and idx < 8) {
+            try self.emitByte(0x40); // mandatory REX for SPL/BPL/SIL/DIL
+        } else {
+            try self.rex(false, .rax, dst);
+        }
         try self.emitByte(0x0F);
         try self.emitByte(0x90 | @as(u8, cc));
         try self.modrm(0b11, 0, dst.low3());
@@ -365,6 +373,63 @@ pub const CodeBuffer = struct {
         try self.rexW(dst, src);
         try self.emitByte(0x0F);
         try self.emitByte(0xB8);
+        try self.modrm(0b11, dst.low3(), src.low3());
+    }
+
+    /// LZCNT r32, r/m32 — 32-bit leading zero count (no REX.W).
+    pub fn lzcnt32(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        try self.emitByte(0xF3);
+        if (dst.isExtended() or src.isExtended()) try self.rex(false, dst, src);
+        try self.emitByte(0x0F);
+        try self.emitByte(0xBD);
+        try self.modrm(0b11, dst.low3(), src.low3());
+    }
+
+    /// TZCNT r32, r/m32 — 32-bit trailing zero count (no REX.W).
+    pub fn tzcnt32(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        try self.emitByte(0xF3);
+        if (dst.isExtended() or src.isExtended()) try self.rex(false, dst, src);
+        try self.emitByte(0x0F);
+        try self.emitByte(0xBC);
+        try self.modrm(0b11, dst.low3(), src.low3());
+    }
+
+    /// POPCNT r32, r/m32 — 32-bit population count (no REX.W).
+    pub fn popcnt32(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        try self.emitByte(0xF3);
+        if (dst.isExtended() or src.isExtended()) try self.rex(false, dst, src);
+        try self.emitByte(0x0F);
+        try self.emitByte(0xB8);
+        try self.modrm(0b11, dst.low3(), src.low3());
+    }
+
+    /// MOV r32, r/m32 — 32-bit reg-reg move. Implicitly zero-extends to 64.
+    pub fn movRegReg32(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        if (dst.isExtended() or src.isExtended()) try self.rex(false, src, dst);
+        try self.emitByte(0x89);
+        try self.modrm(0b11, src.low3(), dst.low3());
+    }
+
+    /// MOVSXD r64, r/m32 — sign-extend 32→64.
+    pub fn movsxd(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        try self.rexW(dst, src);
+        try self.emitByte(0x63);
+        try self.modrm(0b11, dst.low3(), src.low3());
+    }
+
+    /// MOVSX r64, r/m8 — sign-extend 8→64.
+    pub fn movsxByteToReg(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        try self.rexW(dst, src);
+        try self.emitByte(0x0F);
+        try self.emitByte(0xBE);
+        try self.modrm(0b11, dst.low3(), src.low3());
+    }
+
+    /// MOVSX r64, r/m16 — sign-extend 16→64.
+    pub fn movsxWordToReg(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        try self.rexW(dst, src);
+        try self.emitByte(0x0F);
+        try self.emitByte(0xBF);
         try self.modrm(0b11, dst.low3(), src.low3());
     }
 
@@ -1110,6 +1175,93 @@ test "movMemRegSized 8-bit" {
     try hexEqual(buf.getCode(), &.{ 0x88, 0x81, 0x10, 0x00, 0x00, 0x00 });
 }
 
+test "setcc on legacy byte reg (al) omits REX" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.setcc(0x4, .rax); // sete al
+    try hexEqual(buf.getCode(), &.{ 0x0F, 0x94, 0xC0 });
+}
+
+test "setcc on rsi emits mandatory REX for sil" {
+    // Without the REX prefix, 0F 94 C6 encodes `sete DH`, which would be
+    // incorrect — we need `sete SIL`. Ensure the 0x40 REX is emitted.
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.setcc(0x4, .rsi);
+    try hexEqual(buf.getCode(), &.{ 0x40, 0x0F, 0x94, 0xC6 });
+}
+
+test "setcc on rdi emits mandatory REX for dil" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.setcc(0x5, .rdi); // setne dil
+    try hexEqual(buf.getCode(), &.{ 0x40, 0x0F, 0x95, 0xC7 });
+}
+
+test "setcc on extended reg r8 uses REX.B" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.setcc(0x4, .r8); // sete r8b
+    // REX.B = 0x41
+    try hexEqual(buf.getCode(), &.{ 0x41, 0x0F, 0x94, 0xC0 });
+}
+
+test "lzcnt32 on rdx encodes without REX.W" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.lzcnt32(.rdx, .rdx);
+    // F3 0F BD /r with ModR/M 11_010_010 = 0xD2 (no REX)
+    try hexEqual(buf.getCode(), &.{ 0xF3, 0x0F, 0xBD, 0xD2 });
+}
+
+test "tzcnt32 on r9 emits REX.RB" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.tzcnt32(.r9, .r9);
+    // F3 REX.RB(0x45) 0F BC /r with ModR/M 11_001_001 = 0xC9
+    try hexEqual(buf.getCode(), &.{ 0xF3, 0x45, 0x0F, 0xBC, 0xC9 });
+}
+
+test "popcnt32 between different regs" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.popcnt32(.rsi, .rdi);
+    // F3 0F B8 /r with ModR/M 11_110_111 = 0xF7 (no REX: both legacy)
+    try hexEqual(buf.getCode(), &.{ 0xF3, 0x0F, 0xB8, 0xF7 });
+}
+
+test "movRegReg32 rdx to rsi" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.movRegReg32(.rsi, .rdx);
+    // MOV r/m32, r32 opcode 0x89 with reg=src=rdx=2, rm=dst=rsi=6 → 11_010_110 = D6
+    try hexEqual(buf.getCode(), &.{ 0x89, 0xD6 });
+}
+
+test "movsxd rsi, edx" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.movsxd(.rsi, .rdx);
+    // REX.W 63 /r with ModR/M 11_110_010 = 0xF2
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x63, 0xF2 });
+}
+
+test "movsxByteToReg rdi, dl" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.movsxByteToReg(.rdi, .rdx);
+    // REX.W 0F BE /r with ModR/M 11_111_010 = 0xFA
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x0F, 0xBE, 0xFA });
+}
+
+test "movsxWordToReg r8, si" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.movsxWordToReg(.r8, .rsi);
+    // REX.WR (0x4C) 0F BF /r with ModR/M 11_000_110 = 0xC6
+    try hexEqual(buf.getCode(), &.{ 0x4C, 0x0F, 0xBF, 0xC6 });
+}
+
 test "movMemRegSized 16-bit" {
     var buf = CodeBuffer.init(std.testing.allocator);
     defer buf.deinit();
@@ -1303,3 +1455,4 @@ test "xorReg32 r8 (extended, 3 bytes)" {
     // REX 45 31 C0 (XOR r8d, r8d)
     try hexEqual(buf.getCode(), &.{ 0x45, 0x31, 0xC0 });
 }
+

--- a/src/compiler/codegen/x86_64/emit.zig
+++ b/src/compiler/codegen/x86_64/emit.zig
@@ -57,6 +57,14 @@ pub const CodeBuffer = struct {
         return self.bytes.items;
     }
 
+    /// Truncate the buffer to `new_len`. Used by block-level peepholes
+    /// (e.g. dropping a trailing fall-through jmp). Must not be called
+    /// with a length greater than current len.
+    pub fn truncate(self: *CodeBuffer, new_len: usize) void {
+        std.debug.assert(new_len <= self.bytes.items.len);
+        self.bytes.shrinkRetainingCapacity(new_len);
+    }
+
     // ── Raw byte emission ─────────────────────────────────────────────
 
     pub fn emitByte(self: *CodeBuffer, byte: u8) !void {

--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -41,8 +41,10 @@ pub const AllocResult = struct {
 /// Allocatable registers as PhysReg IDs.
 /// Excludes RAX (0), RCX (1) — used as scratch temporaries by codegen,
 /// RSP (4), RBP (5) — frame pointers, and R10 (10), R11 (11) — scratch regs.
-const alloc_regs = [_]PhysReg{ 2, 6, 7, 8, 9 };
-// rdx=2, rsi=6, rdi=7, r8=8, r9=9
+/// R12/R13 are callee-saved on both Win64 and SysV, so prologue/epilogue
+/// preserves them when used.
+const alloc_regs = [_]PhysReg{ 2, 6, 7, 8, 9, 12, 13 };
+// rdx=2, rsi=6, rdi=7, r8=8, r9=9, r12=12, r13=13
 
 /// Scratch registers for spill loads (not allocatable).
 pub const scratch1: PhysReg = 10; // r10


### PR DESCRIPTION
Phase 2 AOT codegen optimizations for the x86-64 backend, follow-up to #95 / #99.

Closes most of #100 (a3 callee-saved bias deferred — small win, big test churn).

## Commits (in order)

1. **A1** `ad574a87` — migrate remaining handlers (compare/eqz/br_if/global_set/memory_size/count/convert) to use the allocated destination register instead of hardcoding `rax`/`rcx`.
2. **A2** `50f9b64b` — expand the allocatable register pool to include `r12` and `r13` (5 → 7 regs).
3. **B1** `15042e73` — remove the dead `mov r11,rax` / `mov rax,r11` pair around the div/rem and shift operand load. The clobber-aware allocator makes the stash unnecessary.
4. **B2** `4f6a382e` — fold wasm memory offsets into the `mov` `disp32` for both load and store paths; also drop the obsolete `r11` stash from the store path so it mirrors load.
5. **C1** `1e3fb149` — use the 8-bit-immediate (sign-extended) `0x83` form of add/sub/and/or/xor/cmp `reg, imm` when the immediate fits in `i8`. Saves 3 bytes per eligible op.
6. **C2** `027249f9` — emit `lea dst, [lhs + rhs]` instead of `mov dst, lhs; add dst, rhs` when the binary add has three distinct register operands. Saves one instruction.
7. **B3** `bdf0cd7a` — elide self-moves (`mov r64,r64` with src == dst) at emit time. The 32-bit form is deliberately untouched because `mov eax,eax` has a zero-extension side effect used by `i32.wrap_i64`.
8. **C3** `b3d9ee06` — block-level fall-through peephole: drop the trailing `E9 disp32` when the terminator's fall-through target is the next block. Covers `br next` and `br_if cond, then, else=next`. No IR reorder, no patch-offset remapping; we only trim buffer tail and pop one patch so other patches stay valid.

## Verification

- **570 / 570** unit tests pass (up from 538 at baseline).
- Spec-test wasts clean (0 failures in each):
  i32, i64, int_exprs, int_literals, conversions, address, memory, align, loop,
  br_table, if, select, block, br_if, br, traps, memory_grow, memory_size, switch.
- No change to external API / no host-facing behavior changes.

## Deferred

- **a3 callee-saved bias** — reordering `alloc_regs` to prefer caller-saved for short-lived ranges on Win64 changes the first-picked register in most tests, churning dozens of byte-pattern expectations for a modest win. Best revisited as its own focused PR.
