### PR TITLE
regalloc: parameterize linear-scan allocator over a RegSet (Phase 0)

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -3771,6 +3771,119 @@ pub fn compileModule(ir_module: *const ir.IrModule, allocator: std.mem.Allocator
     };
 }
 
+// ── Register-Allocator Preparation ─────────────────────────────────────────
+//
+// Phase 1 of the linear-scan regalloc adoption (plan in issue #100): define
+// the aarch64 `RegSet` and a `collectClobberPoints` helper that mirrors the
+// x86-64 version in `../x86_64/compile.zig`. This code is not yet wired into
+// codegen — `RegMap` remains the source of truth for vreg → physreg
+// assignment. It exists so Phase 2 can run allocation in shadow mode and
+// Phase 3 can flip emitters without also introducing new analysis in the
+// same step.
+
+const regalloc = @import("../../ir/regalloc.zig");
+
+/// Allocatable aarch64 GPRs, in stable index order used by clobber masks.
+///
+/// Indices 0..14 map to x0..x14 (AAPCS64 caller-saved; x15 is reserved as
+/// a non-allocatable scratch `RegMap.tmp2`). Indices 15..24 map to
+/// x19..x28 (callee-saved). x16/x17 are `RegMap.tmp0/tmp1`, x18 is the
+/// platform register, x29/x30 are FP/LR, and x31 is SP — all excluded.
+pub const aarch64_alloc_regs = [_]regalloc.PhysReg{
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+    19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+};
+
+/// Indices into `aarch64_alloc_regs` of AAPCS64 caller-saved registers
+/// (x0..x14). Used as the "prefer when live range doesn't span a call"
+/// pool.
+pub const aarch64_caller_saved_indices = [_]u8{
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+};
+
+/// Indices into `aarch64_alloc_regs` of AAPCS64 callee-saved registers
+/// (x19..x28). Preferred for live ranges that span a call, since they
+/// survive without save/restore.
+pub const aarch64_callee_saved_indices = [_]u8{
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+};
+
+/// Bitmask over `aarch64_alloc_regs` of registers destroyed by any
+/// AAPCS64-compatible procedure call (direct, indirect, or vmctx
+/// helper): x0..x14 (indices 0..14). x15..x17 are our own non-
+/// allocatable scratches, x18 is platform-reserved.
+pub const aarch64_call_clobber_mask: u64 = (@as(u64, 1) << 15) - 1;
+
+/// Build the per-function `RegSet` for aarch64. `local_count` sets the
+/// spill-slot origin above the operand stack.
+///
+/// Frame layout (matches `compileFunctionImpl` / `emitEntrySpill`):
+/// `[fp+0]` = saved fp, `[fp+8]` = saved lr, `[fp+16]` = vmctx slot,
+/// `[fp+24 .. fp+24+LC*8]` = locals, then a 64-slot operand stack, then
+/// spills growing upward. Spills begin at `fp + 24 + (LC + 64)*8`.
+pub fn aarch64RegSet(local_count: u32) regalloc.RegSet {
+    return .{
+        .alloc_regs = &aarch64_alloc_regs,
+        .callee_saved_indices = &aarch64_callee_saved_indices,
+        .caller_saved_indices = &aarch64_caller_saved_indices,
+        .spill_base = @as(i32, 24) + @as(i32, @intCast(local_count + 64)) * 8,
+        .spill_stride = 8,
+    };
+}
+
+/// Scan `func` and emit a `ClobberPoint` for every instruction that
+/// destroys caller-saved registers under AAPCS64. Positions use the same
+/// flat indexing as `analysis.computeLiveRanges` (one counter, block-
+/// major, instruction-minor), so they line up with the allocator's live
+/// ranges without further translation.
+///
+/// Clobbering ops on aarch64:
+///   - `.call`, `.call_indirect`, `.call_ref` — direct/indirect/callable-
+///     reference calls, all go through `bl`/`blr`.
+///   - `.memory_grow`, `.memory_copy`, `.memory_fill`, `.memory_init` —
+///     compiled as vmctx helper calls (see `emitVmctxHelperCall`).
+///   - `.table_set`, `.table_grow`, `.table_init` — likewise.
+///   - `.atomic_wait`, `.atomic_notify` — vmctx helper calls.
+/// All use a `bl` to a C ABI helper and therefore clobber the full
+/// caller-saved set.
+///
+/// Not clobbered (executed inline): `.atomic_load`, `.atomic_store`,
+/// `.atomic_rmw`, `.atomic_cmpxchg`, `.atomic_fence` (LSE atomics).
+pub fn collectClobberPoints(
+    func: *const ir.IrFunction,
+    allocator: std.mem.Allocator,
+) !std.ArrayList(regalloc.ClobberPoint) {
+    var clobbers: std.ArrayList(regalloc.ClobberPoint) = .empty;
+    errdefer clobbers.deinit(allocator);
+
+    var pos: u32 = 0;
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |ci| {
+            switch (ci.op) {
+                .call,
+                .call_indirect,
+                .call_ref,
+                .memory_grow,
+                .memory_copy,
+                .memory_fill,
+                .memory_init,
+                .table_set,
+                .table_grow,
+                .table_init,
+                .atomic_wait,
+                .atomic_notify,
+                => try clobbers.append(allocator, .{
+                    .pos = pos,
+                    .regs_clobbered = aarch64_call_clobber_mask,
+                }),
+                else => {},
+            }
+            pos += 1;
+        }
+    }
+    return clobbers;
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 test "compileFunction: iconst_32 + ret" {
@@ -4901,4 +5014,83 @@ test "compileFunction: FMA fusion does not skip mul with non-arith uses" {
     const code = try compileFunction(&func, allocator);
     defer allocator.free(code);
     try std.testing.expect(code.len > 0);
+}
+
+test "collectClobberPoints: no calls → empty" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const block = func.getBlock(b0);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v0 } });
+
+    var cps = try collectClobberPoints(&func, allocator);
+    defer cps.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 0), cps.items.len);
+}
+
+test "collectClobberPoints: one ClobberPoint per call, correct mask" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const block = func.getBlock(b0);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    // Mix of clobbering and non-clobbering ops to verify positions.
+    try block.append(.{ .op = .{ .iconst_32 = 3 }, .dest = v0, .type = .i32 }); // pos 0
+    try block.append(.{ .op = .{ .call = .{ .func_idx = 0 } }, .dest = v1 });    // pos 1
+    try block.append(.{ .op = .{ .iconst_32 = 5 }, .dest = func.newVReg(), .type = .i32 }); // pos 2
+    try block.append(.{ .op = .{ .memory_fill = .{ .dst = v0, .val = v0, .len = v0 } } });  // pos 3
+    try block.append(.{ .op = .{ .ret = v1 } });                                 // pos 4
+
+    var cps = try collectClobberPoints(&func, allocator);
+    defer cps.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), cps.items.len);
+    try std.testing.expectEqual(@as(u32, 1), cps.items[0].pos);
+    try std.testing.expectEqual(@as(u32, 3), cps.items[1].pos);
+    // Full caller-saved set (x0..x14 = indices 0..14): (1<<15) - 1 = 0x7FFF.
+    try std.testing.expectEqual(@as(u64, 0x7FFF), cps.items[0].regs_clobbered);
+    try std.testing.expectEqual(@as(u64, 0x7FFF), cps.items[1].regs_clobbered);
+}
+
+test "collectClobberPoints: positions are monotonic across blocks" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const block0 = func.getBlock(b0);
+    const block1 = func.getBlock(b1);
+    const v0 = func.newVReg();
+    try block0.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0, .type = .i32 }); // pos 0
+    try block0.append(.{ .op = .{ .call = .{ .func_idx = 0 } }, .dest = func.newVReg() }); // pos 1
+    try block0.append(.{ .op = .{ .br = b1 } });                   // pos 2
+    try block1.append(.{ .op = .{ .call = .{ .func_idx = 0 } }, .dest = func.newVReg() }); // pos 3
+    try block1.append(.{ .op = .{ .ret = v0 } });                                 // pos 4
+
+    var cps = try collectClobberPoints(&func, allocator);
+    defer cps.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), cps.items.len);
+    try std.testing.expectEqual(@as(u32, 1), cps.items[0].pos);
+    try std.testing.expectEqual(@as(u32, 3), cps.items[1].pos);
+    try std.testing.expect(cps.items[0].pos < cps.items[1].pos);
+}
+
+test "aarch64RegSet: sane layout for a tiny function" {
+    const rs = aarch64RegSet(0);
+    // 25 allocatable GPRs, 15 caller-saved + 10 callee-saved.
+    try std.testing.expectEqual(@as(usize, 25), rs.alloc_regs.len);
+    try std.testing.expectEqual(@as(usize, 15), rs.caller_saved_indices.len);
+    try std.testing.expectEqual(@as(usize, 10), rs.callee_saved_indices.len);
+    // Spill stride grows upward (away from fp).
+    try std.testing.expect(rs.spill_stride > 0);
+    // With zero locals, first spill lives above the 64-slot operand stack.
+    try std.testing.expect(rs.spill_base >= 24 + 64 * 8);
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1202,19 +1202,15 @@ fn dumpFuncIRAlloc(func: *const ir.IrFunction, fi: u32, import_count: u32, alloc
         for (block.instructions.items) |ci| {
             switch (ci.op) {
                 .call, .call_indirect, .call_ref, .memory_grow, .memory_copy, .table_grow, .table_set => {
-                    const mask = if (comptime builtin.os.tag == .windows)
-                        [_]bool{ true, false, false, false, true, true, false, false, false, false }
-                    else
-                        [_]bool{ true, false, true, true, true, true, false, false, false, false };
-                    try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = mask });
+                    try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = x86_64_call_clobber_mask });
                 },
