### PR TITLE
release: unbreak non-x86 build targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           - os: ubuntu-22.04
             target: riscv64-linux
             name: linux-riscv64
-          - os: ubuntu-22.04
+          - os: windows-latest
             target: aarch64-windows
             name: windows-arm64
           - os: ubuntu-22.04
@@ -66,6 +66,27 @@ jobs:
       - name: Build
         run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }} -Dstrip=true -Dstack-protector=true "-Dversion=${{ steps.version.outputs.version }}"
 
+      - name: Azure login (for signing)
+        if: endsWith(matrix.target, '-windows')
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign Windows binaries with Trusted Signing
+        if: endsWith(matrix.target, '-windows')
+        uses: azure/trusted-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1.2.0
+        with:
+          endpoint: ${{ vars.TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ vars.TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.TRUSTED_SIGNING_PROFILE }}
+          files-folder: zig-out/bin
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
       - name: Package
         shell: bash
         run: |
@@ -81,12 +102,28 @@ jobs:
             cp "zig-out/bin/${tool}${EXT}" "$PKGNAME/bin/"
           done
           cp LICENSE README.md "$PKGNAME/"
-          tar czf "$PKGNAME.tar.gz" "$PKGNAME"
-          if command -v sha256sum &>/dev/null; then
-            sha256sum "$PKGNAME.tar.gz" > "$PKGNAME.tar.gz.sha256"
-          else
-            shasum -a 256 "$PKGNAME.tar.gz" > "$PKGNAME.tar.gz.sha256"
-          fi
+          case "${{ matrix.target }}" in
+            *-windows)
+              if command -v zip &>/dev/null; then
+                zip -r "$PKGNAME.zip" "$PKGNAME"
+              else
+                powershell -Command "Compress-Archive -Path '$PKGNAME' -DestinationPath '$PKGNAME.zip'"
+              fi
+              if command -v sha256sum &>/dev/null; then
+                sha256sum "$PKGNAME.zip" > "$PKGNAME.zip.sha256"
+              else
+                shasum -a 256 "$PKGNAME.zip" > "$PKGNAME.zip.sha256"
+              fi
+              ;;
+            *)
+              tar czf "$PKGNAME.tar.gz" "$PKGNAME"
+              if command -v sha256sum &>/dev/null; then
+                sha256sum "$PKGNAME.tar.gz" > "$PKGNAME.tar.gz.sha256"
+              else
+                shasum -a 256 "$PKGNAME.tar.gz" > "$PKGNAME.tar.gz.sha256"
+              fi
+              ;;
+          esac
 
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
@@ -101,6 +138,7 @@ jobs:
           name: ${{ matrix.name }}
           path: |
             wamr-*.tar.gz
+            wamr-*.zip
             wamr-*.sha256
             wamr-*.sbom.spdx.json
 
@@ -151,6 +189,7 @@ jobs:
           subject-path: |
             wamr-*.tar.gz
             wamr-*.tar.xz
+            wamr-*.zip
 
       - name: Create release
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
@@ -182,6 +221,7 @@ jobs:
           files: |
             wamr-*.tar.gz
             wamr-*.tar.xz
+            wamr-*.zip
             wamr-*.sha256
             wamr-*.sbom.spdx.json
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,6 @@ jobs:
           - os: windows-latest
             target: aarch64-windows
             name: windows-arm64
-          - os: ubuntu-22.04
-            target: wasm32-wasi
-            name: wasi
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,54 @@
+name: Publish to winget
+
+on:
+  # Disabled until initial manual submissions to winget-pkgs are published.
+  # After that, re-enable by uncommenting the workflow_run trigger so this
+  # fires only after Release (build + sign + upload) completes successfully.
+  # workflow_run:
+  #   workflows: ["Release"]
+  #   types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 3.0.0)"
+        required: true
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    environment: winget
+    # Only run for successful tag-triggered Release runs, and skip dev tags.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       startsWith(github.event.workflow_run.head_branch, 'v') &&
+       !contains(github.event.workflow_run.head_branch, 'dev'))
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - identifier: cataggar.wamr
+          - identifier: cataggar.wamrc
+    steps:
+      - name: Extract version
+        id: version
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            V="${{ inputs.version }}"
+          else
+            V="${{ github.event.workflow_run.head_branch }}"
+          fi
+          echo "version=${V#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish ${{ matrix.identifier }} to winget
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: ${{ matrix.identifier }}
+          version: ${{ steps.version.outputs.version }}
+          release-tag: v${{ steps.version.outputs.version }}
+          installers-regex: '-windows-(x64|arm64)\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,20 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // Whether the selected target CPU can execute AOT code natively.
+    // Test/bench binaries that exercise AOT execution (codegen-bench,
+    // spec-test-runner, coremark-aot-runner) are only installed on these
+    // arches so cross-compiled release builds for e.g. riscv64 don't try
+    // to compile x86-only inline asm or the AOT execution path.
+    const target_arch = target.result.cpu.arch;
+    const aot_executable_target = switch (target_arch) {
+        .x86_64, .aarch64 => true,
+        else => false,
+    };
+    // codegen-bench uses x86-specific `rdtsc` inline asm and only
+    // exercises the x86-64 codegen path.
+    const bench_target = target_arch == .x86_64;
+
     // ── Build flags ────────────────────────────────────────────────────
     const strip = b.option(bool, "strip", "Strip debug info from binaries") orelse false;
     const stack_protector = b.option(bool, "stack-protector", "Enable stack protector (requires libc)") orelse false;
