### PR TITLE
ir: strength-reduce mul by power-of-two to shl (closes #127)

### DIFF
--- a/src/compiler/bench_codegen.zig
+++ b/src/compiler/bench_codegen.zig
@@ -194,6 +194,18 @@ fn bodyDeadIntermediates(func: *ir.IrFunction, block: *ir.BasicBlock) void {
     block.append(.{ .op = .{ .ret = result } }) catch unreachable;
 }
 
+/// Body that multiplies a function-result placeholder by a power-of-two
+/// constant (8). With the `strengthReduceMul` pass this becomes `shl x, 3`.
+fn bodyMulByPow2(func: *ir.IrFunction, block: *ir.BasicBlock) void {
+    const x = func.newVReg();
+    const c = func.newVReg();
+    const result = func.newVReg();
+    block.append(.{ .op = .{ .iconst_32 = 5 }, .dest = x }) catch unreachable;
+    block.append(.{ .op = .{ .iconst_32 = 8 }, .dest = c }) catch unreachable;
+    block.append(.{ .op = .{ .mul = .{ .lhs = x, .rhs = c } }, .dest = result }) catch unreachable;
+    block.append(.{ .op = .{ .ret = result } }) catch unreachable;
+}
+
 fn runBenchWithPasses(
     allocator: std.mem.Allocator,
     name: []const u8,
@@ -277,6 +289,13 @@ pub fn main() !void {
         dce_result.name,
         dce_result.cyclesPerOp(),
         dce_result.code_size,
+    });
+
+    const mul_result = try runBenchWithPasses(allocator, "mul(x, 8) → shl(x, 3)", &bodyMulByPow2);
+    std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{
+        mul_result.name,
+        mul_result.cyclesPerOp(),
+        mul_result.code_size,
     });
 
     std.debug.print("\n", .{});

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -417,6 +417,116 @@ fn evalBinOp(op: ir.Inst.Op, lhs: i64, rhs: i64) ?i64 {
     };
 }
 
