### PR TITLE
component: redispatch .type_idx in push/popInterfaceValue (#156 H4d)

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -346,14 +346,35 @@ fn pushInterfaceValue(env: *ExecEnv, val: InterfaceValue, t: ctypes.ValType, reg
                 try env.pushI32(0);
             }
         },
-        .record, .variant, .tuple, .flags, .enum_, .option, .type_idx => {
+        .record, .variant, .tuple, .flags, .enum_, .option => {
             return error.CompoundNeedsRegistry;
+        },
+        // Resolve `.type_idx` through the registry and re-dispatch on
+        // the reified ValType. The registry may have been extended with
+        // an instance-type body's local types (#156 H4a/H4b), so the
+        // index can land on a `.val v` wrapper, a resource definition,
+        // or any compound TypeDef.
+        .type_idx => |idx| {
+            const td = registry.get(idx) orelse return error.CompoundNeedsRegistry;
+            const reified: ctypes.ValType = switch (td) {
+                .val => |inner| inner,
+                .list => .{ .list = idx },
+                .record => .{ .record = idx },
+                .tuple => .{ .tuple = idx },
+                .variant => .{ .variant = idx },
+                .flags => .{ .flags = idx },
+                .enum_ => .{ .enum_ = idx },
+                .option => .{ .option = idx },
+                .result => .{ .result = idx },
+                .resource => .{ .own = idx },
+                else => return error.CompoundNeedsRegistry,
+            };
+            try pushInterfaceValue(env, val, reified, registry);
         },
     }
 }
 
 fn popInterfaceValue(env: *ExecEnv, t: ctypes.ValType, registry: TypeRegistry, allocator: Allocator) !InterfaceValue {
-    _ = allocator;
     return switch (t) {
         .bool => .{ .bool = (try env.popI32()) != 0 },
         .s8 => .{ .s8 = @truncate(try env.popI32()) },
@@ -408,7 +429,26 @@ fn popInterfaceValue(env: *ExecEnv, t: ctypes.ValType, registry: TypeRegistry, a
             const disc = try env.popI32();
             break :blk .{ .result_val = .{ .is_ok = disc == 0, .payload = null } };
         },
-        .record, .variant, .tuple, .flags, .enum_, .option, .type_idx => error.CompoundNeedsRegistry,
+        .record, .variant, .tuple, .flags, .enum_, .option => error.CompoundNeedsRegistry,
+        // Mirror `pushInterfaceValue`: resolve `.type_idx` and re-pop on
+        // the reified ValType.
+        .type_idx => |idx| blk: {
+            const td = registry.get(idx) orelse return error.CompoundNeedsRegistry;
+            const reified: ctypes.ValType = switch (td) {
+                .val => |inner| inner,
+                .list => .{ .list = idx },
+                .record => .{ .record = idx },
+                .tuple => .{ .tuple = idx },
+                .variant => .{ .variant = idx },
+                .flags => .{ .flags = idx },
+                .enum_ => .{ .enum_ = idx },
+                .option => .{ .option = idx },
+                .result => .{ .result = idx },
+                .resource => .{ .own = idx },
+                else => return error.CompoundNeedsRegistry,
+            };
+            break :blk try popInterfaceValue(env, reified, registry, allocator);
+        },
     };
 }
 


### PR DESCRIPTION
Stacked on #163. With the per-trampoline registry extension (#156 H4a/H4b) populated and the *Def helpers complete (#156 H4c), `pushInterfaceValue` / `popInterfaceValue` are the last canonical-ABI sites that bail with `CompoundNeedsRegistry` on a `.type_idx` slot.

## What this lands

When a result/argument's static `ValType` is `.type_idx N`, both helpers now resolve through the registry and reify the indirection as the appropriate `ValType` variant before recursing:

- `.val v` → recurse on the inner ValType directly.
- `.list` / `.record` / `.tuple` / `.variant` / `.flags` / `.enum_` / `.option` / `.result` → recurse with the same idx rebranded as the corresponding compound ValType.
- `.resource` → treat the value as a resource handle (`.own`), flattened to i32 with `val.handle` unchanged.

## Validation

The stdio-echo regression fixture (#156) **runs end-to-end** with this slice and produces the expected `echo: hello` on stdout. The remaining failure mode is the pre-existing loader-side leak (no `Component.deinit` yet, tracked under #142 Phase 1B); un-gating the regression test is split out into the next slice (H4e), which switches the test to an `ArenaAllocator` to side-step the loader leak.

`zig build test` — 916 pass / 2 skip / 0 fail.

Refs #156, #142.