### PR TITLE
component: extend TypeRegistry with per-trampoline type-indexspace (#156 H4a)

### DIFF
--- a/src/component/canonical_abi.zig
+++ b/src/component/canonical_abi.zig
@@ -11,12 +11,30 @@ const Allocator = std.mem.Allocator;
 // ── Type registry ───────────────────────────────────────────────────────────
 
 /// Resolves type indices to their definitions from a parsed Component.
+///
+/// May be augmented with a per-trampoline "extended" type indexspace whose
+/// entries cover instance-type-body local type defs that aren't otherwise
+/// reachable from the component-level indexspace. When `extended_indexspace`
+/// is populated, indices `>= component.type_indexspace.len` are looked up
+/// in the extended view first and fall back to direct indexing of
+/// `extended_types`.
 pub const TypeRegistry = struct {
     types: []const ctypes.TypeDef,
     /// When non-empty, indexed by type-indexspace position to map to a
     /// local `types[]` index (or null for non-materialized slots).
     /// When empty, `get(idx)` falls back to direct indexing of `types`.
     indexspace: []const ?u32 = &.{},
+
+    /// Optional second type-def array consulted for indices that fall
+    /// past `indexspace.len` (or `types.len` when `indexspace` is empty).
+    /// Populated by canon.lower trampolines that need to resolve
+    /// instance-type-body local types.
+    extended_types: []const ctypes.TypeDef = &.{},
+    /// Maps extended-indexspace positions (relative to the start of the
+    /// extension; absolute index = `base + i`) to a local index into
+    /// `extended_types`. When empty and `extended_types` is non-empty,
+    /// extension lookups index `extended_types` directly.
+    extended_indexspace: []const ?u32 = &.{},
 
     pub fn init(component: *const ctypes.Component) TypeRegistry {
         return .{ .types = component.types, .indexspace = component.type_indexspace };
@@ -26,16 +44,53 @@ pub const TypeRegistry = struct {
         return .{ .types = types };
     }
 
+    /// Build a registry that looks up `idx` in `(component, extension)`.
+    /// `extension_types` and `extension_indexspace` are appended to the
+    /// component's view: for an index `i` past the component's indexspace
+    /// (or types) length, the extension is consulted with the offset
+    /// `i - base`.
+    pub fn fromExtended(
+        component: *const ctypes.Component,
+        extension_types: []const ctypes.TypeDef,
+        extension_indexspace: []const ?u32,
+    ) TypeRegistry {
+        return .{
+            .types = component.types,
+            .indexspace = component.type_indexspace,
+            .extended_types = extension_types,
+            .extended_indexspace = extension_indexspace,
+        };
+    }
+
+    /// Returns the index past which `get` consults the extension.
+    fn baseSpan(self: TypeRegistry) u32 {
+        if (self.indexspace.len > 0) return @intCast(self.indexspace.len);
+        return @intCast(self.types.len);
+    }
+
     /// Resolve a type indexspace position to its TypeDef.
     pub fn get(self: TypeRegistry, idx: u32) ?ctypes.TypeDef {
-        if (self.indexspace.len > 0) {
-            if (idx >= self.indexspace.len) return null;
-            const local = self.indexspace[idx] orelse return null;
-            if (local >= self.types.len) return null;
-            return self.types[local];
+        const base = self.baseSpan();
+        if (idx < base) {
+            if (self.indexspace.len > 0) {
+                const local = self.indexspace[idx] orelse return null;
+                if (local >= self.types.len) return null;
+                return self.types[local];
+            }
+            if (idx >= self.types.len) return null;
+            return self.types[idx];
         }
-        if (idx >= self.types.len) return null;
-        return self.types[idx];
+        // Extension lookup. `idx` is offset by `base`.
+        if (self.extended_types.len == 0) return null;
+        const ext_idx: u32 = idx - base;
+        if (self.extended_indexspace.len > 0) {
+            if (ext_idx >= self.extended_indexspace.len) return null;
+            const local = self.extended_indexspace[ext_idx] orelse return null;
+            if (local >= self.extended_types.len) return null;
+            return self.extended_types[local];
+        }
+        if (ext_idx >= self.extended_types.len) return null;
+        return self.extended_types[ext_idx];
     }
 
     /// Resolve a ValType that carries a type index to its TypeDef.
@@ -1234,6 +1289,50 @@ test "elemSize: primitive types" {
 
 test "elemSize: compounds return 0 without registry" {
     try std.testing.expectEqual(@as(u32, 0), elemSize(.{ .record = 0 }));
+}
+
+test "TypeRegistry: extended types append past component indexspace" {
+    // Component with one direct type and a 2-slot indexspace.
+    const comp_types = [_]ctypes.TypeDef{
+        .{ .val = .u32 },
+    };
+    const comp_idxspace = [_]?u32{ 0, null };
+    var component = std.mem.zeroes(ctypes.Component);
+    component.types = &comp_types;
+    component.type_indexspace = &comp_idxspace;
+
+    // Extension: two more typedefs (a list and a result), with a
+    // compact identity indexspace mapping ext_idx 0 -> 0, 1 -> 1.
+    const ext_types = [_]ctypes.TypeDef{
+        .{ .list = .{ .element = .u8 } },
+        .{ .result = .{ .ok = .u32, .err = null } },
+    };
+    const ext_idxspace = [_]?u32{ 0, 1 };
+
+    const reg = TypeRegistry.fromExtended(&component, &ext_types, &ext_idxspace);
+
+    // Component-level lookup unchanged.
+    const td0 = reg.get(0) orelse return error.TestUnexpectedNull;
+    try std.testing.expect(td0 == .val);
+    try std.testing.expect(reg.get(1) == null); // null indexspace slot
+
+    // Extension lookups: idx >= base (= component.type_indexspace.len = 2).
+    const td_ext0 = reg.get(2) orelse return error.TestUnexpectedNull;
+    try std.testing.expect(td_ext0 == .list);
+    const td_ext1 = reg.get(3) orelse return error.TestUnexpectedNull;
+    try std.testing.expect(td_ext1 == .result);
+    try std.testing.expect(reg.get(4) == null); // past extension
+}
+
+test "TypeRegistry: fromExtended falls back to component-only when ext empty" {
+    const comp_types = [_]ctypes.TypeDef{ .{ .val = .u32 } };
+    var component = std.mem.zeroes(ctypes.Component);
+    component.types = &comp_types;
+
+    const reg = TypeRegistry.fromExtended(&component, &.{}, &.{});
+    const td = reg.get(0) orelse return error.TestUnexpectedNull;
+    try std.testing.expect(td == .val);
+    try std.testing.expect(reg.get(1) == null);
 }
 
 test "flatten: basic types" {

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -891,9 +891,19 @@ pub const ComponentTrampolineCtx = struct {
     result_types: []const ctypes.ValType,
     lower_opts: LowerOptions,
 
+    /// Per-trampoline extension to the component's type indexspace, used
+    /// to resolve param/result `.type_idx` references that point into an
+    /// instance-type body's local type space. Empty when the FuncType
+    /// for this trampoline came from the component-level type indexspace
+    /// directly (e.g. hand-authored fixtures).
+    extended_types: []const ctypes.TypeDef = &.{},
+    extended_indexspace: []const ?u32 = &.{},
+
     pub fn deinit(self: *ComponentTrampolineCtx, allocator: Allocator) void {
         allocator.free(self.param_types);
         allocator.free(self.result_types);
+        if (self.extended_types.len > 0) allocator.free(self.extended_types);
+        if (self.extended_indexspace.len > 0) allocator.free(self.extended_indexspace);
     }
 };
 
@@ -927,7 +937,10 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
     const env: *ExecEnv = @ptrCast(@alignCast(env_opaque));
     const ctx: *ComponentTrampolineCtx = @ptrCast(@alignCast(ctx_opaque.?));
     const allocator = ctx.comp_inst.allocator;
-    const registry = TypeRegistry.init(ctx.comp_inst.component);
+    const registry = if (ctx.extended_types.len > 0)
+        TypeRegistry.fromExtended(ctx.comp_inst.component, ctx.extended_types, ctx.extended_indexspace)
+    else
+        TypeRegistry.init(ctx.comp_inst.component);
     std.debug.print("\nTRAMP-ENTRY comp_func={} comp.core_instances.len={} ci.core_instances.len={}\n", .{
         ctx.component_func_idx,
         ctx.comp_inst.component.core_instances.len,


### PR DESCRIPTION
Foundation slice for resolving canon.lower trampoline param/result `.type_idx` references that point into an instance-type body's local type indexspace. **No behavior change yet** — no caller populates the extension; that comes in H4b.

## What this lands

- **`TypeRegistry`** gains `extended_types` and `extended_indexspace` fields plus a `fromExtended(component, ext_types, ext_indexspace)` constructor. `get(idx)` consults the component-level view first and falls through to the extension for indices past `component.type_indexspace.len` (or `types.len` when the indexspace is empty), with the offset rebased to the start of the extension.
- **`ComponentTrampolineCtx`** carries an optional `extended_types` / `extended_indexspace` pair, freed on `deinit`. `componentTrampoline` constructs its registry via `fromExtended` when the ctx populates them.

## Why

The component-level type indexspace can't see into `(instance (type ...))` bodies. Functions whose `lower.func_idx` resolves through a nested instance-type body have param/result `.type_idx = N` values local to that body. Without an extension mechanism, `flattenCount` / `typeSize` / `loadVal` / `storeVal` fall back to wrong defaults, undercounting flat slots and skipping the canonical-ABI return-area-pointer pop.

H4b will populate the extension at the canon.lower trampoline build site by deeply rewriting instance-type-body local TypeDefs and appending them to a per-trampoline extension.

## Tests

`zig build test` — 916 pass / 2 skip / 0 fail. Two new unit tests cover the chained lookup and the extension-empty fallback.

Refs #156, #142.