-                .memory_fill => try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = .{ false, false, false, true, false, false, false, false, false, false } }),
+                .memory_fill => try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = @as(u64, 1) << 3 }),
                 else => {},
             }
             cp_pos += 1;
         }
     }
-    var alloc = try regalloc.allocate(func, allocator, clobbers.items);
+    var alloc = try regalloc.allocate(func, allocator, x86_64_reg_set(func.local_count), clobbers.items);
     defer alloc.deinit();
 
     var pos: u32 = 0;
@@ -1342,6 +1338,47 @@ const GlobalCallPatch = struct {
 
 const regalloc = @import("../../ir/regalloc.zig");
 
+/// x86-64 allocatable GPR set: rdx(2), rbx(3), rsi(6), rdi(7), r8(8), r9(9),
+/// r12(12), r13(13), r14(14), r15(15). Order matches the legacy mask layout,
+/// so `caller_saved_indices` / `callee_saved_indices` are stable indices
+/// into `alloc_regs` and match the bit positions used in clobber masks below.
+const x86_64_alloc_regs = [_]regalloc.PhysReg{ 2, 3, 6, 7, 8, 9, 12, 13, 14, 15 };
+
+/// Indices into `x86_64_alloc_regs` of callee-saved registers (same on
+/// Win64 and SysV): rbx(idx 1), r12..r15 (idx 6..9).
+const x86_64_callee_saved_indices = [_]u8{ 1, 6, 7, 8, 9 };
+
+/// Indices into `x86_64_alloc_regs` of caller-saved registers, by ABI.
+/// On Win64: rdx, r8, r9. On SysV: add rsi, rdi.
+const x86_64_caller_saved_indices = if (builtin.os.tag == .windows)
+    [_]u8{ 0, 4, 5 }
+else
+    [_]u8{ 0, 2, 3, 4, 5 };
+
+/// Bitmask over `x86_64_alloc_regs` indices of caller-saved registers
+/// clobbered by a normal call / host runtime call (memory.grow, table.set,
+/// etc.).
+const x86_64_call_clobber_mask: u64 = blk: {
+    var m: u64 = 0;
+    for (x86_64_caller_saved_indices) |i| m |= @as(u64, 1) << i;
+    break :blk m;
+};
+
+/// Build the per-function `RegSet` for x86-64. `local_count` determines
+/// the spill-slot origin so it must be passed in.
+fn x86_64_reg_set(local_count: u32) regalloc.RegSet {
+    return .{
+        .alloc_regs = &x86_64_alloc_regs,
+        .callee_saved_indices = &x86_64_callee_saved_indices,
+        .caller_saved_indices = &x86_64_caller_saved_indices,
+        // Frame layout (see compileFunctionImpl): [rbp-8]=VmCtx,
+        // [rbp-16..-(1+LC)*8]=locals (LC slots), [-(2+LC)*8..-(65+LC)*8]
+        // =op-stack (64 slots). Spills begin at -(66+LC)*8 and grow down.
+        .spill_base = -@as(i32, @intCast((local_count + 66) * 8)),
+        .spill_stride = -8,
+    };
+}
+
 /// Compile an IR function using the linear scan register allocator.
 /// VRegs are assigned to physical registers; instructions operate directly
 /// on assigned registers without push/pop through a CachedStack.
@@ -1359,20 +1396,13 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
                         // Calls clobber caller-saved allocatable regs.
                         // memory.grow / memory.copy are compiled as host calls (same ABI),
                         // so they clobber the same set of caller-saved registers.
-                        // alloc_regs = [rdx(0), rbx(1), rsi(2), rdi(3), r8(4), r9(5), r12(6), r13(7), r14(8), r15(9)]
-                        // On Win64: rdx, r8, r9 are volatile; rbx/rsi/rdi/r12-r15 callee-saved.
-                        // On SysV: rdx, rsi, rdi, r8, r9 are volatile; rbx/r12-r15 callee-saved.
-                        const mask = if (comptime builtin.os.tag == .windows)
-                            [_]bool{ true, false, false, false, true, true, false, false, false, false }
-                        else
-                            [_]bool{ true, false, true, true, true, true, false, false, false, false };
-                        try clobber_points.append(allocator, .{ .pos = pos, .regs_clobbered = mask });
+                        try clobber_points.append(allocator, .{ .pos = pos, .regs_clobbered = x86_64_call_clobber_mask });
                     },
                     .memory_fill => {
-                        // REP STOSB clobbers rdi(7) → index 3
+                        // REP STOSB clobbers rdi (index 3 in alloc_regs).
                         try clobber_points.append(allocator, .{
                             .pos = pos,
-                            .regs_clobbered = .{ false, false, false, true, false, false, false, false, false, false },
+                            .regs_clobbered = @as(u64, 1) << 3,
                         });
                     },
                     else => {},