+// ── Strength Reduction ──────────────────────────────────────────────────────
+
+/// Return the shift amount `k` if `c` is a power of two that fits
+/// within a legal shift for `ir_type` (i32 → k in [1,31], i64 → k in [1,63]).
+/// For i32, `c` is interpreted modulo 2^32 since wasm `i32.mul` is modular,
+/// so `c = 0x80000000` (negative as i32) correctly maps to a shift of 31.
+/// Returns `null` for `c == 0`, `c == 1`, non-powers-of-two, or shift
+/// amounts outside the legal range.
+fn powerOfTwoShift(c: i64, ir_type: ir.IrType) ?u6 {
+    const u: u64 = switch (ir_type) {
+        .i32 => @as(u32, @truncate(@as(u64, @bitCast(c)))),
+        .i64 => @bitCast(c),
+        else => return null,
+    };
+    if (u <= 1) return null;
+    if (u & (u - 1) != 0) return null; // not a power of two
+    const k: u6 = @intCast(@ctz(u));
+    const max: u6 = if (ir_type == .i32) 31 else 63;
+    if (k == 0 or k > max) return null;
+    return k;
+}
+
+/// Rewrite `mul(x, 2^k)` → `shl(x, k)`. `imul` has higher latency than
+/// `shl` on modern x86-64 (3 vs 1 cycles) and on AArch64, so this is a
+/// win for both backends and for code size (no 64-bit immediate needed).
+///
+/// Matches when either operand of a `.mul` is defined by an `iconst_32`
+/// / `iconst_64` whose value is a power of two in `[2, 2^31]` (i32) or
+/// `[2, 2^63]` (i64). A new iconst for the shift amount is inserted
+/// immediately before the rewritten instruction; the original constant
+/// instruction is left untouched (DCE will remove it if it becomes
+/// unused).
+pub fn strengthReduceMul(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    var changed = false;
+    var constants = std.AutoHashMap(ir.VReg, i64).init(allocator);
+    defer constants.deinit();
+
+    for (func.blocks.items) |*block| {
+        // Build constants map for this block (linear SSA within a block is
+        // sufficient: all producers of a power-of-two constant we care about
+        // are iconst_32 / iconst_64 instructions defined earlier in the same
+        // block via the frontend's straight-line lowering of `i32.const`.)
+        constants.clearRetainingCapacity();
+
+        var i: usize = 0;
+        while (i < block.instructions.items.len) : (i += 1) {
+            const inst = block.instructions.items[i];
+            switch (inst.op) {
+                .iconst_32 => |v| if (inst.dest) |d| {
+                    try constants.put(d, v);
+                },
+                .iconst_64 => |v| if (inst.dest) |d| {
+                    try constants.put(d, v);
+                },
+                .mul => |bin| {
+                    const dest = inst.dest orelse continue;
+                    // Determine which operand is the constant power of two.
+                    const lhs_const = constants.get(bin.lhs);
+                    const rhs_const = constants.get(bin.rhs);
+
+                    var non_const_vreg: ir.VReg = undefined;
+                    var k: u6 = undefined;
+                    if (rhs_const) |c| {
+                        if (powerOfTwoShift(c, inst.type)) |s| {
+                            non_const_vreg = bin.lhs;
+                            k = s;
+                        } else if (lhs_const) |lc| {
+                            if (powerOfTwoShift(lc, inst.type)) |s| {
+                                non_const_vreg = bin.rhs;
+                                k = s;
+                            } else continue;
+                        } else continue;
+                    } else if (lhs_const) |c| {
+                        if (powerOfTwoShift(c, inst.type)) |s| {
+                            non_const_vreg = bin.rhs;
+                            k = s;
+                        } else continue;
+                    } else continue;
+
+                    // Insert a fresh iconst for the shift amount *before* the
+                    // mul, then rewrite the mul into a shl.
+                    const shift_vreg = func.newVReg();
+                    const shift_op: ir.Inst.Op = if (inst.type == .i64)
+                        .{ .iconst_64 = @intCast(k) }
+                    else
+                        .{ .iconst_32 = @intCast(k) };
+                    try block.instructions.insert(
+                        block.allocator,
+                        i,
+                        .{ .op = shift_op, .dest = shift_vreg, .type = inst.type },
+                    );
+                    // After insertion, what was at index i is now at i+1.
+                    block.instructions.items[i + 1].op = .{ .shl = .{
+                        .lhs = non_const_vreg,
+                        .rhs = shift_vreg,
+                    } };
+                    block.instructions.items[i + 1].dest = dest;
+                    // Record the new shift amount constant so downstream muls
+                    // in the same block can see it (harmless — value is small).
+                    try constants.put(shift_vreg, @intCast(k));
+                    changed = true;
+                    i += 1; // skip over the newly-inserted iconst
+                },
+                else => {},
+            }
+        }
+    }
+    return changed;
+}
+
 // ── Dead Code Elimination ───────────────────────────────────────────────────
 
 /// Remove instructions whose dest VReg is never used.
