### PR TITLE
Sign Windows binaries with Trusted Signing; publish to winget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           - os: ubuntu-22.04
             target: riscv64-linux
             name: linux-riscv64
-          - os: ubuntu-22.04
+          - os: windows-latest
             target: aarch64-windows
             name: windows-arm64
           - os: ubuntu-22.04
@@ -66,6 +66,27 @@ jobs:
       - name: Build
         run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }} -Dstrip=true -Dstack-protector=true "-Dversion=${{ steps.version.outputs.version }}"
 
+      - name: Azure login (for signing)
+        if: endsWith(matrix.target, '-windows')
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign Windows binaries with Trusted Signing
+        if: endsWith(matrix.target, '-windows')
+        uses: azure/trusted-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1.2.0
+        with:
+          endpoint: ${{ vars.TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ vars.TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.TRUSTED_SIGNING_PROFILE }}
+          files-folder: zig-out/bin
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
       - name: Package
         shell: bash
         run: |
@@ -81,12 +102,28 @@ jobs:
             cp "zig-out/bin/${tool}${EXT}" "$PKGNAME/bin/"
           done
           cp LICENSE README.md "$PKGNAME/"
-          tar czf "$PKGNAME.tar.gz" "$PKGNAME"
-          if command -v sha256sum &>/dev/null; then
-            sha256sum "$PKGNAME.tar.gz" > "$PKGNAME.tar.gz.sha256"
-          else
-            shasum -a 256 "$PKGNAME.tar.gz" > "$PKGNAME.tar.gz.sha256"
-          fi
+          case "${{ matrix.target }}" in
+            *-windows)
+              if command -v zip &>/dev/null; then
+                zip -r "$PKGNAME.zip" "$PKGNAME"
+              else
+                powershell -Command "Compress-Archive -Path '$PKGNAME' -DestinationPath '$PKGNAME.zip'"
+              fi
+              if command -v sha256sum &>/dev/null; then
+                sha256sum "$PKGNAME.zip" > "$PKGNAME.zip.sha256"
+              else
+                shasum -a 256 "$PKGNAME.zip" > "$PKGNAME.zip.sha256"
+              fi
+              ;;
+            *)
+              tar czf "$PKGNAME.tar.gz" "$PKGNAME"
+              if command -v sha256sum &>/dev/null; then
+                sha256sum "$PKGNAME.tar.gz" > "$PKGNAME.tar.gz.sha256"
+              else
+                shasum -a 256 "$PKGNAME.tar.gz" > "$PKGNAME.tar.gz.sha256"
+              fi
+              ;;
+          esac
 
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
@@ -101,6 +138,7 @@ jobs:
           name: ${{ matrix.name }}
           path: |
             wamr-*.tar.gz
+            wamr-*.zip
             wamr-*.sha256
             wamr-*.sbom.spdx.json
 
@@ -151,6 +189,7 @@ jobs:
           subject-path: |
             wamr-*.tar.gz
             wamr-*.tar.xz
+            wamr-*.zip
 
       - name: Create release
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
@@ -182,6 +221,7 @@ jobs:
           files: |
             wamr-*.tar.gz
             wamr-*.tar.xz
+            wamr-*.zip
             wamr-*.sha256
             wamr-*.sbom.spdx.json
           draft: false

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,54 @@
+name: Publish to winget
+
+on:
+  # Disabled until initial manual submissions to winget-pkgs are published.
+  # After that, re-enable by uncommenting the workflow_run trigger so this
+  # fires only after Release (build + sign + upload) completes successfully.
+  # workflow_run:
+  #   workflows: ["Release"]
+  #   types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 3.0.0)"
+        required: true
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    environment: winget
+    # Only run for successful tag-triggered Release runs, and skip dev tags.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       startsWith(github.event.workflow_run.head_branch, 'v') &&
+       !contains(github.event.workflow_run.head_branch, 'dev'))
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - identifier: cataggar.wamr
+          - identifier: cataggar.wamrc
+    steps:
+      - name: Extract version
+        id: version
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            V="${{ inputs.version }}"
+          else
+            V="${{ github.event.workflow_run.head_branch }}"
+          fi
+          echo "version=${V#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish ${{ matrix.identifier }} to winget
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: ${{ matrix.identifier }}
+          version: ${{ steps.version.outputs.version }}
+          release-tag: v${{ steps.version.outputs.version }}
+          installers-regex: '-windows-(x64|arm64)\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Follows the `cataggar/ghr` setup.

## release.yml
- Adds Azure Trusted Signing steps (`azure/login` + `azure/trusted-signing-action`) for any `*-windows` target; `files-folder-filter: exe` signs both `wamr.exe` and `wamrc.exe`.
- Moves `aarch64-windows` matrix entry to `windows-latest` (the signing action is Windows-only), matching ghr.
- Windows targets now produce `.zip` + `.sha256` (winget requires zip); other platforms keep `.tar.gz`.
- Adds `wamr-*.zip` to artifact upload, provenance attestation `subject-path`, and release `files:`.

## winget.yml (new)
- Matrix publishes **`cataggar.wamr`** and **`cataggar.wamrc`** via `vedantmgoyal9/winget-releaser@v2`.
- Trigger is `workflow_run` on `Release` completion (commented out until the initial manual winget-pkgs submissions are merged), so the winget PR only opens **after** the signed build + upload succeeds.
- `workflow_dispatch` fallback with a `version` input is always available.
- Installers regex picks up `-windows-(x64|arm64).zip`.

## Prereqs before the first signed release
- Azure AD federated credential on the existing app registration for `repo:cataggar/wamr:ref:refs/tags/*`.
- Repo `vars`: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `TRUSTED_SIGNING_ENDPOINT`, `TRUSTED_SIGNING_ACCOUNT`, `TRUSTED_SIGNING_PROFILE`.
- `winget` environment secret: `WINGET_TOKEN` (classic PAT with `public_repo`).

## Rollout
1. Merge this PR.
2. Tag a release (e.g. `v3.0.0`) — signed zips will land in the release.
3. Manually submit initial `cataggar.wamr` and `cataggar.wamrc` manifests to `microsoft/winget-pkgs` (using sha256 of the released zips).
4. Uncomment the `workflow_run:` trigger in `winget.yml` to auto-publish subsequent stable tags.