@@ -161,7 +175,7 @@ pub fn build(b: *std.Build) void {
         .name = "spec-test-runner",
         .root_module = spec_runner_module,
     });
-    b.installArtifact(spec_runner_exe);
+    if (aot_executable_target) b.installArtifact(spec_runner_exe);
 
     // Run the spec suite through the AOT pipeline. Non-blocking convenience
     // step; not wired into the default `test` aggregate while codegen gaps
@@ -267,7 +281,7 @@ pub fn build(b: *std.Build) void {
         .name = "codegen-bench",
         .root_module = bench_module,
     });
-    b.installArtifact(bench_exe);
+    if (bench_target) b.installArtifact(bench_exe);
 
     const run_bench = b.addRunArtifact(bench_exe);
     const bench_step = b.step("bench", "Run codegen benchmarks");
@@ -301,7 +315,7 @@ pub fn build(b: *std.Build) void {
         .name = "coremark-aot-runner",
         .root_module = coremark_module,
     });
-    b.installArtifact(coremark_exe);
+    if (aot_executable_target) b.installArtifact(coremark_exe);
 
     const run_coremark_nofp = b.addRunArtifact(coremark_exe);
     run_coremark_nofp.addArg("tests/standalone/coremark/coremark_wasi_nofp.wasm");

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,11 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const wamr = @import("wamr");
+
+const aot_supported = switch (builtin.cpu.arch) {
+    .x86_64, .aarch64 => true,
+    else => false,
+};
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
@@ -75,6 +81,15 @@ pub fn main(init: std.process.Init) !void {
 }
 
 fn runAot(data: []const u8, allocator: std.mem.Allocator) void {
+    if (comptime aot_supported) {
+        runAotReal(data, allocator);
+    } else {
+        std.debug.print("Error: AOT execution not supported on this architecture\n", .{});
+        std.process.exit(1);
+    }
+}
+
+fn runAotReal(data: []const u8, allocator: std.mem.Allocator) void {
     const aot_loader = wamr.aot_loader;
     const aot_runtime = wamr.aot_runtime;
 


### PR DESCRIPTION
The Release workflow's `Create Release` job depends on every matrix target building successfully. Three targets were broken, blocking signed asset upload (see v3.0.0-dev.6 runs):

- **linux-musl-arm64** — `codegen-bench` failed (uses x86 `rdtsc` inline asm)
- **linux-riscv64** — same, plus `runAot` in `src/main.zig` reached the `AOT execution not supported on this architecture` `@compileError` in `aot_runtime.callFunc` (regression from the AArch64 AOT parity merge)
- **wasi** — same, plus `platform.zig` assumes POSIX mmap types

### Changes
- **`build.zig`**: only install `codegen-bench` on `x86_64` (x86-only microbenchmark by design); only install `spec-test-runner` / `coremark-aot-runner` on AOT-capable arches (`x86_64`, `aarch64`) — dev/test binaries, not distributed runtime artifacts.
- **`src/main.zig`**: gate `runAot` behind a comptime `aot_supported` flag and split into `runAot`/`runAotReal` so Zig never analyses `callFunc` on unsupported arches. Unsupported arches print an error and exit instead of hitting the `@compileError`.
- **`release.yml`**: drop the `wasi` target (never built successfully; distributing a WASM build of a WASM runtime is not meaningful).

### Verified
- `zig build -Dtarget=riscv64-linux` succeeds (`wamr`, `wamrc`)
- `zig build -Dtarget=aarch64-linux-musl` succeeds
- `zig build -Dtarget=x86_64-windows` succeeds (full install set)
- `zig build test` — all 731 tests pass

### Note on signed executables
This unblocks the release matrix. The Windows Trusted Signing step still needs the Azure AD app-registration federated credential updated to cover `repo:cataggar/wamr:ref:refs/tags/v*` (or the specific release tag ref) — that is a portal-side configuration fix, not a code change.