@@ -594,6 +704,7 @@ pub fn runPasses(module: *ir.IrModule, passes: []const PassFn, allocator: std.me
 /// The default optimization pipeline.
 pub const default_passes: []const PassFn = &.{
     &constantFold,
+    &strengthReduceMul,
     &commonSubexprElimination,
     &deadCodeElimination,
 };
@@ -1054,4 +1165,155 @@ test "reorderBlocks: unreachable block appended at end" {
     try std.testing.expectEqual(@as(ir.BlockId, 1), order[1]);
     // Unreachable block 2 at end
     try std.testing.expectEqual(@as(ir.BlockId, 2), order[2]);
+}
+
+test "strengthReduceMul: mul(x, 8) → shl(x, 3)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const block_id = try func.newBlock();
+    var block = &func.blocks.items[block_id];
+
+    const v_x = func.newVReg(); // param (fake)
+    const v_c = func.newVReg();
+    const v_r = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 8 }, .dest = v_c });
+    try block.append(.{ .op = .{ .mul = .{ .lhs = v_x, .rhs = v_c } }, .dest = v_r });
+    try block.append(.{ .op = .{ .ret = v_r } });
+
+    const changed = try strengthReduceMul(&func, allocator);
+    try std.testing.expect(changed);
+
+    // Block should now be: iconst_32=8, iconst_32=3, shl(v_x, new_vreg), ret
+    try std.testing.expectEqual(@as(usize, 4), block.instructions.items.len);
+    try std.testing.expectEqual(ir.Inst.Op{ .iconst_32 = 3 }, block.instructions.items[1].op);
+    const shl = block.instructions.items[2];
+    switch (shl.op) {
+        .shl => |bin| {
+            try std.testing.expectEqual(v_x, bin.lhs);
+            try std.testing.expectEqual(block.instructions.items[1].dest.?, bin.rhs);
+        },
+        else => try std.testing.expect(false),
+    }
+    try std.testing.expectEqual(v_r, shl.dest.?);
+}
+
+test "strengthReduceMul: commutative mul(C, x)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const block_id = try func.newBlock();
+    var block = &func.blocks.items[block_id];
+
+    const v_x = func.newVReg();
+    const v_c = func.newVReg();
+    const v_r = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 16 }, .dest = v_c });
+    try block.append(.{ .op = .{ .mul = .{ .lhs = v_c, .rhs = v_x } }, .dest = v_r });
+    try block.append(.{ .op = .{ .ret = v_r } });
+
+    const changed = try strengthReduceMul(&func, allocator);
+    try std.testing.expect(changed);
+    const shl = block.instructions.items[2];
+    switch (shl.op) {
+        .shl => |bin| try std.testing.expectEqual(v_x, bin.lhs),
+        else => try std.testing.expect(false),
+    }
+    try std.testing.expectEqual(ir.Inst.Op{ .iconst_32 = 4 }, block.instructions.items[1].op);
+}
+
+test "strengthReduceMul: i64 mul by power of two" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const block_id = try func.newBlock();
+    var block = &func.blocks.items[block_id];
+
+    const v_x = func.newVReg();
+    const v_c = func.newVReg();
+    const v_r = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_64 = 1 << 40 }, .dest = v_c, .type = .i64 });
+    try block.append(.{
+        .op = .{ .mul = .{ .lhs = v_x, .rhs = v_c } },
+        .dest = v_r,
+        .type = .i64,
+    });
+    try block.append(.{ .op = .{ .ret = v_r } });
+
+    const changed = try strengthReduceMul(&func, allocator);
+    try std.testing.expect(changed);
+    try std.testing.expectEqual(ir.Inst.Op{ .iconst_64 = 40 }, block.instructions.items[1].op);
+    try std.testing.expectEqual(ir.IrType.i64, block.instructions.items[1].type);
+    try std.testing.expectEqual(ir.IrType.i64, block.instructions.items[2].type);
+}
+
+test "strengthReduceMul: does not rewrite mul by non-power-of-two" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const block_id = try func.newBlock();
+    var block = &func.blocks.items[block_id];
+
+    const v_x = func.newVReg();
+    const v_c = func.newVReg();
+    const v_r = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 3 }, .dest = v_c });
+    try block.append(.{ .op = .{ .mul = .{ .lhs = v_x, .rhs = v_c } }, .dest = v_r });
+    try block.append(.{ .op = .{ .ret = v_r } });
+
+    const changed = try strengthReduceMul(&func, allocator);
+    try std.testing.expect(!changed);
+    try std.testing.expectEqual(@as(usize, 3), block.instructions.items.len);
+    switch (block.instructions.items[1].op) {
+        .mul => {},
+        else => try std.testing.expect(false),
+    }
+}
+
+test "strengthReduceMul: skips C=1 and C=0 and negatives" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const block_id = try func.newBlock();
+    var block = &func.blocks.items[block_id];
+
+    const v_x = func.newVReg();
+    const v_c0 = func.newVReg();
+    const v_c1 = func.newVReg();
+    const v_cneg = func.newVReg();
+    const v_r0 = func.newVReg();
+    const v_r1 = func.newVReg();
+    const v_rn = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = v_c0 });
+    try block.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_c1 });
+    try block.append(.{ .op = .{ .iconst_32 = -4 }, .dest = v_cneg });
+    try block.append(.{ .op = .{ .mul = .{ .lhs = v_x, .rhs = v_c0 } }, .dest = v_r0 });
+    try block.append(.{ .op = .{ .mul = .{ .lhs = v_x, .rhs = v_c1 } }, .dest = v_r1 });
+    try block.append(.{ .op = .{ .mul = .{ .lhs = v_x, .rhs = v_cneg } }, .dest = v_rn });
+    try block.append(.{ .op = .{ .ret = v_r0 } });
+
+    const changed = try strengthReduceMul(&func, allocator);
+    try std.testing.expect(!changed);
+}
+
+test "strengthReduceMul: i32 does not rewrite shift >= 32" {
+    // 2^32 fits in i64 but is illegal as an i32 shift amount.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const block_id = try func.newBlock();
+    var block = &func.blocks.items[block_id];
+
+    const v_x = func.newVReg();
+    const v_c = func.newVReg();
+    const v_r = func.newVReg();
+    // i32 iconst; value 1<<31 = -2147483648 as i32 → still a power of two,
+    // and 31 is a legal shift amount, so this should rewrite.
+    try block.append(.{ .op = .{ .iconst_32 = @bitCast(@as(u32, 1) << 31) }, .dest = v_c });
+    try block.append(.{ .op = .{ .mul = .{ .lhs = v_x, .rhs = v_c } }, .dest = v_r });
+    try block.append(.{ .op = .{ .ret = v_r } });
+
+    const changed = try strengthReduceMul(&func, allocator);
+    try std.testing.expect(changed);
+    try std.testing.expectEqual(ir.Inst.Op{ .iconst_32 = 31 }, block.instructions.items[1].op);
 }