@@ -1382,7 +1412,7 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
         }
     }
 
-    var alloc_result = try regalloc.allocate(func, allocator, clobber_points.items);
+    var alloc_result = try regalloc.allocate(func, allocator, x86_64_reg_set(func.local_count), clobber_points.items);
     defer alloc_result.deinit();
 
     // Compute which caller-saved registers are actually used by this function.

--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -1,6 +1,6 @@
 //! Linear Scan Register Allocator
 //!
-//! Assigns physical x86-64 registers to VRegs based on live range intervals.
+//! Assigns physical registers to VRegs based on live range intervals.
 //! Uses the Poletto & Sarkar algorithm: sort intervals by start, walk in order,
 //! assign from free pool, spill the longest-remaining interval when exhausted.
 //!
@@ -8,18 +8,53 @@
 //! memory_copy, etc.) are modeled as ClobberPoints. The allocator ensures
 //! no VReg assigned to a clobbered register has its live range span the
 //! clobber, eliminating the need for push/pop at those sites.
+//!
+//! Architecture-agnostic: the caller passes a `RegSet` describing the
+//! allocatable registers, their caller/callee-saved partition, and the
+//! spill-slot layout. x86-64 and aarch64 share this implementation.
 
 const std = @import("std");
 const ir = @import("ir.zig");
 const analysis = @import("analysis.zig");
 
