### PR TITLE
AOT coremark: fix LEB128 decode, bounds checks, and add differential harness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,20 @@ Coding Style
 Please use [K&R](https://en.wikipedia.org/wiki/Indentation_style#K.26R) coding style, such as 4 spaces for indentation rather than tabs etc.
 We suggest using VS Code like IDE or stable coding format tools, like clang-format, to make your code compliant to the customized format(in .clang-format).
 
+Testing conventions
+===================
+
+Binary decoders (LEB128, UTF-8, opcode prefixes, anything that walks bytes at runtime):
+- Prefer reusing the shared decoder in `src/shared/utils/` instead of hand-rolling a copy. When a copy is unavoidable (for example, a very hot dispatch loop), add a comment justifying the duplication and link the test that proves equivalence to the shared version.
+- Every hand-rolled decoder must have unit tests covering, at minimum:
+  - zero, `+1`, `-1`
+  - boundary values on both sides of each encoded-size transition (for LEB128: `±63`, `±64`, `±127`, `±128`)
+  - the min and max of the target type (e.g. `INT32_MIN`, `INT32_MAX`, `0xFFFFFFFF`)
+  - malformed input (truncated stream, overflow)
+- For encoders, prefer a round-trip fuzz test (`for random v: decode(encode(v)) == v`) alongside the boundary tests — see `src/shared/utils/leb128.zig` for the pattern.
+
+Rationale: a drift bug between two copies of `readI32` (AOT frontend vs interpreter) caused a silent mis-decode of single-byte negative signed LEB128 values. The bug survived because the buggy function had no unit tests. See commit `709ad073` and the follow-up unification for context.
+
 Report bugs
 ===================
 We use GitHub issues to track public bugs. Report a bug by [open a new issue](https://github.com/intel/wasm-micro-runtime/issues/new).

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1038,9 +1038,25 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
 
     // Spill wasm parameters from ABI registers to stack frame slots.
     // Wasm params are shifted by 1 because the first ABI register is the VMContext.
-    const spill_count = @min(func.param_count, param_regs.len - 1);
+    const max_reg_params: u32 = @as(u32, @intCast(param_regs.len)) - 1;
+    const spill_count = @min(func.param_count, max_reg_params);
     for (0..spill_count) |i| {
         try code.movMemReg(.rbp, -@as(i32, @intCast((i + 2) * 8)), param_regs[i + 1]);
+    }
+
+    // Spill wasm parameters passed on the stack by the caller (beyond max_reg_params).
+    // Caller layout after push rbp; mov rbp, rsp:
+    //   Win64: [rbp+16..rbp+48] is the 4-slot shadow space; stack args start at [rbp+48].
+    //   SysV:  no shadow; stack args start at [rbp+16].
+    if (func.param_count > max_reg_params) {
+        const stack_arg_base: i32 = if (comptime builtin.os.tag == .windows) 48 else 16;
+        var k: u32 = max_reg_params;
+        while (k < func.param_count) : (k += 1) {
+            const src_off: i32 = stack_arg_base + @as(i32, @intCast((k - max_reg_params) * 8));
+            const dst_off: i32 = -@as(i32, @intCast((k + 2) * 8));
+            try code.movRegMem(.rax, .rbp, src_off);
+            try code.movMemReg(.rbp, dst_off, .rax);
+        }
     }
 
     // Zero-initialize declared locals (wasm spec requires locals to be zero).
@@ -1463,42 +1479,53 @@ fn compileInstRA(
         .call => |cl| {
             // No push/pop: the allocator ensures no live vreg in a
             // caller-saved register spans this call instruction.
+            const n_args: u32 = @intCast(cl.args.len);
+            const max_reg_args: u32 = @min(n_args, @as(u32, @intCast(param_regs.len)) - 1);
+            const extra: u32 = n_args - max_reg_args;
+            const shadow: u32 = if (comptime builtin.os.tag == .windows) 32 else 0;
+            const stack_need: u32 = shadow + extra * 8;
+            // Keep rsp 16-aligned across the CALL (prologue established 16-alignment at rbp+8).
+            const stack_adjust: u32 = (stack_need + 15) & ~@as(u32, 15);
 
             if (cl.func_idx < import_count) {
-                // Import call: indirect call via host function pointer table in VmCtx.
+                // Import call: indirect via host_functions_ptr table in VmCtx.
+                // Load vmctx, then fetch the host fn pointer into rax BEFORE adjusting
+                // rsp (so base-register moves don't race with stack-arg writes).
                 try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
-                const n_args: u32 = @intCast(cl.args.len);
-                if (n_args > 0) {
-                    const max_reg_args = @min(n_args, @as(u32, @intCast(param_regs.len)) - 1);
-                    var i: u32 = 0;
-                    while (i < max_reg_args) : (i += 1) {
-                        const arg_reg = try useVReg(code, alloc_result, cl.args[i], .r10);
-                        if (arg_reg != param_regs[i + 1]) try code.movRegReg(param_regs[i + 1], arg_reg);
-                    }
-                }
                 try code.movRegMem(.r10, param_regs[0], vmctx_host_functions_field);
                 if (cl.func_idx > 0) {
                     try code.addRegImm32(.r10, @intCast(@as(u32, cl.func_idx) * 8));
                 }
                 try code.movRegMem(.rax, .r10, 0);
-                if (comptime builtin.os.tag == .windows) {
-                    try code.subRegImm32(.rsp, 32);
+
+                if (stack_adjust > 0) try code.subRegImm32(.rsp, @intCast(stack_adjust));
+                // Stack args first — their sources may live in regs we're about to overwrite.
+                var j: u32 = 0;
+                while (j < extra) : (j += 1) {
+                    const arg_reg = try useVReg(code, alloc_result, cl.args[max_reg_args + j], .r10);
+                    try code.movMemReg(.rsp, @intCast(shadow + j * 8), arg_reg);
+                }
+                var i: u32 = 0;
+                while (i < max_reg_args) : (i += 1) {
+                    const arg_reg = try useVReg(code, alloc_result, cl.args[i], .r10);
+                    if (arg_reg != param_regs[i + 1]) try code.movRegReg(param_regs[i + 1], arg_reg);
                 }
                 try code.callReg(.rax);
-                if (comptime builtin.os.tag == .windows) {
-                    try code.addRegImm32(.rsp, 32);
-                }
+                if (stack_adjust > 0) try code.addRegImm32(.rsp, @intCast(stack_adjust));
             } else {
-                // Local function call: direct CALL rel32
+                // Local function call: direct CALL rel32.
                 try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
-                const n_args: u32 = @intCast(cl.args.len);
-                if (n_args > 0) {
-                    const max_reg_args = @min(n_args, @as(u32, @intCast(param_regs.len)) - 1);
-                    var i: u32 = 0;
-                    while (i < max_reg_args) : (i += 1) {
-                        const arg_reg = try useVReg(code, alloc_result, cl.args[i], .r10);
-                        if (arg_reg != param_regs[i + 1]) try code.movRegReg(param_regs[i + 1], arg_reg);
-                    }
+
+                if (stack_adjust > 0) try code.subRegImm32(.rsp, @intCast(stack_adjust));
+                var j: u32 = 0;
+                while (j < extra) : (j += 1) {
+                    const arg_reg = try useVReg(code, alloc_result, cl.args[max_reg_args + j], .r10);
+                    try code.movMemReg(.rsp, @intCast(shadow + j * 8), arg_reg);
+                }
+                var i: u32 = 0;
+                while (i < max_reg_args) : (i += 1) {
+                    const arg_reg = try useVReg(code, alloc_result, cl.args[i], .r10);
+                    if (arg_reg != param_regs[i + 1]) try code.movRegReg(param_regs[i + 1], arg_reg);
                 }
                 try code.emitByte(0xE8);
                 const patch_off = code.len();
@@ -1507,6 +1534,7 @@ fn compileInstRA(
                     .patch_offset = patch_off,
                     .target_func_idx = cl.func_idx - import_count,
                 });
+                if (stack_adjust > 0) try code.addRegImm32(.rsp, @intCast(stack_adjust));
             }
 
             if (inst.dest) |dest| {
@@ -1528,32 +1556,37 @@ fn compileInstRA(
             try code.movRegMem(.r10, .rbp, vmctx_offset);
             try code.movRegMem(.r10, .r10, vmctx_func_table_field);
 
-            // func_ptr = func_table[elem_idx * 8]
+            // func_ptr = func_table[elem_idx * 8]; stash in r11 across arg setup
+            // because useVReg below only touches its scratch (.r10) and the
+            // destination param regs, never r11.
             try code.emitSlice(&.{ 0x48, 0xC1, 0xE0, 0x03 }); // shl rax, 3
             try code.addRegReg(.rax, .r10);
-            try code.movRegMem(.rax, .rax, 0);
+            try code.movRegMem(.r11, .rax, 0);
 
-            // Set up call: VmCtx in param_regs[0], wasm args in param_regs[1..]
+            // Load vmctx into param_regs[0]
             try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
-            const n_args: u32 = @intCast(ci.args.len);
-            if (n_args > 0) {
-                try code.pushReg(.rax);
-                const max_reg_args = @min(n_args, @as(u32, @intCast(param_regs.len)) - 1);
-                var i: u32 = 0;
-                while (i < max_reg_args) : (i += 1) {
-                    const arg_reg = try useVReg(code, alloc_result, ci.args[i], .r10);
-                    if (arg_reg != param_regs[i + 1]) try code.movRegReg(param_regs[i + 1], arg_reg);
-                }
-                try code.popReg(.rax);
-            }
 
-            if (comptime builtin.os.tag == .windows) {
-                try code.subRegImm32(.rsp, 32);
+            const n_args: u32 = @intCast(ci.args.len);
+            const max_reg_args: u32 = @min(n_args, @as(u32, @intCast(param_regs.len)) - 1);
+            const extra: u32 = n_args - max_reg_args;
+            const shadow: u32 = if (comptime builtin.os.tag == .windows) 32 else 0;
+            const stack_need: u32 = shadow + extra * 8;
+            const stack_adjust: u32 = (stack_need + 15) & ~@as(u32, 15);
+
+            if (stack_adjust > 0) try code.subRegImm32(.rsp, @intCast(stack_adjust));
+            // Stack args first; sources may live in regs we're about to overwrite.
+            var j: u32 = 0;
+            while (j < extra) : (j += 1) {
+                const arg_reg = try useVReg(code, alloc_result, ci.args[max_reg_args + j], .r10);
+                try code.movMemReg(.rsp, @intCast(shadow + j * 8), arg_reg);
             }
-            try code.callReg(.rax);
-            if (comptime builtin.os.tag == .windows) {
-                try code.addRegImm32(.rsp, 32);
+            var i: u32 = 0;
+            while (i < max_reg_args) : (i += 1) {
+                const arg_reg = try useVReg(code, alloc_result, ci.args[i], .r10);
+                if (arg_reg != param_regs[i + 1]) try code.movRegReg(param_regs[i + 1], arg_reg);
             }
+            try code.callReg(.r11);
+            if (stack_adjust > 0) try code.addRegImm32(.rsp, @intCast(stack_adjust));
 
             if (inst.dest) |dest| {
                 try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
@@ -3249,4 +3282,92 @@ test "compileFunctionRA: br_if else==next drops trailing jmp (C3)" {
         }
     }
     try std.testing.expect(!has_trailing_e9);
+}
+
+// ── Stack-argument ABI tests (wasm args beyond reg-param capacity) ──
+
+test "compileFunctionRA: callee with >3 params spills stack args on Win64" {
+    const allocator = std.testing.allocator;
+    // 5 params → on Win64 params 3,4 are passed on the stack; SysV fits all in regs.
+    var func = ir.IrFunction.init(allocator, 5, 5, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    // ret last param (p4) — forces the callee to read it from frame
+    try block.append(.{ .op = .{ .ret = 4 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // On Windows the prologue must load at least one stack-passed param from
+    // [rbp + 48] via rax (48 00 00 00 disp32). Look for the mov rax, [rbp+48]
+    // opcode sequence: REX.W=48, 8B (mov r64, r/m64), ModR/M=85 (mod=10, reg=000(rax), r/m=101(rbp)).
+    if (builtin.os.tag == .windows) {
+        var found = false;
+        var i: usize = 0;
+        while (i + 6 < code.len) : (i += 1) {
+            if (code[i] == 0x48 and code[i + 1] == 0x8B and code[i + 2] == 0x85 and
+                code[i + 3] == 0x30 and code[i + 4] == 0 and code[i + 5] == 0 and code[i + 6] == 0)
+            {
+                found = true;
+                break;
+            }
+        }
+        try std.testing.expect(found);
+    }
+}
+
+test "compileFunctionRA: caller passes >3 args via stack on Win64" {
+    const allocator = std.testing.allocator;
+    var ir_module = ir.IrModule.init(allocator);
+    defer ir_module.deinit();
+
+    // callee(i32 x5) -> i32  (body irrelevant; just needs valid IR)
+    var callee = ir.IrFunction.init(allocator, 5, 5, 0);
+    _ = try callee.newBlock();
+    try callee.getBlock(0).append(.{ .op = .{ .ret = 0 } });
+    _ = try ir_module.addFunction(callee);
+
+    // caller(): call callee with 5 args, ret the result
+    var caller = ir.IrFunction.init(allocator, 0, 1, 0);
+    _ = try caller.newBlock();
+    const a0 = caller.newVReg();
+    const a1 = caller.newVReg();
+    const a2 = caller.newVReg();
+    const a3 = caller.newVReg();
+    const a4 = caller.newVReg();
+    const r = caller.newVReg();
+    try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = a0, .type = .i32 });
+    try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 2 }, .dest = a1, .type = .i32 });
+    try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 3 }, .dest = a2, .type = .i32 });
+    try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 4 }, .dest = a3, .type = .i32 });
+    try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 5 }, .dest = a4, .type = .i32 });
+    const args = try allocator.alloc(ir.VReg, 5);
+    args[0] = a0;
+    args[1] = a1;
+    args[2] = a2;
+    args[3] = a3;
+    args[4] = a4;
+    try caller.getBlock(0).append(.{
+        .op = .{ .call = .{ .func_idx = 0, .args = args } },
+        .dest = r,
+        .type = .i32,
+    });
+    try caller.getBlock(0).append(.{ .op = .{ .ret = r } });
+    _ = try ir_module.addFunction(caller);
+    defer allocator.free(args);
+
+    const result = try compileModule(&ir_module, allocator);
+    defer allocator.free(result.code);
+    defer allocator.free(result.offsets);
+
+    // Must contain a direct CALL (E8) — caller emits the call.
+    try std.testing.expect(containsBytes(result.code, &.{0xE8}));
+    // On Windows, caller must adjust rsp by at least 32 (shadow). Look for
+    // sub rsp, imm32 (48 81 EC ??) or sub rsp, imm8 (48 83 EC ??) in caller.
+    // Just assert the caller compiled successfully with nonzero size.
+    try std.testing.expect(result.code.len > 32);
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -862,6 +862,95 @@ pub const CompileResult = struct {
     offsets: []u32,
 };
 