### PR DESCRIPTION
Closes #127.

## What

Adds an IR peephole pass `strengthReduceMul` that rewrites `mul(x, 2^k)` → `shl(x, k)` when the constant operand (either side) is a power of two. Slotted into `default_passes` between `constantFold` and `commonSubexprElimination` so the original `iconst` becomes dead and DCE cleans it up.

## Details

- Operand position: commutative — matches constant on lhs or rhs of `.mul`.
- Types: handles both `i32` and `i64`. For `i32` the constant is interpreted mod 2^32, so e.g. `0x80000000` (negative as `i32`) correctly rewrites to `shl 31`.
- Shift range: skips `C=0` and `C=1` (log2=0 is a no-op), and any `k` outside the legal shift range (`[1,31]` for i32, `[1,63]` for i64).
- Constant tracking is per-block (straight-line SSA), same style as `constantFold`. A new `iconst` for the shift amount is inserted immediately before the rewritten instruction; the old constant instruction is left for DCE.

## Why

`imul r,imm` has higher latency than `shl r,imm` on both x86-64 (3 vs 1 cycle) and AArch64, and `shl` by an immediate avoids a 32/64-bit immediate load for the constant. This mirrors Cranelift's algebraic peephole.

## Tests

Six new unit tests in `passes.zig`:

- rewrite `mul(x, 8)` → `shl(x, 3)`
- commutative: rewrite `mul(16, x)`
- i64 path: `mul(x, 1<<40)` → `shl(x, 40)`
- negative: `mul(x, 3)` unchanged
- negative: `C ∈ {0, 1, -4}` unchanged
- i32 high bit: `mul(x, 1<<31)` → `shl(x, 31)`

All 867/867 existing tests still pass (`zig build test` on aarch64).

Also adds a mul-by-pow2 body to `bench_codegen.zig`.

## Notes

`zig build spec-tests-aot` and `zig build bench` fail on this branch for reasons pre-existing on main (spec-tests hits an unrelated `wasm trap: unreachable`; bench uses `rdtsc` inline asm that isn't available on this aarch64 host). Both will be exercised on x86-64 in CI.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>