-/// Physical register identifier (0-15 for x86-64 GPRs).
-pub const PhysReg = u4;
+/// Physical register identifier. Widest architecture we target is aarch64
+/// with 0..30 (v0..v31 is separate). `u8` leaves headroom.
+pub const PhysReg = u8;
+
+/// Maximum number of allocatable registers supported by the bitmasks below.
+/// aarch64's allocatable GPR pool is 25; x86-64's is 10. 64 is ample.
+pub const max_alloc_regs: usize = 64;
 
 /// Physical register or stack slot assignment.
 pub const Allocation = union(enum) {
     reg: PhysReg,
-    stack: i32, // offset from RBP
+    /// Byte offset of the spill slot from the frame pointer. Sign and
+    /// stride come from `RegSet.spill_base`/`spill_stride`.
+    stack: i32,
+};
+
+/// Describes the architecture's register file and spill-slot layout.
+/// Caller constructs this per-function (spill_base may depend on the
+/// locals area size, for example).
+pub const RegSet = struct {
+    /// Allocatable physical register numbers, in preference order within
+    /// the caller- and callee-saved partitions. Length must be ≤
+    /// `max_alloc_regs`.
+    alloc_regs: []const PhysReg,
+    /// Indices into `alloc_regs` of registers that survive a call
+    /// without save/restore. Prefer these for live ranges that span a
+    /// clobber point.
+    callee_saved_indices: []const u8,
+    /// Indices into `alloc_regs` of registers that do NOT survive a
+    /// call. Prefer these for short-lived values to avoid the cost of
+    /// preserving callee-saved regs in the prologue.
+    caller_saved_indices: []const u8,
+    /// Byte offset (from the frame pointer) of the first spill slot.
+    spill_base: i32,
+    /// Byte stride from one spill slot to the next. Negative on
+    /// downward-growing frames (x86-64: -8), positive on upward
+    /// (aarch64: +8).
+    spill_stride: i32,
 };
 
 /// Result of register allocation for one function.
