### PR TITLE
WASI preview-2 host surface + run-export resolution (#150–#155, partial #156)

### DIFF
--- a/src/component/canonical_abi.zig
+++ b/src/component/canonical_abi.zig
@@ -13,17 +13,27 @@ const Allocator = std.mem.Allocator;
 /// Resolves type indices to their definitions from a parsed Component.
 pub const TypeRegistry = struct {
     types: []const ctypes.TypeDef,
+    /// When non-empty, indexed by type-indexspace position to map to a
+    /// local `types[]` index (or null for non-materialized slots).
+    /// When empty, `get(idx)` falls back to direct indexing of `types`.
+    indexspace: []const ?u32 = &.{},
 
     pub fn init(component: *const ctypes.Component) TypeRegistry {
-        return .{ .types = component.types };
+        return .{ .types = component.types, .indexspace = component.type_indexspace };
     }
 
     pub fn fromTypes(types: []const ctypes.TypeDef) TypeRegistry {
         return .{ .types = types };
     }
 
-    /// Resolve a type index to its TypeDef.
+    /// Resolve a type indexspace position to its TypeDef.
     pub fn get(self: TypeRegistry, idx: u32) ?ctypes.TypeDef {
+        if (self.indexspace.len > 0) {
+            if (idx >= self.indexspace.len) return null;
+            const local = self.indexspace[idx] orelse return null;
+            if (local >= self.types.len) return null;
+            return self.types[local];
+        }
         if (idx >= self.types.len) return null;
         return self.types[idx];
     }

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -977,9 +977,13 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
     }
 
     // Invoke host. Host owns allocation of any compound result values via
-    // `allocator`; simple values need no cleanup.
+    // `allocator`; we deinit each result after lowering so payloads
+    // (e.g. `.result_val.payload` for input-stream.blocking-read) don't leak.
     const results = allocator.alloc(InterfaceValue, ctx.result_types.len) catch return error.Trap;
-    defer allocator.free(results);
+    defer {
+        for (results) |r| r.deinit(allocator);
+        allocator.free(results);
+    }
     const call = ctx.host_func.call orelse return error.Trap;
     call(ctx.host_func.context, ctx.comp_inst, args, results, allocator) catch return error.Trap;
 

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -320,20 +320,33 @@ fn pushInterfaceValue(env: *ExecEnv, val: InterfaceValue, t: ctypes.ValType, reg
             try env.pushI32(@bitCast(val.list.ptr));
             try env.pushI32(@bitCast(val.list.len));
         },
-        // result<no-payload, no-payload>: flat repr is just the i32
-        // discriminant. WASI commonly returns this from `wasi:cli/run.run`
-        // and `wasi:io/streams.[method]output-stream.blocking-write-and-flush`,
-        // so the trampoline+lift paths support it directly. Result variants
-        // with payloads still go through the registry-aware spill path.
+        // result<T, E>: flat repr is `[i32 disc] ++ join(flatten(T), flatten(E))`,
+        // where the per-slot join takes the wider of the two arms (treated as
+        // i32 here since stdio-echo's variants land on i32-only payloads).
+        // Inactive slots are zero-filled; payload values for the active arm
+        // are recursively pushed and any remaining slots are then zero-filled.
+        // A future slice can extend this to mixed i32/i64/f32/f64 joins.
         .result => |idx| {
             const td = registry.get(idx) orelse return error.CompoundNeedsRegistry;
             const r = switch (td) {
                 .result => |rt| rt,
                 else => return error.CompoundNeedsRegistry,
             };
-            if (r.ok != null or r.err != null) return error.CompoundNeedsRegistry;
+            const total_payload_slots = abi.flattenCount(registry, t) - 1;
             const disc: i32 = if (val.result_val.is_ok) 0 else 1;
             try env.pushI32(disc);
+
+            const arm_type: ?ctypes.ValType = if (val.result_val.is_ok) r.ok else r.err;
+            var pushed: u32 = 0;
+            if (arm_type) |at| {
+                if (val.result_val.payload) |p| {
+                    try pushInterfaceValue(env, p.*, at, registry);
+                    pushed = abi.flattenCount(registry, at);
+                }
+            }
+            while (pushed < total_payload_slots) : (pushed += 1) {
+                try env.pushI32(0);
+            }
         },
         .record, .variant, .tuple, .flags, .enum_, .option, .type_idx => {
             return error.CompoundNeedsRegistry;
@@ -378,15 +391,22 @@ fn popInterfaceValue(env: *ExecEnv, t: ctypes.ValType, registry: TypeRegistry, a
             .len = @bitCast(try env.popI32()),
             .ptr = @bitCast(try env.popI32()),
         } },
-        // result<no-payload, no-payload>: pop one i32 discriminant.
-        // See pushInterfaceValue rationale.
+        // result<T, E>: pop the discriminant, then pop and discard all
+        // remaining payload slots (caller currently doesn't inspect the
+        // typed payload; a future slice can lift it through `loadValReg`-
+        // style logic). See pushInterfaceValue for the join rationale.
         .result => |idx| blk: {
             const td = registry.get(idx) orelse return error.CompoundNeedsRegistry;
-            const r = switch (td) {
+            _ = switch (td) {
                 .result => |rt| rt,
                 else => return error.CompoundNeedsRegistry,
             };
-            if (r.ok != null or r.err != null) return error.CompoundNeedsRegistry;
+            const total_payload_slots = abi.flattenCount(registry, t) - 1;
+            // Payload slots are pushed last, so they pop first.
+            var i: u32 = 0;
+            while (i < total_payload_slots) : (i += 1) {
+                _ = try env.popI32();
+            }
             const disc = try env.popI32();
             break :blk .{ .result_val = .{ .is_ok = disc == 0, .payload = null } };
         },
@@ -1304,4 +1324,48 @@ test "componentTrampoline: result spill stores tuple into memory" {
     const r1 = std.mem.readInt(i32, mem.data[dest_ptr + 4 ..][0..4], .little);
     try testing.expectEqual(@as(i32, 0xCAFE), r0);
     try testing.expectEqual(@as(i32, 0xBEEF), r1);
+}
+
+test "pushInterfaceValue/popInterfaceValue: result<_, primitive> roundtrip (#155)" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    // result<_, u32>: ok arm empty, err arm flat = [i32]; total = 2 i32s.
+    const type_defs = [_]ctypes.TypeDef{
+        .{ .result = .{ .ok = null, .err = .u32 } },
+    };
+    var component = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &type_defs,      .canons = &.{},
+        .imports = &.{},          .exports = &.{},
+    };
+    const registry = TypeRegistry.init(&component);
+    const t: ctypes.ValType = .{ .result = 0 };
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    // Push ok arm: should produce [i32 0, i32 0] (zero-filled payload slot).
+    try pushInterfaceValue(env, .{ .result_val = .{ .is_ok = true, .payload = null } }, t, registry);
+    const lifted_ok = try popInterfaceValue(env, t, registry, testing.allocator);
+    try testing.expect(lifted_ok.result_val.is_ok);
+
+    // Push err arm with payload u32=0xCAFEu: produces [i32 1, i32 0xCAFE].
+    const err_payload: InterfaceValue = .{ .u32 = 0xCAFE };
+    try pushInterfaceValue(
+        env,
+        .{ .result_val = .{ .is_ok = false, .payload = &err_payload } },
+        t,
+        registry,
+    );
+    // Verify the underlying core stack layout: top = payload (0xCAFE), below = disc (1).
+    const payload_slot: u32 = @bitCast(try env.popI32());
+    const disc_slot = try env.popI32();
+    try testing.expectEqual(@as(u32, 0xCAFE), payload_slot);
+    try testing.expectEqual(@as(i32, 1), disc_slot);
 }

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -126,14 +126,11 @@ pub fn callComponentFunc(
 
     // Resolve the function type
     const func_type = blk: {
-        if (exported.func_type_idx < comp_inst.component.types.len) {
-            const td = comp_inst.component.types[exported.func_type_idx];
-            switch (td) {
-                .func => |ft| break :blk ft,
-                else => return error.InvalidFuncType,
-            }
+        const td = registry.get(exported.func_type_idx) orelse return error.InvalidFuncType;
+        switch (td) {
+            .func => |ft| break :blk ft,
+            else => return error.InvalidFuncType,
         }
-        return error.InvalidFuncType;
     };
 
     // 2. Compute flat counts for params and results
@@ -550,8 +547,8 @@ pub fn callComponentFuncAsync(
 
     // Get function type for result count
     const result_count: usize = blk: {
-        if (exported.func_type_idx < comp_inst.component.types.len) {
-            const td = comp_inst.component.types[exported.func_type_idx];
+        const reg = TypeRegistry.init(comp_inst.component);
+        if (reg.get(exported.func_type_idx)) |td| {
             switch (td) {
                 .func => |ft| {
                     switch (ft.results) {

--- a/src/component/indexspace.zig
+++ b/src/component/indexspace.zig
@@ -1,0 +1,311 @@
+//! Component-model index-space resolvers.
+//!
+//! The component-model spec defines several flat index spaces (component
+//! func, component instance, core func, core instance, type, …). Each is
+//! contributed to by a specific subset of declaration kinds, and entries
+//! are appended in declaration order as the binary is walked.
+//!
+//! Phase 1A's loader stores declarations in *separate per-section arrays*
+//! (`component.imports`, `component.aliases`, `component.canons`, …)
+//! rather than the original mixed-section ordering. We assume the canonical
+//! section order produced by both `wasm-tools` and `wit-bindgen`:
+//!
+//!   imports → instances → aliases → canons (… → exports)
+//!
+//! That assumption is sufficient for every component we currently care
+//! about (hand-authored Phase 2B fixtures *and* `stdio-echo.wasm` from
+//! `cargo build --target wasm32-wasip2`). A future slice can replace this
+//! with binary-decl-order tagging if non-canonical layouts ever appear.
+//!
+//! The resolvers in this module are pure functions over the parsed
+//! `Component` AST — they don't touch a `ComponentInstance`, allowing them
+//! to be reused for both pre-instantiation analysis and runtime resolution.
+
+const std = @import("std");
+const ctypes = @import("types.zig");
+
+// ── Component-func index space ────────────────────────────────────────────
+//
+// Contributors, in section order:
+//   1. `import` decls of kind `.func` (top-level component func imports —
+//      rare in real components but used by hand-authored fixtures).
+//   2. `alias` decls with `sort = .func` (member aliases of imported or
+//      local component instances — every wit-bindgen-generated component
+//      uses this to surface WASI member funcs).
+//   3. `canon.lift` entries (the only contributor that produces *callable*
+//      component funcs from core funcs).
+
+pub const CompFuncRef = union(enum) {
+    /// Top-level `import (… (func type_idx))` — index into `component.imports`.
+    imported: u32,
+    /// `alias … (func)` — index into `component.aliases`. Resolves to a
+    /// member of an instance, which itself sits in the component-instance
+    /// index space (resolve via `resolveCompInstance` against
+    /// `instance_export.instance_idx`).
+    aliased: u32,
+    /// `canon lift core_func_idx … type_idx` — index into `component.canons`.
+    lifted: u32,
+};
+
+pub fn resolveCompFunc(component: *const ctypes.Component, idx: u32) ?CompFuncRef {
+    var n: u32 = 0;
+    for (component.imports, 0..) |imp, i| {
+        if (imp.desc != .func) continue;
+        if (n == idx) return .{ .imported = @intCast(i) };
+        n += 1;
+    }
+    for (component.aliases, 0..) |a, i| {
+        if (!aliasContributesTo(a, .comp_func)) continue;
+        if (n == idx) return .{ .aliased = @intCast(i) };
+        n += 1;
+    }
+    for (component.canons, 0..) |c, i| {
+        switch (c) {
+            .lift => {
+                if (n == idx) return .{ .lifted = @intCast(i) };
+                n += 1;
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+// ── Component-instance index space ────────────────────────────────────────
+//
+// Contributors, in section order:
+//   1. `import` decls of kind `.instance`.
+//   2. `instance` expressions (locally instantiated or `from_exports`-style
+//      bundles synthesizing an instance from already-defined members).
+//   3. `alias` decls with `sort = .instance`.
+
+pub const CompInstanceRef = union(enum) {
+    /// Index into `component.imports` (filtered to instance-typed).
+    imported: u32,
+    /// Index into `component.instances`.
+    local: u32,
+    /// Index into `component.aliases`.
+    aliased: u32,
+};
+
+pub fn resolveCompInstance(component: *const ctypes.Component, idx: u32) ?CompInstanceRef {
+    var n: u32 = 0;
+    for (component.imports, 0..) |imp, i| {
+        if (imp.desc != .instance) continue;
+        if (n == idx) return .{ .imported = @intCast(i) };
+        n += 1;
+    }
+    for (component.instances, 0..) |_, i| {
+        if (n == idx) return .{ .local = @intCast(i) };
+        n += 1;
+    }
+    for (component.aliases, 0..) |a, i| {
+        if (!aliasContributesTo(a, .comp_instance)) continue;
+        if (n == idx) return .{ .aliased = @intCast(i) };
+        n += 1;
+    }
+    return null;
+}
+
+// ── Core-func index space ─────────────────────────────────────────────────
+//
+// Contributors, in section order:
+//   1. `canon.lower` entries (the bridge from component func to core func).
+//   2. `alias` decls with `sort = .core(.func)` (exposing a core instance's
+//      core func export under a top-level core-func index).
+
+pub const CoreFuncRef = union(enum) {
+    /// Index into `component.canons`.
+    lowered: u32,
+    /// Index into `component.aliases`.
+    aliased: u32,
+};
+
+pub fn resolveCoreFunc(component: *const ctypes.Component, idx: u32) ?CoreFuncRef {
+    var n: u32 = 0;
+    for (component.canons, 0..) |c, i| {
+        switch (c) {
+            .lower => {
+                if (n == idx) return .{ .lowered = @intCast(i) };
+                n += 1;
+            },
+            else => {},
+        }
+    }
+    for (component.aliases, 0..) |a, i| {
+        if (!aliasContributesTo(a, .core_func)) continue;
+        if (n == idx) return .{ .aliased = @intCast(i) };
+        n += 1;
+    }
+    return null;
+}
+
+// ── Member lookup ─────────────────────────────────────────────────────────
+
+/// Look up a named member in a locally-instantiated `from_exports`-style
+/// component instance. Returns the member's `SortIdx` (back-pointer into
+/// the appropriate index space) or null.
+///
+/// Only the `.exports` form is supported; `.instantiate` would require
+/// us to recursively resolve another component's exports, which we do
+/// not yet do (the only real-world contributor is wit-bindgen's
+/// synthesized `wasi:cli/run` instance, which always uses `.exports`).
+pub fn lookupLocalInstanceMember(
+    component: *const ctypes.Component,
+    local_inst_idx: u32,
+    name: []const u8,
+) ?ctypes.SortIdx {
+    if (local_inst_idx >= component.instances.len) return null;
+    const expr = component.instances[local_inst_idx];
+    return switch (expr) {
+        .exports => |exports| blk: {
+            for (exports) |e| {
+                if (std.mem.eql(u8, e.name, name)) break :blk e.sort_idx;
+            }
+            break :blk null;
+        },
+        .instantiate => null,
+    };
+}
+
+// ── Internal: "which index space does this alias contribute to?" ─────────
+
+const AliasTarget = enum { comp_func, comp_instance, core_func, core_instance, type_x, value };
+
+fn aliasContributesTo(a: ctypes.Alias, target: AliasTarget) bool {
+    return switch (a) {
+        .instance_export => |ie| switch (ie.sort) {
+            .func => target == .comp_func,
+            .instance => target == .comp_instance,
+            .core => |cs| switch (cs) {
+                .func => target == .core_func,
+                .instance => target == .core_instance,
+                .type => target == .type_x,
+                .table, .memory, .global, .tag, .module => false,
+            },
+            .type => target == .type_x,
+            .value => target == .value,
+            .component => false,
+        },
+        // Outer / core aliases — not yet observed; default to false. A
+        // future slice handling nested components will need to extend this.
+        else => false,
+    };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "resolveCompFunc: imports → aliases → lifts in section order" {
+    // Synthesized component with one func import, one alias.func, one
+    // canon.lift. Expected comp-func index space: 0=import, 1=alias, 2=lift.
+    const imports = [_]ctypes.ImportDecl{
+        .{ .name = "host:fn", .desc = .{ .func = 0 } },
+    };
+    const aliases = [_]ctypes.Alias{
+        .{ .instance_export = .{ .sort = .func, .instance_idx = 0, .name = "m" } },
+    };
+    const canons = [_]ctypes.Canon{
+        .{ .lift = .{ .core_func_idx = 0, .type_idx = 0, .opts = &.{} } },
+    };
+    const comp = ctypes.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &aliases,
+        .types = &.{},
+        .canons = &canons,
+        .imports = &imports,
+        .exports = &.{},
+    };
+    try testing.expect(resolveCompFunc(&comp, 0).? == .imported);
+    try testing.expect(resolveCompFunc(&comp, 1).? == .aliased);
+    try testing.expect(resolveCompFunc(&comp, 2).? == .lifted);
+    try testing.expect(resolveCompFunc(&comp, 3) == null);
+}
+
+test "resolveCompInstance: imports → locals → aliases" {
+    const imports = [_]ctypes.ImportDecl{
+        .{ .name = "wasi:io/streams", .desc = .{ .instance = 0 } },
+    };
+    const inline_exp = [_]ctypes.InlineExport{
+        .{ .name = "run", .sort_idx = .{ .sort = .func, .idx = 5 } },
+    };
+    const instances = [_]ctypes.InstanceExpr{
+        .{ .exports = &inline_exp },
+    };
+    const aliases = [_]ctypes.Alias{
+        .{ .instance_export = .{ .sort = .instance, .instance_idx = 0, .name = "x" } },
+    };
+    const comp = ctypes.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &instances,
+        .aliases = &aliases,
+        .types = &.{},
+        .canons = &.{},
+        .imports = &imports,
+        .exports = &.{},
+    };
+    try testing.expect(resolveCompInstance(&comp, 0).? == .imported);
+    try testing.expect(resolveCompInstance(&comp, 1).? == .local);
+    try testing.expect(resolveCompInstance(&comp, 2).? == .aliased);
+    try testing.expect(resolveCompInstance(&comp, 3) == null);
+}
+
+test "resolveCoreFunc: canon.lowers → core(.func) aliases" {
+    const aliases = [_]ctypes.Alias{
+        // A non-core-func alias (sort=.func) — should be ignored here.
+        .{ .instance_export = .{ .sort = .func, .instance_idx = 0, .name = "skip" } },
+        // Core func alias #1 — contributes at idx 2.
+        .{ .instance_export = .{ .sort = .{ .core = .func }, .instance_idx = 0, .name = "x" } },
+    };
+    const canons = [_]ctypes.Canon{
+        .{ .lower = .{ .func_idx = 0, .opts = &.{} } },
+        .{ .lower = .{ .func_idx = 1, .opts = &.{} } },
+    };
+    const comp = ctypes.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &aliases,
+        .types = &.{},
+        .canons = &canons,
+        .imports = &.{},
+        .exports = &.{},
+    };
+    try testing.expect(resolveCoreFunc(&comp, 0).? == .lowered);
+    try testing.expect(resolveCoreFunc(&comp, 1).? == .lowered);
+    try testing.expect(resolveCoreFunc(&comp, 2).? == .aliased);
+    try testing.expect(resolveCoreFunc(&comp, 3) == null);
+}
+
+test "lookupLocalInstanceMember: finds named export in inline-exports instance" {
+    const inline_exp = [_]ctypes.InlineExport{
+        .{ .name = "run", .sort_idx = .{ .sort = .func, .idx = 7 } },
+        .{ .name = "other", .sort_idx = .{ .sort = .func, .idx = 8 } },
+    };
+    const instances = [_]ctypes.InstanceExpr{.{ .exports = &inline_exp }};
+    const comp = ctypes.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &instances,
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &.{},
+        .exports = &.{},
+    };
+    const m = lookupLocalInstanceMember(&comp, 0, "run").?;
+    try testing.expectEqual(@as(u32, 7), m.idx);
+    try testing.expect(lookupLocalInstanceMember(&comp, 0, "missing") == null);
+}

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -660,22 +660,63 @@ fn registerInstanceExport(
     };
     if (local_idx >= component.instances.len) return;
     const expr = component.instances[local_idx];
-    const inline_exports = switch (expr) {
-        .exports => |e| e,
-        // An `instantiate`-form local instance would require resolving
-        // exports of another component definition; not yet supported.
-        .instantiate => return,
-    };
-
     const expose_bare = isWasiCliRunName(instance_name);
 
-    for (inline_exports) |mem| {
-        if (mem.sort_idx.sort != .func) continue;
-        const dotted = std.fmt.allocPrint(inst.module_arena.allocator(), "{s}/{s}", .{ instance_name, mem.name }) catch continue;
-        registerLiftedExport(inst, component, allocator, dotted, mem.sort_idx.idx);
-        if (expose_bare and std.mem.eql(u8, mem.name, "run")) {
-            registerLiftedExport(inst, component, allocator, "run", mem.sort_idx.idx);
-        }
+    switch (expr) {
+        .exports => |inline_exports| {
+            for (inline_exports) |mem| {
+                if (mem.sort_idx.sort != .func) continue;
+                const dotted = std.fmt.allocPrint(inst.module_arena.allocator(), "{s}/{s}", .{ instance_name, mem.name }) catch continue;
+                registerLiftedExport(inst, component, allocator, dotted, mem.sort_idx.idx);
+                if (expose_bare and std.mem.eql(u8, mem.name, "run")) {
+                    registerLiftedExport(inst, component, allocator, "run", mem.sort_idx.idx);
+                }
+            }
+        },
+        .instantiate => |inst_expr| {
+            // The wit-bindgen "0.2.0-shim" pattern: the wasi:cli/run
+            // export is an instance produced by instantiating a tiny
+            // sub-component whose only purpose is to re-export an
+            // imported func ("import-func-run") under the canonical
+            // member name "run". We resolve such an instance member by:
+            //   1. looking up the sub-component's named export,
+            //   2. mapping its func sort_idx into the sub-component's
+            //      func index space (it must be an imported func),
+            //   3. matching that import's name against the parent
+            //      `with` arg list, and
+            //   4. resolving the parent's argument through the parent's
+            //      indexspace. The parent func ref is the one we
+            //      register under `<instance>/<member>`.
+            if (inst_expr.component_idx >= component.components.len) return;
+            const subcomp = component.components[inst_expr.component_idx];
+            for (subcomp.exports) |sub_exp| {
+                if (sub_exp.desc != .func) continue;
+                const sub_si = sub_exp.sort_idx orelse continue;
+                if (sub_si.sort != .func) continue;
+                const sub_ref = indexspace.resolveCompFunc(subcomp, sub_si.idx) orelse continue;
+                const sub_imp_idx: u32 = switch (sub_ref) {
+                    .imported => |i| i,
+                    else => continue,
+                };
+                if (sub_imp_idx >= subcomp.imports.len) continue;
+                const import_name = subcomp.imports[sub_imp_idx].name;
+                // Find matching `with` arg in the parent instantiate.
+                const parent_func_idx: u32 = blk: {
+                    for (inst_expr.args) |arg| {
+                        if (arg.sort_idx.sort != .func) continue;
+                        if (std.mem.eql(u8, arg.name, import_name)) {
+                            break :blk arg.sort_idx.idx;
+                        }
+                    }
+                    continue;
+                };
+                const dotted = std.fmt.allocPrint(inst.module_arena.allocator(), "{s}/{s}", .{ instance_name, sub_exp.name }) catch continue;
+                registerLiftedExport(inst, component, allocator, dotted, parent_func_idx);
+                if (expose_bare and std.mem.eql(u8, sub_exp.name, "run")) {
+                    registerLiftedExport(inst, component, allocator, "run", parent_func_idx);
+                }
+            }
+        },
     }
 }
 

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -255,6 +255,33 @@ pub const ComponentInstance = struct {
         return mem.data[ptr..end];
     }
 
+    /// Allocate `len` bytes inside the canonical guest linear memory and
+    /// copy `bytes` into them. Returns the guest-side pointer or null on
+    /// failure (no `cabi_realloc` export, OOM, or invocation error).
+    ///
+    /// Used by host-side callbacks (e.g. `wasi:io/streams.[method]
+    /// input-stream.blocking-read`) that must materialize a `list<u8>`
+    /// or `string` value into guest memory before the canonical ABI
+    /// stores its `(ptr, len)` representation in a spilled result tuple.
+    ///
+    /// Convention: wit-bindgen emits a single `cabi_realloc` export on
+    /// the main core module; we call it with `(0, 0, align=1, len)` to
+    /// allocate fresh space.
+    pub fn hostAllocAndWrite(self: *ComponentInstance, bytes: []const u8) ?u32 {
+        const mi = self.firstModuleInst() orelse return null;
+        const realloc_local = mi.getExportFunc("cabi_realloc") orelse return null;
+        const ExecEnv = @import("../runtime/common/exec_env.zig").ExecEnv;
+        const executor = @import("executor.zig");
+        const env = ExecEnv.create(mi, 4096, self.allocator) catch return null;
+        defer env.destroy();
+        const ptr = executor.callRealloc(env, realloc_local, 0, 0, 1, @intCast(bytes.len)) catch return null;
+        const mem = mi.getMemory(0) orelse return null;
+        const end = @as(usize, ptr) + bytes.len;
+        if (end > mem.data.len) return null;
+        @memcpy(mem.data[ptr..end], bytes);
+        return ptr;
+    }
+
     /// Kind-classify a top-level component import. Pure-type imports (those
     /// whose sole purpose is to introduce a type index) do not need a runtime
     /// binding; every other kind must be satisfied by `linkImports`.

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -7,6 +7,7 @@ const std = @import("std");
 const ctypes = @import("types.zig");
 const core_types = @import("../runtime/common/types.zig");
 const executor_mod = @import("executor.zig");
+const indexspace = @import("indexspace.zig");
 
 // ── Resource Table ──────────────────────────────────────────────────────────
 
@@ -567,25 +568,28 @@ pub fn instantiate(
         inst.core_instances = cis;
     }
 
-    // Build export map
+    // Build export map: walk top-level component exports, resolve each
+    // `.func` export through the component-func index space to its backing
+    // `canon.lift`, and register an entry in `exported_funcs` keyed by the
+    // export name. Locally-built instance exports (e.g. `wasi:cli/run`) are
+    // a separate slice (#151).
     for (component.exports) |exp| {
-        switch (exp.desc) {
-            .func => |func_idx| {
-                if (func_idx < component.canons.len) {
-                    const canon = component.canons[func_idx];
-                    switch (canon) {
-                        .lift => |lift| {
-                            const resolved = resolveLiftedCoreFunc(inst, component, lift.core_func_idx);
-                            inst.exported_funcs.put(allocator, exp.name, .{
-                                .core_instance_idx = if (resolved) |r| r.core_instance_idx else 0,
-                                .core_func_idx = if (resolved) |r| r.local_func_idx else lift.core_func_idx,
-                                .func_type_idx = lift.type_idx,
-                                .opts = lift.opts,
-                            }) catch {};
-                        },
-                        else => {},
-                    }
-                }
+        const si = exp.sort_idx orelse continue;
+        if (si.sort != .func) continue;
+        const ref = indexspace.resolveCompFunc(component, si.idx) orelse continue;
+        const canon_idx = switch (ref) {
+            .lifted => |i| i,
+            else => continue,
+        };
+        switch (component.canons[canon_idx]) {
+            .lift => |lift| {
+                const resolved = resolveLiftedCoreFunc(inst, component, lift.core_func_idx);
+                inst.exported_funcs.put(allocator, exp.name, .{
+                    .core_instance_idx = if (resolved) |r| r.core_instance_idx else 0,
+                    .core_func_idx = if (resolved) |r| r.local_func_idx else lift.core_func_idx,
+                    .func_type_idx = lift.type_idx,
+                    .opts = lift.opts,
+                }) catch {};
             },
             else => {},
         }
@@ -603,20 +607,13 @@ pub fn instantiate(
 // handles arbitrary component layouts including `stdio-echo.wasm`.
 
 /// Map a core-func-index-space index back to the canon.lower that
-/// produced it. Assumes canon.lowers are the sole contributors to the
-/// core-func-index-space.
+/// produced it. Returns null when the index does not point to a lower
+/// (e.g. when it refers to an aliased core func).
 fn resolveCoreFuncLower(component: *const ctypes.Component, core_func_idx: u32) ?u32 {
-    var n: u32 = 0;
-    for (component.canons, 0..) |c, i| {
-        switch (c) {
-            .lower => {
-                if (n == core_func_idx) return @intCast(i);
-                n += 1;
-            },
-            else => {},
-        }
-    }
-    return null;
+    return switch (indexspace.resolveCoreFunc(component, core_func_idx) orelse return null) {
+        .lowered => |i| i,
+        .aliased => null,
+    };
 }
 
 /// Find which `ComponentInstance.core_instances[i]` hosts the core function
@@ -654,46 +651,24 @@ fn resolveLiftedCoreFunc(
     component: *const ctypes.Component,
     core_func_idx: u32,
 ) ?struct { core_instance_idx: u32, local_func_idx: u32 } {
-    var n: u32 = 0;
-
-    // canon.lowers occupy the low end of the core-func-index-space. They are
-    // imports into a core module — not callable as exports — so a canon.lift
-    // pointing at one would be malformed; we still skip past their slots.
-    for (component.canons) |c| {
-        switch (c) {
-            .lower => {
-                if (n == core_func_idx) return null;
-                n += 1;
-            },
-            else => {},
-        }
+    const ref = indexspace.resolveCoreFunc(component, core_func_idx) orelse return null;
+    switch (ref) {
+        // canon.lowers are imports into core modules — not callable as
+        // exports — so a canon.lift pointing at one is malformed.
+        .lowered => return null,
+        .aliased => |alias_idx| {
+            const a = component.aliases[alias_idx];
+            const ie = a.instance_export;
+            if (ie.instance_idx >= inst.core_instances.len) return null;
+            const target = inst.core_instances[ie.instance_idx];
+            const mi = target.module_inst orelse return null;
+            const local = mi.getExportFunc(ie.name) orelse return null;
+            return .{
+                .core_instance_idx = ie.instance_idx,
+                .local_func_idx = local,
+            };
+        },
     }
-
-    // Then aliases of core-instance exports of sort = .core(.func).
-    for (component.aliases) |a| {
-        switch (a) {
-            .instance_export => |ie| {
-                const is_core_func = switch (ie.sort) {
-                    .core => |cs| cs == .func,
-                    else => false,
-                };
-                if (!is_core_func) continue;
-                if (n == core_func_idx) {
-                    if (ie.instance_idx >= inst.core_instances.len) return null;
-                    const target = inst.core_instances[ie.instance_idx];
-                    const mi = target.module_inst orelse return null;
-                    const local = mi.getExportFunc(ie.name) orelse return null;
-                    return .{
-                        .core_instance_idx = ie.instance_idx,
-                        .local_func_idx = local,
-                    };
-                }
-                n += 1;
-            },
-            else => {},
-        }
-    }
-    return null;
 }
 
 /// Resolve a component-level func index to a bound `HostFunc`.
@@ -710,80 +685,56 @@ fn resolveComponentFuncToHostFunc(
     component: *const ctypes.Component,
     func_idx: u32,
 ) ?HostFunc {
-    var n: u32 = 0;
-
-    // 1) Direct top-level func imports.
-    for (component.imports) |imp| {
-        switch (imp.desc) {
-            .func => {
-                if (n == func_idx) {
-                    const binding = inst.imports.get(imp.name) orelse return null;
-                    return switch (binding) {
-                        .host_func => |hf| hf,
-                        else => null,
-                    };
-                }
-                n += 1;
-            },
-            else => {},
-        }
+    const ref = indexspace.resolveCompFunc(component, func_idx) orelse return null;
+    switch (ref) {
+        .imported => |imp_idx| {
+            const imp = component.imports[imp_idx];
+            const binding = inst.imports.get(imp.name) orelse return null;
+            return switch (binding) {
+                .host_func => |hf| hf,
+                else => null,
+            };
+        },
+        .aliased => |alias_idx| {
+            const ie = component.aliases[alias_idx].instance_export;
+            const inst_ref = indexspace.resolveCompInstance(component, ie.instance_idx) orelse return null;
+            // Only aliases pointing at imported component instances are
+            // host-bound. Aliases of locally-instantiated instances are
+            // resolved to their underlying canon.lift / canon.lower elsewhere.
+            const imp_decl = switch (inst_ref) {
+                .imported => |i| component.imports[i],
+                else => return null,
+            };
+            const binding = inst.imports.get(imp_decl.name) orelse return null;
+            const host_inst = switch (binding) {
+                .host_instance => |hi| hi,
+                else => return null,
+            };
+            const member = host_inst.members.get(ie.name) orelse return null;
+            return switch (member) {
+                .func => |hf| hf,
+                .resource_type => null,
+            };
+        },
+        // canon.lifts are not host-bound — they are component-defined
+        // funcs implemented by core code.
+        .lifted => return null,
     }
-
-    // 2) Aliases that name a component-level func member of an imported
-    //    component instance.
-    for (component.aliases) |a| {
-        switch (a) {
-            .instance_export => |ie| {
-                const is_comp_func = switch (ie.sort) {
-                    .func => true,
-                    else => false,
-                };
-                if (!is_comp_func) continue;
-                if (n == func_idx) {
-                    const imp_decl = resolveImportedInstance(component, ie.instance_idx) orelse return null;
-                    const binding = inst.imports.get(imp_decl.name) orelse return null;
-                    const host_inst = switch (binding) {
-                        .host_instance => |hi| hi,
-                        else => return null,
-                    };
-                    const member = host_inst.members.get(ie.name) orelse return null;
-                    return switch (member) {
-                        .func => |hf| hf,
-                        .resource_type => null,
-                    };
-                }
-                n += 1;
-            },
-            else => {},
-        }
-    }
-
-    return null;
 }
 
 /// Resolve a component-level instance index to its `ImportDecl` if it
-/// refers to an imported component instance.
-///
-/// The component instance index space is contributed by: imports of kind
-/// `instance`, then locally instantiated component instances
-/// (`component.instances`), then aliases of `Sort.instance` (rare).
-/// Phase 2B narrow assumption: only the imported-instance prefix is
-/// supported. Returns null for indices past the imported region.
+/// refers to an imported component instance. Returns null for locally
+/// instantiated or aliased instances (callers wanting the broader form
+/// should use `indexspace.resolveCompInstance` directly).
 fn resolveImportedInstance(
     component: *const ctypes.Component,
     instance_idx: u32,
 ) ?ctypes.ImportDecl {
-    var n: u32 = 0;
-    for (component.imports) |imp| {
-        switch (imp.desc) {
-            .instance => {
-                if (n == instance_idx) return imp;
-                n += 1;
-            },
-            else => {},
-        }
-    }
-    return null;
+    const ref = indexspace.resolveCompInstance(component, instance_idx) orelse return null;
+    return switch (ref) {
+        .imported => |i| component.imports[i],
+        else => null,
+    };
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -1238,7 +1189,7 @@ test "callComponentFunc: invokes lifted export through alias (2A.2c)" {
         } },
     };
     const exports_decl = [_]ctypes.ExportDecl{
-        .{ .name = "run", .desc = .{ .func = 1 } },
+        .{ .name = "run", .desc = .{ .func = 1 }, .sort_idx = .{ .sort = .func, .idx = 1 } },
     };
 
     const component = ctypes.Component{

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -571,31 +571,93 @@ pub fn instantiate(
     // Build export map: walk top-level component exports, resolve each
     // `.func` export through the component-func index space to its backing
     // `canon.lift`, and register an entry in `exported_funcs` keyed by the
-    // export name. Locally-built instance exports (e.g. `wasi:cli/run`) are
-    // a separate slice (#151).
+    // export name.
+    //
+    // Top-level *instance* exports (e.g. `wasi:cli/run@0.2.6`) are
+    // handled by walking the locally-instantiated instance's inline-exports
+    // and registering each member func under both the dotted name
+    // (`<instance-name>/<member>`) and — for the canonical `wasi:cli/run`
+    // shape — the bare member name so the existing `runComponent` adapter
+    // can locate `"run"` without knowing the version suffix.
     for (component.exports) |exp| {
         const si = exp.sort_idx orelse continue;
-        if (si.sort != .func) continue;
-        const ref = indexspace.resolveCompFunc(component, si.idx) orelse continue;
-        const canon_idx = switch (ref) {
-            .lifted => |i| i,
-            else => continue,
-        };
-        switch (component.canons[canon_idx]) {
-            .lift => |lift| {
-                const resolved = resolveLiftedCoreFunc(inst, component, lift.core_func_idx);
-                inst.exported_funcs.put(allocator, exp.name, .{
-                    .core_instance_idx = if (resolved) |r| r.core_instance_idx else 0,
-                    .core_func_idx = if (resolved) |r| r.local_func_idx else lift.core_func_idx,
-                    .func_type_idx = lift.type_idx,
-                    .opts = lift.opts,
-                }) catch {};
-            },
+        switch (si.sort) {
+            .func => registerLiftedExport(inst, component, allocator, exp.name, si.idx),
+            .instance => registerInstanceExport(inst, component, allocator, exp.name, si.idx),
             else => {},
         }
     }
 
     return inst;
+}
+
+fn registerLiftedExport(
+    inst: *ComponentInstance,
+    component: *const ctypes.Component,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    func_idx: u32,
+) void {
+    const ref = indexspace.resolveCompFunc(component, func_idx) orelse return;
+    const canon_idx = switch (ref) {
+        .lifted => |i| i,
+        else => return,
+    };
+    switch (component.canons[canon_idx]) {
+        .lift => |lift| {
+            const resolved = resolveLiftedCoreFunc(inst, component, lift.core_func_idx);
+            inst.exported_funcs.put(allocator, name, .{
+                .core_instance_idx = if (resolved) |r| r.core_instance_idx else 0,
+                .core_func_idx = if (resolved) |r| r.local_func_idx else lift.core_func_idx,
+                .func_type_idx = lift.type_idx,
+                .opts = lift.opts,
+            }) catch {};
+        },
+        else => {},
+    }
+}
+
+fn registerInstanceExport(
+    inst: *ComponentInstance,
+    component: *const ctypes.Component,
+    allocator: std.mem.Allocator,
+    instance_name: []const u8,
+    instance_idx: u32,
+) void {
+    const ref = indexspace.resolveCompInstance(component, instance_idx) orelse return;
+    const local_idx = switch (ref) {
+        .local => |i| i,
+        // Re-exported imported instances and aliased instances aren't
+        // backed by lifts inside this component — nothing to register.
+        else => return,
+    };
+    if (local_idx >= component.instances.len) return;
+    const expr = component.instances[local_idx];
+    const inline_exports = switch (expr) {
+        .exports => |e| e,
+        // An `instantiate`-form local instance would require resolving
+        // exports of another component definition; not yet supported.
+        .instantiate => return,
+    };
+
+    const expose_bare = isWasiCliRunName(instance_name);
+
+    for (inline_exports) |mem| {
+        if (mem.sort_idx.sort != .func) continue;
+        const dotted = std.fmt.allocPrint(inst.module_arena.allocator(), "{s}/{s}", .{ instance_name, mem.name }) catch continue;
+        registerLiftedExport(inst, component, allocator, dotted, mem.sort_idx.idx);
+        if (expose_bare and std.mem.eql(u8, mem.name, "run")) {
+            registerLiftedExport(inst, component, allocator, "run", mem.sort_idx.idx);
+        }
+    }
+}
+
+/// Match `wasi:cli/run` and `wasi:cli/run@<version>` instance export names.
+fn isWasiCliRunName(name: []const u8) bool {
+    const prefix = "wasi:cli/run";
+    if (!std.mem.startsWith(u8, name, prefix)) return false;
+    const rest = name[prefix.len..];
+    return rest.len == 0 or rest[0] == '@';
 }
 
 // ── Index-space helpers ─────────────────────────────────────────────────────
@@ -1003,7 +1065,6 @@ test "ComponentInstance: resource tables are lazy and keyed by typeidx" {
 }
 
 test "instantiate: canon.lower wires host func into core import (2A.2b)" {
-    const testing = std.testing;
 
     // Minimal core module:
     //   (type (func (param i32 i32) (result i32)))
@@ -1077,7 +1138,7 @@ test "instantiate: canon.lower wires host func into core import (2A.2b)" {
         .exports = &.{},
     };
 
-    const inst = try instantiate(&component, testing.allocator);
+    const inst = try instantiate(&component, std.testing.allocator);
     defer inst.deinit();
 
     // Register a host sub: returns a - b. Non-commutative to catch argument
@@ -1094,8 +1155,8 @@ test "instantiate: canon.lower wires host func into core import (2A.2b)" {
         }
     };
     var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
-    defer providers.deinit(testing.allocator);
-    try providers.put(testing.allocator, "host-sub", .{
+    defer providers.deinit(std.testing.allocator);
+    try providers.put(std.testing.allocator, "host-sub", .{
         .host_func = .{ .call = &Host.sub },
     });
     try inst.linkImports(providers);
@@ -1109,14 +1170,13 @@ test "instantiate: canon.lower wires host func into core import (2A.2b)" {
 
     // Invoke the exported "run" core function.
     const run_idx = mi.getExportFunc("run") orelse return error.TestFailed;
-    const env = try @import("../runtime/common/exec_env.zig").ExecEnv.create(mi, 512, testing.allocator);
+    const env = try @import("../runtime/common/exec_env.zig").ExecEnv.create(mi, 512, std.testing.allocator);
     defer env.destroy();
     try @import("../runtime/interpreter/interp.zig").executeFunction(env, run_idx);
     try std.testing.expectEqual(@as(i32, 5), try env.popI32());
 }
 
 test "callComponentFunc: invokes lifted export through alias (2A.2c)" {
-    const testing = std.testing;
     const executor = @import("executor.zig");
     const abi_mod = @import("canonical_abi.zig");
 
@@ -1205,7 +1265,7 @@ test "callComponentFunc: invokes lifted export through alias (2A.2c)" {
         .exports = &exports_decl,
     };
 
-    const inst = try instantiate(&component, testing.allocator);
+    const inst = try instantiate(&component, std.testing.allocator);
     defer inst.deinit();
 
     const Host = struct {
@@ -1220,8 +1280,8 @@ test "callComponentFunc: invokes lifted export through alias (2A.2c)" {
         }
     };
     var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
-    defer providers.deinit(testing.allocator);
-    try providers.put(testing.allocator, "host-sub", .{
+    defer providers.deinit(std.testing.allocator);
+    try providers.put(std.testing.allocator, "host-sub", .{
         .host_func = .{ .call = &Host.sub },
     });
     try inst.linkImports(providers);
@@ -1236,6 +1296,87 @@ test "callComponentFunc: invokes lifted export through alias (2A.2c)" {
         .{ .s32 = 2 },
     };
     var results: [1]abi_mod.InterfaceValue = undefined;
-    try executor.callComponentFunc(inst, "run", &args, &results, testing.allocator);
+    try executor.callComponentFunc(inst, "run", &args, &results, std.testing.allocator);
     try std.testing.expectEqual(@as(i32, 5), results[0].s32);
+}
+
+test "instantiate: registers nested wasi:cli/run instance member as 'run' (#151)" {
+    // Hand-authored component:
+    //   - 1 core module exporting "run" (no imports, no host calls)
+    //   - 1 core instance instantiating it
+    //   - 1 alias of the core "run" → core-func-idx 0
+    //   - 1 canon.lift over that core func → comp-func-idx 0
+    //   - 1 local component-instance bundling { "run": comp-func 0 }
+    //     (instance-idx 0)
+    //   - 1 top-level export "wasi:cli/run@0.2.6" → instance 0
+    //
+    // After instantiate(), inst.getExport("run") and
+    // inst.getExport("wasi:cli/run@0.2.6/run") must both resolve to
+    // the lifted core export.
+    const core_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: () -> ()
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        // function section: 1 fn of type 0
+        0x03, 0x02, 0x01, 0x00,
+        // export section: "run" -> func 0
+        0x07, 0x07, 0x01, 0x03, 'r', 'u', 'n', 0x00, 0x00,
+        // code section: empty body
+        0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b,
+    };
+
+    const core_modules = [_]ctypes.CoreModule{.{ .data = &core_wasm }};
+    const type_defs = [_]ctypes.TypeDef{
+        .{ .func = .{ .params = &.{}, .results = .none } },
+    };
+    const core_insts = [_]ctypes.CoreInstanceExpr{
+        .{ .instantiate = .{ .module_idx = 0, .args = &.{} } },
+    };
+    const aliases_decl = [_]ctypes.Alias{
+        .{ .instance_export = .{
+            .sort = .{ .core = .func },
+            .instance_idx = 0,
+            .name = "run",
+        } },
+    };
+    const canons = [_]ctypes.Canon{
+        .{ .lift = .{ .core_func_idx = 0, .type_idx = 0, .opts = &.{} } },
+    };
+    const inline_exp = [_]ctypes.InlineExport{
+        .{ .name = "run", .sort_idx = .{ .sort = .func, .idx = 0 } },
+    };
+    const instances = [_]ctypes.InstanceExpr{
+        .{ .exports = &inline_exp },
+    };
+    const exports_decl = [_]ctypes.ExportDecl{
+        .{
+            .name = "wasi:cli/run@0.2.6",
+            .desc = .{ .instance = 0 },
+            .sort_idx = .{ .sort = .instance, .idx = 0 },
+        },
+    };
+
+    const component = ctypes.Component{
+        .core_modules = &core_modules,
+        .core_instances = &core_insts,
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &instances,
+        .aliases = &aliases_decl,
+        .types = &type_defs,
+        .canons = &canons,
+        .imports = &.{},
+        .exports = &exports_decl,
+    };
+
+    const inst = try instantiate(&component, std.testing.allocator);
+    defer inst.deinit();
+
+    const bare = inst.getExport("run") orelse return error.TestFailed;
+    try std.testing.expectEqual(@as(u32, 0), bare.core_instance_idx);
+    try std.testing.expectEqual(@as(u32, 0), bare.core_func_idx);
+
+    const dotted = inst.getExport("wasi:cli/run@0.2.6/run") orelse return error.TestFailed;
+    try std.testing.expectEqual(@as(u32, 0), dotted.core_instance_idx);
+    try std.testing.expectEqual(@as(u32, 0), dotted.core_func_idx);
 }

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -134,6 +134,12 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
     var imports: std.ArrayListUnmanaged(ctypes.ImportDecl) = .empty;
     var exports: std.ArrayListUnmanaged(ctypes.ExportDecl) = .empty;
     var start: ?ctypes.Start = null;
+    // Tracks the type index space in section-encounter order. Each entry
+    // is the local idx into `type_defs` for that slot, or null when
+    // the slot is consumed by an import (`.type`-bound) or alias whose
+    // target type def we don't materialize. Required to resolve real
+    // wasm32-wasip2 components where types and aliases interleave.
+    var type_indexspace: std.ArrayListUnmanaged(?u32) = .empty;
 
     while (reader.remaining() > 0) {
         const section_id_byte = try reader.readByte();
@@ -189,14 +195,24 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
                 const count = try reader.readU32();
                 var i: u32 = 0;
                 while (i < count) : (i += 1) {
-                    try aliases.append(allocator, try parseAlias(&reader));
+                    const a = try parseAlias(&reader);
+                    try aliases.append(allocator, a);
+                    // Aliases of sort .type contribute a slot to the
+                    // type indexspace (target unresolved here → null).
+                    const sort: ctypes.Sort = switch (a) {
+                        .instance_export => |ie| ie.sort,
+                        .outer => |o| o.sort,
+                    };
+                    if (sort == .type) try type_indexspace.append(allocator, null);
                 }
             },
             .type => {
                 const count = try reader.readU32();
                 var i: u32 = 0;
                 while (i < count) : (i += 1) {
+                    const local_idx: u32 = @intCast(type_defs.items.len);
                     try type_defs.append(allocator, try parseTypeDef(&reader, allocator));
+                    try type_indexspace.append(allocator, local_idx);
                 }
             },
             .canon => {
@@ -213,7 +229,9 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
                 const count = try reader.readU32();
                 var i: u32 = 0;
                 while (i < count) : (i += 1) {
-                    try imports.append(allocator, try parseImport(&reader));
+                    const imp = try parseImport(&reader);
+                    try imports.append(allocator, imp);
+                    if (imp.desc == .type) try type_indexspace.append(allocator, null);
                 }
             },
             .@"export" => {
@@ -242,6 +260,7 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
         .instances = try instances.toOwnedSlice(allocator),
         .aliases = try aliases.toOwnedSlice(allocator),
         .types = try type_defs.toOwnedSlice(allocator),
+        .type_indexspace = try type_indexspace.toOwnedSlice(allocator),
         .canons = try canons.toOwnedSlice(allocator),
         .start = start,
         .imports = try imports.toOwnedSlice(allocator),

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -444,6 +444,13 @@ pub const Component = struct {
     aliases: []const Alias,
     /// Component-level type definitions.
     types: []const TypeDef,
+    /// Type index-space → local `types[]` mapping. Each entry is the
+    /// local idx into `types` for slots produced by a `(type ...)` def,
+    /// or null for slots produced by a `(import ... (type ...))` /
+    /// `(alias ... (type ...))` whose target def isn't materialized
+    /// in `types`. When empty (hand-authored fixtures), callers fall
+    /// back to direct indexing of `types`.
+    type_indexspace: []const ?u32 = &.{},
     /// Canonical function definitions.
     canons: []const Canon,
     /// Start function.

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -48,12 +48,18 @@ const streams = @import("../wasi/preview2/streams.zig");
 pub const WasiCliAdapter = struct {
     allocator: Allocator,
     stdout: streams.OutputStream,
+    /// Captured stdin buffer. Defaults to empty; callers populate via
+    /// `setStdinBytes` before running the component. The slice is
+    /// borrowed — keep it alive for as long as the component runs.
+    stdin: streams.InputStream = .{ .source = .closed },
     /// `HostInstance` registered for the simple test interface name
     /// (e.g. `"wasi:hello/world"`). Stored inline so the adapter owns its
     /// lifetime; callers pass a stable pointer to `linkImports`.
     write_iface: HostInstance = .{},
     /// `HostInstance` for `wasi:cli/stdout` (member: `get-stdout`).
     cli_stdout_iface: HostInstance = .{},
+    /// `HostInstance` for `wasi:cli/stdin` (member: `get-stdin`).
+    cli_stdin_iface: HostInstance = .{},
     /// `HostInstance` for `wasi:io/streams` (members:
     /// `[method]output-stream.blocking-write-and-flush`,
     /// `[resource-drop]output-stream`).
@@ -76,6 +82,9 @@ pub const WasiCliAdapter = struct {
     /// "stdout"; future handle types (stderr, files) will get distinct
     /// non-zero values.
     stream_table: std.ArrayListUnmanaged(?*streams.OutputStream) = .empty,
+    /// Adapter-internal input-stream handles, parallel to `stream_table`.
+    /// Same handle-vs-resource-table rationale.
+    input_stream_table: std.ArrayListUnmanaged(?*streams.InputStream) = .empty,
 
     /// Initialize with a buffer-backed stdout sink. Use `getStdoutBytes`
     /// after the component runs to inspect captured output.
@@ -90,10 +99,18 @@ pub const WasiCliAdapter = struct {
         self.stdout.deinit(self.allocator);
         self.write_iface.deinit(self.allocator);
         self.cli_stdout_iface.deinit(self.allocator);
+        self.cli_stdin_iface.deinit(self.allocator);
         self.io_streams_iface.deinit(self.allocator);
         self.io_poll_iface.deinit(self.allocator);
         self.io_error_iface.deinit(self.allocator);
         self.stream_table.deinit(self.allocator);
+        self.input_stream_table.deinit(self.allocator);
+    }
+
+    /// Set the captured stdin to read from `bytes`. The slice is
+    /// borrowed — caller must keep it alive for the run.
+    pub fn setStdinBytes(self: *WasiCliAdapter, bytes: []const u8) void {
+        self.stdin = streams.InputStream.fromBuffer(bytes);
     }
 
     /// Captured stdout bytes (valid for buffer-backed sinks).
@@ -155,8 +172,35 @@ pub const WasiCliAdapter = struct {
             "[resource-drop]output-stream",
             .{ .func = .{ .context = self, .call = &dropOutputStream } },
         );
+        // Input-stream member surface used by stdio-echo via stdin reads.
+        try self.io_streams_iface.members.put(
+            self.allocator,
+            "[method]input-stream.blocking-read",
+            .{ .func = .{ .context = self, .call = &blockingRead } },
+        );
+        try self.io_streams_iface.members.put(
+            self.allocator,
+            "[resource-drop]input-stream",
+            .{ .func = .{ .context = self, .call = &dropInputStream } },
+        );
         try providers.put(self.allocator, io_streams_name, .{
             .host_instance = &self.io_streams_iface,
+        });
+    }
+
+    /// Register `wasi:cli/stdin` host binding. Members:
+    ///   - `get-stdin: () -> own<input-stream>` returns a handle into
+    ///     `self.input_stream_table` pointing at the captured stdin.
+    pub fn populateWasiCliStdin(
+        self: *WasiCliAdapter,
+        providers: *std.StringHashMapUnmanaged(ImportBinding),
+        cli_stdin_name: []const u8,
+    ) !void {
+        try self.cli_stdin_iface.members.put(self.allocator, "get-stdin", .{
+            .func = .{ .context = self, .call = &getStdinHandle },
+        });
+        try providers.put(self.allocator, cli_stdin_name, .{
+            .host_instance = &self.cli_stdin_iface,
         });
     }
 
@@ -312,6 +356,108 @@ pub const WasiCliAdapter = struct {
             self.stream_table.items[handle] = null;
         }
     }
+
+    fn allocInputStreamHandle(self: *WasiCliAdapter, stream: *streams.InputStream) !u32 {
+        for (self.input_stream_table.items, 0..) |slot, i| {
+            if (slot == null) {
+                self.input_stream_table.items[i] = stream;
+                return @intCast(i);
+            }
+        }
+        const idx: u32 = @intCast(self.input_stream_table.items.len);
+        try self.input_stream_table.append(self.allocator, stream);
+        return idx;
+    }
+
+    fn lookupInputStream(self: *WasiCliAdapter, handle: u32) ?*streams.InputStream {
+        if (handle >= self.input_stream_table.items.len) return null;
+        return self.input_stream_table.items[handle];
+    }
+
+    /// `wasi:cli/stdin.get-stdin: () -> own<input-stream>`.
+    fn getStdinHandle(
+        ctx_opaque: ?*anyopaque,
+        _: *ComponentInstance,
+        _: []const InterfaceValue,
+        results: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        const self: *WasiCliAdapter = @ptrCast(@alignCast(ctx_opaque.?));
+        if (results.len == 0) return error.InvalidArgs;
+        const handle = try self.allocInputStreamHandle(&self.stdin);
+        results[0] = .{ .handle = handle };
+    }
+
+    /// `wasi:io/streams.[method]input-stream.blocking-read:
+    ///   (borrow<input-stream>, u64) -> result<list<u8>, stream-error>`.
+    /// Reads up to `len` bytes from the captured stdin into a freshly
+    /// guest-allocated buffer (via `cabi_realloc`) and returns the list
+    /// in the ok arm. End-of-stream surfaces as the closed variant in
+    /// the err arm with payload omitted (caller's `result_val.payload`
+    /// is `null` — the canonical-ABI store path zero-fills the payload
+    /// slots that aren't populated).
+    fn blockingRead(
+        ctx_opaque: ?*anyopaque,
+        ci: *ComponentInstance,
+        args: []const InterfaceValue,
+        results: []InterfaceValue,
+        allocator: Allocator,
+    ) anyerror!void {
+        const self: *WasiCliAdapter = @ptrCast(@alignCast(ctx_opaque.?));
+        if (args.len < 2 or results.len == 0) return error.InvalidArgs;
+        const handle = switch (args[0]) {
+            .handle => |h| h,
+            else => return error.InvalidArgs,
+        };
+        const want_u64 = switch (args[1]) {
+            .u64 => |v| v,
+            else => return error.InvalidArgs,
+        };
+        const stream = self.lookupInputStream(handle) orelse return error.InvalidHandle;
+
+        const want: usize = @min(want_u64, std.math.maxInt(usize));
+        // Cap at a sane upper bound so an unbounded request from the guest
+        // (Rust's read_line passes 0xFFFF_FFFF_FFFF_FFFF) doesn't allocate
+        // a multi-exabyte host buffer. 64 KiB matches the canonical-ABI
+        // chunk used by wit-bindgen.
+        const capped: usize = @min(want, 64 * 1024);
+
+        const buf = try allocator.alloc(u8, capped);
+        defer allocator.free(buf);
+
+        switch (stream.read(buf)) {
+            .ok => |n| {
+                const guest_ptr = ci.hostAllocAndWrite(buf[0..n]) orelse return error.IoError;
+                const list_val = try allocator.create(InterfaceValue);
+                list_val.* = .{ .list = .{ .ptr = guest_ptr, .len = @intCast(n) } };
+                results[0] = .{ .result_val = .{ .is_ok = true, .payload = list_val } };
+            },
+            .closed => {
+                // err arm; payload (stream-error variant) zero-fills.
+                results[0] = .{ .result_val = .{ .is_ok = false, .payload = null } };
+            },
+            .err => return error.IoError,
+        }
+    }
+
+    /// `wasi:io/streams.[resource-drop]input-stream: (own<input-stream>) -> ()`.
+    fn dropInputStream(
+        ctx_opaque: ?*anyopaque,
+        _: *ComponentInstance,
+        args: []const InterfaceValue,
+        _: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        const self: *WasiCliAdapter = @ptrCast(@alignCast(ctx_opaque.?));
+        if (args.len == 0) return error.InvalidArgs;
+        const handle = switch (args[0]) {
+            .handle => |h| h,
+            else => return error.InvalidArgs,
+        };
+        if (handle < self.input_stream_table.items.len) {
+            self.input_stream_table.items[handle] = null;
+        }
+    }
 };
 
 // ── Top-level CLI dispatch ─────────────────────────────────────────────────
@@ -357,6 +503,7 @@ pub fn populateWasiProviders(
     providers: *std.StringHashMapUnmanaged(ImportBinding),
 ) !void {
     var matched_stdout: ?[]const u8 = null;
+    var matched_stdin: ?[]const u8 = null;
     var matched_streams: ?[]const u8 = null;
     var matched_poll: ?[]const u8 = null;
     var matched_error: ?[]const u8 = null;
@@ -364,6 +511,8 @@ pub fn populateWasiProviders(
         if (imp.desc != .instance) continue;
         if (matched_stdout == null and matchesWasiPrefix(imp.name, "wasi:cli/stdout"))
             matched_stdout = imp.name;
+        if (matched_stdin == null and matchesWasiPrefix(imp.name, "wasi:cli/stdin"))
+            matched_stdin = imp.name;
         if (matched_streams == null and matchesWasiPrefix(imp.name, "wasi:io/streams"))
             matched_streams = imp.name;
         if (matched_poll == null and matchesWasiPrefix(imp.name, "wasi:io/poll"))
@@ -382,6 +531,12 @@ pub fn populateWasiProviders(
     );
     if (matched_stdout == null) _ = providers.remove("wasi:cli/stdout");
     if (matched_streams == null) _ = providers.remove("wasi:io/streams");
+
+    try adapter.populateWasiCliStdin(
+        providers,
+        matched_stdin orelse "wasi:cli/stdin",
+    );
+    if (matched_stdin == null) _ = providers.remove("wasi:cli/stdin");
 
     try adapter.populateWasiIoPollError(
         providers,
@@ -960,4 +1115,41 @@ test "populateWasiProviders: binds wasi:io/poll and wasi:io/error (#154)" {
     // Resource-drop members are wired so the guest can drop pollables/errors.
     try testing.expect(adapter.io_poll_iface.members.contains("[resource-drop]pollable"));
     try testing.expect(adapter.io_error_iface.members.contains("[resource-drop]error"));
+}
+
+test "populateWasiProviders: binds wasi:cli/stdin (#152)" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+    adapter.setStdinBytes("hello\n");
+
+    const imports = [_]ctypes_root.ImportDecl{
+        .{ .name = "wasi:cli/stdin@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:io/streams@0.2.6", .desc = .{ .instance = 0 } },
+    };
+    const component = ctypes_root.Component{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},   .instances = &.{},      .aliases = &.{},
+        .types = &.{},        .canons = &.{},
+        .imports = &imports,  .exports = &.{},
+    };
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+
+    try populateWasiProviders(&adapter, &component, &providers);
+
+    try testing.expect(providers.contains("wasi:cli/stdin@0.2.6"));
+    try testing.expect(!providers.contains("wasi:cli/stdin"));
+    try testing.expect(adapter.cli_stdin_iface.members.contains("get-stdin"));
+    try testing.expect(adapter.io_streams_iface.members.contains("[method]input-stream.blocking-read"));
+    try testing.expect(adapter.io_streams_iface.members.contains("[resource-drop]input-stream"));
+
+    // The captured stdin buffer is reachable as an InputStream.
+    var buf: [16]u8 = undefined;
+    const r = adapter.stdin.read(&buf);
+    switch (r) {
+        .ok => |n| try testing.expectEqualStrings("hello\n", buf[0..n]),
+        else => try testing.expect(false),
+    }
 }

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -1605,3 +1605,45 @@ test "populateWasiProviders: binds full cli surface (#153)" {
     try testing.expect(adapter.io_streams_iface.members.contains("[method]output-stream.subscribe"));
     try testing.expect(adapter.io_streams_iface.members.contains("[method]input-stream.subscribe"));
 }
+
+test "stdio-echo: end-to-end real wasi-p2 component (#156)" {
+    // The stdio-echo fixture (Rust → wasm32-wasip2 via wit-component) uses
+    // composition machinery this runtime doesn't yet implement:
+    //   * three core modules (`$main`, `$wit-component-shim-module`,
+    //     `$wit-component-fixup`) wired via `(core instance (instantiate
+    //     $m (with ...)))` with cross-instance export aliases;
+    //   * an indirect-call trampoline table patched by `$fixup` after
+    //     `$main` is instantiated;
+    //   * `(canon resource.drop ...)` core funcs and full resource
+    //     indexspace plumbing;
+    //   * `(canon lower ...)` of host-instance methods sourced from
+    //     aliased imported instance exports rather than direct imports.
+    //
+    // The host-side WASI surface (#150–#155) is in place, and the loader
+    // / TypeRegistry now handle the type indexspace correctly so the run
+    // export resolves through the wit-bindgen 0.2.0 shim. Lighting up
+    // execution requires a follow-up slice that extends the core-side
+    // resolver; tracked alongside #156. Once that lands, drop the skip
+    // and the body below becomes the regression gate.
+    return error.SkipZigTest;
+}
+
+test "stdio-echo: end-to-end real wasi-p2 component (#156, disabled body)" {
+    if (true) return error.SkipZigTest;
+    const testing = std.testing;
+    const data = @embedFile("fixtures/stdio-echo.wasm");
+
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+    adapter.setStdinBytes("hello\n");
+
+    const outcome = runComponentBytes(data, testing.allocator, &adapter) catch |err| {
+        std.debug.print("stdio-echo run failed: {s}\n", .{@errorName(err)});
+        std.debug.print("stdout so far: {s}\n", .{adapter.getStdoutBytes()});
+        std.debug.print("stderr so far: {s}\n", .{adapter.getStderrBytes()});
+        return err;
+    };
+
+    try testing.expect(outcome.is_ok);
+    try testing.expectEqualStrings("echo: hello\n", adapter.getStdoutBytes());
+}

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -675,7 +675,7 @@ test "WasiCliAdapter: hello-world fixture (cli/stdout + io/streams + run)" {
     };
 
     const exports_decl = [_]ctypes.ExportDecl{
-        .{ .name = "run", .desc = .{ .func = 3 } },
+        .{ .name = "run", .desc = .{ .func = 3 }, .sort_idx = .{ .sort = .func, .idx = 3 } },
     };
 
     const component = ctypes.Component{
@@ -839,7 +839,7 @@ test "runLoadedComponent: matches versioned WASI import names" {
     };
 
     const exports_decl = [_]ctypes.ExportDecl{
-        .{ .name = "run", .desc = .{ .func = 3 } },
+        .{ .name = "run", .desc = .{ .func = 3 }, .sort_idx = .{ .sort = .func, .idx = 3 } },
     };
 
     const component = ctypes.Component{

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -48,42 +48,36 @@ const streams = @import("../wasi/preview2/streams.zig");
 pub const WasiCliAdapter = struct {
     allocator: Allocator,
     stdout: streams.OutputStream,
+    stderr: streams.OutputStream,
     /// Captured stdin buffer. Defaults to empty; callers populate via
     /// `setStdinBytes` before running the component. The slice is
     /// borrowed — keep it alive for as long as the component runs.
     stdin: streams.InputStream = .{ .source = .closed },
+
+    /// Set by `wasi:cli/exit.exit` (or `exit-with-code`). The host fn
+    /// also returns `error.Trap`; `runLoadedComponent` checks this
+    /// field to translate the trap into a normal `RunOutcome`.
+    exit_code: ?u32 = null,
+
     /// `HostInstance` registered for the simple test interface name
     /// (e.g. `"wasi:hello/world"`). Stored inline so the adapter owns its
     /// lifetime; callers pass a stable pointer to `linkImports`.
     write_iface: HostInstance = .{},
-    /// `HostInstance` for `wasi:cli/stdout` (member: `get-stdout`).
     cli_stdout_iface: HostInstance = .{},
-    /// `HostInstance` for `wasi:cli/stdin` (member: `get-stdin`).
+    cli_stderr_iface: HostInstance = .{},
     cli_stdin_iface: HostInstance = .{},
-    /// `HostInstance` for `wasi:io/streams` (members:
-    /// `[method]output-stream.blocking-write-and-flush`,
-    /// `[resource-drop]output-stream`).
+    cli_exit_iface: HostInstance = .{},
+    cli_environment_iface: HostInstance = .{},
+    cli_terminal_stdin_iface: HostInstance = .{},
+    cli_terminal_stdout_iface: HostInstance = .{},
+    cli_terminal_stderr_iface: HostInstance = .{},
+    cli_terminal_input_iface: HostInstance = .{},
+    cli_terminal_output_iface: HostInstance = .{},
     io_streams_iface: HostInstance = .{},
-    /// `HostInstance` for `wasi:io/poll`. Stdio-echo imports this for
-    /// type-resolution; only `[resource-drop]pollable` is wired with a
-    /// no-op since the guest never blocks on stdout. Other members trap
-    /// on call (left absent, so the trampoline reports an unresolved
-    /// import).
     io_poll_iface: HostInstance = .{},
-    /// `HostInstance` for `wasi:io/error`. Same shape as `io_poll_iface`:
-    /// only `[resource-drop]error` is wired; the host never produces an
-    /// `error` resource on the happy path.
     io_error_iface: HostInstance = .{},
 
-    /// Adapter-internal output-stream resource handles. Deliberately
-    /// independent of `ComponentInstance.resource_tables` — these handles
-    /// only flow through host calls and never need to round-trip into
-    /// guest-side `resource.{new,drop,rep}`. `0` is reserved and means
-    /// "stdout"; future handle types (stderr, files) will get distinct
-    /// non-zero values.
     stream_table: std.ArrayListUnmanaged(?*streams.OutputStream) = .empty,
-    /// Adapter-internal input-stream handles, parallel to `stream_table`.
-    /// Same handle-vs-resource-table rationale.
     input_stream_table: std.ArrayListUnmanaged(?*streams.InputStream) = .empty,
 
     /// Initialize with a buffer-backed stdout sink. Use `getStdoutBytes`
@@ -92,19 +86,34 @@ pub const WasiCliAdapter = struct {
         return .{
             .allocator = allocator,
             .stdout = streams.OutputStream.toBuffer(),
+            .stderr = streams.OutputStream.toBuffer(),
         };
     }
 
     pub fn deinit(self: *WasiCliAdapter) void {
         self.stdout.deinit(self.allocator);
+        self.stderr.deinit(self.allocator);
         self.write_iface.deinit(self.allocator);
         self.cli_stdout_iface.deinit(self.allocator);
+        self.cli_stderr_iface.deinit(self.allocator);
         self.cli_stdin_iface.deinit(self.allocator);
+        self.cli_exit_iface.deinit(self.allocator);
+        self.cli_environment_iface.deinit(self.allocator);
+        self.cli_terminal_stdin_iface.deinit(self.allocator);
+        self.cli_terminal_stdout_iface.deinit(self.allocator);
+        self.cli_terminal_stderr_iface.deinit(self.allocator);
+        self.cli_terminal_input_iface.deinit(self.allocator);
+        self.cli_terminal_output_iface.deinit(self.allocator);
         self.io_streams_iface.deinit(self.allocator);
         self.io_poll_iface.deinit(self.allocator);
         self.io_error_iface.deinit(self.allocator);
         self.stream_table.deinit(self.allocator);
         self.input_stream_table.deinit(self.allocator);
+    }
+
+    /// Captured stderr bytes (separate buffer from stdout).
+    pub fn getStderrBytes(self: *const WasiCliAdapter) []const u8 {
+        return self.stderr.getBufferContents();
     }
 
     /// Set the captured stdin to read from `bytes`. The slice is
@@ -169,6 +178,36 @@ pub const WasiCliAdapter = struct {
         );
         try self.io_streams_iface.members.put(
             self.allocator,
+            "[method]output-stream.write",
+            .{ .func = .{ .context = self, .call = &outputStreamWrite } },
+        );
+        try self.io_streams_iface.members.put(
+            self.allocator,
+            "[method]output-stream.check-write",
+            .{ .func = .{ .context = self, .call = &outputStreamCheckWrite } },
+        );
+        try self.io_streams_iface.members.put(
+            self.allocator,
+            "[method]output-stream.blocking-flush",
+            .{ .func = .{ .context = self, .call = &outputStreamBlockingFlush } },
+        );
+        try self.io_streams_iface.members.put(
+            self.allocator,
+            "[method]output-stream.flush",
+            .{ .func = .{ .context = self, .call = &outputStreamBlockingFlush } },
+        );
+        try self.io_streams_iface.members.put(
+            self.allocator,
+            "[method]output-stream.subscribe",
+            .{ .func = .{ .context = self, .call = &outputStreamSubscribe } },
+        );
+        try self.io_streams_iface.members.put(
+            self.allocator,
+            "[method]input-stream.subscribe",
+            .{ .func = .{ .context = self, .call = &inputStreamSubscribe } },
+        );
+        try self.io_streams_iface.members.put(
+            self.allocator,
             "[resource-drop]output-stream",
             .{ .func = .{ .context = self, .call = &dropOutputStream } },
         );
@@ -180,11 +219,118 @@ pub const WasiCliAdapter = struct {
         );
         try self.io_streams_iface.members.put(
             self.allocator,
+            "[method]input-stream.read",
+            .{ .func = .{ .context = self, .call = &blockingRead } },
+        );
+        try self.io_streams_iface.members.put(
+            self.allocator,
             "[resource-drop]input-stream",
             .{ .func = .{ .context = self, .call = &dropInputStream } },
         );
         try providers.put(self.allocator, io_streams_name, .{
             .host_instance = &self.io_streams_iface,
+        });
+    }
+
+    /// Register `wasi:cli/stderr` (mirror of stdout but writing to the
+    /// adapter's separate stderr buffer).
+    pub fn populateWasiCliStderr(
+        self: *WasiCliAdapter,
+        providers: *std.StringHashMapUnmanaged(ImportBinding),
+        cli_stderr_name: []const u8,
+    ) !void {
+        try self.cli_stderr_iface.members.put(self.allocator, "get-stderr", .{
+            .func = .{ .context = self, .call = &getStderrHandle },
+        });
+        try providers.put(self.allocator, cli_stderr_name, .{
+            .host_instance = &self.cli_stderr_iface,
+        });
+    }
+
+    /// Register `wasi:cli/exit`. `exit` and `exit-with-code` set
+    /// `self.exit_code` and surface as `error.Trap`; `runLoadedComponent`
+    /// translates that into a normal `RunOutcome` carrying the code.
+    pub fn populateWasiCliExit(
+        self: *WasiCliAdapter,
+        providers: *std.StringHashMapUnmanaged(ImportBinding),
+        cli_exit_name: []const u8,
+    ) !void {
+        try self.cli_exit_iface.members.put(self.allocator, "exit", .{
+            .func = .{ .context = self, .call = &cliExit },
+        });
+        try self.cli_exit_iface.members.put(self.allocator, "exit-with-code", .{
+            .func = .{ .context = self, .call = &cliExitWithCode },
+        });
+        try providers.put(self.allocator, cli_exit_name, .{
+            .host_instance = &self.cli_exit_iface,
+        });
+    }
+
+    /// Register `wasi:cli/environment`. All three accessors return
+    /// empty/none — sufficient for stdio-style components that don't
+    /// inspect env or args.
+    pub fn populateWasiCliEnvironment(
+        self: *WasiCliAdapter,
+        providers: *std.StringHashMapUnmanaged(ImportBinding),
+        cli_env_name: []const u8,
+    ) !void {
+        try self.cli_environment_iface.members.put(self.allocator, "get-environment", .{
+            .func = .{ .context = self, .call = &getEnvironment },
+        });
+        try self.cli_environment_iface.members.put(self.allocator, "get-arguments", .{
+            .func = .{ .context = self, .call = &getArguments },
+        });
+        try self.cli_environment_iface.members.put(self.allocator, "initial-cwd", .{
+            .func = .{ .context = self, .call = &initialCwd },
+        });
+        try providers.put(self.allocator, cli_env_name, .{
+            .host_instance = &self.cli_environment_iface,
+        });
+    }
+
+    /// Register `wasi:cli/terminal-{stdin,stdout,stderr,input,output}`.
+    /// In captured-buffer mode there is no real TTY, so each
+    /// `get-terminal-*` returns `none`. Resource-drop members on
+    /// `terminal-input` / `terminal-output` are wired as no-ops in
+    /// case the guest's runtime drops a freshly-pulled handle.
+    pub fn populateWasiCliTerminal(
+        self: *WasiCliAdapter,
+        providers: *std.StringHashMapUnmanaged(ImportBinding),
+        terminal_stdin_name: []const u8,
+        terminal_stdout_name: []const u8,
+        terminal_stderr_name: []const u8,
+        terminal_input_name: []const u8,
+        terminal_output_name: []const u8,
+    ) !void {
+        try self.cli_terminal_stdin_iface.members.put(self.allocator, "get-terminal-stdin", .{
+            .func = .{ .context = self, .call = &getTerminalNone },
+        });
+        try providers.put(self.allocator, terminal_stdin_name, .{
+            .host_instance = &self.cli_terminal_stdin_iface,
+        });
+        try self.cli_terminal_stdout_iface.members.put(self.allocator, "get-terminal-stdout", .{
+            .func = .{ .context = self, .call = &getTerminalNone },
+        });
+        try providers.put(self.allocator, terminal_stdout_name, .{
+            .host_instance = &self.cli_terminal_stdout_iface,
+        });
+        try self.cli_terminal_stderr_iface.members.put(self.allocator, "get-terminal-stderr", .{
+            .func = .{ .context = self, .call = &getTerminalNone },
+        });
+        try providers.put(self.allocator, terminal_stderr_name, .{
+            .host_instance = &self.cli_terminal_stderr_iface,
+        });
+        try self.cli_terminal_input_iface.members.put(self.allocator, "[resource-drop]terminal-input", .{
+            .func = .{ .context = self, .call = &noopResourceDrop },
+        });
+        try providers.put(self.allocator, terminal_input_name, .{
+            .host_instance = &self.cli_terminal_input_iface,
+        });
+        try self.cli_terminal_output_iface.members.put(self.allocator, "[resource-drop]terminal-output", .{
+            .func = .{ .context = self, .call = &noopResourceDrop },
+        });
+        try providers.put(self.allocator, terminal_output_name, .{
+            .host_instance = &self.cli_terminal_output_iface,
         });
     }
 
@@ -302,6 +448,111 @@ pub const WasiCliAdapter = struct {
         results[0] = .{ .handle = handle };
     }
 
+    /// `wasi:cli/stderr.get-stderr: () -> own<output-stream>`. Mirror of
+    /// `getStdoutHandle` for the captured stderr buffer.
+    fn getStderrHandle(
+        ctx_opaque: ?*anyopaque,
+        _: *ComponentInstance,
+        _: []const InterfaceValue,
+        results: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        const self: *WasiCliAdapter = @ptrCast(@alignCast(ctx_opaque.?));
+        if (results.len == 0) return error.InvalidArgs;
+        const handle = try self.allocStreamHandle(&self.stderr);
+        results[0] = .{ .handle = handle };
+    }
+
+    /// `wasi:cli/exit.exit: (result<_, _>) -> ()`. The arg is a
+    /// `result<_, _>` discriminant where `0` (ok) → exit 0, `1` (err) →
+    /// exit 1. Sets `self.exit_code` then traps so the run unwinds.
+    fn cliExit(
+        ctx_opaque: ?*anyopaque,
+        _: *ComponentInstance,
+        args: []const InterfaceValue,
+        _: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        const self: *WasiCliAdapter = @ptrCast(@alignCast(ctx_opaque.?));
+        const code: u32 = if (args.len > 0) switch (args[0]) {
+            .result_val => |rv| if (rv.is_ok) @as(u32, 0) else 1,
+            else => 0,
+        } else 0;
+        self.exit_code = code;
+        return error.WasiExit;
+    }
+
+    /// `wasi:cli/exit.exit-with-code: (u8) -> ()`. Sets the exit code
+    /// and traps. Mirrors `cliExit` for the typed-code form added in
+    /// later WASI 0.2 drafts.
+    fn cliExitWithCode(
+        ctx_opaque: ?*anyopaque,
+        _: *ComponentInstance,
+        args: []const InterfaceValue,
+        _: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        const self: *WasiCliAdapter = @ptrCast(@alignCast(ctx_opaque.?));
+        const code: u32 = if (args.len > 0) switch (args[0]) {
+            .u8 => |v| @intCast(v),
+            .u32 => |v| v,
+            .u64 => |v| @truncate(v),
+            else => 0,
+        } else 0;
+        self.exit_code = code;
+        return error.WasiExit;
+    }
+
+    /// `wasi:cli/environment.get-environment: () -> list<tuple<string,string>>`.
+    /// Returns an empty list (canonical pair `ptr=0, len=0`).
+    fn getEnvironment(
+        _: ?*anyopaque,
+        _: *ComponentInstance,
+        _: []const InterfaceValue,
+        results: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        if (results.len == 0) return error.InvalidArgs;
+        results[0] = .{ .list = .{ .ptr = 0, .len = 0 } };
+    }
+
+    /// `wasi:cli/environment.get-arguments: () -> list<string>`. Empty.
+    fn getArguments(
+        _: ?*anyopaque,
+        _: *ComponentInstance,
+        _: []const InterfaceValue,
+        results: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        if (results.len == 0) return error.InvalidArgs;
+        results[0] = .{ .list = .{ .ptr = 0, .len = 0 } };
+    }
+
+    /// `wasi:cli/environment.initial-cwd: () -> option<string>`. None.
+    fn initialCwd(
+        _: ?*anyopaque,
+        _: *ComponentInstance,
+        _: []const InterfaceValue,
+        results: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        if (results.len == 0) return error.InvalidArgs;
+        results[0] = .{ .option_val = .{ .is_some = false, .payload = null } };
+    }
+
+    /// `wasi:cli/terminal-*.get-terminal-*: () -> option<terminal-*>`.
+    /// Captured-buffer mode has no TTY → return `none`.
+    fn getTerminalNone(
+        _: ?*anyopaque,
+        _: *ComponentInstance,
+        _: []const InterfaceValue,
+        results: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        if (results.len == 0) return error.InvalidArgs;
+        results[0] = .{ .option_val = .{ .is_some = false, .payload = null } };
+    }
+
     /// `wasi:io/streams.[method]output-stream.blocking-write-and-flush:
     ///   (own<output-stream>, list<u8>) -> result<_, stream-error>`.
     /// Looks up the handle, writes the guest bytes through, and returns
@@ -334,6 +585,94 @@ pub const WasiCliAdapter = struct {
             .err, .closed => return error.IoError,
         }
         results[0] = .{ .result_val = .{ .is_ok = true, .payload = null } };
+    }
+
+    /// `[method]output-stream.write: (borrow<output-stream>, list<u8>)
+    ///   -> result<_, stream-error>`. Same write semantics as
+    /// `blocking-write-and-flush`; the captured buffer never blocks.
+    fn outputStreamWrite(
+        ctx_opaque: ?*anyopaque,
+        ci: *ComponentInstance,
+        args: []const InterfaceValue,
+        results: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        const self: *WasiCliAdapter = @ptrCast(@alignCast(ctx_opaque.?));
+        if (args.len < 2 or results.len == 0) return error.InvalidArgs;
+        const handle = switch (args[0]) {
+            .handle => |h| h,
+            else => return error.InvalidArgs,
+        };
+        const list = switch (args[1]) {
+            .list => |pl| pl,
+            else => return error.InvalidArgs,
+        };
+        const stream = self.lookupStream(handle) orelse return error.InvalidHandle;
+        const bytes = ci.readGuestBytes(list.ptr, list.len) orelse
+            return error.OutOfBoundsMemory;
+        switch (stream.write(bytes, self.allocator)) {
+            .ok => {},
+            .err, .closed => return error.IoError,
+        }
+        results[0] = .{ .result_val = .{ .is_ok = true, .payload = null } };
+    }
+
+    /// `[method]output-stream.check-write: (borrow<output-stream>)
+    ///   -> result<u64, stream-error>`. The captured buffer can always
+    /// accept; report a generous chunk so the guest writes in one call.
+    fn outputStreamCheckWrite(
+        ctx_opaque: ?*anyopaque,
+        _: *ComponentInstance,
+        args: []const InterfaceValue,
+        results: []InterfaceValue,
+        allocator: Allocator,
+    ) anyerror!void {
+        _ = ctx_opaque;
+        if (args.len == 0 or results.len == 0) return error.InvalidArgs;
+        const payload = try allocator.create(InterfaceValue);
+        payload.* = .{ .u64 = 64 * 1024 };
+        results[0] = .{ .result_val = .{ .is_ok = true, .payload = payload } };
+    }
+
+    /// `[method]output-stream.blocking-flush: (borrow<output-stream>)
+    ///   -> result<_, stream-error>`. Captured buffer is unbuffered; ok.
+    fn outputStreamBlockingFlush(
+        _: ?*anyopaque,
+        _: *ComponentInstance,
+        _: []const InterfaceValue,
+        results: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        if (results.len == 0) return error.InvalidArgs;
+        results[0] = .{ .result_val = .{ .is_ok = true, .payload = null } };
+    }
+
+    /// `[method]output-stream.subscribe: (borrow<output-stream>)
+    ///   -> own<pollable>`. Captured-buffer streams are always ready;
+    /// return a sentinel handle that drop-pollable will swallow.
+    fn outputStreamSubscribe(
+        _: ?*anyopaque,
+        _: *ComponentInstance,
+        args: []const InterfaceValue,
+        results: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        if (args.len == 0 or results.len == 0) return error.InvalidArgs;
+        results[0] = .{ .handle = 0 };
+    }
+
+    /// `[method]input-stream.subscribe: (borrow<input-stream>)
+    ///   -> own<pollable>`. Same sentinel as the output side — the
+    /// captured stdin buffer is always ready.
+    fn inputStreamSubscribe(
+        _: ?*anyopaque,
+        _: *ComponentInstance,
+        args: []const InterfaceValue,
+        results: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {
+        if (args.len == 0 or results.len == 0) return error.InvalidArgs;
+        results[0] = .{ .handle = 0 };
     }
 
     /// `wasi:io/streams.[resource-drop]output-stream: (own<output-stream>) -> ()`.
@@ -503,7 +842,15 @@ pub fn populateWasiProviders(
     providers: *std.StringHashMapUnmanaged(ImportBinding),
 ) !void {
     var matched_stdout: ?[]const u8 = null;
+    var matched_stderr: ?[]const u8 = null;
     var matched_stdin: ?[]const u8 = null;
+    var matched_exit: ?[]const u8 = null;
+    var matched_environment: ?[]const u8 = null;
+    var matched_terminal_stdin: ?[]const u8 = null;
+    var matched_terminal_stdout: ?[]const u8 = null;
+    var matched_terminal_stderr: ?[]const u8 = null;
+    var matched_terminal_input: ?[]const u8 = null;
+    var matched_terminal_output: ?[]const u8 = null;
     var matched_streams: ?[]const u8 = null;
     var matched_poll: ?[]const u8 = null;
     var matched_error: ?[]const u8 = null;
@@ -511,8 +858,24 @@ pub fn populateWasiProviders(
         if (imp.desc != .instance) continue;
         if (matched_stdout == null and matchesWasiPrefix(imp.name, "wasi:cli/stdout"))
             matched_stdout = imp.name;
+        if (matched_stderr == null and matchesWasiPrefix(imp.name, "wasi:cli/stderr"))
+            matched_stderr = imp.name;
         if (matched_stdin == null and matchesWasiPrefix(imp.name, "wasi:cli/stdin"))
             matched_stdin = imp.name;
+        if (matched_exit == null and matchesWasiPrefix(imp.name, "wasi:cli/exit"))
+            matched_exit = imp.name;
+        if (matched_environment == null and matchesWasiPrefix(imp.name, "wasi:cli/environment"))
+            matched_environment = imp.name;
+        if (matched_terminal_stdin == null and matchesWasiPrefix(imp.name, "wasi:cli/terminal-stdin"))
+            matched_terminal_stdin = imp.name;
+        if (matched_terminal_stdout == null and matchesWasiPrefix(imp.name, "wasi:cli/terminal-stdout"))
+            matched_terminal_stdout = imp.name;
+        if (matched_terminal_stderr == null and matchesWasiPrefix(imp.name, "wasi:cli/terminal-stderr"))
+            matched_terminal_stderr = imp.name;
+        if (matched_terminal_input == null and matchesWasiPrefix(imp.name, "wasi:cli/terminal-input"))
+            matched_terminal_input = imp.name;
+        if (matched_terminal_output == null and matchesWasiPrefix(imp.name, "wasi:cli/terminal-output"))
+            matched_terminal_output = imp.name;
         if (matched_streams == null and matchesWasiPrefix(imp.name, "wasi:io/streams"))
             matched_streams = imp.name;
         if (matched_poll == null and matchesWasiPrefix(imp.name, "wasi:io/poll"))
@@ -532,11 +895,43 @@ pub fn populateWasiProviders(
     if (matched_stdout == null) _ = providers.remove("wasi:cli/stdout");
     if (matched_streams == null) _ = providers.remove("wasi:io/streams");
 
+    try adapter.populateWasiCliStderr(
+        providers,
+        matched_stderr orelse "wasi:cli/stderr",
+    );
+    if (matched_stderr == null) _ = providers.remove("wasi:cli/stderr");
+
     try adapter.populateWasiCliStdin(
         providers,
         matched_stdin orelse "wasi:cli/stdin",
     );
     if (matched_stdin == null) _ = providers.remove("wasi:cli/stdin");
+
+    try adapter.populateWasiCliExit(
+        providers,
+        matched_exit orelse "wasi:cli/exit",
+    );
+    if (matched_exit == null) _ = providers.remove("wasi:cli/exit");
+
+    try adapter.populateWasiCliEnvironment(
+        providers,
+        matched_environment orelse "wasi:cli/environment",
+    );
+    if (matched_environment == null) _ = providers.remove("wasi:cli/environment");
+
+    try adapter.populateWasiCliTerminal(
+        providers,
+        matched_terminal_stdin orelse "wasi:cli/terminal-stdin",
+        matched_terminal_stdout orelse "wasi:cli/terminal-stdout",
+        matched_terminal_stderr orelse "wasi:cli/terminal-stderr",
+        matched_terminal_input orelse "wasi:cli/terminal-input",
+        matched_terminal_output orelse "wasi:cli/terminal-output",
+    );
+    if (matched_terminal_stdin == null) _ = providers.remove("wasi:cli/terminal-stdin");
+    if (matched_terminal_stdout == null) _ = providers.remove("wasi:cli/terminal-stdout");
+    if (matched_terminal_stderr == null) _ = providers.remove("wasi:cli/terminal-stderr");
+    if (matched_terminal_input == null) _ = providers.remove("wasi:cli/terminal-input");
+    if (matched_terminal_output == null) _ = providers.remove("wasi:cli/terminal-output");
 
     try adapter.populateWasiIoPollError(
         providers,
@@ -566,12 +961,17 @@ pub fn runLoadedComponent(
     if (inst.getExport("run") == null) return error.NoRunExport;
 
     var results: [1]abi_root.InterfaceValue = undefined;
-    executor_root.callComponentFunc(inst, "run", &.{}, &results, allocator) catch return error.Trap;
-
-    return .{ .is_ok = switch (results[0]) {
-        .result_val => |rv| rv.is_ok,
-        else => true,
-    } };
+    if (executor_root.callComponentFunc(inst, "run", &.{}, &results, allocator)) |_| {
+        return .{ .is_ok = switch (results[0]) {
+            .result_val => |rv| rv.is_ok,
+            else => true,
+        } };
+    } else |_| {
+        // `wasi:cli/exit.{exit, exit-with-code}` traps after stashing
+        // a code on the adapter; translate that into a normal outcome.
+        if (adapter.exit_code) |code| return .{ .is_ok = code == 0 };
+        return error.Trap;
+    }
 }
 
 /// Load + instantiate + run a component binary, mapping its `run` export
@@ -1152,4 +1552,56 @@ test "populateWasiProviders: binds wasi:cli/stdin (#152)" {
         .ok => |n| try testing.expectEqualStrings("hello\n", buf[0..n]),
         else => try testing.expect(false),
     }
+}
+
+test "populateWasiProviders: binds full cli surface (#153)" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    const imports = [_]ctypes_root.ImportDecl{
+        .{ .name = "wasi:cli/stderr@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:cli/exit@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:cli/environment@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:cli/terminal-stdin@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:cli/terminal-stdout@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:cli/terminal-stderr@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:cli/terminal-input@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:cli/terminal-output@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:io/streams@0.2.6", .desc = .{ .instance = 0 } },
+    };
+    const component = ctypes_root.Component{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},   .instances = &.{},      .aliases = &.{},
+        .types = &.{},        .canons = &.{},
+        .imports = &imports,  .exports = &.{},
+    };
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+    try populateWasiProviders(&adapter, &component, &providers);
+
+    try testing.expect(providers.contains("wasi:cli/stderr@0.2.6"));
+    try testing.expect(providers.contains("wasi:cli/exit@0.2.6"));
+    try testing.expect(providers.contains("wasi:cli/environment@0.2.6"));
+    try testing.expect(providers.contains("wasi:cli/terminal-stdin@0.2.6"));
+    try testing.expect(providers.contains("wasi:cli/terminal-output@0.2.6"));
+
+    try testing.expect(adapter.cli_stderr_iface.members.contains("get-stderr"));
+    try testing.expect(adapter.cli_exit_iface.members.contains("exit"));
+    try testing.expect(adapter.cli_exit_iface.members.contains("exit-with-code"));
+    try testing.expect(adapter.cli_environment_iface.members.contains("get-environment"));
+    try testing.expect(adapter.cli_environment_iface.members.contains("get-arguments"));
+    try testing.expect(adapter.cli_environment_iface.members.contains("initial-cwd"));
+    try testing.expect(adapter.cli_terminal_stdin_iface.members.contains("get-terminal-stdin"));
+    try testing.expect(adapter.cli_terminal_input_iface.members.contains("[resource-drop]terminal-input"));
+    try testing.expect(adapter.cli_terminal_output_iface.members.contains("[resource-drop]terminal-output"));
+
+    // Output-stream method trio used by Rust's stdlib (instead of
+    // `blocking-write-and-flush`).
+    try testing.expect(adapter.io_streams_iface.members.contains("[method]output-stream.write"));
+    try testing.expect(adapter.io_streams_iface.members.contains("[method]output-stream.check-write"));
+    try testing.expect(adapter.io_streams_iface.members.contains("[method]output-stream.blocking-flush"));
+    try testing.expect(adapter.io_streams_iface.members.contains("[method]output-stream.subscribe"));
+    try testing.expect(adapter.io_streams_iface.members.contains("[method]input-stream.subscribe"));
 }

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -58,6 +58,16 @@ pub const WasiCliAdapter = struct {
     /// `[method]output-stream.blocking-write-and-flush`,
     /// `[resource-drop]output-stream`).
     io_streams_iface: HostInstance = .{},
+    /// `HostInstance` for `wasi:io/poll`. Stdio-echo imports this for
+    /// type-resolution; only `[resource-drop]pollable` is wired with a
+    /// no-op since the guest never blocks on stdout. Other members trap
+    /// on call (left absent, so the trampoline reports an unresolved
+    /// import).
+    io_poll_iface: HostInstance = .{},
+    /// `HostInstance` for `wasi:io/error`. Same shape as `io_poll_iface`:
+    /// only `[resource-drop]error` is wired; the host never produces an
+    /// `error` resource on the happy path.
+    io_error_iface: HostInstance = .{},
 
     /// Adapter-internal output-stream resource handles. Deliberately
     /// independent of `ComponentInstance.resource_tables` — these handles
@@ -81,6 +91,8 @@ pub const WasiCliAdapter = struct {
         self.write_iface.deinit(self.allocator);
         self.cli_stdout_iface.deinit(self.allocator);
         self.io_streams_iface.deinit(self.allocator);
+        self.io_poll_iface.deinit(self.allocator);
+        self.io_error_iface.deinit(self.allocator);
         self.stream_table.deinit(self.allocator);
     }
 
@@ -147,6 +159,44 @@ pub const WasiCliAdapter = struct {
             .host_instance = &self.io_streams_iface,
         });
     }
+
+    /// Register `wasi:io/poll` and `wasi:io/error` host bindings.
+    ///
+    /// Both interfaces only need `[resource-drop]<resource>` wired for the
+    /// stdio-echo happy path — the guest never blocks on a pollable nor
+    /// inspects an error to-debug-string when stdout writes succeed. Any
+    /// other member call will surface as an unresolved-import trap.
+    pub fn populateWasiIoPollError(
+        self: *WasiCliAdapter,
+        providers: *std.StringHashMapUnmanaged(ImportBinding),
+        io_poll_name: []const u8,
+        io_error_name: []const u8,
+    ) !void {
+        try self.io_poll_iface.members.put(self.allocator, "[resource-drop]pollable", .{
+            .func = .{ .context = self, .call = &noopResourceDrop },
+        });
+        try providers.put(self.allocator, io_poll_name, .{
+            .host_instance = &self.io_poll_iface,
+        });
+
+        try self.io_error_iface.members.put(self.allocator, "[resource-drop]error", .{
+            .func = .{ .context = self, .call = &noopResourceDrop },
+        });
+        try providers.put(self.allocator, io_error_name, .{
+            .host_instance = &self.io_error_iface,
+        });
+    }
+
+    /// `(own<R>) -> ()` no-op — the host never produces non-stream
+    /// resources on the happy path, so dropping one is purely guest-side
+    /// bookkeeping that we can swallow.
+    fn noopResourceDrop(
+        _: ?*anyopaque,
+        _: *ComponentInstance,
+        _: []const InterfaceValue,
+        _: []InterfaceValue,
+        _: Allocator,
+    ) anyerror!void {}
 
     fn allocStreamHandle(self: *WasiCliAdapter, stream: *streams.OutputStream) !u32 {
         // Linear scan for a free slot before extending; output streams are
@@ -308,16 +358,23 @@ pub fn populateWasiProviders(
 ) !void {
     var matched_stdout: ?[]const u8 = null;
     var matched_streams: ?[]const u8 = null;
+    var matched_poll: ?[]const u8 = null;
+    var matched_error: ?[]const u8 = null;
     for (component.imports) |imp| {
         if (imp.desc != .instance) continue;
         if (matched_stdout == null and matchesWasiPrefix(imp.name, "wasi:cli/stdout"))
             matched_stdout = imp.name;
         if (matched_streams == null and matchesWasiPrefix(imp.name, "wasi:io/streams"))
             matched_streams = imp.name;
+        if (matched_poll == null and matchesWasiPrefix(imp.name, "wasi:io/poll"))
+            matched_poll = imp.name;
+        if (matched_error == null and matchesWasiPrefix(imp.name, "wasi:io/error"))
+            matched_error = imp.name;
     }
-    // Always populate both interfaces' members; only register
-    // providers for the names the component actually imports so
-    // `linkImports` strict-checking surfaces unrelated misses.
+    // Always populate every interface's members so the adapter's
+    // HostInstance maps are well-formed; only register providers for
+    // the names the component actually imports so `linkImports`
+    // strict-checking surfaces unrelated misses.
     try adapter.populateWasiCliRun(
         providers,
         matched_stdout orelse "wasi:cli/stdout",
@@ -325,6 +382,14 @@ pub fn populateWasiProviders(
     );
     if (matched_stdout == null) _ = providers.remove("wasi:cli/stdout");
     if (matched_streams == null) _ = providers.remove("wasi:io/streams");
+
+    try adapter.populateWasiIoPollError(
+        providers,
+        matched_poll orelse "wasi:io/poll",
+        matched_error orelse "wasi:io/error",
+    );
+    if (matched_poll == null) _ = providers.remove("wasi:io/poll");
+    if (matched_error == null) _ = providers.remove("wasi:io/error");
 }
 
 /// Run an already-loaded component. See `runComponentBytes` for the
@@ -861,4 +926,38 @@ test "runLoadedComponent: matches versioned WASI import names" {
     const outcome = try runLoadedComponent(&component, testing.allocator, &adapter);
     try testing.expect(outcome.is_ok);
     try testing.expectEqualStrings("hello, world!\n", adapter.getStdoutBytes());
+}
+
+test "populateWasiProviders: binds wasi:io/poll and wasi:io/error (#154)" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    // Hand-build a component with versioned poll + error instance imports.
+    const imports = [_]ctypes_root.ImportDecl{
+        .{ .name = "wasi:io/poll@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:io/error@0.2.6", .desc = .{ .instance = 0 } },
+    };
+    const component = ctypes_root.Component{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},   .instances = &.{},      .aliases = &.{},
+        .types = &.{},        .canons = &.{},
+        .imports = &imports,  .exports = &.{},
+    };
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+
+    try populateWasiProviders(&adapter, &component, &providers);
+
+    try testing.expect(providers.contains("wasi:io/poll@0.2.6"));
+    try testing.expect(providers.contains("wasi:io/error@0.2.6"));
+    // Bare names (no version suffix) must NOT be registered when the
+    // component imports the versioned form.
+    try testing.expect(!providers.contains("wasi:io/poll"));
+    try testing.expect(!providers.contains("wasi:io/error"));
+
+    // Resource-drop members are wired so the guest can drop pollables/errors.
+    try testing.expect(adapter.io_poll_iface.members.contains("[resource-drop]pollable"));
+    try testing.expect(adapter.io_error_iface.members.contains("[resource-drop]error"));
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -109,6 +109,9 @@ pub const canonical_abi = @import("component/canonical_abi.zig");
 /// Component Model function executor.
 pub const component_executor = @import("component/executor.zig");
 
+/// Component Model index-space resolvers.
+pub const component_indexspace = @import("component/indexspace.zig");
+
 /// Component Model instance and resource store.
 pub const component_instance = @import("component/instance.zig");
 


### PR DESCRIPTION
Stacked work toward #156 (stdio-echo end-to-end). Lands the host-side WASI preview-2 surface and the loader/instance-resolver fixes needed to even reach the guest's \`run\` body. The fixture test for #156 itself is in-tree but \`SkipZigTest\`-guarded — see *Follow-up* below for what's still missing on the core-side composition front.

## Slices on this branch

| Issue | Title | Commit |
|------|-------|--------|
| #150 | component-level indexspace resolver (narrow) | landed earlier |
| #151 | nested-instance \`run\` plumbing | landed earlier |
| #155 | result-with-payload lift/lower | landed earlier |
| #154 | wasi:io/poll + wasi:io/error host instances | landed earlier |
| #152 | wasi:cli/stdin + input-stream method trio | \`cd6f5cea\` |
| #153 | wasi:cli/stderr/exit/environment/terminal-* + output-stream method trio | \`54284cd2\` |
| #156 (partial) | type-indexspace map + 0.2.0-shim run-export resolution | \`0f6451de\` |

## Highlights

- **Loader + TypeRegistry**: \`canon.lift.type_idx\` is a *type indexspace* position, not an offset into the type section. The loader now records the indexspace order (interleaving \`(import (type))\` / \`(type)\` / \`(alias (type))\` slots), and \`TypeRegistry.get\` consults the map. Hand-authored fixtures with no aliases keep the old direct-indexing fallback.
- **\`registerInstanceExport\` (.instantiate form)**: wit-bindgen's 0.2.0-shim re-exports \`run\` via a sub-component whose sole job is to forward a parent-supplied imported func. The resolver walks subcomponent exports → finds the imported func slot → matches by name against the parent's \`with\` args → registers the parent func.
- **\`wasi:cli\` surface**: stdin/stdout/stderr/exit/environment/terminal-{stdin,stdout,stderr,input,output} populate fns; matching extension to \`populateWasiProviders\`. Output-stream method trio (\`write\` / \`check-write\` / \`blocking-flush\` + \`subscribe\`) and input-stream \`{read, blocking-read, subscribe}\`.
- **Trap-with-exit-code**: \`runLoadedComponent\` translates \`error.WasiExit\` into a clean \`RunOutcome\` using \`adapter.exit_code\`.
- **Trampoline cleanup**: \`componentTrampoline\` deinits result \`InterfaceValue\`s after store, fixing payload leaks.
- **Host alloc helper**: \`ComponentInstance.hostAllocAndWrite\` calls \`cabi_realloc\` to materialize host-owned bytes into guest memory (used by \`blocking-read\`).

## Test status

- 770/772 in main suite pass; 2 skipped (the #156 fixture and its disabled body — see below).
- Cross-compile (\`-Dtarget=x86_64-windows\`) clean.

## Follow-up (not in this PR)

\`stdio-echo.wasm\` requires runtime machinery beyond #150–#155 to actually execute:
1. Multi-core-module composition: three core modules (\`\$main\`, \`\$wit-component-shim-module\`, \`\$wit-component-fixup\`) wired via \`(core instance (instantiate \$m (with ...)))\` with cross-instance \`(alias core export ...)\`.
2. Indirect-call trampoline tables that \`\$fixup\` patches via \`table.set\` after \`\$main\` is instantiated.
3. \`(canon resource.drop \$type)\` core funcs and a real resource-handle indexspace.
4. \`(canon lower)\` sourced from aliased imported component-instance exports (not just direct func imports).

These will be tracked as a new issue stack on top of post-#156 main. The fixture test body is preserved in-tree behind a \`SkipZigTest\` guard so flipping it on becomes a one-line change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>