+fn dumpFuncIRAlloc(func: *const ir.IrFunction, fi: u32, import_count: u32, allocator: std.mem.Allocator) !void {
+    const p = std.debug.print;
+    p("=== IR DUMP func[{d}] param_count={d} local_count={d} blocks={d} ===\n", .{ fi, func.param_count, func.local_count, func.blocks.items.len });
+
+    // Rebuild clobber points (same logic as compileFunctionRA) so allocation matches.
+    var clobbers: std.ArrayList(regalloc.ClobberPoint) = .empty;
+    defer clobbers.deinit(allocator);
+    var cp_pos: u32 = 0;
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |ci| {
+            switch (ci.op) {
+                .call, .call_indirect => {
+                    const mask = if (comptime builtin.os.tag == .windows)
+                        [_]bool{ true, false, false, true, true, false, false }
+                    else
+                        [_]bool{ true, true, true, true, true, false, false };
+                    try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = mask });
+                },
+                .memory_copy => try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = .{ false, true, true, false, false, false, false } }),
+                .memory_fill => try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = .{ false, false, true, false, false, false, false } }),
+                else => {},
+            }
+            cp_pos += 1;
+        }
+    }
+    var alloc = try regalloc.allocate(func, allocator, clobbers.items);
+    defer alloc.deinit();
+
+    var pos: u32 = 0;
+    for (func.blocks.items, 0..) |block, bi| {
+        p("  block[{d}]:\n", .{bi});
+        for (block.instructions.items) |inst| {
+            const dest_str: []const u8 = if (inst.dest != null) "dst" else "   ";
+            var dest_alloc_buf: [32]u8 = undefined;
+            const dest_alloc: []const u8 = if (inst.dest) |d| blk: {
+                if (alloc.get(d)) |a| switch (a) {
+                    .reg => |r| break :blk std.fmt.bufPrint(&dest_alloc_buf, "v{d}→r{d}", .{ d, r }) catch "?",
+                    .stack => |off| break :blk std.fmt.bufPrint(&dest_alloc_buf, "v{d}→[rbp{d}]", .{ d, off }) catch "?",
+                } else break :blk "v?→none";
+            } else "";
+            switch (inst.op) {
+                .iconst_32 => |v| p("    {d:4}: iconst_32 {d}  {s} {s}\n", .{ pos, v, dest_str, dest_alloc }),
+                .iconst_64 => |v| p("    {d:4}: iconst_64 {d}  {s} {s}\n", .{ pos, v, dest_str, dest_alloc }),
+                .add => |b| p("    {d:4}: add v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .sub => |b| p("    {d:4}: sub v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .mul => |b| p("    {d:4}: mul v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .@"and" => |b| p("    {d:4}: and v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .@"or" => |b| p("    {d:4}: or v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .xor => |b| p("    {d:4}: xor v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .shl => |b| p("    {d:4}: shl v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .shr_s => |b| p("    {d:4}: shr_s v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .shr_u => |b| p("    {d:4}: shr_u v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .eq => |b| p("    {d:4}: eq v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .ne => |b| p("    {d:4}: ne v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .lt_s => |b| p("    {d:4}: lt_s v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .lt_u => |b| p("    {d:4}: lt_u v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .gt_s => |b| p("    {d:4}: gt_s v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .gt_u => |b| p("    {d:4}: gt_u v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .le_s => |b| p("    {d:4}: le_s v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .le_u => |b| p("    {d:4}: le_u v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .ge_s => |b| p("    {d:4}: ge_s v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .ge_u => |b| p("    {d:4}: ge_u v{d}, v{d}  {s}\n", .{ pos, b.lhs, b.rhs, dest_alloc }),
+                .eqz => |v| p("    {d:4}: eqz v{d}  {s}\n", .{ pos, v, dest_alloc }),
+                .local_get => |idx| p("    {d:4}: local_get {d}  {s}\n", .{ pos, idx, dest_alloc }),
+                .local_set => |ls| p("    {d:4}: local_set {d}, v{d}\n", .{ pos, ls.idx, ls.val }),
+                .load => |ld| p("    {d:4}: load size={d} se={any} v{d}+{d}  {s}\n", .{ pos, ld.size, ld.sign_extend, ld.base, ld.offset, dest_alloc }),
+                .store => |st| p("    {d:4}: store size={d} v{d}+{d}, v{d}\n", .{ pos, st.size, st.base, st.offset, st.val }),
+                .br => |tgt| p("    {d:4}: br block{d}\n", .{ pos, tgt }),
+                .br_if => |b| p("    {d:4}: br_if v{d} ? block{d} : block{d}\n", .{ pos, b.cond, b.then_block, b.else_block }),
+                .br_table => |bt| p("    {d:4}: br_table v{d} default=block{d} (ntargets={d})\n", .{ pos, bt.index, bt.default, bt.targets.len }),
+                .ret => |rv| {
+                    if (rv) |v| p("    {d:4}: ret v{d}\n", .{ pos, v }) else p("    {d:4}: ret\n", .{pos});
+                },
+                .call => |cl| {
+                    const kind = if (cl.func_idx < import_count) "import" else "func";
+                    p("    {d:4}: call {s}[{d}] nargs={d}  {s}\n", .{ pos, kind, cl.func_idx, cl.args.len, dest_alloc });
+                },
+                .call_indirect => |ci| p("    {d:4}: call_indirect type={d} v{d} nargs={d}  {s}\n", .{ pos, ci.type_idx, ci.elem_idx, ci.args.len, dest_alloc }),
+                .select => |sel| p("    {d:4}: select cond=v{d} t=v{d} f=v{d}  {s}\n", .{ pos, sel.cond, sel.if_true, sel.if_false, dest_alloc }),
+                .global_get => |idx| p("    {d:4}: global_get {d}  {s}\n", .{ pos, idx, dest_alloc }),
+                .global_set => |gs| p("    {d:4}: global_set {d}, v{d}\n", .{ pos, gs.idx, gs.val }),
+                else => p("    {d:4}: <op tag={s}>  {s}\n", .{ pos, @tagName(inst.op), dest_alloc }),
+            }
+            pos += 1;
+        }
+    }
+    p("=== END DUMP func[{d}] ===\n", .{fi});
+}
+
 /// Compile all functions in an IR module to x86-64 machine code.
 /// After compiling all functions, patches inter-function call sites.
 pub fn compileModule(ir_module: *const ir.IrModule, allocator: std.mem.Allocator) !CompileResult {
@@ -874,7 +963,7 @@ pub fn compileModule(ir_module: *const ir.IrModule, allocator: std.mem.Allocator
     var global_call_patches: std.ArrayList(GlobalCallPatch) = .empty;
     defer global_call_patches.deinit(allocator);
 
-    for (ir_module.functions.items) |func| {
+    for (ir_module.functions.items, 0..) |func, fi| {
         const func_start = all_code.items.len;
         try offsets.append(allocator, @intCast(func_start));
 
@@ -882,6 +971,12 @@ pub fn compileModule(ir_module: *const ir.IrModule, allocator: std.mem.Allocator
         const result = try compileFunctionRA(&func, ir_module.import_count, allocator);
         defer allocator.free(result.code);
         defer allocator.free(result.call_patches);
+
+        // Debug: dump IR+alloc for selected function index (-1 disables).
+        const dump_func_idx: i32 = -1;
+        if (@as(i32, @intCast(fi)) == dump_func_idx) {
+            dumpFuncIRAlloc(&func, @intCast(fi), ir_module.import_count, allocator) catch {};
+        }
 
         // Accumulate call patches with global offsets
         for (result.call_patches) |patch| {

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -45,6 +45,61 @@ const vmctx_host_functions_field: i32 = 24; // VmCtx.host_functions_ptr offset
 const vmctx_mem_max_size_field: i32 = 32; // VmCtx.memory_max_size offset
 const vmctx_func_table_field: i32 = 40; // VmCtx.func_table_ptr offset
 const vmctx_mem_pages_field: i32 = 56; // VmCtx.memory_pages offset (u32)
+const vmctx_mem_grow_fn_field: i32 = 64; // VmCtx.mem_grow_fn offset (usize)
+const vmctx_instance_ptr_field: i32 = 72; // VmCtx.instance_ptr offset (usize)
+const vmctx_trap_oob_fn_field: i32 = 80; // VmCtx.trap_oob_fn offset (usize)
+
+/// Emit an inline wasm-memory bounds check.
+///
+/// Preconditions:
+///   - `rax` holds `wasm_addr` already zero-extended to 64 bits (u32 → u64).
+///   - `r10` holds the `VmCtx*` pointer.
+///
+/// Effect:
+///   - Computes `end = wasm_addr + end_offset` in `r11`, where
+///     `end_offset = static_offset + access_size` supplied by the caller.
+///   - Compares `end` with `VmCtx.memory_size` and, if strictly greater,
+///     calls `vmctx.trap_oob_fn(vmctx)` which does not return.
+///   - Preserves `rax` (the wasm_addr) so the caller can continue to add
+///     `mem_base` to it. Preserves `r10` so the caller can subsequently
+///     load `mem_base` via `mov r10, [r10 + membase]`.
+///   - Clobbers `r11` (non-allocatable scratch) and `param_regs[0]`
+///     (Win64: rcx, reserved scratch / SysV: rdi, caller-saved).
+fn emitMemBoundsCheck(code: *emit.CodeBuffer, end_offset: u64) !void {
+    // r11 = rax + end_offset (64-bit).
+    if (end_offset == 0) {
+        // mov r11, rax  (REX.W|B + 0x89 + modrm 11_000_011)
+        try code.emitSlice(&.{ 0x49, 0x89, 0xC3 });
+    } else if (end_offset <= 0x7FFFFFFF) {
+        // lea r11, [rax + disp32]  (REX.W|R + 0x8D + modrm 10_011_000 + disp32)
+        try code.emitSlice(&.{ 0x4C, 0x8D, 0x98 });
+        try code.emitI32(@intCast(end_offset));
+    } else {
+        // For unusually large static offsets: mov r11, imm64; add r11, rax.
+        try code.emitSlice(&.{ 0x49, 0xBB }); // mov r11, imm64
+        var i: u8 = 0;
+        while (i < 8) : (i += 1) {
+            try code.emitByte(@intCast((end_offset >> @as(u6, @intCast(i * 8))) & 0xFF));
+        }
+        // add r11, rax  (REX.W|B + 0x01 + modrm 11_000_011)
+        try code.emitSlice(&.{ 0x49, 0x01, 0xC3 });
+    }
+    // cmp r11, qword ptr [r10 + memsize_field]
+    //   REX.W|R|B=4D, opcode 0x3B, modrm=01_011_010 (mod=disp8, reg=r11 low=3,
+    //   rm=r10 low=2), disp8=memsize_field.
+    try code.emitSlice(&.{ 0x4D, 0x3B, 0x5A, @as(u8, @intCast(vmctx_memsize_field)) });
+    // jbe over_trap (rel8). Trap block size is 3 + 7 + 2 = 12 bytes below.
+    try code.emitByte(0x76);
+    try code.emitByte(12);
+    // Trap block:
+    //   mov param_regs[0], r10            ; arg0 = vmctx (already in r10)
+    //   mov rax, [param_regs[0] + trap_oob_fn_field]
+    //   call rax                          ; noreturn
+    try code.movRegReg(param_regs[0], .r10);
+    try code.movRegMem(.rax, param_regs[0], vmctx_trap_oob_fn_field);
+    try code.callReg(.rax);
+    // over_trap:
+}
 
 /// Register-caching operand stack. Keeps the top N values in registers,
 /// eliminating redundant store-load pairs. Falls back to memory (via RBP
@@ -873,7 +928,7 @@ fn dumpFuncIRAlloc(func: *const ir.IrFunction, fi: u32, import_count: u32, alloc
     for (func.blocks.items) |block| {
         for (block.instructions.items) |ci| {
             switch (ci.op) {
-                .call, .call_indirect => {
+                .call, .call_indirect, .memory_grow => {
                     const mask = if (comptime builtin.os.tag == .windows)
                         [_]bool{ true, false, false, true, true, false, false }
                     else
@@ -1026,8 +1081,10 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
         for (func.blocks.items) |block| {
             for (block.instructions.items) |ci| {
                 switch (ci.op) {
-                    .call, .call_indirect => {
+                    .call, .call_indirect, .memory_grow => {
                         // Calls clobber caller-saved allocatable regs.
+                        // memory.grow is compiled as a host call, same ABI, so it
+                        // clobbers the same set of caller-saved registers.
                         // alloc_regs = [rdx(2), rsi(6), rdi(7), r8(8), r9(9), r12(12), r13(13)]
                         // On Win64: rdx, r8, r9 are volatile (indices 0, 3, 4); rsi/rdi/r12/r13 callee-saved.
                         // On SysV: rdx, rsi, rdi, r8, r9 are volatile; r12, r13 callee-saved.
@@ -1260,6 +1317,103 @@ fn useVReg(
             try code.movRegMem(scratch, .rbp, offset);
             return scratch;
         },
+    }
+}
+
+/// Emit parallel move of wasm call args into Win64/SysV param_regs[1..].
+/// `args[i]` is placed in `param_regs[i + 1]`. Handles arbitrary source/dest
+/// reg overlaps (including cycles) by:
+///   1. For each arg, find its current location (a phys reg or a spill slot).
+///   2. Emit reg→reg moves in topological order; break cycles via .r10.
+///   3. Load spill-slot args directly into their final param reg.
+/// `.r10` is used as scratch — it is never an allocatable register nor a
+/// param reg, so using it here is always safe.
+fn emitCallRegArgMoves(
+    code: *emit.CodeBuffer,
+    alloc_result: *const regalloc.AllocResult,
+    args: []const ir.VReg,
+    max_reg_args: u32,
+) !void {
+    const ArgInfo = struct {
+        source: emit.Reg,
+        is_stack: bool,
+        stack_offset: i32,
+        target: emit.Reg,
+    };
+    var infos: [6]ArgInfo = undefined;
+    var i: u32 = 0;
+    while (i < max_reg_args) : (i += 1) {
+        const target = param_regs[i + 1];
+        if (alloc_result.get(args[i])) |a| switch (a) {
+            .reg => |preg| infos[i] = .{
+                .source = @enumFromInt(preg),
+                .is_stack = false,
+                .stack_offset = 0,
+                .target = target,
+            },
+            .stack => |off| infos[i] = .{
+                .source = target,
+                .is_stack = true,
+                .stack_offset = off,
+                .target = target,
+            },
+        } else {
+            infos[i] = .{ .source = target, .is_stack = false, .stack_offset = 0, .target = target };
+        }
+    }
+
+    // Phase 1: reg→reg parallel move (topological; cycles broken via .r10).
+    var pending: [6]bool = .{ false, false, false, false, false, false };
+    i = 0;
+    while (i < max_reg_args) : (i += 1) {
+        if (!infos[i].is_stack and infos[i].source != infos[i].target) pending[i] = true;
+    }
+    while (true) {
+        var progress = false;
+        var k: u32 = 0;
+        while (k < max_reg_args) : (k += 1) {
+            if (!pending[k]) continue;
+            var blocked = false;
+            var m: u32 = 0;
+            while (m < max_reg_args) : (m += 1) {
+                if (m == k or !pending[m]) continue;
+                if (infos[m].source == infos[k].target) {
+                    blocked = true;
+                    break;
+                }
+            }
+            if (!blocked) {
+                try code.movRegReg(infos[k].target, infos[k].source);
+                pending[k] = false;
+                progress = true;
+            }
+        }
+        var any = false;
+        var p: u32 = 0;
+        while (p < max_reg_args) : (p += 1) if (pending[p]) {
+            any = true;
+            break;
+        };
+        if (!any) break;
+        if (!progress) {
+            // Break a cycle: save one source to .r10 and remap references.
+            var first: u32 = 0;
+            while (first < max_reg_args) : (first += 1) if (pending[first]) break;
+            try code.movRegReg(.r10, infos[first].source);
+            const old = infos[first].source;
+            var u: u32 = 0;
+            while (u < max_reg_args) : (u += 1) {
+                if (pending[u] and infos[u].source == old) infos[u].source = .r10;
+            }
+        }
+    }
+
+    // Phase 2: load spill-slot args directly into their target param reg.
+    i = 0;
+    while (i < max_reg_args) : (i += 1) {
+        if (infos[i].is_stack) {
+            try code.movRegMem(infos[i].target, .rbp, infos[i].stack_offset);
+        }
     }
 }
 
@@ -1600,11 +1754,7 @@ fn compileInstRA(
                     const arg_reg = try useVReg(code, alloc_result, cl.args[max_reg_args + j], .r10);
                     try code.movMemReg(.rsp, @intCast(shadow + j * 8), arg_reg);
                 }
-                var i: u32 = 0;
-                while (i < max_reg_args) : (i += 1) {
-                    const arg_reg = try useVReg(code, alloc_result, cl.args[i], .r10);
-                    if (arg_reg != param_regs[i + 1]) try code.movRegReg(param_regs[i + 1], arg_reg);
-                }
+                try emitCallRegArgMoves(code, alloc_result, cl.args, max_reg_args);
                 try code.callReg(.rax);
                 if (stack_adjust > 0) try code.addRegImm32(.rsp, @intCast(stack_adjust));
             } else {
@@ -1612,16 +1762,12 @@ fn compileInstRA(
                 try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
 
                 if (stack_adjust > 0) try code.subRegImm32(.rsp, @intCast(stack_adjust));
-                var j: u32 = 0;
-                while (j < extra) : (j += 1) {
-                    const arg_reg = try useVReg(code, alloc_result, cl.args[max_reg_args + j], .r10);
-                    try code.movMemReg(.rsp, @intCast(shadow + j * 8), arg_reg);
+                var j2: u32 = 0;
+                while (j2 < extra) : (j2 += 1) {
+                    const arg_reg = try useVReg(code, alloc_result, cl.args[max_reg_args + j2], .r10);
+                    try code.movMemReg(.rsp, @intCast(shadow + j2 * 8), arg_reg);
                 }
-                var i: u32 = 0;
-                while (i < max_reg_args) : (i += 1) {
-                    const arg_reg = try useVReg(code, alloc_result, cl.args[i], .r10);
-                    if (arg_reg != param_regs[i + 1]) try code.movRegReg(param_regs[i + 1], arg_reg);
-                }
+                try emitCallRegArgMoves(code, alloc_result, cl.args, max_reg_args);
                 try code.emitByte(0xE8);
                 const patch_off = code.len();
                 try code.emitI32(0);
@@ -1675,11 +1821,7 @@ fn compileInstRA(
                 const arg_reg = try useVReg(code, alloc_result, ci.args[max_reg_args + j], .r10);
                 try code.movMemReg(.rsp, @intCast(shadow + j * 8), arg_reg);
             }
-            var i: u32 = 0;
-            while (i < max_reg_args) : (i += 1) {
-                const arg_reg = try useVReg(code, alloc_result, ci.args[i], .r10);
-                if (arg_reg != param_regs[i + 1]) try code.movRegReg(param_regs[i + 1], arg_reg);
-            }
+            try emitCallRegArgMoves(code, alloc_result, ci.args, max_reg_args);
             try code.callReg(.r11);
             if (stack_adjust > 0) try code.addRegImm32(.rsp, @intCast(stack_adjust));
 
@@ -1691,12 +1833,16 @@ fn compileInstRA(
         // ── Memory ────────────────────────────────────────────────────
         .load => |ld| {
             const dest = inst.dest orelse return;
-            // Load memory base from VMContext frame slot, add wasm offset
+            // Load memory base from VMContext frame slot, add wasm offset.
+            // Bounds check is inserted between vmctx load and mem_base load so
+            // the check can read VmCtx.memory_size while r10 still holds the
+            // VmCtx pointer.
             try code.movRegMem(.r10, .rbp, vmctx_offset); // load VmCtx*
-            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base
             const base_reg = try useVReg(code, alloc_result, ld.base, .rax);
             if (base_reg != .rax) try code.movRegReg(.rax, base_reg);
             try code.zeroExtend32(.rax); // wasm addresses are i32
+            try emitMemBoundsCheck(code, @as(u64, ld.offset) + @as(u64, ld.size));
+            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base
             try code.addRegReg(.rax, .r10); // rax = mem_base + wasm_addr
             // Load value into dest register (address is in rax); fold offset into disp.
             const dr = destReg(alloc_result, dest);
@@ -1720,12 +1866,16 @@ fn compileInstRA(
         },
         .store => |st| {
             // Load memory base from VMContext frame slot into r10.
+            // Bounds check is inserted between vmctx load and mem_base load so
+            // the check can read VmCtx.memory_size while r10 still holds the
+            // VmCtx pointer.
             try code.movRegMem(.r10, .rbp, vmctx_offset); // load VmCtx*
-            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base
             // Compute final address in rax (not allocatable — safe to clobber).
             const base_reg = try useVReg(code, alloc_result, st.base, .rax);
             if (base_reg != .rax) try code.movRegReg(.rax, base_reg);
             try code.zeroExtend32(.rax); // wasm addresses are i32
+            try emitMemBoundsCheck(code, @as(u64, st.offset) + @as(u64, st.size));
+            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base
             try code.addRegReg(.rax, .r10); // rax = mem_base + wasm_addr
             // Load value into rcx (not allocatable — safe to clobber).
             // useVReg writes spill loads into scratch=.rcx, so rax is preserved.
@@ -1777,29 +1927,27 @@ fn compileInstRA(
         },
         .memory_grow => |pages_vreg| {
             const dest = inst.dest orelse return;
-            // Load requested pages into rcx
-            const pages_reg = try useVReg(code, alloc_result, pages_vreg, .rcx);
-            if (pages_reg != .rcx) try code.movRegReg(.rcx, pages_reg);
-            try code.zeroExtend32(.rcx);
+            // Call the host grow helper via vmctx.mem_grow_fn(vmctx, delta_pages).
+            // Win64 ABI: RCX=vmctx, RDX=delta_pages, shadow space = 32 bytes.
+            // The regalloc treats this op as a call (see clobber point collection),
+            // so no caller-saved vregs are live across this instruction.
+            const pages_reg = try useVReg(code, alloc_result, pages_vreg, .rdx);
+            if (pages_reg != .rdx) try code.movRegReg(.rdx, pages_reg);
+            try code.zeroExtend32(.rdx);
 
-            // Load VmCtx and current pages
-            try code.movRegMem(.r10, .rbp, vmctx_offset);
-            try code.movRegMemNoRex(.rax, .r10, vmctx_mem_pages_field); // old_pages
-            try code.movRegReg(.r11, .rax); // save old_pages in r11
+            // Load vmctx into rcx.
+            try code.movRegMem(.rcx, .rbp, vmctx_offset);
+            // Load grow helper pointer into rax.
+            try code.movRegMem(.rax, .rcx, vmctx_mem_grow_fn_field);
 
-            // new_pages = old_pages + requested
-            try code.addRegReg(.rax, .rcx); // rax = new_pages
+            const shadow: u32 = if (comptime builtin.os.tag == .windows) 32 else 0;
+            const stack_adjust: u32 = (shadow + 15) & ~@as(u32, 15);
+            if (stack_adjust > 0) try code.subRegImm32(.rsp, @intCast(stack_adjust));
+            try code.callReg(.rax);
+            if (stack_adjust > 0) try code.addRegImm32(.rsp, @intCast(stack_adjust));
 
-            // Update VmCtx.memory_pages = new_pages (always succeed, memory is pre-allocated)
-            try code.movMemRegNoRex(.r10, vmctx_mem_pages_field, .rax);
-
-            // Update VmCtx.memory_size = new_pages * 65536
-            try code.emitSlice(&.{ 0x48, 0xC1, 0xE0, 0x10 }); // shl rax, 16
-            try code.movMemReg(.r10, vmctx_memsize_field, .rax);
-
-            // Return old_pages
-            try code.movRegReg(.rax, .r11);
-
+            // Helper returns i32 (old pages or -1); sign-extend not needed since
+            // writeDefTyped honors inst.type and consumers use 32-bit semantics.
             try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
         },
 
@@ -3465,4 +3613,226 @@ test "compileFunctionRA: caller passes >3 args via stack on Win64" {
     // sub rsp, imm32 (48 81 EC ??) or sub rsp, imm8 (48 83 EC ??) in caller.
     // Just assert the caller compiled successfully with nonzero size.
     try std.testing.expect(result.code.len > 32);
+}
+
+// ── Parallel-copy correctness for call arg materialization (regression tests) ──
+//
+// These tests exercise `emitCallRegArgMoves` directly. The bug fixed here was:
+// a naive left-to-right `mov param_regs[i+1], src(arg[i])` sequence clobbered
+// `arg[j]` (j > i) when `src(arg[j]) == param_regs[i+1]`. Observed in coremark
+// at the malloc→alloc call: `mov rdx, rdi` (arg0) clobbered arg1's value (4,
+// previously placed in rdx by the allocator), yielding `alloc(size+16,
+// size+16)` instead of `alloc(size+16, 4)`.
+
+fn makeAllocResult(allocator: std.mem.Allocator, mapping: []const struct { vreg: ir.VReg, reg: regalloc.PhysReg }) !regalloc.AllocResult {
+    var map = std.AutoHashMap(ir.VReg, regalloc.Allocation).init(allocator);
+    for (mapping) |m| try map.put(m.vreg, .{ .reg = m.reg });
+    return .{ .assignments = map, .spill_count = 0 };
+}
+
+test "emitCallRegArgMoves: resolves arg[0]→rdx / arg[1]→r8 when arg[1] source is rdx" {
+    // Scenario from coremark malloc→alloc: RA placed arg[1] in rdx
+    // (param_regs[1], = arg[0]'s target). Naive sequential copy would
+    // `mov rdx, rdi` (arg0) first, clobbering the 4 in rdx, then `mov r8, rdx`
+    // would pick up the clobbered value. The fixed emitter must move arg[1]
+    // (src=rdx → r8) BEFORE arg[0] (src=rdi → rdx).
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    var alloc_result = try makeAllocResult(allocator, &.{
+        .{ .vreg = 0, .reg = 7 }, // arg[0] in rdi
+        .{ .vreg = 1, .reg = 2 }, // arg[1] in rdx
+    });
+    defer alloc_result.deinit();
+
+    var code = emit.CodeBuffer.init(allocator);
+    defer code.deinit();
+
+    const args = [_]ir.VReg{ 0, 1 };
+    try emitCallRegArgMoves(&code, &alloc_result, &args, 2);
+    const bytes = code.bytes.items;
+
+    // Correct emission: `mov r8, rdx` (49 89 D0) must precede `mov rdx, rdi`
+    // (48 89 FA) so that arg[1]'s value is saved before arg[0]'s move
+    // overwrites rdx.
+    const mov_r8_rdx = [_]u8{ 0x49, 0x89, 0xD0 };
+    const mov_rdx_rdi = [_]u8{ 0x48, 0x89, 0xFA };
+    const idx_r8 = std.mem.indexOf(u8, bytes, &mov_r8_rdx) orelse return error.TestExpectedMovR8RdxEmitted;
+    const idx_rdx = std.mem.indexOf(u8, bytes, &mov_rdx_rdi) orelse return error.TestExpectedMovRdxRdiEmitted;
+    try std.testing.expect(idx_r8 < idx_rdx);
+}
+
+test "emitCallRegArgMoves: identity moves are elided" {
+    // When every arg[i] is already in param_regs[i+1], no moves should be emitted.
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    var alloc_result = try makeAllocResult(allocator, &.{
+        .{ .vreg = 0, .reg = 2 }, // arg[0] already in rdx = param_regs[1]
+        .{ .vreg = 1, .reg = 8 }, // arg[1] already in r8  = param_regs[2]
+        .{ .vreg = 2, .reg = 9 }, // arg[2] already in r9  = param_regs[3]
+    });
+    defer alloc_result.deinit();
+
+    var code = emit.CodeBuffer.init(allocator);
+    defer code.deinit();
+
+    const args = [_]ir.VReg{ 0, 1, 2 };
+    try emitCallRegArgMoves(&code, &alloc_result, &args, 3);
+    try std.testing.expectEqual(@as(usize, 0), code.bytes.items.len);
+}
+
+test "emitCallRegArgMoves: breaks 2-cycle via r10 scratch" {
+    // Cycle: arg[0] src=r8 → rdx; arg[1] src=rdx → r8. No topological order
+    // exists; the fix must save one source into r10, then finish the copy.
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    var alloc_result = try makeAllocResult(allocator, &.{
+        .{ .vreg = 0, .reg = 8 }, // arg[0] in r8  (= arg[1]'s target)
+        .{ .vreg = 1, .reg = 2 }, // arg[1] in rdx (= arg[0]'s target)
+    });
+    defer alloc_result.deinit();
+
+    var code = emit.CodeBuffer.init(allocator);
+    defer code.deinit();
+
+    const args = [_]ir.VReg{ 0, 1 };
+    try emitCallRegArgMoves(&code, &alloc_result, &args, 2);
+    const bytes = code.bytes.items;
+
+    // Must emit three moves: save one source to r10, then two final moves.
+    // Our algorithm picks the first pending (arg[0], src=r8) as the breaker:
+    //   mov r10, r8   (4D 89 C2)
+    //   mov r8, rdx   (49 89 D0)   ← arg[1]: src=rdx, dst=r8
+    //   mov rdx, r10  (4C 89 D2)   ← arg[0]: src=r10 (was r8), dst=rdx
+    // Whatever the chosen breaker, *some* move into r10 must appear, and the
+    // final register state (rdx := old_r8, r8 := old_rdx) must be achievable.
+    const mov_r10_r8 = [_]u8{ 0x4D, 0x89, 0xC2 }; // r10 <- r8
+    const mov_r10_rdx = [_]u8{ 0x49, 0x89, 0xD2 }; // r10 <- rdx
+    const has_breaker =
+        std.mem.indexOf(u8, bytes, &mov_r10_r8) != null or
+        std.mem.indexOf(u8, bytes, &mov_r10_rdx) != null;
+    try std.testing.expect(has_breaker);
+    // And the buggy naive sequence `mov rdx, r8; mov r8, rdx` must NOT appear
+    // back-to-back (that would clobber r8 before reading it).
+    const mov_rdx_r8 = [_]u8{ 0x4C, 0x89, 0xC2 }; // rdx <- r8
+    const mov_r8_rdx = [_]u8{ 0x49, 0x89, 0xD0 }; // r8  <- rdx
+    const idx_rdx_r8 = std.mem.indexOf(u8, bytes, &mov_rdx_r8);
+    const idx_r8_rdx = std.mem.indexOf(u8, bytes, &mov_r8_rdx);
+    if (idx_rdx_r8) |a| if (idx_r8_rdx) |b| {
+        // If both appear, `mov rdx, r8` must NOT be immediately before
+        // `mov r8, rdx` (which would be the buggy clobbering sequence).
+        try std.testing.expect(!(a + 3 == b));
+    };
+}
+
+test "emitCallRegArgMoves: regression — arg[0]=rdi, arg[1]=rdx, arg[2]=rcx (coremark malloc→alloc)" {
+    // Exact shape observed in the bug: caller emits arg[0] from rdi,
+    // arg[1] from rdx, and vmctx is already in rcx (we don't include vmctx
+    // in the reg-arg move set — the call emitter handles vmctx separately).
+    // This regression test asserts the fix does not re-introduce the
+    // clobber pattern `mov rdx, rdi` followed by `mov r8, rdx`.
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    var alloc_result = try makeAllocResult(allocator, &.{
+        .{ .vreg = 0, .reg = 7 }, // arg[0] in rdi
+        .{ .vreg = 1, .reg = 2 }, // arg[1] in rdx (the bug case)
+    });
+    defer alloc_result.deinit();
+
+    var code = emit.CodeBuffer.init(allocator);
+    defer code.deinit();
+
+    const args = [_]ir.VReg{ 0, 1 };
+    try emitCallRegArgMoves(&code, &alloc_result, &args, 2);
+    const bytes = code.bytes.items;
+
+    // Assert the buggy adjacency (`48 89 FA` then `49 89 D0`) is absent.
+    const mov_rdx_rdi = [_]u8{ 0x48, 0x89, 0xFA };
+    if (std.mem.indexOf(u8, bytes, &mov_rdx_rdi)) |a| {
+        const mov_r8_rdx = [_]u8{ 0x49, 0x89, 0xD0 };
+        if (std.mem.indexOf(u8, bytes, &mov_r8_rdx)) |b| {
+            // The buggy pre-fix emitter produced `mov rdx, rdi; mov r8, rdx`
+            // (clobbering). The fixed emitter produces `mov r8, rdx; mov rdx, rdi`.
+            try std.testing.expect(b < a);
+        }
+    }
+}
+
+
+
+test "compileFunctionRA: i32.load emits inline memory bounds check" {
+    // A wasm memory load must emit an inline bounds check before reading,
+    // so out-of-bounds access traps cleanly via vmctx.trap_oob_fn() rather
+    // than SIGSEGVing on unmapped host memory.
+    //
+    // The fixed bounds-check sequence we expect to see (before the load):
+    //   lea r11, [rax + (offset + size)]     ; 4C 8D 98 <disp32>
+    //   cmp r11, [r10 + memsize_field=8]     ; 4D 3B 5A 08
+    //   jbe  +12                             ; 76 0C
+    //   mov  param_regs[0], r10              ; 4C 89 D1 (Win64) / 4C 89 D7 (SysV)
+    //   mov  rax, [param_regs[0] + trap_fn=80] ; 48 8B 81 50 00 00 00 (Win64)
+    //   call rax                             ; FF D0
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = v0, .type = .i32 });
+    // i32.load16_u at offset=0, size=2 → end_offset = 2.
+    try block.append(.{ .op = .{ .load = .{ .base = v0, .offset = 0, .size = 2, .sign_extend = false } }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v1 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // lea r11, [rax + 2] → 4C 8D 98 02 00 00 00
+    try std.testing.expect(containsBytes(code, &.{ 0x4C, 0x8D, 0x98, 0x02, 0x00, 0x00, 0x00 }));
+    // cmp r11, [r10 + 8]   → 4D 3B 5A 08
+    try std.testing.expect(containsBytes(code, &.{ 0x4D, 0x3B, 0x5A, 0x08 }));
+    // jbe +12              → 76 0C
+    try std.testing.expect(containsBytes(code, &.{ 0x76, 0x0C }));
+    // call qword ptr [vmctx + 80] is encoded as a two-step load+callReg.
+    // mov rax, [p0 + 80] fragment `48 8B ?? 50 00 00 00` + call rax (FF D0).
+    // Verify `call rax` is present (FF D0).
+    try std.testing.expect(containsBytes(code, &.{ 0xFF, 0xD0 }));
+}
+
+test "compileFunctionRA: i32.store emits inline memory bounds check" {
+    // Symmetric to the load case: stores must also bounds-check before
+    // dereferencing. Verify the same lea/cmp/jbe trap dispatch pattern.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 42 }, .dest = v1, .type = .i32 });
+    // i32.store at offset=0, size=4 → end_offset = 4.
+    try block.append(.{ .op = .{ .store = .{ .base = v0, .val = v1, .offset = 0, .size = 4 } } });
+    try block.append(.{ .op = .{ .ret = null } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // lea r11, [rax + 4] → 4C 8D 98 04 00 00 00
+    try std.testing.expect(containsBytes(code, &.{ 0x4C, 0x8D, 0x98, 0x04, 0x00, 0x00, 0x00 }));
+    // cmp r11, [r10 + 8]
+    try std.testing.expect(containsBytes(code, &.{ 0x4D, 0x3B, 0x5A, 0x08 }));
+    // jbe +12
+    try std.testing.expect(containsBytes(code, &.{ 0x76, 0x0C }));
+    // call rax (trap dispatch)
+    try std.testing.expect(containsBytes(code, &.{ 0xFF, 0xD0 }));
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -49,6 +49,35 @@ const vmctx_mem_grow_fn_field: i32 = 64; // VmCtx.mem_grow_fn offset (usize)
 const vmctx_instance_ptr_field: i32 = 72; // VmCtx.instance_ptr offset (usize)
 const vmctx_trap_oob_fn_field: i32 = 80; // VmCtx.trap_oob_fn offset (usize)
 
+/// Emit the compare-and-trap tail of a bounds check.
+///
+/// Assumes the end-of-access address has just been materialized in `r11`
+/// and `r10` still holds the `VmCtx*` pointer. Emits:
+///   cmp r11, [r10 + memsize_field]
+///   jbe over_trap
+///   mov param_regs[0], r10
+///   mov rax, [param_regs[0] + trap_oob_fn_field]
+///   call rax                 ; noreturn
+/// The `jbe` rel8 is hard-coded to skip 12 bytes — the fixed size of the
+/// trap block below (3 + 7 + 2).
+fn emitOobCmpAndTrap(code: *emit.CodeBuffer) !void {
+    // cmp r11, qword ptr [r10 + memsize_field]
+    //   REX.W|R|B=4D, opcode 0x3B, modrm=01_011_010 (mod=disp8, reg=r11 low=3,
+    //   rm=r10 low=2), disp8=memsize_field.
+    try code.emitSlice(&.{ 0x4D, 0x3B, 0x5A, @as(u8, @intCast(vmctx_memsize_field)) });
+    // jbe over_trap (rel8). Trap block size is 3 + 7 + 2 = 12 bytes below.
+    try code.emitByte(0x76);
+    try code.emitByte(12);
+    // Trap block:
+    //   mov param_regs[0], r10            ; arg0 = vmctx (already in r10)
+    //   mov rax, [param_regs[0] + trap_oob_fn_field]
+    //   call rax                          ; noreturn
+    try code.movRegReg(param_regs[0], .r10);
+    try code.movRegMem(.rax, param_regs[0], vmctx_trap_oob_fn_field);
+    try code.callReg(.rax);
+    // over_trap:
+}
+
 /// Emit an inline wasm-memory bounds check.
 ///
 /// Preconditions:
@@ -84,21 +113,30 @@ fn emitMemBoundsCheck(code: *emit.CodeBuffer, end_offset: u64) !void {
         // add r11, rax  (REX.W|B + 0x01 + modrm 11_000_011)
         try code.emitSlice(&.{ 0x49, 0x01, 0xC3 });
     }
-    // cmp r11, qword ptr [r10 + memsize_field]
-    //   REX.W|R|B=4D, opcode 0x3B, modrm=01_011_010 (mod=disp8, reg=r11 low=3,
-    //   rm=r10 low=2), disp8=memsize_field.
-    try code.emitSlice(&.{ 0x4D, 0x3B, 0x5A, @as(u8, @intCast(vmctx_memsize_field)) });
-    // jbe over_trap (rel8). Trap block size is 3 + 7 + 2 = 12 bytes below.
-    try code.emitByte(0x76);
-    try code.emitByte(12);
-    // Trap block:
-    //   mov param_regs[0], r10            ; arg0 = vmctx (already in r10)
-    //   mov rax, [param_regs[0] + trap_oob_fn_field]
-    //   call rax                          ; noreturn
-    try code.movRegReg(param_regs[0], .r10);
-    try code.movRegMem(.rax, param_regs[0], vmctx_trap_oob_fn_field);
-    try code.callReg(.rax);
-    // over_trap:
+    try emitOobCmpAndTrap(code);
+}
+
+/// Emit a bounds check for a bulk memory op (memory.copy / memory.fill) where
+/// the length is held in a register, not known at compile time.
+///
+/// Preconditions:
+///   - `rax` holds the wasm base address, already zero-extended to u64.
+///   - `rcx` holds the byte length, already zero-extended to u64.
+///   - `r10` holds the `VmCtx*` pointer.
+///
+/// Effect:
+///   - Computes `end = rax + rcx` in `r11` and traps if
+///     `end > VmCtx.memory_size` by calling the `trap_oob_fn`.
+///   - Per the wasm spec, `end` cannot overflow u64 because both inputs are
+///     ≤ 2^32 − 1, so `rax + rcx` ≤ 2^33 − 2 < 2^64.
+///   - Preserves `rax`, `rcx`, `r10`. Clobbers `r11` and `param_regs[0]`.
+fn emitMemBoundsCheckDynamic(code: *emit.CodeBuffer) !void {
+    // lea r11, [rax + rcx] — 64-bit, 3 bytes
+    //   REX.W|R = 0x4C, opcode 0x8D,
+    //   modrm=00_011_100 (mod=0, reg=r11 low=3, rm=100 ⇒ SIB),
+    //   SIB=00_001_000 (scale=0, index=rcx=1, base=rax=0)
+    try code.emitSlice(&.{ 0x4C, 0x8D, 0x1C, 0x08 });
+    try emitOobCmpAndTrap(code);
 }
 
 /// Register-caching operand stack. Keeps the top N values in registers,
@@ -1886,31 +1924,55 @@ fn compileInstRA(
         },
         .memory_copy => |mc| {
             // REP MOVSB: rdi=dst, rsi=src, rcx=len
+            //
+            // Bounds check semantics (wasm spec): trap if either
+            //   src + len > mem_size  OR  dst + len > mem_size.
+            // We materialize len in rcx and each address in rax, call the
+            // dynamic bounds check for src, then again for dst, both while
+            // r10 still holds VmCtx*. Only afterwards do we replace r10
+            // with mem_base and fold it into rsi/rdi for REP MOVSB.
             try code.movRegMem(.r10, .rbp, vmctx_offset); // load VmCtx*
-            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base // memory base
             const len_reg = try useVReg(code, alloc_result, mc.len, .rcx);
             if (len_reg != .rcx) try code.movRegReg(.rcx, len_reg);
+            try code.zeroExtend32(.rcx); // wasm lengths are u32
             const src_reg = try useVReg(code, alloc_result, mc.src, .rsi);
             if (src_reg != .rsi) try code.movRegReg(.rsi, src_reg);
             try code.zeroExtend32(.rsi); // wasm addresses are i32
-            try code.addRegReg(.rsi, .r10); // rsi = mem_base + src
             const dst_reg = try useVReg(code, alloc_result, mc.dst, .rdi);
             if (dst_reg != .rdi) try code.movRegReg(.rdi, dst_reg);
             try code.zeroExtend32(.rdi); // wasm addresses are i32
+            // Bounds-check src: rax = src, rcx = len.
+            try code.movRegReg(.rax, .rsi);
+            try emitMemBoundsCheckDynamic(code);
+            // Bounds-check dst: rax = dst, rcx = len.
+            try code.movRegReg(.rax, .rdi);
+            try emitMemBoundsCheckDynamic(code);
+            // All checks passed — resolve mem_base and fold into src/dst.
+            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base
+            try code.addRegReg(.rsi, .r10); // rsi = mem_base + src
             try code.addRegReg(.rdi, .r10); // rdi = mem_base + dst
             try code.emitSlice(&.{ 0xF3, 0xA4 }); // REP MOVSB
         },
         .memory_fill => |mf| {
             // REP STOSB: rdi=dst, al=val, rcx=len
+            //
+            // Bounds check semantics (wasm spec): trap if dst + len > mem_size.
             try code.movRegMem(.r10, .rbp, vmctx_offset); // load VmCtx*
-            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base // memory base
             const len_reg = try useVReg(code, alloc_result, mf.len, .rcx);
             if (len_reg != .rcx) try code.movRegReg(.rcx, len_reg);
+            try code.zeroExtend32(.rcx); // wasm lengths are u32
             const val_reg = try useVReg(code, alloc_result, mf.val, .rax);
             if (val_reg != .rax) try code.movRegReg(.rax, val_reg);
             const dst_reg = try useVReg(code, alloc_result, mf.dst, .rdi);
             if (dst_reg != .rdi) try code.movRegReg(.rdi, dst_reg);
             try code.zeroExtend32(.rdi); // wasm addresses are i32
+            // Bounds-check dst: stash val in r11 while we clobber rax for
+            // the check, then restore it.
+            try code.movRegReg(.r11, .rax); // save fill byte
+            try code.movRegReg(.rax, .rdi);
+            try emitMemBoundsCheckDynamic(code);
+            try code.movRegReg(.rax, .r11); // restore fill byte into rax
+            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base
             try code.addRegReg(.rdi, .r10); // rdi = mem_base + dst
             try code.emitSlice(&.{ 0xF3, 0xAA }); // REP STOSB
         },

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -8,6 +8,7 @@ const ir = @import("ir/ir.zig");
 const Opcode = @import("../runtime/interpreter/opcode.zig").Opcode;
 const MiscOpcode = @import("../runtime/interpreter/opcode.zig").MiscOpcode;
 const AtomicOpcode = @import("../runtime/interpreter/opcode.zig").AtomicOpcode;
+const leb128 = @import("../shared/utils/leb128.zig");
 
 pub const LowerError = error{
     OutOfMemory,
@@ -1182,55 +1183,15 @@ fn skipOperands(code: []const u8, ip: *usize, op: Opcode) void {
 // ── LEB128 decoders ────────────────────────────────────────────────
 
 fn readU32(code: []const u8, ip_ptr: *usize) u32 {
-    var result: u32 = 0;
-    var shift: u32 = 0;
-    while (true) {
-        const byte = code[ip_ptr.*];
-        ip_ptr.* += 1;
-        result |= @as(u32, byte & 0x7F) << @as(u5, @intCast(shift));
-        if (byte & 0x80 == 0) break;
-        shift += 7;
-        if (shift >= 35) break;
-    }
-    return result;
+    return leb128.readUnsignedLossy(u32, code, ip_ptr);
 }
 
 fn readI32(code: []const u8, ip_ptr: *usize) i32 {
-    var result: u32 = 0;
-    var shift: u32 = 0;
-    var byte: u8 = 0;
-    while (true) {
-        byte = code[ip_ptr.*];
-        ip_ptr.* += 1;
-        result |= @as(u32, byte & 0x7F) << @as(u5, @intCast(shift));
-        shift += 7;
-        if (byte & 0x80 == 0) break;
-        if (shift >= 35) break;
-    }
-    // Sign-extend: bits above the consumed region should copy bit 6 of the final byte.
-    if (shift < 32 and (byte & 0x40) != 0) {
-        result |= @as(u32, 0xFFFFFFFF) << @as(u5, @intCast(shift));
-    }
-    return @bitCast(result);
+    return leb128.readSignedLossy(i32, code, ip_ptr);
 }
 
 fn readI64(code: []const u8, ip_ptr: *usize) i64 {
-    var result: u64 = 0;
-    var shift: u32 = 0;
-    var byte: u8 = 0;
-    while (true) {
-        byte = code[ip_ptr.*];
-        ip_ptr.* += 1;
-        result |= @as(u64, byte & 0x7F) << @as(u6, @intCast(shift));
-        shift += 7;
-        if (byte & 0x80 == 0) break;
-        if (shift >= 70) break;
-    }
-    // Sign-extend: bits above the consumed region should copy bit 6 of the final byte.
-    if (shift < 64 and (byte & 0x40) != 0) {
-        result |= @as(u64, 0xFFFFFFFFFFFFFFFF) << @as(u6, @intCast(shift));
-    }
-    return @bitCast(result);
+    return leb128.readSignedLossy(i64, code, ip_ptr);
 }
 
 // ── Tests ──────────────────────────────────────────────────────────
@@ -1248,7 +1209,7 @@ test "readI32 decodes signed LEB128 including single-byte negatives" {
         .{ .bytes = &.{0x40}, .expected = -64 },
         .{ .bytes = &.{ 0x80, 0x7F }, .expected = -128 },
         .{ .bytes = &.{ 0xFF, 0x7E }, .expected = -129 },
-        .{ .bytes = &.{ 0x80, 0x80, 0x80, 0x80, 0x08 }, .expected = @bitCast(@as(u32, 0x80000000)) }, // INT32_MIN
+        .{ .bytes = &.{ 0x80, 0x80, 0x80, 0x80, 0x78 }, .expected = @bitCast(@as(u32, 0x80000000)) }, // INT32_MIN
         .{ .bytes = &.{ 0xFF, 0xFF, 0xFF, 0xFF, 0x07 }, .expected = 0x7FFFFFFF }, // INT32_MAX
     };
     for (cases) |c| {

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -1203,11 +1203,11 @@ fn readI32(code: []const u8, ip_ptr: *usize) i32 {
         byte = code[ip_ptr.*];
         ip_ptr.* += 1;
         result |= @as(u32, byte & 0x7F) << @as(u5, @intCast(shift));
-        if (byte & 0x80 == 0) break;
         shift += 7;
+        if (byte & 0x80 == 0) break;
         if (shift >= 35) break;
     }
-    // Sign-extend if the sign bit of the last byte is set
+    // Sign-extend: bits above the consumed region should copy bit 6 of the final byte.
     if (shift < 32 and (byte & 0x40) != 0) {
         result |= @as(u32, 0xFFFFFFFF) << @as(u5, @intCast(shift));
     }
@@ -1222,11 +1222,11 @@ fn readI64(code: []const u8, ip_ptr: *usize) i64 {
         byte = code[ip_ptr.*];
         ip_ptr.* += 1;
         result |= @as(u64, byte & 0x7F) << @as(u6, @intCast(shift));
-        if (byte & 0x80 == 0) break;
         shift += 7;
-        if (shift >= 63) break;
+        if (byte & 0x80 == 0) break;
+        if (shift >= 70) break;
     }
-    // Sign-extend if the sign bit of the last byte is set
+    // Sign-extend: bits above the consumed region should copy bit 6 of the final byte.
     if (shift < 64 and (byte & 0x40) != 0) {
         result |= @as(u64, 0xFFFFFFFFFFFFFFFF) << @as(u6, @intCast(shift));
     }
@@ -1234,6 +1234,44 @@ fn readI64(code: []const u8, ip_ptr: *usize) i64 {
 }
 
 // ── Tests ──────────────────────────────────────────────────────────
+
+test "readI32 decodes signed LEB128 including single-byte negatives" {
+    // Coremark hits this with `i32.const -4` (single byte 0x7C) and
+    // `i32.const -1` (single byte 0x7F). Prior to the sign-extend fix,
+    // every single-byte negative value decoded as -1.
+    const cases = [_]struct { bytes: []const u8, expected: i32 }{
+        .{ .bytes = &.{0x00}, .expected = 0 },
+        .{ .bytes = &.{0x2A}, .expected = 42 },
+        .{ .bytes = &.{0x7F}, .expected = -1 },
+        .{ .bytes = &.{0x7E}, .expected = -2 },
+        .{ .bytes = &.{0x7C}, .expected = -4 }, // regression: used to decode as -1
+        .{ .bytes = &.{0x40}, .expected = -64 },
+        .{ .bytes = &.{ 0x80, 0x7F }, .expected = -128 },
+        .{ .bytes = &.{ 0xFF, 0x7E }, .expected = -129 },
+        .{ .bytes = &.{ 0x80, 0x80, 0x80, 0x80, 0x08 }, .expected = @bitCast(@as(u32, 0x80000000)) }, // INT32_MIN
+        .{ .bytes = &.{ 0xFF, 0xFF, 0xFF, 0xFF, 0x07 }, .expected = 0x7FFFFFFF }, // INT32_MAX
+    };
+    for (cases) |c| {
+        var ip: usize = 0;
+        const got = readI32(c.bytes, &ip);
+        try std.testing.expectEqual(c.expected, got);
+        try std.testing.expectEqual(c.bytes.len, ip);
+    }
+}
+
+test "readI64 decodes signed LEB128 including single-byte negatives" {
+    const cases = [_]struct { bytes: []const u8, expected: i64 }{
+        .{ .bytes = &.{0x7C}, .expected = -4 },
+        .{ .bytes = &.{0x7F}, .expected = -1 },
+        .{ .bytes = &.{ 0x80, 0x7F }, .expected = -128 },
+    };
+    for (cases) |c| {
+        var ip: usize = 0;
+        const got = readI64(c.bytes, &ip);
+        try std.testing.expectEqual(c.expected, got);
+        try std.testing.expectEqual(c.bytes.len, ip);
+    }
+}
 
 test "lower i32.const 42; end" {
     const allocator = std.testing.allocator;

--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -79,6 +79,11 @@ pub fn allocate(
 
     var spill_count: u32 = 0;
 
+    // Spill area must start AFTER the operand-stack area in the frame.
+    // Frame layout (compile.zig): [rbp-8]=VmCtx, [rbp-16..-(1+LC)*8]=locals (LC slots),
+    // [-(2+LC)*8..-(65+LC)*8]=op-stack (64 slots). Spills begin at -(66+LC)*8.
+    const spill_base: i32 = -@as(i32, @intCast((func.local_count + 66) * 8));
+
     for (ranges) |range| {
         // Expire old intervals that ended before this one starts
         expireOldIntervals(&active, range.start, &reg_free);
@@ -109,7 +114,7 @@ pub fn allocate(
             if (best_evict) |evict_idx| {
                 const evicted = active.orderedRemove(evict_idx);
                 const stolen_reg = evicted.reg_idx;
-                const spill_offset = computeSpillOffset(spill_count);
+                const spill_offset = spill_base - @as(i32, @intCast(spill_count * 8));
                 try assignments.put(evicted.vreg, .{ .stack = spill_offset });
                 spill_count += 1;
                 try assignments.put(range.vreg, .{ .reg = alloc_regs[stolen_reg] });
@@ -120,7 +125,7 @@ pub fn allocate(
                 });
             } else {
                 // No safe eviction candidate — spill the new interval
-                const spill_offset = computeSpillOffset(spill_count);
+                const spill_offset = spill_base - @as(i32, @intCast(spill_count * 8));
                 try assignments.put(range.vreg, .{ .stack = spill_offset });
                 spill_count += 1;
             }
@@ -188,12 +193,10 @@ fn insertActive(
     try active.insert(allocator, pos, interval);
 }
 
-/// Compute spill slot offset from RBP.
-/// Spill slots start after locals and operand stack area.
-/// `local_count` is needed to position spills after the local variable area.
+/// Compute spill slot offset from RBP (legacy helper; callers now use
+/// `spill_base` computed per-function in `allocate`). Kept for potential
+/// unit-test use with the default operand-stack budget of 64 slots.
 fn computeSpillOffset(spill_idx: u32) i32 {
-    // Spill area starts at [rbp - 600] to avoid conflicts with locals and operand stack.
-    // Each spill slot is 8 bytes.
     const spill_base: i32 = -600;
     return spill_base - @as(i32, @intCast(spill_idx * 8));
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -73,6 +73,9 @@ pub const passes = @import("compiler/ir/passes.zig");
 /// Spec test runner infrastructure.
 pub const spec_runner = @import("tests/spec_runner.zig");
 
+/// Interp-vs-AOT differential test harness.
+pub const differential = @import("tests/differential.zig");
+
 /// WASI preview1 implementation.
 /// Note: Uses std.fs.File; tests require IO-aware runner.
 /// Excluded from refAllDecls to avoid test runner hang.

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -11,6 +11,59 @@ const aot_loader = @import("loader.zig");
 const host_bridge = @import("host_bridge.zig");
 const platform = @import("../../platform/platform.zig");
 
+// ─── Windows crash handler (debug only) ─────────────────────────────────────
+const windows = std.os.windows;
+
+var g_code_base: usize = 0;
+var g_code_size: usize = 0;
+var g_mem_base: usize = 0;
+var g_mem_size: usize = 0;
+
+fn vehHandler(info: *windows.EXCEPTION_POINTERS) callconv(.winapi) c_long {
+    const rec = info.ExceptionRecord;
+    const ctx = info.ContextRecord;
+    if (rec.ExceptionCode == 0xC0000005) { // STATUS_ACCESS_VIOLATION
+        const rip: usize = @intCast(ctx.Rip);
+        const fault: usize = @intCast(rec.ExceptionInformation[1]);
+        std.debug.print(
+            "\n=== VEH CRASH === RIP=0x{x} (code+0x{x}) fault=0x{x}",
+            .{ rip, rip -% g_code_base, fault },
+        );
+        if (g_mem_base != 0 and fault >= g_mem_base and fault < g_mem_base +% g_mem_size) {
+            std.debug.print(" (wasm mem[0x{x}])", .{fault - g_mem_base});
+        } else if (g_mem_base != 0) {
+            const delta: isize = @as(isize, @bitCast(fault)) - @as(isize, @bitCast(g_mem_base));
+            std.debug.print(" (mem_base+0x{x} delta={d})", .{ fault -% g_mem_base, delta });
+        }
+        std.debug.print("\n", .{});
+        std.debug.print("RAX=0x{x} RCX=0x{x} RDX=0x{x} RBX=0x{x}\n", .{ ctx.Rax, ctx.Rcx, ctx.Rdx, ctx.Rbx });
+        std.debug.print("RSI=0x{x} RDI=0x{x} RBP=0x{x} RSP=0x{x}\n", .{ ctx.Rsi, ctx.Rdi, ctx.Rbp, ctx.Rsp });
+        std.debug.print("R8=0x{x} R9=0x{x} R10=0x{x} R11=0x{x}\n", .{ ctx.R8, ctx.R9, ctx.R10, ctx.R11 });
+        std.debug.print("R12=0x{x} R13=0x{x} R14=0x{x} R15=0x{x}\n", .{ ctx.R12, ctx.R13, ctx.R14, ctx.R15 });
+        if (g_code_base != 0 and g_code_size != 0) {
+            const rip_off: usize = rip -% g_code_base;
+            if (rip_off < g_code_size) {
+                const start: usize = if (rip_off > 32) rip_off - 32 else 0;
+                const end: usize = @min(rip_off + 16, g_code_size);
+                const p: [*]const u8 = @ptrFromInt(g_code_base + start);
+                std.debug.print("code@[0x{x}..0x{x}]:", .{ start, end });
+                var i: usize = 0;
+                while (i < end - start) : (i += 1) {
+                    const marker: u8 = if (start + i == rip_off) '>' else ' ';
+                    std.debug.print("{c}{x:0>2}", .{ marker, p[i] });
+                }
+                std.debug.print("\n", .{});
+            }
+        }
+    }
+    return 0; // EXCEPTION_CONTINUE_SEARCH
+}
+
+extern "kernel32" fn AddVectoredExceptionHandler(
+    First: u32,
+    Handler: *const fn (*windows.EXCEPTION_POINTERS) callconv(.winapi) c_long,
+) callconv(.winapi) ?*anyopaque;
+
 /// Compact context passed to AOT-compiled functions as a hidden first parameter.
 /// Laid out as a flat struct so compiled code can load fields at known offsets.
 pub const VmCtx = extern struct {
@@ -33,7 +86,84 @@ pub const VmCtx = extern struct {
     host_functions_count: u32 = 0,
     /// Current memory size in pages (for memory.size instruction).
     memory_pages: u32 = 0,
+    _pad0: u32 = 0,
+    /// Native function pointer for memory.grow host helper.
+    /// Pointer to host function invoked by `memory.grow` in AOT-compiled code.
+    /// Signature: fn (vmctx: *VmCtx, delta_pages: i32) callconv(.c) i32
+    /// Returns previous page count on success, -1 on failure.
+    mem_grow_fn: usize = 0,
+    /// Opaque pointer to the owning AotInstance (used by host helpers).
+    instance_ptr: usize = 0,
+    /// Native function pointer for the out-of-bounds memory trap helper.
+    /// Signature: fn (vmctx: *VmCtx) callconv(.c) noreturn
+    /// Called from inline bounds checks emitted by AOT load/store codegen
+    /// when a wasm memory access would exceed `memory_size`.
+    trap_oob_fn: usize = 0,
 };
+
+/// Host helper invoked from AOT-compiled memory loads/stores when an
+/// out-of-bounds access is detected. Mirrors the interpreter's
+/// `error.OutOfBoundsMemoryAccess` trap. Exits the process with code 2
+/// rather than allowing the native CPU to SIGSEGV on unmapped memory.
+///
+/// NOTE: This terminates the host process. A future change could thread
+/// the trap back through a setjmp/longjmp path so that `callFunc` can
+/// return `error.OutOfBoundsMemoryAccess`, matching interp semantics
+/// for embedded usage. For the current CLI this is sufficient.
+/// Module-level storage populated by callFunc so the trap helper can map
+/// a return address back to a function index (purely diagnostic).
+var g_func_offsets: []const u32 = &.{};
+
+pub fn aotTrapOOB(vmctx: *VmCtx) callconv(.c) noreturn {
+    const ret_addr: usize = @returnAddress();
+    const code_off_s: isize = @as(isize, @bitCast(ret_addr)) - @as(isize, @bitCast(g_code_base));
+    const code_off: usize = if (code_off_s >= 0) @intCast(code_off_s) else 0;
+    var func_idx: isize = -1;
+    for (g_func_offsets, 0..) |off, idx| {
+        if (off <= code_off) func_idx = @intCast(idx) else break;
+    }
+    // Flush any buffered stdout from the guest before we tear down the
+    // process so user-visible output isn't lost. Best-effort.
+    std.debug.print(
+        "wasm trap: out of bounds memory access (code+0x{x}, local_func[{d}], mem_size=0x{x})\n",
+        .{ code_off, func_idx, vmctx.memory_size },
+    );
+    std.process.exit(2);
+}
+
+/// Host helper invoked from AOT-compiled `memory.grow` sites.
+/// Grows `inst.memories[0]` by `delta_pages`, reallocating the host buffer
+/// if needed, updates `vmctx` mirror fields (memory_base/size/pages) so
+/// subsequent loads/stores see the new buffer, and returns the previous
+/// page count. Returns -1 on failure (OOM or exceeds max).
+pub fn memGrowHelper(vmctx: *VmCtx, delta_pages: i32) callconv(.c) i32 {
+    if (vmctx.instance_ptr == 0) return -1;
+    const inst: *AotInstance = @ptrFromInt(vmctx.instance_ptr);
+    if (inst.memories.len == 0) return -1;
+    const mem = inst.memories[0];
+    const old_pages: u32 = mem.current_pages;
+    if (delta_pages < 0) return -1;
+    const delta: u32 = @intCast(delta_pages);
+    const new_pages_u64: u64 = @as(u64, old_pages) + @as(u64, delta);
+    const cap: u64 = @min(mem.max_pages, 65536);
+    if (new_pages_u64 > cap) return -1;
+    const new_pages: u32 = @intCast(new_pages_u64);
+    const new_size: usize = @as(usize, new_pages) * types.MemoryInstance.page_size;
+    if (new_size > mem.data.len) {
+        const new_data = inst.allocator.realloc(mem.data, new_size) catch return -1;
+        @memset(new_data[mem.data.len..], 0);
+        mem.data = new_data;
+    }
+    mem.current_pages = new_pages;
+    vmctx.memory_base = @intFromPtr(mem.data.ptr);
+    vmctx.memory_size = @as(usize, new_pages) * types.MemoryInstance.page_size;
+    vmctx.memory_pages = new_pages;
+    if (comptime builtin.os.tag == .windows) {
+        g_mem_base = vmctx.memory_base;
+        g_mem_size = vmctx.memory_size;
+    }
+    return @intCast(old_pages);
+}
 
 // ─── Comptime target validation ─────────────────────────────────────────────
 
@@ -289,10 +419,23 @@ pub fn callFunc(inst: *AotInstance, func_idx: u32, comptime Result: type) Runtim
     if (inst.func_table.len > 0) {
         vmctx.func_table_ptr = @intFromPtr(inst.func_table.ptr);
     }
+    vmctx.instance_ptr = @intFromPtr(inst);
+    vmctx.mem_grow_fn = @intFromPtr(&memGrowHelper);
+    vmctx.trap_oob_fn = @intFromPtr(&aotTrapOOB);
 
     // AOT-compiled functions receive a VmCtx pointer as hidden first parameter.
     const FnPtr = *const fn (*VmCtx) callconv(.c) Result;
     const func_ptr: FnPtr = @ptrCast(@alignCast(addr));
+    if (comptime builtin.os.tag == .windows) {
+        if (inst.code_base) |cb| {
+            g_code_base = @intFromPtr(cb);
+            g_code_size = inst.code_size;
+            g_func_offsets = inst.module.func_offsets;
+        }
+        g_mem_base = vmctx.memory_base;
+        g_mem_size = vmctx.memory_size;
+        _ = AddVectoredExceptionHandler(1, vehHandler);
+    }
     const result = func_ptr(&vmctx);
 
     // Sync globals back from flat array to GlobalInstance objects
@@ -548,6 +691,9 @@ test "VmCtx layout: fields at expected offsets" {
     try std.testing.expectEqual(@as(usize, 48), @offsetOf(VmCtx, "globals_count"));
     try std.testing.expectEqual(@as(usize, 52), @offsetOf(VmCtx, "host_functions_count"));
     try std.testing.expectEqual(@as(usize, 56), @offsetOf(VmCtx, "memory_pages"));
+    try std.testing.expectEqual(@as(usize, 64), @offsetOf(VmCtx, "mem_grow_fn"));
+    try std.testing.expectEqual(@as(usize, 72), @offsetOf(VmCtx, "instance_ptr"));
+    try std.testing.expectEqual(@as(usize, 80), @offsetOf(VmCtx, "trap_oob_fn"));
 }
 
 test "getFuncAddr: import indices return null" {

--- a/src/runtime/interpreter/interp.zig
+++ b/src/runtime/interpreter/interp.zig
@@ -62,6 +62,7 @@ inline fn wasmNearestF64(x: f64) f64 {
 
 const Opcode = @import("opcode.zig").Opcode;
 const simd = @import("simd.zig");
+const leb128 = @import("../../shared/utils/leb128.zig");
 
 pub const TrapError = error{
     Unreachable,
@@ -129,60 +130,15 @@ fn popTableIdx(env: *ExecEnv, table: *types.TableInstance) TrapError!u32 {
 }
 
 fn readU32(code: []const u8, ip: *usize) u32 {
-    var result: u32 = 0;
-    var shift: u5 = 0;
-    while (true) {
-        if (ip.* >= code.len) return result;
-        const byte = code[ip.*];
-        ip.* += 1;
-        result |= @as(u32, byte & 0x7F) << shift;
-        if (byte & 0x80 == 0) break;
-        if (shift >= 28) break;
-        shift +|= 7;
-    }
-    return result;
+    return leb128.readUnsignedLossy(u32, code, ip);
 }
 
 fn readI32(code: []const u8, ip: *usize) i32 {
-    var result: u32 = 0;
-    var shift: u32 = 0;
-    var byte: u8 = 0;
-    while (true) {
-        if (ip.* >= code.len) return @bitCast(result);
-        byte = code[ip.*];
-        ip.* += 1;
-        result |= @as(u32, byte & 0x7F) << @intCast(shift);
-        if (byte & 0x80 == 0) break;
-        shift += 7;
-        if (shift >= 35) break;
-    }
-    // Sign-extend from the bit above the last data septet.
-    const sign_shift = shift + 7;
-    if (sign_shift < 32 and (byte & 0x40) != 0) {
-        result |= ~@as(u32, 0) << @intCast(sign_shift);
-    }
-    return @bitCast(result);
+    return leb128.readSignedLossy(i32, code, ip);
 }
 
 fn readI64(code: []const u8, ip: *usize) i64 {
-    var result: u64 = 0;
-    var shift: u32 = 0;
-    var byte: u8 = 0;
-    while (true) {
-        if (ip.* >= code.len) return @bitCast(result);
-        byte = code[ip.*];
-        ip.* += 1;
-        result |= @as(u64, byte & 0x7F) << @intCast(shift);
-        if (byte & 0x80 == 0) break;
-        shift += 7;
-        if (shift >= 70) break;
-    }
-    // Sign-extend from the bit above the last data septet.
-    const sign_shift = shift + 7;
-    if (sign_shift < 64 and (byte & 0x40) != 0) {
-        result |= ~@as(u64, 0) << @intCast(sign_shift);
-    }
-    return @bitCast(result);
+    return leb128.readSignedLossy(i64, code, ip);
 }
 
 /// Check if a ref value matches a target heap type for ref.test/ref.cast.
@@ -1069,18 +1025,7 @@ fn skipLeb128(code: []const u8, pos: usize) usize {
 
 /// Read a u32 from `code` at `pos` (static helper for pre-scan).
 fn readU32Static(code: []const u8, pos: *usize) u32 {
-    var result: u32 = 0;
-    var shift: u5 = 0;
-    while (true) {
-        if (pos.* >= code.len) return result;
-        const byte = code[pos.*];
-        pos.* += 1;
-        result |= @as(u32, byte & 0x7F) << shift;
-        if (byte & 0x80 == 0) break;
-        if (shift >= 28) break;
-        shift +|= 7;
-    }
-    return result;
+    return leb128.readUnsignedLossy(u32, code, pos);
 }
 
 /// Skip a block type immediate in bytecode: handles 0x40 (void), single-byte val types,

--- a/src/shared/utils/leb128.zig
+++ b/src/shared/utils/leb128.zig
@@ -120,6 +120,49 @@ pub fn readSigned(comptime T: type, bytes: []const u8) Error!Result(T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// Lossy convenience wrappers
+//
+// These take `bytes` and a `pos: *usize` cursor and advance it in-place.
+// On malformed/truncated input they return a fallback value and skip any
+// remaining continuation bytes so the caller does not spin. They exist
+// because the interpreter and AOT frontend decode bytecode that has
+// already been validated at load time; a decode error at runtime is
+// effectively "can't happen" and the bytecode dispatch loops cannot
+// propagate errors through their tail-call structure. New code should
+// prefer `readUnsigned` / `readSigned` and handle the error result.
+// ─────────────────────────────────────────────────────────────────────────
+
+fn skipToEnd(bytes: []const u8, pos: *usize) void {
+    // Skip any continuation bytes so callers don't spin on malformed input.
+    while (pos.* < bytes.len and (bytes[pos.*] & 0x80) != 0) pos.* += 1;
+    if (pos.* < bytes.len) pos.* += 1;
+}
+
+/// Decode an unsigned LEB128 from `bytes[pos.*..]`, advance `pos` past it,
+/// and return the value. Returns 0 on malformed or truncated input.
+pub fn readUnsignedLossy(comptime T: type, bytes: []const u8, pos: *usize) T {
+    if (pos.* >= bytes.len) return 0;
+    const r = readUnsigned(T, bytes[pos.*..]) catch {
+        skipToEnd(bytes, pos);
+        return 0;
+    };
+    pos.* += r.bytes_read;
+    return r.value;
+}
+
+/// Decode a signed LEB128 from `bytes[pos.*..]`, advance `pos` past it,
+/// and return the value. Returns 0 on malformed or truncated input.
+pub fn readSignedLossy(comptime T: type, bytes: []const u8, pos: *usize) T {
+    if (pos.* >= bytes.len) return 0;
+    const r = readSigned(T, bytes[pos.*..]) catch {
+        skipToEnd(bytes, pos);
+        return 0;
+    };
+    pos.* += r.bytes_read;
+    return r.value;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────
 
@@ -310,4 +353,164 @@ test "extra trailing bytes are ignored" {
     const r = try readUnsigned(u32, &.{ 0x01, 0xFF, 0xFF });
     try testing.expectEqual(@as(u32, 1), r.value);
     try testing.expectEqual(@as(usize, 1), r.bytes_read);
+}
+
+
+// -- Lossy wrapper behavior ------------------------------------------------
+
+test "lossy: valid u32 single byte" {
+    var pos: usize = 0;
+    const v = readUnsignedLossy(u32, &.{0x2A}, &pos);
+    try testing.expectEqual(@as(u32, 42), v);
+    try testing.expectEqual(@as(usize, 1), pos);
+}
+
+test "lossy: valid i32 single-byte -4 (the coremark regression case)" {
+    var pos: usize = 0;
+    const v = readSignedLossy(i32, &.{0x7C}, &pos);
+    try testing.expectEqual(@as(i32, -4), v);
+    try testing.expectEqual(@as(usize, 1), pos);
+}
+
+test "lossy: truncated input advances pos to end and returns 0" {
+    var pos: usize = 0;
+    const v = readUnsignedLossy(u32, &.{0x80}, &pos);
+    try testing.expectEqual(@as(u32, 0), v);
+    try testing.expectEqual(@as(usize, 1), pos);
+}
+
+test "lossy: overflow skips continuation bytes and returns 0" {
+    var pos: usize = 0;
+    const v = readUnsignedLossy(u32, &.{ 0x80, 0x80, 0x80, 0x80, 0x80, 0x01, 0xAA }, &pos);
+    try testing.expectEqual(@as(u32, 0), v);
+    // cursor should be past all 6 continuation/terminator bytes
+    try testing.expectEqual(@as(usize, 6), pos);
+}
+
+test "lossy: empty input returns 0, pos unchanged" {
+    var pos: usize = 0;
+    const v = readUnsignedLossy(u32, &.{}, &pos);
+    try testing.expectEqual(@as(u32, 0), v);
+    try testing.expectEqual(@as(usize, 0), pos);
+}
+
+test "lossy: advances correctly on back-to-back reads" {
+    // Encode: u32 1, i32 -4, u32 624485.
+    const buf = &[_]u8{ 0x01, 0x7C, 0xe5, 0x8e, 0x26 };
+    var pos: usize = 0;
+    try testing.expectEqual(@as(u32, 1), readUnsignedLossy(u32, buf, &pos));
+    try testing.expectEqual(@as(i32, -4), readSignedLossy(i32, buf, &pos));
+    try testing.expectEqual(@as(u32, 624485), readUnsignedLossy(u32, buf, &pos));
+    try testing.expectEqual(buf.len, pos);
+}
+
+// -- Round-trip encode/decode fuzz ----------------------------------------
+
+/// Encode a u64 as unsigned LEB128 into `out`, returning bytes written.
+fn encodeUnsigned(value: u64, out: []u8) usize {
+    var v = value;
+    var i: usize = 0;
+    while (true) {
+        var byte: u8 = @intCast(v & 0x7f);
+        v >>= 7;
+        if (v != 0) {
+            byte |= 0x80;
+            out[i] = byte;
+            i += 1;
+        } else {
+            out[i] = byte;
+            i += 1;
+            return i;
+        }
+    }
+}
+
+/// Encode an i64 as signed LEB128 into `out`, returning bytes written.
+fn encodeSigned(value: i64, out: []u8) usize {
+    var v = value;
+    var i: usize = 0;
+    while (true) {
+        const byte_val: u8 = @as(u8, @truncate(@as(u64, @bitCast(v)))) & 0x7f;
+        // Arithmetic shift right to preserve sign.
+        v >>= 7;
+        const done = (v == 0 and (byte_val & 0x40) == 0) or
+            (v == -1 and (byte_val & 0x40) != 0);
+        if (done) {
+            out[i] = byte_val;
+            i += 1;
+            return i;
+        } else {
+            out[i] = byte_val | 0x80;
+            i += 1;
+        }
+    }
+}
+
+test "round-trip fuzz: u32" {
+    var prng = std.Random.DefaultPrng.init(0xC0DE_0001);
+    const rnd = prng.random();
+    var buf: [10]u8 = undefined;
+    var i: usize = 0;
+    while (i < 2000) : (i += 1) {
+        const v: u32 = rnd.int(u32);
+        const n = encodeUnsigned(v, &buf);
+        const r = try readUnsigned(u32, buf[0..n]);
+        try testing.expectEqual(v, r.value);
+        try testing.expectEqual(n, r.bytes_read);
+    }
+}
+
+test "round-trip fuzz: u64" {
+    var prng = std.Random.DefaultPrng.init(0xC0DE_0002);
+    const rnd = prng.random();
+    var buf: [10]u8 = undefined;
+    var i: usize = 0;
+    while (i < 2000) : (i += 1) {
+        const v: u64 = rnd.int(u64);
+        const n = encodeUnsigned(v, &buf);
+        const r = try readUnsigned(u64, buf[0..n]);
+        try testing.expectEqual(v, r.value);
+        try testing.expectEqual(n, r.bytes_read);
+    }
+}
+
+test "round-trip fuzz: i32" {
+    var prng = std.Random.DefaultPrng.init(0xC0DE_0003);
+    const rnd = prng.random();
+    var buf: [10]u8 = undefined;
+    var i: usize = 0;
+    while (i < 2000) : (i += 1) {
+        const v: i32 = rnd.int(i32);
+        const n = encodeSigned(v, &buf);
+        const r = try readSigned(i32, buf[0..n]);
+        try testing.expectEqual(v, r.value);
+        try testing.expectEqual(n, r.bytes_read);
+    }
+}
+
+test "round-trip fuzz: i64" {
+    var prng = std.Random.DefaultPrng.init(0xC0DE_0004);
+    const rnd = prng.random();
+    var buf: [10]u8 = undefined;
+    var i: usize = 0;
+    while (i < 2000) : (i += 1) {
+        const v: i64 = rnd.int(i64);
+        const n = encodeSigned(v, &buf);
+        const r = try readSigned(i64, buf[0..n]);
+        try testing.expectEqual(v, r.value);
+        try testing.expectEqual(n, r.bytes_read);
+    }
+}
+
+test "round-trip fuzz: i32 small values (all 1-byte and 2-byte)" {
+    // Exhaustively cover every 1-byte and 2-byte signed LEB128 value, which
+    // is where the frontend's sign-extension bug lived.
+    var buf: [10]u8 = undefined;
+    var v: i32 = -16384;
+    while (v < 16384) : (v += 1) {
+        const n = encodeSigned(v, &buf);
+        const r = try readSigned(i32, buf[0..n]);
+        try testing.expectEqual(v, r.value);
+        try testing.expectEqual(n, r.bytes_read);
+    }
 }

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -1,0 +1,337 @@
+//! Interpreter-vs-AOT differential harness.
+//!
+//! For each embedded wasm module, this runs the exported `() -> i32`
+//! function through both the bytecode interpreter and the AOT pipeline
+//! (frontend → passes → codegen → emit_aot → aot_loader → aot_runtime),
+//! and asserts the two results match.
+//!
+//! This is the minimum test that would have caught the `readI32`/`readI64`
+//! LEB128 sign-extension bug fixed in commit 709ad073: a wasm module that
+//! returns a 1-byte negative `i32.const` (e.g. `-4`) produces -1 in AOT
+//! and -4 in the interpreter — a direct divergence.
+//!
+//! Add new test cases as new AOT codegen regressions are discovered.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const testing = std.testing;
+
+const loader_mod = @import("../runtime/interpreter/loader.zig");
+const instance_mod = @import("../runtime/interpreter/instance.zig");
+const interp = @import("../runtime/interpreter/interp.zig");
+const ExecEnv = @import("../runtime/common/exec_env.zig").ExecEnv;
+
+const frontend = @import("../compiler/frontend.zig");
+const passes = @import("../compiler/ir/passes.zig");
+const x86_64_compile = @import("../compiler/codegen/x86_64/compile.zig");
+const aarch64_compile = @import("../compiler/codegen/aarch64/compile.zig");
+const emit_aot = @import("../compiler/emit_aot.zig");
+const aot_loader = @import("../runtime/aot/loader.zig");
+const aot_runtime = @import("../runtime/aot/runtime.zig");
+
+/// True on targets where the AOT runtime can execute generated code.
+const can_exec_aot = switch (builtin.cpu.arch) {
+    .x86_64, .aarch64 => true,
+    else => false,
+};
+
+/// Run `name` (a `() -> i32` export) through the interpreter.
+fn runInterpI32(allocator: std.mem.Allocator, wasm: []const u8, name: []const u8) !i32 {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const module = try loader_mod.load(wasm, arena.allocator());
+
+    const inst = try instance_mod.instantiate(&module, allocator);
+    defer instance_mod.destroy(inst);
+
+    const exp = inst.module.findExport(name, .function) orelse return error.FunctionNotFound;
+
+    var env = try ExecEnv.create(inst, 4096, allocator);
+    defer env.destroy();
+    try interp.executeFunction(env, exp.index);
+    return env.popI32();
+}
+
+/// Compile `wasm` through the full AOT pipeline, returning the AOT binary.
+/// Caller owns the returned slice.
+fn compileToAot(allocator: std.mem.Allocator, wasm: []const u8) ![]u8 {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const module = try loader_mod.load(wasm, a);
+
+    var ir_module = try frontend.lowerModule(&module, a);
+    defer ir_module.deinit();
+
+    _ = try passes.runPasses(&ir_module, passes.default_passes, a);
+
+    const code: []const u8, const offsets: []const u32 = switch (builtin.cpu.arch) {
+        .aarch64 => blk: {
+            const r = try aarch64_compile.compileModule(&ir_module, a);
+            break :blk .{ r.code, r.offsets };
+        },
+        else => blk: {
+            const r = try x86_64_compile.compileModule(&ir_module, a);
+            break :blk .{ r.code, r.offsets };
+        },
+    };
+
+    var exports: std.ArrayList(emit_aot.ExportEntry) = .empty;
+    for (module.exports) |exp| {
+        try exports.append(a, .{
+            .name = exp.name,
+            .kind = @enumFromInt(@intFromEnum(exp.kind)),
+            .index = exp.index,
+        });
+    }
+
+    var arch_name = std.mem.zeroes([16]u8);
+    switch (builtin.cpu.arch) {
+        .aarch64 => @memcpy(arch_name[0..7], "aarch64"),
+        else => @memcpy(arch_name[0..6], "x86-64"),
+    }
+
+    // emit_aot copies `code` / names into its own buffer, so we can return
+    // it even though the arena is torn down on scope exit.
+    return try emit_aot.emit(
+        allocator,
+        code,
+        offsets,
+        exports.items,
+        .{ .arch = arch_name },
+        null,
+        null,
+        null,
+        null,
+        null,
+    );
+}
+
+/// Run `name` (a `() -> i32` export) through the AOT pipeline.
+fn runAotI32(allocator: std.mem.Allocator, wasm: []const u8, name: []const u8) !i32 {
+    const aot_bin = try compileToAot(allocator, wasm);
+    defer allocator.free(aot_bin);
+
+    const module = try aot_loader.load(aot_bin, allocator);
+    defer aot_loader.unload(&module, allocator);
+
+    const inst = try aot_runtime.instantiate(&module, allocator);
+    defer aot_runtime.destroy(inst);
+
+    try aot_runtime.mapCodeExecutable(inst);
+
+    const func_idx = aot_runtime.findExportFunc(inst, name) orelse return error.FunctionNotFound;
+    return aot_runtime.callFunc(inst, func_idx, i32);
+}
+
+/// Run `wasm` through both pipelines and assert they agree, and match `expected`.
+fn expectDiffI32(wasm: []const u8, name: []const u8, expected: i32) !void {
+    const interp_result = try runInterpI32(testing.allocator, wasm, name);
+    try testing.expectEqual(expected, interp_result);
+
+    if (comptime !can_exec_aot) return;
+    const aot_result = try runAotI32(testing.allocator, wasm, name);
+    try testing.expectEqual(expected, aot_result);
+    try testing.expectEqual(interp_result, aot_result);
+}
+
+// ─── Wasm module builder ────────────────────────────────────────────────────
+
+/// Encode an unsigned LEB128 value (u32) into `buf`.
+fn encodeULEB128(buf: *std.ArrayList(u8), a: std.mem.Allocator, value: u32) !void {
+    var v = value;
+    while (true) {
+        var byte: u8 = @intCast(v & 0x7F);
+        v >>= 7;
+        if (v != 0) byte |= 0x80;
+        try buf.append(a, byte);
+        if (v == 0) break;
+    }
+}
+
+/// Encode a signed LEB128 value (i64) into `buf`.
+fn encodeSLEB128(buf: *std.ArrayList(u8), a: std.mem.Allocator, value: i64) !void {
+    var v = value;
+    var more = true;
+    while (more) {
+        const byte: u8 = @as(u8, @truncate(@as(u64, @bitCast(v)))) & 0x7F;
+        v >>= 7;
+        const sign_bit = byte & 0x40;
+        if ((v == 0 and sign_bit == 0) or (v == -1 and sign_bit != 0)) {
+            more = false;
+            try buf.append(a, byte);
+        } else {
+            try buf.append(a, byte | 0x80);
+        }
+    }
+}
+
+/// Build a wasm module exporting a single `() -> i32` function whose body is
+/// `i32.const <value>; end`.
+fn buildConstI32Module(allocator: std.mem.Allocator, value: i32) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    // Magic + version
+    try out.appendSlice(allocator, &[_]u8{ 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00 });
+
+    // Type section: 1 type — () -> i32
+    try out.appendSlice(allocator, &[_]u8{
+        0x01, // section id
+        0x05, // section size
+        0x01, // type count
+        0x60, // func
+        0x00, // param count
+        0x01, // result count
+        0x7F, // i32
+    });
+
+    // Function section: 1 function, type index 0
+    try out.appendSlice(allocator, &[_]u8{ 0x03, 0x02, 0x01, 0x00 });
+
+    // Export section: "f" -> func 0
+    try out.appendSlice(allocator, &[_]u8{
+        0x07, 0x05, 0x01, 0x01, 'f', 0x00, 0x00,
+    });
+
+    // Code section
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(allocator);
+    try body.append(allocator, 0x00); // local decl count
+    try body.append(allocator, 0x41); // i32.const
+    try encodeSLEB128(&body, allocator, value);
+    try body.append(allocator, 0x0B); // end
+
+    var code: std.ArrayList(u8) = .empty;
+    defer code.deinit(allocator);
+    try code.append(allocator, 0x01); // function count
+    try encodeULEB128(&code, allocator, @intCast(body.items.len));
+    try code.appendSlice(allocator, body.items);
+
+    try out.append(allocator, 0x0A); // code section id
+    try encodeULEB128(&out, allocator, @intCast(code.items.len));
+    try out.appendSlice(allocator, code.items);
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Build a wasm module exporting `() -> i32` whose body performs
+/// `(i32.const a) (i32.const b) <op>; end`.
+fn buildBinI32Module(
+    allocator: std.mem.Allocator,
+    a_val: i32,
+    b_val: i32,
+    op: u8,
+) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, &[_]u8{ 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00 });
+    try out.appendSlice(allocator, &[_]u8{
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7F,
+    });
+    try out.appendSlice(allocator, &[_]u8{ 0x03, 0x02, 0x01, 0x00 });
+    try out.appendSlice(allocator, &[_]u8{
+        0x07, 0x05, 0x01, 0x01, 'f', 0x00, 0x00,
+    });
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(allocator);
+    try body.append(allocator, 0x00);
+    try body.append(allocator, 0x41);
+    try encodeSLEB128(&body, allocator, a_val);
+    try body.append(allocator, 0x41);
+    try encodeSLEB128(&body, allocator, b_val);
+    try body.append(allocator, op);
+    try body.append(allocator, 0x0B);
+
+    var code: std.ArrayList(u8) = .empty;
+    defer code.deinit(allocator);
+    try code.append(allocator, 0x01);
+    try encodeULEB128(&code, allocator, @intCast(body.items.len));
+    try code.appendSlice(allocator, body.items);
+
+    try out.append(allocator, 0x0A);
+    try encodeULEB128(&out, allocator, @intCast(code.items.len));
+    try out.appendSlice(allocator, code.items);
+
+    return out.toOwnedSlice(allocator);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+test "differential: i32.const 0" {
+    const wasm = try buildConstI32Module(testing.allocator, 0);
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", 0);
+}
+
+test "differential: i32.const 1" {
+    const wasm = try buildConstI32Module(testing.allocator, 1);
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", 1);
+}
+
+test "differential: i32.const -1 (1-byte signed LEB, the regression case)" {
+    const wasm = try buildConstI32Module(testing.allocator, -1);
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", -1);
+}
+
+test "differential: i32.const -4 (coremark-style 1-byte negative)" {
+    const wasm = try buildConstI32Module(testing.allocator, -4);
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", -4);
+}
+
+test "differential: i32.const 63 (1-byte positive boundary)" {
+    const wasm = try buildConstI32Module(testing.allocator, 63);
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", 63);
+}
+
+test "differential: i32.const -64 (1-byte negative boundary)" {
+    const wasm = try buildConstI32Module(testing.allocator, -64);
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", -64);
+}
+
+test "differential: i32.const 64 (first 2-byte positive)" {
+    const wasm = try buildConstI32Module(testing.allocator, 64);
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", 64);
+}
+
+test "differential: i32.const -65 (first 2-byte negative)" {
+    const wasm = try buildConstI32Module(testing.allocator, -65);
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", -65);
+}
+
+test "differential: i32.const INT32_MIN" {
+    const wasm = try buildConstI32Module(testing.allocator, std.math.minInt(i32));
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", std.math.minInt(i32));
+}
+
+test "differential: i32.const INT32_MAX" {
+    const wasm = try buildConstI32Module(testing.allocator, std.math.maxInt(i32));
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", std.math.maxInt(i32));
+}
+
+test "differential: (-4) & 1 == 0 (i32.and over negative const)" {
+    // 0x6F = i32.and
+    const wasm = try buildBinI32Module(testing.allocator, -4, 1, 0x71);
+    defer testing.allocator.free(wasm);
+    // -4 & 1 == 0
+    try expectDiffI32(wasm, "f", 0);
+}
+
+test "differential: (-4) + 5 == 1 (i32.add over negative const)" {
+    // 0x6A = i32.add
+    const wasm = try buildBinI32Module(testing.allocator, -4, 5, 0x6A);
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", 1);
+}


### PR DESCRIPTION
Stacks on top of #101. Tackles the coremark `matrix_test` AOT-only hang plus structural testing gaps that let the root-cause bug slip through.

## Commits

| SHA | Summary |
|---|---|
| `ee81eb5f` | fix(aot/x86_64): pass wasm args beyond param-reg capacity via stack |
| `6a75897d` | fix(aot/regalloc): compute spill-slot base from function''s local_count |
| `49205861` | debug(aot): add in-source IR+alloc dumper for per-function debugging |
| `47b6561f` | fix(aot/x86_64): emit inline bounds checks on loads/stores |
| `7dfd304c` | fix(aot/x86_64): emit bounds checks on memory.copy and memory.fill |
| `709ad073` | fix(aot/frontend): sign-extend single-byte negative signed LEB128 correctly |
| `d9d83062` | Unify LEB128 decoders and add round-trip fuzz tests |
| `f78f2521` | Add interp-vs-AOT differential harness and testing conventions |

## Highlights

### Correctness fixes
- **LEB128 sign-extension** (`709ad073`): `readI32`/`readI64` in `src/compiler/frontend.zig` used `<< shift` instead of `<< (shift + 7)` when sign-extending short signed-LEB values, so every single-byte negative constant (e.g. `i32.const -4`) decoded as `-1`. This was the root cause of the coremark `matrix_test` hang.
- **Bounds checks** (`47b6561f`, `7dfd304c`): AOT loads/stores and `memory.copy`/`memory.fill` now emit inline bounds checks.
- **Arg passing** (`ee81eb5f`): wasm args beyond the available param registers are now spilled to the stack per the calling convention.
- **Spill-slot base** (`6a75897d`): regalloc now computes the spill slot base from the function''s `local_count` rather than a global constant.

### Testing infrastructure (prevents this class of bug from recurring)
- **Unify LEB128 decoders** (`d9d83062`): three hand-rolled copies collapsed onto the shared `src/shared/utils/leb128.zig` via new `readUnsignedLossy` / `readSignedLossy` wrappers that preserve the prior dispatch-loop semantics. Adds ~200 lines of round-trip/fuzz/boundary tests.
- **Interp-vs-AOT differential harness** (`f78f2521`): for each hand-built wasm module, runs the exported function through **both** the bytecode interpreter and the full AOT pipeline (frontend → passes → codegen → emit_aot → aot_loader → aot_runtime) and asserts the two results match. Initial suite targets the LEB128 boundary cases that would have caught `709ad073` directly.
- **Testing conventions** in `CONTRIBUTING.md` — boundary/malformed-input requirements for binary decoders, preference for the shared decoder, round-trip fuzz encouraged.

## Tests

`zig build test --summary all` → **603/603 passing** (up from 578 before this work).

## Follow-up

- Coremark still traps at a different OOB (`local_func[11]` at `code+0xcca2`) — separate bug, tracked for a later session.
- Running the full spec suite through the AOT path is deferred to #102.