@@ -38,23 +73,14 @@ pub const AllocResult = struct {
     }
 };
 
-/// Allocatable registers as PhysReg IDs.
-/// Excludes RAX (0), RCX (1) — used as scratch temporaries by codegen,
-/// RSP (4), RBP (5) — frame pointers, and R10 (10), R11 (11) — scratch regs.
-/// Callee-saved regs (rbx, r12-r15) are preserved in prologue/epilogue when used.
-const alloc_regs = [_]PhysReg{ 2, 3, 6, 7, 8, 9, 12, 13, 14, 15 };
-// rdx=2, rbx=3, rsi=6, rdi=7, r8=8, r9=9, r12=12, r13=13, r14=14, r15=15
-
-/// Scratch registers for spill loads (not allocatable).
-pub const scratch1: PhysReg = 10; // r10
-pub const scratch2: PhysReg = 11; // r11
-
 /// A point in the instruction stream where specific registers are destroyed.
 /// Used to model calls (clobber caller-saved), memory_copy (clobber rsi+rdi), etc.
+///
+/// `regs_clobbered` is a bitmask over the caller's `RegSet.alloc_regs`:
+/// bit i set means `alloc_regs[i]` is destroyed at this position.
 pub const ClobberPoint = struct {
     pos: u32,
-    /// Which alloc_regs indices are clobbered at this position.
-    regs_clobbered: [alloc_regs.len]bool,
+    regs_clobbered: u64,
 };
 
 /// Run linear scan register allocation on a function.
