### PR TITLE
api: comptime-typed host function registration

### DIFF
--- a/src/api/host.zig
+++ b/src/api/host.zig
@@ -58,6 +58,14 @@ pub const HostContext = struct {
             .mem_len = if (mem) |m| m.data.len else 0,
         };
     }
+
+    /// Build a HostContext from an AOT VmCtx pointer.
+    pub fn fromVmCtx(vmctx: anytype) HostContext {
+        return .{
+            .mem_base = if (vmctx.memory_base != 0) @ptrFromInt(vmctx.memory_base) else null,
+            .mem_len = vmctx.memory_size,
+        };
+    }
 };
 
 /// Valid wasm value types for host function parameters and returns.
@@ -70,6 +78,7 @@ pub const ImportEntry = struct {
     module_name: []const u8,
     field_name: []const u8,
     interp_fn: types.HostFn,
+    aot_fn: *const anyopaque,
 };
 
 /// Build a comptime host import table from a tuple of (module, name, function) descriptors.
@@ -122,6 +131,7 @@ pub fn HostImports(comptime descriptors: anytype) type {
                     .module_name = desc[0],
                     .field_name = desc[1],
                     .interp_fn = makeInterpAdapter(desc[2]),
+                    .aot_fn = makeAotAdapter(desc[2]),
                 };
             }
             break :blk e;
@@ -179,6 +189,38 @@ fn makeInterpAdapter(comptime func: anytype) types.HostFn {
         }
     };
     return S.adapter;
