### PR TITLE
component: fill .val/.list gaps in canonical-ABI *Def helpers (#156 H4c)

### DIFF
--- a/src/component/canonical_abi.zig
+++ b/src/component/canonical_abi.zig
@@ -316,6 +316,7 @@ fn alignOfTypeDef(reg: TypeRegistry, td: ctypes.TypeDef) u32 {
             break :blk @max(1, payload_align);
         },
         .resource => 4,
+        .val => |v| @max(1, alignOfType(reg, v)),
         else => 4,
     };
 }
@@ -397,6 +398,7 @@ fn sizeOfTypeDef(reg: TypeRegistry, td: ctypes.TypeDef) u32 {
             break :blk alignUp(payload_offset + payload_size, total_align);
         },
         .resource => 4,
+        .val => |v| sizeOfType(reg, v),
         else => 4,
     };
 }
@@ -507,6 +509,7 @@ pub fn flattenCountDef(reg: TypeRegistry, td: ctypes.TypeDef) u32 {
             break :blk 1 + max_payload;
         },
         .resource => 1,
+        .list => 2,
         else => 1,
     };
 }
@@ -658,6 +661,13 @@ pub fn loadValReg(memory: []const u8, ptr: u32, t: ctypes.ValType, reg: TypeRegi
 
 fn loadValFromDef(memory: []const u8, ptr: u32, td: ctypes.TypeDef, reg: TypeRegistry, alloc: Allocator) LoadError!InterfaceValue {
     return switch (td) {
+        // `(type (val <vt>))` — re-dispatch on the inner ValType.
+        .val => |v| try loadValReg(memory, ptr, v, reg, alloc),
+        // `(type (list T))` — list is laid out in linear memory as (ptr, len).
+        .list => .{ .list = .{
+            .ptr = loadU32(memory, ptr),
+            .len = loadU32(memory, ptr + 4),
+        } },
         .record => |r| blk: {
             const vals = try alloc.alloc(InterfaceValue, r.fields.len);
             var offset: u32 = ptr;
@@ -892,6 +902,13 @@ pub fn storeValReg(memory: []u8, ptr: u32, t: ctypes.ValType, val: InterfaceValu
 
 fn storeValFromDef(memory: []u8, ptr: u32, td: ctypes.TypeDef, val: InterfaceValue, reg: TypeRegistry) StoreError!void {
     switch (td) {
+        // `(type (val <vt>))` — re-dispatch on the inner ValType.
+        .val => |v| try storeValReg(memory, ptr, v, val, reg),
+        // `(type (list T))` — store as (ptr, len) pair in linear memory.
+        .list => {
+            storeU32(memory, ptr, val.list.ptr);
+            storeU32(memory, ptr + 4, val.list.len);
+        },
         .record => |r| {
             var offset: u32 = ptr;
             for (r.fields, 0..) |f, i| {


### PR DESCRIPTION
Stacked on #162. The TypeDef-keyed canonical-ABI helpers had silent fallthroughs for two TypeDef shapes the per-trampoline registry extension (#156 H4a/H4b) now hands them.

## Gaps closed

- **`.val v`** — `(type (val <vt>))` inside an instance-type body (e.g. `(type $u64 u64)`).
  - `alignOfTypeDef` / `sizeOfTypeDef` returned `4` even for `.val .u64`.
  - `loadValFromDef` / `storeValFromDef` fell through to `{ .handle = 0 }` / no-op.
  - Now re-dispatch to the ValType-keyed paths on the inner type.

- **`.list T`** — `(type (list <T>))`.
  - `flattenCountDef` returned `1` instead of `2`.
  - Load/store helpers had no case at all.
  - Now flatten to 2 core values and lay out `(ptr, len)` the same way the ValType-keyed `.list` already does.

These are the gaps the rubber-duck pass flagged before H4b landed — necessary so `flat_p` / `flat_r` and load/store offsets are right when the trampoline resolves a param/result through a TypeDef the registry extension owns.

`zig build test` — 916 pass / 2 skip / 0 fail.

Refs #156, #142.