### PR TITLE
component: un-gate stdio-echo regression test + strip H4 debug prints (#156 H4e)

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -992,11 +992,6 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
         TypeRegistry.fromExtended(ctx.comp_inst.component, ctx.extended_types, ctx.extended_indexspace)
     else
         TypeRegistry.init(ctx.comp_inst.component);
-    std.debug.print("\nTRAMP-ENTRY comp_func={} comp.core_instances.len={} ci.core_instances.len={}\n", .{
-        ctx.component_func_idx,
-        ctx.comp_inst.component.core_instances.len,
-        ctx.comp_inst.core_instances.len,
-    });
 
     const flat_params = countFlatTypes(registry, ctx.param_types);
     const flat_results = countFlatTypes(registry, ctx.result_types);
@@ -1051,47 +1046,17 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
         allocator.free(results);
     }
     const call = ctx.host_func.call orelse {
-        std.debug.print("TRAMP-TRAP no-call cf={}\n", .{ctx.component_func_idx});
         return error.Trap;
     };
-    std.debug.print("TRAMP cf={} flat_p={} flat_r={} args.len={} pre-call\n", .{ ctx.component_func_idx, flat_params, flat_results, args.len });
     call(ctx.host_func.context, ctx.comp_inst, args, results, allocator) catch {
-        std.debug.print("TRAMP-TRAP host-call cf={}\n", .{ctx.component_func_idx});
         return error.Trap;
     };
-    std.debug.print("TRAMP cf={} post-call results.len={}\n", .{ ctx.component_func_idx, results.len });
 
     // Lower results.
     if (results_spill) {
         const mem_idx = ctx.lower_opts.memory_idx.?;
         const mem_via_resolve = ctx.comp_inst.resolveTopLevelMemory(mem_idx);
-        const ref_dbg = indexspace.resolveCoreMemory(ctx.comp_inst.component, mem_idx);
-        std.debug.print("\nTRAMP-DBG comp_func={} mem_idx={} resolved={} alias_ref={any} num_core_inst={}\n", .{
-            ctx.component_func_idx, mem_idx, mem_via_resolve != null, ref_dbg, ctx.comp_inst.core_instances.len,
-        });
-        if (ref_dbg) |r| {
-            const a = ctx.comp_inst.component.aliases[r.aliased];
-            std.debug.print("  alias[{}] = {any}\n", .{ r.aliased, a });
-        }
-        for (ctx.comp_inst.core_instances, 0..) |ci, i| {
-            if (ci.module_inst) |mi| {
-                std.debug.print("  core_inst[{}] mod_inst nmemories={} ", .{ i, mi.memories.len });
-                for (mi.memories, 0..) |m, k| std.debug.print("mem[{}].len=0x{x} ", .{ k, m.data.len });
-                std.debug.print("\n", .{});
-            } else {
-                std.debug.print("  core_inst[{}] inline-exports\n", .{i});
-            }
-        }
         const mem = mem_via_resolve orelse return error.Trap;
-        std.debug.print("\nTRAMP-LOW comp_func={} dest_ptr=0x{x} mem_idx={} mem_len=0x{x} flat_p={} flat_r={} n_args={} n_res={}\n", .{
-            ctx.component_func_idx, result_dest_ptr, mem_idx, mem.data.len, flat_params, flat_results, args.len, results.len,
-        });
-        for (args, ctx.param_types, 0..) |a, pt, i| {
-            std.debug.print("  arg[{}] type={s} val={any}\n", .{ i, @tagName(pt), a });
-        }
-        for (results, ctx.result_types, 0..) |r, t, i| {
-            std.debug.print("  res[{}] type={s} val={any}\n", .{ i, @tagName(t), r });
-        }
         var offset: u32 = result_dest_ptr;
         for (results, ctx.result_types) |r, t| {
             const al = typeAlign(registry, t);
@@ -1099,19 +1064,12 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
             storeInterfaceValue(mem.data, offset, r, t, registry);
             offset += typeSize(registry, t);
         }
-        std.debug.print("  AFTER-STORE bytes@0x{x}: ", .{result_dest_ptr});
-        const dump_n = @min(@as(usize, 16), mem.data.len - result_dest_ptr);
-        for (0..dump_n) |k| std.debug.print("{x:0>2} ", .{mem.data[result_dest_ptr + k]});
-        std.debug.print("\n", .{});
     } else {
         for (results, ctx.result_types) |r, t| {
-            std.debug.print("TRAMP cf={} push res tag={s} type={s}\n", .{ ctx.component_func_idx, @tagName(r), @tagName(t) });
-            pushInterfaceValue(env, r, t, registry) catch |e| {
-                std.debug.print("TRAMP-TRAP push cf={} err={s}\n", .{ ctx.component_func_idx, @errorName(e) });
+            pushInterfaceValue(env, r, t, registry) catch {
                 return error.Trap;
             };
         }
-        std.debug.print("TRAMP cf={} done\n", .{ctx.component_func_idx});
     }
 }
 

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -406,9 +406,7 @@ pub const ComponentInstance = struct {
         for (self.trampoline_ctxs.items) |ctx| {
             if (resolveComponentFuncToHostFunc(self, self.component, ctx.component_func_idx)) |hf| {
                 ctx.host_func = hf;
-                std.debug.print("LINK comp_func={} -> host_func.call={any}\n", .{ ctx.component_func_idx, hf.call != null });
             } else {
-                std.debug.print("LINK comp_func={} -> NULL\n", .{ctx.component_func_idx});
             }
         }
     }