+}
+
+/// Generate an AOT adapter that bridges C-calling-convention dispatch to a
+/// typed Zig function. The AOT codegen calls imported functions with VmCtx
+/// as the hidden first parameter and wasm values in subsequent registers.
+fn makeAotAdapter(comptime func: anytype) *const anyopaque {
+    const VmCtx = @import("../runtime/aot/runtime.zig").VmCtx;
+    const FnType = @TypeOf(func);
+    const info = @typeInfo(FnType).@"fn";
+    const wasm_param_count = info.params.len - 1;
+    const RetT = info.return_type.?;
+    const AbiRet = if (RetT == void) void else if (RetT == i64 or RetT == u64) i64 else i32;
+
+    const S = struct {
+        fn adapter(vmctx: *VmCtx, p0: i64, p1: i64, p2: i64, p3: i64, p4: i64, p5: i64) callconv(.c) AbiRet {
+            const ctx = HostContext.fromVmCtx(vmctx);
+            const raw = [_]i64{ p0, p1, p2, p3, p4, p5 };
+            var args: std.meta.ArgsTuple(FnType) = undefined;
+            args[0] = ctx;
+            inline for (0..wasm_param_count) |i| {
+                const ParamT = info.params[i + 1].type.?;
+                args[i + 1] = if (ParamT == i64 or ParamT == u64)
+                    @bitCast(raw[i])
+                else
+                    @as(ParamT, @bitCast(@as(i32, @truncate(raw[i]))));
+            }
+            const result = @call(.auto, func, args);
+            if (RetT == void) return;
+            return @bitCast(result);
+        }
+    };
+    return @ptrCast(&S.adapter);
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────

--- a/src/api/host.zig
+++ b/src/api/host.zig
@@ -1,0 +1,261 @@
+//! Host function registration for embedding WAMR in Zig applications.
+//!
+//! Provides a comptime-typed API for registering native Zig functions as
+//! WebAssembly imports. Generates adapter glue for both interpreter (stack-
+//! based) and AOT (C-calling-convention) dispatch automatically.
+//!
+//! Usage:
+//!   const host = @import("wamr").host;
+//!
+//!   fn add(ctx: host.HostContext, a: i32, b: i32) i32 {
+//!       return a + b;
+//!   }
+//!
+//!   const imports = host.HostImports(.{
+//!       .{ "env", "add", add },
+//!   });
+
+const std = @import("std");
+const types = @import("../runtime/common/types.zig");
+
+/// Context passed to host functions — provides access to wasm linear memory.
+/// Constructed automatically by the adapter from either ExecEnv (interpreter)
+/// or VmCtx (AOT). Host functions should not store this beyond the call.
+pub const HostContext = struct {
+    mem_base: ?[*]u8,
+    mem_len: usize,
+
+    /// Get a mutable slice over the entire wasm linear memory.
+    pub fn memory(self: HostContext) ?[]u8 {
+        const base = self.mem_base orelse return null;
+        return base[0..self.mem_len];
+    }
+
+    /// Read a value of type T from linear memory at `offset`.
+    pub fn read(self: HostContext, comptime T: type, offset: u32) ?T {
+        const size = @sizeOf(T);
+        if (offset + size > self.mem_len) return null;
+        const base = self.mem_base orelse return null;
+        return std.mem.readInt(T, @as(*const [@sizeOf(T)]u8, @ptrCast(base + offset)), .little);
+    }
+
+    /// Write a value of type T to linear memory at `offset`.
+    pub fn write(self: HostContext, comptime T: type, offset: u32, value: T) bool {
+        const size = @sizeOf(T);
+        if (offset + size > self.mem_len) return false;
+        const base = self.mem_base orelse return false;
+        std.mem.writeInt(T, @as(*[@sizeOf(T)]u8, @ptrCast(base + offset)), value, .little);
+        return true;
+    }
+
+    /// Build a HostContext from an interpreter ExecEnv.
+    pub fn fromExecEnv(env_opaque: *anyopaque) HostContext {
+        const ExecEnv = @import("../runtime/common/exec_env.zig").ExecEnv;
+        const env: *ExecEnv = @ptrCast(@alignCast(env_opaque));
+        const mem = if (env.module_inst.memories.len > 0) env.module_inst.memories[0] else null;
+        return .{
+            .mem_base = if (mem) |m| m.data.ptr else null,
+            .mem_len = if (mem) |m| m.data.len else 0,
+        };
+    }
+};
+
+/// Valid wasm value types for host function parameters and returns.
+fn isWasmType(comptime T: type) bool {
+    return T == i32 or T == u32 or T == i64 or T == u64;
+}
+
+/// A resolved host import entry.
+pub const ImportEntry = struct {
+    module_name: []const u8,
+    field_name: []const u8,
+    interp_fn: types.HostFn,
+};
+
+/// Build a comptime host import table from a tuple of (module, name, function) descriptors.
+///
+/// Each descriptor is a .{ "module_name", "field_name", zig_function } tuple.
+/// The zig function must have signature: fn(HostContext, ...wasm_params) ReturnType
+/// where ReturnType is i32, i64, or void, and params are i32/i64.
+///
+/// Returns a type with:
+///   - `entries: [N]ImportEntry` — the resolved import table
+///   - `resolve(module, field) ?ImportEntry` — lookup by name
+pub fn HostImports(comptime descriptors: anytype) type {
+    const N = descriptors.len;
+
+    // Validate all descriptors at comptime
+    comptime {
+        for (descriptors) |desc| {
+            const FnType = @TypeOf(desc[2]);
+            const info = @typeInfo(FnType).@"fn";
+
+            // First param must be HostContext
+            if (info.params.len == 0)
+                @compileError("Host function must take HostContext as first parameter");
+            if (info.params[0].type.? != HostContext)
+                @compileError("First parameter of host function must be HostContext, got " ++
+                    @typeName(info.params[0].type.?));
+
+            // Remaining params must be wasm types
+            for (info.params[1..]) |p| {
+                if (!isWasmType(p.type.?))
+                    @compileError("Host function parameter must be i32, u32, i64, or u64, got " ++
+                        @typeName(p.type.?));
+            }
+
+            // Return type must be void or a wasm type
+            const RetT = info.return_type.?;
+            if (RetT != void and !isWasmType(RetT))
+                @compileError("Host function must return void, i32, u32, i64, or u64, got " ++
+                    @typeName(RetT));
+        }
+    }
+
+    return struct {
+        pub const count = N;
+
+        pub const entries: [N]ImportEntry = blk: {
+            var e: [N]ImportEntry = undefined;
+            for (descriptors, 0..) |desc, i| {
+                e[i] = .{
+                    .module_name = desc[0],
+                    .field_name = desc[1],
+                    .interp_fn = makeInterpAdapter(desc[2]),
+                };
+            }
+            break :blk e;
+        };
+
+        /// Look up a host function by import module + field name.
+        pub fn resolve(module_name: []const u8, field_name: []const u8) ?ImportEntry {
+            for (entries) |entry| {
+                if (std.mem.eql(u8, entry.module_name, module_name) and
+                    std.mem.eql(u8, entry.field_name, field_name))
+                    return entry;
+            }
+            return null;
+        }
+    };
+}
+
+/// Generate an interpreter adapter that bridges stack-based dispatch to a
+/// typed Zig function. The adapter pops arguments, builds a HostContext,
+/// calls the real function, and pushes the result.
+fn makeInterpAdapter(comptime func: anytype) types.HostFn {
+    const FnType = @TypeOf(func);
+    const info = @typeInfo(FnType).@"fn";
+    const wasm_param_count = info.params.len - 1; // exclude HostContext
+    const RetT = info.return_type.?;
+
+    const S = struct {
+        fn adapter(env_opaque: *anyopaque) types.HostFnError!void {
+            const ExecEnv = @import("../runtime/common/exec_env.zig").ExecEnv;
+            const env: *ExecEnv = @ptrCast(@alignCast(env_opaque));
+
+            // Pop arguments in reverse order (stack is LIFO)
+            var args: std.meta.ArgsTuple(FnType) = undefined;
+            args[0] = HostContext.fromExecEnv(env_opaque);
+
+            comptime var i = wasm_param_count;
+            inline while (i > 0) {
+                i -= 1;
+                const ParamT = info.params[i + 1].type.?;
+                args[i + 1] = if (ParamT == i64 or ParamT == u64)
+                    @bitCast(env.popI64() catch return error.StackUnderflow)
+                else
+                    @bitCast(env.popI32() catch return error.StackUnderflow);
+            }
+
+            const result = @call(.auto, func, args);
+
+            if (RetT != void) {
+                if (RetT == i64 or RetT == u64) {
+                    env.pushI64(@bitCast(result)) catch return error.StackOverflow;
+                } else {
+                    env.pushI32(@bitCast(result)) catch return error.StackOverflow;
+                }
+            }
+        }
+    };
+    return S.adapter;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+fn testAdd(_: HostContext, a: i32, b: i32) i32 {
+    return a + b;
+}
+
+fn testVoid(_: HostContext) void {}
+
+fn testOneParam(_: HostContext, x: i32) i32 {
+    return x * 2;
+}
+
+fn testI64(_: HostContext, a: i64, b: i64) i64 {
+    return a + b;
+}
+
+test "HostImports: basic compile and resolve" {
+    const imports = HostImports(.{
+        .{ "env", "add", testAdd },
+        .{ "env", "nop", testVoid },
+        .{ "math", "double", testOneParam },
+    });
+
+    try testing.expectEqual(@as(usize, 3), imports.count);
+
+    const add_entry = imports.resolve("env", "add");
+    try testing.expect(add_entry != null);
+    try testing.expectEqualStrings("env", add_entry.?.module_name);
+    try testing.expectEqualStrings("add", add_entry.?.field_name);
+
+    const nop_entry = imports.resolve("env", "nop");
+    try testing.expect(nop_entry != null);
+
+    const dbl_entry = imports.resolve("math", "double");
+    try testing.expect(dbl_entry != null);
+
+    try testing.expect(imports.resolve("env", "missing") == null);
+    try testing.expect(imports.resolve("missing", "add") == null);
+}
+
+test "HostImports: i64 parameters" {
+    const imports = HostImports(.{
+        .{ "env", "add64", testI64 },
+    });
+    try testing.expectEqual(@as(usize, 1), imports.count);
+    try testing.expect(imports.resolve("env", "add64") != null);
+}
+
+test "HostContext: memory access" {
+    var buf = [_]u8{ 0x42, 0x00, 0x00, 0x00, 0xFE, 0xFF, 0xFF, 0xFF };
+    const ctx = HostContext{ .mem_base = &buf, .mem_len = buf.len };
+
+    const mem = ctx.memory();
+    try testing.expect(mem != null);
+    try testing.expectEqual(@as(usize, 8), mem.?.len);
+
+    try testing.expectEqual(@as(i32, 0x42), ctx.read(i32, 0).?);
+    try testing.expectEqual(@as(i32, -2), ctx.read(i32, 4).?);
+
+    // Out of bounds
+    try testing.expect(ctx.read(i32, 6) == null);
+
+    // Write
+    try testing.expect(ctx.write(i32, 0, 99));
+    try testing.expectEqual(@as(i32, 99), ctx.read(i32, 0).?);
+
+    // Write OOB
+    try testing.expect(!ctx.write(i32, 6, 0));
+}
+
+test "HostContext: null memory" {
+    const ctx = HostContext{ .mem_base = null, .mem_len = 0 };
+    try testing.expect(ctx.memory() == null);
+    try testing.expect(ctx.read(i32, 0) == null);
+    try testing.expect(!ctx.write(i32, 0, 42));
+}

--- a/src/api/wamr.zig
+++ b/src/api/wamr.zig
@@ -78,6 +78,13 @@ pub const Module = struct {
         return .{ .inner = inst, .allocator = self.allocator };
     }
 
+    /// Instantiate with comptime-typed host functions.
+    /// Custom host functions take priority; unmatched imports fall back to WASI.
+    pub fn instantiateWithHosts(self: *Module, comptime HostImportsT: type) !Instance {
+        const inst = try instance_mod.instantiateWithHosts(&self.inner, self.allocator, HostImportsT);
+        return .{ .inner = inst, .allocator = self.allocator };
+    }
+
     /// Find an exported function by name.
     pub fn findExport(self: *const Module, name: []const u8, kind: types.ExternalKind) ?types.ExportDesc {
         return self.inner.findExport(name, kind);
@@ -282,4 +289,54 @@ test "wamr: loadModule rejects component binary" {
     defer runtime.deinit();
     const data = [_]u8{ 0x00, 0x61, 0x73, 0x6D, 0x0d, 0x00, 0x01, 0x00 };
     try testing.expectError(error.IsComponent, runtime.loadModule(&data));
+}
+
+test "wamr: host function add via HostImports" {
+    // Wasm module that imports (env, add) and exports "call_add":
+    //   (import "env" "add" (func $add (param i32 i32) (result i32)))
+    //   (func (export "call_add") (result i32)
+    //     i32.const 3  i32.const 4  call $add)
+    const wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: 2 types
+        0x01, 0x0b, 0x02,
+        0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, // type 0: (i32,i32)->i32
+        0x60, 0x00, 0x01, 0x7f, // type 1: ()->i32
+        // import section: 1 import
+        0x02, 0x0b, 0x01,
+        0x03, 'e', 'n', 'v', // module "env"
+        0x03, 'a', 'd', 'd', // field "add"
+        0x00, 0x00, // func, type 0
+        // function section: 1 local function, type 1
+        0x03, 0x02, 0x01, 0x01,
+        // export section: "call_add" -> func 1
+        0x07, 0x0c, 0x01,
+        0x08, 'c', 'a', 'l', 'l', '_', 'a', 'd', 'd',
+        0x00, 0x01,
+        // code section
+        0x0a, 0x0a, 0x01,
+        0x08, 0x00, // body size, 0 locals
+        0x41, 0x03, // i32.const 3
+        0x41, 0x04, // i32.const 4
+        0x10, 0x00, // call func 0 (imported add)
+        0x0b, // end
+    };
+
+    const MyHosts = host.HostImports(.{
+        .{ "env", "add", struct {
+            fn f(_: host.HostContext, a: i32, b: i32) i32 {
+                return a + b;
+            }
+        }.f },
+    });
+
+    var runtime = Runtime.init(testing.allocator);
+    defer runtime.deinit();
+    var module = try runtime.loadModule(&wasm);
+    defer module.deinit();
+    var instance = try module.instantiateWithHosts(MyHosts);
+    defer instance.deinit();
+
+    const result = try instance.callI32("call_add", &.{});
+    try testing.expectEqual(@as(i32, 7), result);
 }

--- a/src/api/wamr.zig
+++ b/src/api/wamr.zig
@@ -340,3 +340,67 @@ test "wamr: host function add via HostImports" {
     const result = try instance.callI32("call_add", &.{});
     try testing.expectEqual(@as(i32, 7), result);
 }
+
+test "wamr: host function reads memory" {
+    // Wasm module with memory that imports (env, sum_bytes):
+    //   (memory 1)
+    //   (import "env" "sum_bytes" (func $sum (param i32 i32) (result i32)))
+    //   (data (i32.const 0) "\x0a\x14\x1e")  ;; bytes 10, 20, 30 at offset 0
+    //   (func (export "test") (result i32)
+    //     i32.const 0  i32.const 3  call $sum)
+    const wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: 2 types
+        0x01, 0x0b, 0x02,
+        0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, // (i32,i32)->i32
+        0x60, 0x00, 0x01, 0x7f, // ()->i32
+        // import section
+        0x02, 0x11, 0x01,
+        0x03, 'e', 'n', 'v',
+        0x09, 's', 'u', 'm', '_', 'b', 'y', 't', 'e', 's',
+        0x00, 0x00,
+        // function section
+        0x03, 0x02, 0x01, 0x01,
+        // memory section
+        0x05, 0x03, 0x01, 0x00, 0x01,
+        // export section: "test" -> func 1
+        0x07, 0x08, 0x01,
+        0x04, 't', 'e', 's', 't',
+        0x00, 0x01,
+        // code section
+        0x0a, 0x0a, 0x01,
+        0x08, 0x00,
+        0x41, 0x00, // i32.const 0
+        0x41, 0x03, // i32.const 3
+        0x10, 0x00, // call $sum
+        0x0b,
+        // data section: 3 bytes at offset 0
+        0x0b, 0x09, 0x01,
+        0x00, 0x41, 0x00, 0x0b, // active, offset = i32.const 0
+        0x03, 0x0a, 0x14, 0x1e, // 3 bytes: 10, 20, 30
+    };
+
+    const MyHosts = host.HostImports(.{
+        .{ "env", "sum_bytes", struct {
+            fn f(ctx: host.HostContext, ptr: i32, len: i32) i32 {
+                const mem = ctx.memory() orelse return -1;
+                const start: u32 = @bitCast(ptr);
+                const end: u32 = start + @as(u32, @bitCast(len));
+                if (end > mem.len) return -1;
+                var sum: i32 = 0;
+                for (mem[start..end]) |b| sum += b;
+                return sum;
+            }
+        }.f },
+    });
+
+    var runtime = Runtime.init(testing.allocator);
+    defer runtime.deinit();
+    var module = try runtime.loadModule(&wasm);
+    defer module.deinit();
+    var instance = try module.instantiateWithHosts(MyHosts);
+    defer instance.deinit();
+
+    const result = try instance.callI32("test", &.{});
+    try testing.expectEqual(@as(i32, 60), result); // 10 + 20 + 30
+}

--- a/src/api/wamr.zig
+++ b/src/api/wamr.zig
@@ -20,6 +20,11 @@ const comp_types = @import("../component/types.zig");
 const comp_loader = @import("../component/loader.zig");
 const comp_instance = @import("../component/instance.zig");
 
+/// Host function registration types.
+pub const host = @import("host.zig");
+pub const HostContext = host.HostContext;
+pub const HostImports = host.HostImports;
+
 /// The WAMR runtime — manages the lifecycle of modules and instances.
 pub const Runtime = struct {
     allocator: std.mem.Allocator,

--- a/src/root.zig
+++ b/src/root.zig
@@ -14,6 +14,9 @@ pub const c_api = @import("api/c_api.zig");
 /// Idiomatic Zig embedding API.
 pub const wamr = @import("api/wamr.zig");
 
+/// Host function registration (comptime-typed native function imports).
+pub const host = @import("api/host.zig");
+
 /// Core WebAssembly types.
 pub const types = @import("runtime/common/types.zig");
 

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -1705,6 +1705,23 @@ fn resolveHostFunctions(
     module: *const aot_loader.AotModule,
     allocator: std.mem.Allocator,
 ) RuntimeError![]const ?*const anyopaque {
+    return resolveHostFunctionsImpl(module, allocator, null);
+}
+
+/// Resolve host functions with optional custom HostImports (comptime-typed).
+pub fn resolveHostFunctionsWithHosts(
+    module: *const aot_loader.AotModule,
+    allocator: std.mem.Allocator,
+    comptime HostImportsT: ?type,
+) RuntimeError![]const ?*const anyopaque {
+    return resolveHostFunctionsImpl(module, allocator, HostImportsT);
+}
+
+fn resolveHostFunctionsImpl(
+    module: *const aot_loader.AotModule,
+    allocator: std.mem.Allocator,
+    comptime HostImportsT: ?type,
+) RuntimeError![]const ?*const anyopaque {
     if (module.import_function_count == 0) return &.{};
 
     const host_fns = allocator.alloc(?*const anyopaque, module.import_function_count) catch
@@ -1715,10 +1732,19 @@ fn resolveHostFunctions(
     for (module.imports) |imp| {
         if (imp.kind == .function) {
             if (func_idx < module.import_function_count) {
-                if (host_bridge.isWasiModule(imp.module_name)) {
-                    host_fns[func_idx] = host_bridge.resolveAotHostFunction(imp.field_name);
-                } else if (host_bridge.isSpectestModule(imp.module_name)) {
-                    host_fns[func_idx] = host_bridge.resolveAotSpectestFunction(imp.field_name);
+                // Layer 1: custom HostImports (comptime-resolved)
+                if (HostImportsT) |HI| {
+                    if (HI.resolve(imp.module_name, imp.field_name)) |entry| {
+                        host_fns[func_idx] = entry.aot_fn;
+                    }
+                }
+                // Layer 2: WASI / spectest (only if not already resolved)
+                if (host_fns[func_idx] == null) {
+                    if (host_bridge.isWasiModule(imp.module_name)) {
+                        host_fns[func_idx] = host_bridge.resolveAotHostFunction(imp.field_name);
+                    } else if (host_bridge.isSpectestModule(imp.module_name)) {
+                        host_fns[func_idx] = host_bridge.resolveAotSpectestFunction(imp.field_name);
+                    }
                 }
             }
             func_idx += 1;

--- a/src/runtime/interpreter/instance.zig
+++ b/src/runtime/interpreter/instance.zig
@@ -46,6 +46,25 @@ pub fn instantiateWithImports(
     allocator: std.mem.Allocator,
     import_ctx: ?ImportContext,
 ) InstantiationError!*types.ModuleInstance {
+    return instantiateImpl(module, allocator, import_ctx, null);
+}
+
+/// Instantiate a module with host (native) functions from a comptime HostImports table.
+/// Custom host functions take priority; unmatched imports fall back to WASI.
+pub fn instantiateWithHosts(
+    module: *const types.WasmModule,
+    allocator: std.mem.Allocator,
+    comptime HostImportsT: type,
+) InstantiationError!*types.ModuleInstance {
+    return instantiateImpl(module, allocator, null, HostImportsT);
+}
+
+fn instantiateImpl(
+    module: *const types.WasmModule,
+    allocator: std.mem.Allocator,
+    import_ctx: ?ImportContext,
+    comptime HostImportsT: ?type,
+) InstantiationError!*types.ModuleInstance {
     const has_non_func_imports =
         module.import_global_count > 0 or
         module.import_memory_count > 0 or
@@ -93,10 +112,35 @@ pub fn instantiateWithImports(
         }
     }
 
-    // Resolve WASI host functions for function imports
+    // Resolve host functions for function imports.
+    // Priority: custom HostImports (if provided) > WASI auto-resolution.
     if (module.import_function_count > 0) {
+        const host_fns = allocator.alloc(?types.HostFn, module.import_function_count) catch return error.OutOfMemory;
+        @memset(host_fns, null);
+
+        // Layer 1: custom host functions from HostImports (comptime-resolved)
+        if (HostImportsT) |HI| {
+            var func_idx: u32 = 0;
+            for (module.imports) |imp| {
+                if (imp.kind == .function) {
+                    if (func_idx < module.import_function_count) {
+                        if (HI.resolve(imp.module_name, imp.field_name)) |entry| {
+                            host_fns[func_idx] = entry.interp_fn;
+                        }
+                    }
+                    func_idx += 1;
+                }
+            }
+        }
+
+        // Layer 2: WASI auto-resolution for any remaining nulls
         const wasi_host = @import("../../wasi/host_functions.zig");
-        const host_fns = wasi_host.resolveWasiHostFunctions(module, allocator) catch return error.OutOfMemory;
+        const wasi_fns = wasi_host.resolveWasiHostFunctions(module, allocator) catch return error.OutOfMemory;
+        defer allocator.free(wasi_fns);
+        for (wasi_fns, 0..) |wasi_fn, i| {
+            if (host_fns[i] == null) host_fns[i] = wasi_fn;
+        }
+
         inst.host_functions = host_fns;
         inst.owns_host_functions = true;
     }


### PR DESCRIPTION
## Summary

Add a public API for registering custom host (native) Zig functions as WebAssembly imports, addressing #110. Unlike C++ WAMR's runtime signature strings, this uses Zig comptime for compile-time type safety and zero-cost adapter generation.

## What Zig comptime provides (vs C++ WAMR)

| | C++ WAMR | Zig WAMR |
|---|---|---|
| Type checking | Runtime (signature strings) | **Compile time** |
| Wrong types | Runtime crash | **Compile error** |
| Adapter glue | Manual (push/pop stack) | **Auto-generated** |
| Memory overhead | NativeSymbol array + strings | **Zero** (comptime-known) |
| Both backends | N/A | **One function works for both interp and AOT** |

## Changes (4 commits)

1. Phase 1: `src/api/host.zig` - HostContext, HostImports, comptime adapter generation
2. Phase 2: `src/runtime/interpreter/instance.zig` - instantiateWithHosts(), priority resolution (custom > WASI)
3. Phase 3: `src/runtime/aot/runtime.zig` - AOT C-calling-convention adapters
4. Phase 4: Integration tests - add(3,4)=7 and memory-reading host function

Fixes #110