@@ -62,35 +88,38 @@ pub const ClobberPoint = struct {
 pub fn allocate(
     func: *const ir.IrFunction,
     allocator: std.mem.Allocator,
+    reg_set: RegSet,
     clobbers: []const ClobberPoint,
 ) !AllocResult {
+    std.debug.assert(reg_set.alloc_regs.len <= max_alloc_regs);
+
     // Compute live ranges (sorted by start position)
     const ranges = try analysis.computeLiveRanges(func, allocator);
     defer allocator.free(ranges);
 
     var assignments = std.AutoHashMap(ir.VReg, Allocation).init(allocator);
 
-    // Track which registers are free
-    var reg_free = [_]bool{true} ** alloc_regs.len;
+    // Track which register indices are free (bit i ↔ alloc_regs[i]).
+    // Start with the low `alloc_regs.len` bits set.
+    var reg_free: u64 = if (reg_set.alloc_regs.len == 64)
+        std.math.maxInt(u64)
+    else
+        (@as(u64, 1) << @intCast(reg_set.alloc_regs.len)) - 1;
+
     // Active intervals (currently assigned to a register), sorted by end position
     var active: std.ArrayList(ActiveInterval) = .empty;
     defer active.deinit(allocator);
 
     var spill_count: u32 = 0;
 
-    // Spill area must start AFTER the operand-stack area in the frame.
-    // Frame layout (compile.zig): [rbp-8]=VmCtx, [rbp-16..-(1+LC)*8]=locals (LC slots),
-    // [-(2+LC)*8..-(65+LC)*8]=op-stack (64 slots). Spills begin at -(66+LC)*8.
-    const spill_base: i32 = -@as(i32, @intCast((func.local_count + 66) * 8));
-
     for (ranges) |range| {
         // Expire old intervals that ended before this one starts
         expireOldIntervals(&active, range.start, &reg_free);
 
         // Try to find a free register that is safe (not clobbered during this range)
-        if (findSafeReg(&reg_free, range.start, range.end, clobbers)) |reg_idx| {
-            reg_free[reg_idx] = false;
-            try assignments.put(range.vreg, .{ .reg = alloc_regs[reg_idx] });
+        if (findSafeReg(reg_set, reg_free, range.start, range.end, clobbers)) |reg_idx| {
+            reg_free &= ~(@as(u64, 1) << @intCast(reg_idx));
+            try assignments.put(range.vreg, .{ .reg = reg_set.alloc_regs[reg_idx] });
             try insertActive(&active, allocator, .{
                 .vreg = range.vreg,
                 .end = range.end,
@@ -113,10 +142,11 @@ pub fn allocate(
             if (best_evict) |evict_idx| {
                 const evicted = active.orderedRemove(evict_idx);
                 const stolen_reg = evicted.reg_idx;
-                const spill_offset = spill_base - @as(i32, @intCast(spill_count * 8));
+                const spill_offset = reg_set.spill_base +
+                    @as(i32, @intCast(spill_count)) * reg_set.spill_stride;
                 try assignments.put(evicted.vreg, .{ .stack = spill_offset });
                 spill_count += 1;
-                try assignments.put(range.vreg, .{ .reg = alloc_regs[stolen_reg] });
+                try assignments.put(range.vreg, .{ .reg = reg_set.alloc_regs[stolen_reg] });
                 try insertActive(&active, allocator, .{
                     .vreg = range.vreg,
                     .end = range.end,
@@ -124,7 +154,8 @@ pub fn allocate(
                 });
             } else {
                 // No safe eviction candidate — spill the new interval
-                const spill_offset = spill_base - @as(i32, @intCast(spill_count * 8));
+                const spill_offset = reg_set.spill_base +
+                    @as(i32, @intCast(spill_count)) * reg_set.spill_stride;
                 try assignments.put(range.vreg, .{ .stack = spill_offset });
                 spill_count += 1;
             }
@@ -140,27 +171,28 @@ pub fn allocate(
 const ActiveInterval = struct {
     vreg: ir.VReg,
     end: u32,
-    reg_idx: usize,
+    reg_idx: u8,
 };
 
 /// Remove intervals from `active` whose end position is <= `pos`.
 fn expireOldIntervals(
     active: *std.ArrayList(ActiveInterval),
     pos: u32,
-    reg_free: *[alloc_regs.len]bool,
+    reg_free: *u64,
 ) void {
     // Active is sorted by end position; remove from front
     while (active.items.len > 0 and active.items[0].end < pos) {
         const expired = active.orderedRemove(0);
-        reg_free[expired.reg_idx] = true;
+        reg_free.* |= (@as(u64, 1) << @intCast(expired.reg_idx));
     }
 }
 
 /// Check if register at `reg_idx` is safe for a live range [start, end].
 /// A register is unsafe if it's clobbered at any point strictly inside the range.
-fn regSafeForRange(reg_idx: usize, start: u32, end: u32, clobbers: []const ClobberPoint) bool {
+fn regSafeForRange(reg_idx: u8, start: u32, end: u32, clobbers: []const ClobberPoint) bool {
+    const bit = @as(u64, 1) << @intCast(reg_idx);
     for (clobbers) |cp| {
-        if (cp.pos > start and cp.pos < end and cp.regs_clobbered[reg_idx]) return false;
+        if (cp.pos > start and cp.pos < end and (cp.regs_clobbered & bit) != 0) return false;
     }
     return true;
 }
@@ -175,40 +207,25 @@ fn spansClobber(start: u32, end: u32, clobbers: []const ClobberPoint) bool {
     return false;
 }
 
-/// Indices of callee-saved registers within alloc_regs.
-/// On both Win64 and SysV: rbx(1), r12(6), r13(7), r14(8), r15(9).
-const callee_saved_indices = [_]usize{ 1, 6, 7, 8, 9 };
-/// Indices of caller-saved registers within alloc_regs.
-/// Win64: rdx(0), r8(4), r9(5). SysV adds: rsi(2), rdi(3).
-const caller_saved_indices = if (@import("builtin").os.tag == .windows)
-    [_]usize{ 0, 4, 5, 2, 3 } // rdx, r8, r9, then rsi/rdi (callee-saved on Win64 but treated as caller-saved for allocation preference since they need prologue save)
-else
-    [_]usize{ 0, 2, 3, 4, 5 }; // rdx, rsi, rdi, r8, r9
-
 /// Find a free register, preferring callee-saved for long-lived values
 /// (those spanning calls) and caller-saved for short-lived values.
 fn findSafeReg(
-    reg_free: *const [alloc_regs.len]bool,
+    reg_set: RegSet,
+    reg_free: u64,
     start: u32,
     end: u32,
     clobbers: []const ClobberPoint,
-) ?usize {
-    if (spansClobber(start, end, clobbers)) {
-        // Prefer callee-saved (survives calls without save/restore)
-        for (callee_saved_indices) |i| {
-            if (reg_free[i] and regSafeForRange(i, start, end, clobbers)) return i;
-        }
-        for (caller_saved_indices) |i| {
-            if (reg_free[i] and regSafeForRange(i, start, end, clobbers)) return i;
-        }
-    } else {
-        // Prefer caller-saved (avoids prologue push/pop cost)
-        for (caller_saved_indices) |i| {
-            if (reg_free[i] and regSafeForRange(i, start, end, clobbers)) return i;
-        }
-        for (callee_saved_indices) |i| {
-            if (reg_free[i] and regSafeForRange(i, start, end, clobbers)) return i;
-        }
+) ?u8 {
+    const prefer_callee = spansClobber(start, end, clobbers);
+    const first: []const u8 = if (prefer_callee) reg_set.callee_saved_indices else reg_set.caller_saved_indices;
+    const second: []const u8 = if (prefer_callee) reg_set.caller_saved_indices else reg_set.callee_saved_indices;
+    for (first) |i| {
+        const bit = @as(u64, 1) << @intCast(i);
+        if ((reg_free & bit) != 0 and regSafeForRange(i, start, end, clobbers)) return i;
+    }
+    for (second) |i| {
+        const bit = @as(u64, 1) << @intCast(i);
+        if ((reg_free & bit) != 0 and regSafeForRange(i, start, end, clobbers)) return i;
     }
     return null;
 }
@@ -227,15 +244,20 @@ fn insertActive(
     try active.insert(allocator, pos, interval);
 }
 
-/// Compute spill slot offset from RBP (legacy helper; callers now use
-/// `spill_base` computed per-function in `allocate`). Kept for potential
-/// unit-test use with the default operand-stack budget of 64 slots.
-fn computeSpillOffset(spill_idx: u32) i32 {
-    const spill_base: i32 = -600;
-    return spill_base - @as(i32, @intCast(spill_idx * 8));
-}
-
 // ── Tests ───────────────────────────────────────────────────────────────
+
+/// Register set used by the in-file tests. Mirrors the legacy x86-64
+/// layout so the test expectations remain meaningful: 10 allocatable
+/// GPRs, rbx+r12..r15 callee-saved, rdx+rsi+rdi+r8+r9 caller-saved,
+/// spill area below rbp with 64-slot operand stack.
+const test_reg_set: RegSet = .{
+    .alloc_regs = &.{ 2, 3, 6, 7, 8, 9, 12, 13, 14, 15 },
+    .callee_saved_indices = &.{ 1, 6, 7, 8, 9 },
+    .caller_saved_indices = &.{ 0, 2, 3, 4, 5 },
+    // func.local_count==1 for all tests: spill_base = -(1 + 66) * 8 = -536.
+    .spill_base = -536,
+    .spill_stride = -8,
+};
 
 test "allocate: simple function gets registers" {
     const allocator = std.testing.allocator;
@@ -252,7 +274,7 @@ test "allocate: simple function gets registers" {
     try block0.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v2 });
     try block0.append(.{ .op = .{ .ret = v2 } });
 
-    var result = try allocate(&func, allocator, &.{});
+    var result = try allocate(&func, allocator, test_reg_set, &.{});
     defer result.deinit();
 
     // All 3 VRegs should get registers (only 3 needed, 9 available)
@@ -287,7 +309,7 @@ test "allocate: no spills with few live values" {
     }
     try block0.append(.{ .op = .{ .ret = prev } });
 
-    var result = try allocate(&func, allocator, &.{});
+    var result = try allocate(&func, allocator, test_reg_set, &.{});
     defer result.deinit();
 
     // Low register pressure — no spills expected
@@ -317,7 +339,7 @@ test "allocate: spills when pressure exceeds registers" {
     }
     try block0.append(.{ .op = .{ .ret = sum } });
 
-    var result = try allocate(&func, allocator, &.{});
+    var result = try allocate(&func, allocator, test_reg_set, &.{});
     defer result.deinit();
 
     // Should have some spills (15 values alive > 9 registers)
@@ -328,3 +350,4 @@ test "allocate: spills when pressure exceeds registers" {
         try std.testing.expect(result.get(v) != null);
     }
 }
+


### PR DESCRIPTION
Phase 0 of the plan to adopt `ir/regalloc.zig` in the aarch64 backend (issue #100).

## What

Remove hardcoded x86-64 assumptions from `ir/regalloc.zig` so aarch64 can plug in its own register file. **Algorithm and allocation quality are unchanged**; this is a pure refactor.

## Changes

- `PhysReg`: `u4` → `u8` (aarch64 needs 0..30).
- `ClobberPoint.regs_clobbered`: `[N]bool` → `u64` bitmask (supports up to 64 allocatable regs).
- `allocate(func, alloc, clobbers)` → `allocate(func, alloc, reg_set, clobbers)`, where `RegSet` carries the architecture's allocatable regs, caller/callee-saved partition, and spill-slot base/stride.
- Spill offsets: `spill_base + i * spill_stride`. Works for x86-64 downward frames (stride -8) and aarch64 upward frames (stride +8).
- Internal `reg_free` moved from `[N]bool` to `u64` bitmask.
- Dropped hardcoded `scratch1`/`scratch2` (callers already had their own).

The x86-64 caller now defines `x86_64_alloc_regs`, `x86_64_call_clobber_mask`, and `x86_64_reg_set()` and passes them in. Bit positions in the new `u64` masks match the indices used in the old bool arrays, so clobber sets are bit-identical.

## Validation

- `zig build test --summary all` → **867/867 pass**.
- CoreMark (aarch64, `zig build coremark-aot -Doptimize=ReleaseFast`): **~7512 iter/s**, unchanged vs post-#132 baseline. Expected — aarch64 doesn't use regalloc yet.

## Next

Phase 1 wires an aarch64 `collectClobberPoints` helper (no codegen change). Phase 3 is the big emitter flip where the performance gain lands.