@@ -657,7 +655,6 @@ pub fn instantiate(
                                 if (member_sort_idx.? != .func) continue;
 
                                 const cfref = indexspace.resolveCoreFunc(component, member_idx) orelse continue;
-                                std.debug.print("IMPORT-RES ci={} imp_func={} field={s} cfref={s}\n", .{ ci_idx, imp_func_idx, imp.field_name, @tagName(cfref) });
                                 // Aliased core func — resolve to the underlying
                                 // {module_inst, func_idx} pair from a previously
                                 // instantiated core instance.
@@ -672,7 +669,6 @@ pub fn instantiate(
                                         const al_src = cis[ie_al.instance_idx];
                                         const al_mi = al_src.module_inst orelse continue;
                                         const al_func_idx = al_mi.getExportFunc(ie_al.name) orelse continue;
-                                        std.debug.print("  ALIASED-WIRED src_ci={} name={s} func_idx={}\n", .{ ie_al.instance_idx, ie_al.name, al_func_idx });
                                         imps_buf[imp_func_idx] = .{ .module_inst = al_mi, .func_idx = al_func_idx };
                                         is_cross[imp_func_idx] = true;
                                         if (first_cross_src == null) first_cross_src = al_mi;
@@ -689,7 +685,6 @@ pub fn instantiate(
                                     else => continue,
                                 };
 
-                                std.debug.print("  LOWERED canon_idx={} lower.func_idx={} types.len={}\n", .{ canon_idx, lower.func_idx, component.types.len });
                                 const ctx_ptr = allocator.create(executor_mod.ComponentTrampolineCtx) catch continue;
                                 // Prefer name-based lookup (correct for real components).
                                 // Fall back to direct types[lower.func_idx] indexing for
@@ -703,7 +698,6 @@ pub fn instantiate(
                                     };
                                 };
                                 const rft = rft_opt orelse {
-                                    std.debug.print("  LOWERED-NO-TYPE func_idx={}\n", .{lower.func_idx});
                                     allocator.destroy(ctx_ptr);
                                     continue;
                                 };
@@ -913,7 +907,6 @@ pub fn instantiate(
                     {
                         var nset: u32 = 0;
                         for (entries) |e| if (e != null) { nset += 1; };
-                        std.debug.print("ATTACH ci={} entries.len={} nset={} import_func_count={}\n", .{ ci_idx, entries.len, nset, import_func_count });
                     }
                     if (imps_buf.len > 0) allocator.free(imps_buf);
                     if (is_cross.len > 0) allocator.free(is_cross);
@@ -1411,7 +1404,6 @@ const ResolvedFuncType = struct {
 
 fn resolveCompFuncType(component: *const ctypes.Component, func_idx: u32) ?ResolvedFuncType {
     const ref = indexspace.resolveCompFunc(component, func_idx) orelse {
-        std.debug.print("    rcft({}) -> null (no compfunc ref)\n", .{func_idx});
         return null;
     };
     switch (ref) {
@@ -1430,7 +1422,6 @@ fn resolveCompFuncType(component: *const ctypes.Component, func_idx: u32) ?Resol
         .aliased => |alias_idx| {
             const ie = component.aliases[alias_idx].instance_export;
             const inst_ref = indexspace.resolveCompInstance(component, ie.instance_idx) orelse {
-                std.debug.print("    rcft({}) aliased -> no compinst ref idx={}\n", .{ func_idx, ie.instance_idx });
                 return null;
             };
             const inst_type_idx: u32 = switch (inst_ref) {
@@ -1439,20 +1430,15 @@ fn resolveCompFuncType(component: *const ctypes.Component, func_idx: u32) ?Resol
                     else => return null,
                 },
                 else => {
-                    std.debug.print("    rcft({}) aliased -> inst_ref={s} (not imported)\n", .{ func_idx, @tagName(inst_ref) });
                     return null;
                 },
             };
             const inst_td = resolveTypeDef(component, inst_type_idx) orelse {
-                std.debug.print("    rcft({}) aliased -> no typedef inst_type_idx={}\n", .{ func_idx, inst_type_idx });
                 return null;
             };
             const decls = switch (inst_td) {
                 .instance => |it| it.decls,
-                else => |t| {
-                    std.debug.print("    rcft({}) aliased -> inst_td not instance: {s}\n", .{ func_idx, @tagName(t) });
-                    return null;
-                },
+                else => return null,
             };
             for (decls) |d| switch (d) {
                 .@"export" => |e| {
@@ -1483,13 +1469,10 @@ fn resolveCompFuncType(component: *const ctypes.Component, func_idx: u32) ?Resol
                         if (found != null) break;
                     }
                     if (found) |ft| return .{ .ft = ft, .decls = decls };
-                    std.debug.print("    rcft({}) aliased -> export found name={s} but type tidx={} not in decls (total={})\n", .{ func_idx, ie.name, tidx, decls.len });
-                    for (decls, 0..) |dd, di| std.debug.print("      [{}]={s}\n", .{ di, @tagName(dd) });
                     return null;
                 },
                 else => {},
             };
-            std.debug.print("    rcft({}) aliased -> export name={s} not found in {} decls\n", .{ func_idx, ie.name, decls.len });
             return null;
         },
         .lifted => |canon_idx| {

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -979,7 +979,6 @@ test "load: real wasm32-wasip2 Rust component (stdio-echo)" {
             }
         }
         std.testing.expect(found) catch |err| {
-            std.debug.print("missing expected import: {s}\n", .{name});
             return err;
         };
     }

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -953,7 +953,11 @@ pub fn runLoadedComponent(
     defer inst.deinit();
 
     var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
-    defer providers.deinit(allocator);
+    // The provider populators allocate hashmap entries via `self.allocator`
+    // (the adapter's allocator) — keep the deinit consistent with that so
+    // hand-rolled callers like `runComponentBytes` (which pass an arena)
+    // don't leak the underlying hashmap storage.
+    defer providers.deinit(adapter.allocator);
 
     populateWasiProviders(adapter, component, &providers) catch return error.OutOfMemory;
     inst.linkImports(providers) catch return error.LinkFailed;
@@ -998,14 +1002,6 @@ pub fn runComponentBytes(
     const component_storage = allocator.create(ctypes_root.Component) catch return error.OutOfMemory;
     defer allocator.destroy(component_storage);
     component_storage.* = component_loader.load(data, allocator) catch return error.LoadFailed;
-    std.debug.print("\nSTDIO-ECHO-LOADED core_modules={} core_instances={} aliases={} canons={} imports={} exports={}\n", .{
-        component_storage.core_modules.len,
-        component_storage.core_instances.len,
-        component_storage.aliases.len,
-        component_storage.canons.len,
-        component_storage.imports.len,
-        component_storage.exports.len,
-    });
     return runLoadedComponent(component_storage, allocator, adapter);
 }
 
@@ -1615,38 +1611,21 @@ test "populateWasiProviders: binds full cli surface (#153)" {
 }
 
 test "stdio-echo: end-to-end real wasi-p2 component (#156)" {
-    // The stdio-echo fixture (Rust → wasm32-wasip2 via wit-component) uses
-    // composition machinery this runtime doesn't yet implement:
-    //   * three core modules (`$main`, `$wit-component-shim-module`,
-    //     `$wit-component-fixup`) wired via `(core instance (instantiate
-    //     $m (with ...)))` with cross-instance export aliases;
-    //   * an indirect-call trampoline table patched by `$fixup` after
-    //     `$main` is instantiated;
-    //   * `(canon resource.drop ...)` core funcs and full resource
-    //     indexspace plumbing;
-    //   * `(canon lower ...)` of host-instance methods sourced from
-    //     aliased imported instance exports rather than direct imports.
-    //
-    // The host-side WASI surface (#150–#155) is in place, and the loader
-    // / TypeRegistry now handle the type indexspace correctly so the run
-    // export resolves through the wit-bindgen 0.2.0 shim. Lighting up
-    // execution requires a follow-up slice that extends the core-side
-    // resolver; tracked alongside #156. Once that lands, drop the skip
-    // and the body below becomes the regression gate.
-    return error.SkipZigTest;
-}
-
-test "stdio-echo: end-to-end real wasi-p2 component (#156, disabled body)" {
-    if (true) return error.SkipZigTest;
-    // PROBE-skip
     const testing = std.testing;
     const data = @embedFile("fixtures/stdio-echo.wasm");
+
+    // The loader has no `Component.deinit` yet (#142 Phase 1B); use an
+    // arena so the test doesn't leak. Mirrors the pattern used by the
+    // other end-to-end component tests in this codebase.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
 
     var adapter = WasiCliAdapter.init(testing.allocator);
     defer adapter.deinit();
     adapter.setStdinBytes("hello\n");
 
-    const outcome = runComponentBytes(data, testing.allocator, &adapter) catch |err| {
+    const outcome = runComponentBytes(data, arena_alloc, &adapter) catch |err| {
         std.debug.print("stdio-echo run failed: {s}\n", .{@errorName(err)});
         std.debug.print("stdout so far: {s}\n", .{adapter.getStdoutBytes()});
         std.debug.print("stderr so far: {s}\n", .{adapter.getStderrBytes()});


### PR DESCRIPTION
Stacked on #164. Final slice in the H4 series — un-gates the stdio-echo regression test and cleans up the per-slice diagnostics that the H1–H4 work accumulated.

## Test changes

- The `stdio-echo: end-to-end real wasi-p2 component (#156)` test is **no longer skipped**. It loads the fixture into an `ArenaAllocator` (mirroring the pattern every other end-to-end component test uses, since the loader still has no `Component.deinit` per #142 Phase 1B), instantiates, runs, and asserts `stdout == "echo: hello\n"`.
- The probe duplicate test (`#156, disabled body`) is removed — the un-gated test supersedes it.
- `runLoadedComponent` now `deinit`s the providers hashmap via `adapter.allocator` rather than the caller-supplied `allocator`. The populators internally `put` entries with `self.allocator` (= `adapter.allocator`); using a different allocator on deinit leaked the hashmap storage when the caller passed an arena (the new e2e test does exactly that). All existing call sites already pass the adapter's allocator on both ends, so this is a no-op for them.

## Debug prints stripped

`executor.zig` (TRAMP-ENTRY / TRAMP-DBG / TRAMP-LOW / TRAMP-TRAP / arg-res dumps), `instance.zig` (LINK / IMPORT-RES / ALIASED-WIRED / LOWERED / ATTACH / rcft resolver dumps), `loader.zig` (missing-import print), `wasi_cli_adapter.zig` (STDIO-ECHO-LOADED shape dump). The test-side `stdio-echo run failed` / `stdout so far` / `stderr so far` diagnostics are kept — they only fire on failure and are worth their weight on CI regressions.

## Validation

`zig build test` — **917 pass / 0 skip / 0 fail** (was 916/2/0 — the prior `#156` skip is gone and we pick up a real assertion).

Refs #156, #142.