### PR TITLE
Perf stack 3/3: SSA-promote infrastructure + LICM/peephole passes (refs #136)

### DIFF
--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1215,6 +1215,9 @@ fn compileInst(
             try code.movRegMem(.rax, .r10, @as(i32, @intCast(fidx * 8)));
             try stack.push(code, .rax);
         },
+        // SSA phi nodes are lowered to synthetic local round-trips before
+        // codegen runs (lowerPhisToLocals). Reaching here is a bug.
+        .phi => unreachable,
     }
 }
 

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -876,6 +876,161 @@ pub fn computeLoops(
     };
 }
 
+// ── Dominance frontier ──────────────────────────────────────────────────
+
+/// Per-block dominance frontier sets. `frontier[b]` is the (sorted, dedup'd)
+/// set of blocks where `b` is the closest dominator that does NOT strictly
+/// dominate them. This is the canonical phi-insertion target set used by
+/// SSA construction.
+///
+/// Unreachable blocks contribute nothing and have an empty frontier.
+pub const DominanceFrontier = struct {
+    frontier: [][]ir.BlockId,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *DominanceFrontier) void {
+        for (self.frontier) |row| self.allocator.free(row);
+        self.allocator.free(self.frontier);
+    }
+};
+
+/// Compute the dominance frontier of every block via the standard
+/// Cytron / Cooper-Harvey-Kennedy "join-point" walk: for each block X
+/// with ≥ 2 predecessors, walk each predecessor P upward through idom
+/// until reaching idom(X), adding X to the frontier of each intermediate
+/// block. Skips unreachable blocks.
+pub fn computeDominanceFrontier(
+    func: *const ir.IrFunction,
+    dom: *const DomTree,
+    allocator: std.mem.Allocator,
+) !DominanceFrontier {
+    const nblocks = func.blocks.items.len;
+
+    var predecessors = try buildPredecessors(func, allocator);
+    defer {
+        var pit = predecessors.iterator();
+        while (pit.next()) |entry| allocator.free(entry.value_ptr.*);
+        predecessors.deinit();
+    }
+
+    // Per-block dense membership bitset, walked into sorted slices at the end.
+    // `present[b * nblocks + x] == true` ⇔ x ∈ DF(b). Block IDs are dense and
+    // small; this is simpler than per-block hashmaps and gives O(N) emit.
+    if (nblocks == 0) {
+        return .{
+            .frontier = try allocator.alloc([]ir.BlockId, 0),
+            .allocator = allocator,
+        };
+    }
+    const present = try allocator.alloc(bool, nblocks * nblocks);
+    defer allocator.free(present);
+    @memset(present, false);
+
+    var bi: usize = 0;
+    while (bi < nblocks) : (bi += 1) {
+        const x: ir.BlockId = @intCast(bi);
+        if (dom.idom[x] == null) continue;
+        const preds = predecessors.get(x) orelse continue;
+        if (preds.len < 2) continue;
+
+        const idom_x = dom.idom[x].?;
+        for (preds) |p| {
+            if (dom.idom[p] == null) continue;
+            var runner: ir.BlockId = p;
+            while (runner != idom_x) {
+                present[@as(usize, runner) * nblocks + @as(usize, x)] = true;
+                const next = dom.idom[runner] orelse break;
+                if (next == runner) break; // entry's idom is itself; stop.
+                runner = next;
+            }
+        }
+    }
+
+    const frontier = try allocator.alloc([]ir.BlockId, nblocks);
+    errdefer {
+        for (frontier) |row| allocator.free(row);
+        allocator.free(frontier);
+    }
+    for (frontier, 0..) |*row, idx| {
+        const base = idx * nblocks;
+        var count: usize = 0;
+        for (0..nblocks) |x| if (present[base + x]) {
+            count += 1;
+        };
+        const slice = try allocator.alloc(ir.BlockId, count);
+        errdefer allocator.free(slice);
+        var i: usize = 0;
+        for (0..nblocks) |x| {
+            if (present[base + x]) {
+                slice[i] = @intCast(x);
+                i += 1;
+            }
+        }
+        // Already sorted ascending by construction.
+        row.* = slice;
+    }
+
+    return .{ .frontier = frontier, .allocator = allocator };
+}
+
+/// Compute the iterated dominance frontier `DF+(S)` of a set of "def" blocks
+/// `def_blocks`. This is the fixpoint of `DF` applied repeatedly: the set
+/// of blocks where phis must be placed for a value defined in any block
+/// of `def_blocks`, accounting for the phis themselves becoming new defs.
+///
+/// Standard worklist algorithm; result is sorted ascending. Caller owns
+/// the returned slice.
+pub fn iteratedDominanceFrontier(
+    df: *const DominanceFrontier,
+    def_blocks: []const ir.BlockId,
+    allocator: std.mem.Allocator,
+) ![]ir.BlockId {
+    const nblocks = df.frontier.len;
+    if (nblocks == 0) return try allocator.alloc(ir.BlockId, 0);
+
+    const in_idf = try allocator.alloc(bool, nblocks);
+    defer allocator.free(in_idf);
+    @memset(in_idf, false);
+    const on_worklist = try allocator.alloc(bool, nblocks);
+    defer allocator.free(on_worklist);
+    @memset(on_worklist, false);
+    var worklist: std.ArrayList(ir.BlockId) = .empty;
+    defer worklist.deinit(allocator);
+
+    for (def_blocks) |b| {
+        if (b < nblocks and !on_worklist[b]) {
+            on_worklist[b] = true;
+            try worklist.append(allocator, b);
+        }
+    }
+
+    while (worklist.pop()) |x| {
+        if (x >= nblocks) continue;
+        for (df.frontier[x]) |y| {
+            if (in_idf[y]) continue;
+            in_idf[y] = true;
+            if (!on_worklist[y]) {
+                on_worklist[y] = true;
+                try worklist.append(allocator, y);
+            }
+        }
+    }
+
+    var count: usize = 0;
+    for (in_idf) |b| if (b) {
+        count += 1;
+    };
+    const out = try allocator.alloc(ir.BlockId, count);
+    var i: usize = 0;
+    for (in_idf, 0..) |b, idx| {
+        if (b) {
+            out[i] = @intCast(idx);
+            i += 1;
+        }
+    }
+    return out;
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 test "buildSuccessors: linear block" {
@@ -1413,4 +1568,200 @@ test "computeLoops: irreducible-ish (no back-edge without dominator) produces no
     try std.testing.expectEqual(@as(usize, 1), lf.loops.len);
     try std.testing.expectEqual(b0, lf.loops[0].header);
     try std.testing.expectEqual(@as(usize, 3), lf.loops[0].blocks.len);
+}
+
+test "computeDominanceFrontier: linear chain has empty frontier" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b2 } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = null } });
+
+    var dom = try computeDominators(&func, allocator);
+    defer dom.deinit();
+    var df = try computeDominanceFrontier(&func, &dom, allocator);
+    defer df.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), df.frontier[b0].len);
+    try std.testing.expectEqual(@as(usize, 0), df.frontier[b1].len);
+    try std.testing.expectEqual(@as(usize, 0), df.frontier[b2].len);
+}
+
+test "computeDominanceFrontier: diamond merge is in DF of both arms" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const v0 = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0 });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = v0, .then_block = b1, .else_block = b2 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = null } });
+
+    var dom = try computeDominators(&func, allocator);
+    defer dom.deinit();
+    var df = try computeDominanceFrontier(&func, &dom, allocator);
+    defer df.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), df.frontier[b0].len);
+    try std.testing.expectEqualSlices(ir.BlockId, &.{b3}, df.frontier[b1]);
+    try std.testing.expectEqualSlices(ir.BlockId, &.{b3}, df.frontier[b2]);
+    try std.testing.expectEqual(@as(usize, 0), df.frontier[b3].len);
+}
+
+test "computeDominanceFrontier: loop header is in its own frontier" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    // b0 → b1; b1 ⇄ b1 (self-loop) | → b2
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const v0 = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v0, .then_block = b1, .else_block = b2 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = null } });
+
+    var dom = try computeDominators(&func, allocator);
+    defer dom.deinit();
+    var df = try computeDominanceFrontier(&func, &dom, allocator);
+    defer df.deinit();
+
+    // b1 has 2 preds (b0, b1); for the b1→b1 back-edge, runner = b1, idom_x = b0,
+    // so b1 is added to its own frontier. b0 is the immediate dominator of b1 so
+    // not added.
+    try std.testing.expectEqualSlices(ir.BlockId, &.{b1}, df.frontier[b1]);
+}
+
+test "computeDominanceFrontier: nested loop frontier" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    // b0 → b1 (outer header) → b2 (inner header) → (back to b2 or b3)
+    // b3 → (back to b1 or b4); b4 = exit.
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const b4 = try func.newBlock();
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b2 } });
+    try func.getBlock(b2).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0 });
+    try func.getBlock(b2).append(.{ .op = .{ .br_if = .{ .cond = v0, .then_block = b2, .else_block = b3 } } });
+    try func.getBlock(b3).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v1 });
+    try func.getBlock(b3).append(.{ .op = .{ .br_if = .{ .cond = v1, .then_block = b1, .else_block = b4 } } });
+    try func.getBlock(b4).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v2 });
+    try func.getBlock(b4).append(.{ .op = .{ .ret = v2 } });
+
+    var dom = try computeDominators(&func, allocator);
+    defer dom.deinit();
+    var df = try computeDominanceFrontier(&func, &dom, allocator);
+    defer df.deinit();
+
+    // b3→b1 back-edge: runner walks b3→b2→b1→(stop at idom(b1)=b0). So b1 is
+    // added to DF(b3), DF(b2), and DF(b1) (b1 is in its own frontier — the
+    // outer-loop header phi site).
+    // b2→b2 self-loop: runner=b2, idom_x=b1, so b2 is added to DF(b2).
+    try std.testing.expectEqualSlices(ir.BlockId, &.{b1}, df.frontier[b3]);
+    try std.testing.expectEqualSlices(ir.BlockId, &.{ b1, b2 }, df.frontier[b2]);
+    try std.testing.expectEqualSlices(ir.BlockId, &.{b1}, df.frontier[b1]);
+    try std.testing.expectEqual(@as(usize, 0), df.frontier[b4].len);
+}
+
+test "computeDominanceFrontier: unreachable block has empty frontier" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock(); // unreachable
+    try func.getBlock(b0).append(.{ .op = .{ .ret = null } });
+    try func.getBlock(b1).append(.{ .op = .{ .ret = null } });
+
+    var dom = try computeDominators(&func, allocator);
+    defer dom.deinit();
+    var df = try computeDominanceFrontier(&func, &dom, allocator);
+    defer df.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), df.frontier[b0].len);
+    try std.testing.expectEqual(@as(usize, 0), df.frontier[b1].len);
+}
+
+test "iteratedDominanceFrontier: diamond defs converge to merge" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const v0 = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0 });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = v0, .then_block = b1, .else_block = b2 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = null } });
+
+    var dom = try computeDominators(&func, allocator);
+    defer dom.deinit();
+    var df = try computeDominanceFrontier(&func, &dom, allocator);
+    defer df.deinit();
+
+    // Defs in {b1, b2} → IDF = {b3}.
+    const idf = try iteratedDominanceFrontier(&df, &.{ b1, b2 }, allocator);
+    defer allocator.free(idf);
+    try std.testing.expectEqualSlices(ir.BlockId, &.{b3}, idf);
+}
+
+test "iteratedDominanceFrontier: loop def needs phi at header" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    // b0 → b1 (header); b1 ⇄ b1 | → b2.
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const v0 = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v0, .then_block = b1, .else_block = b2 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = null } });
+
+    var dom = try computeDominators(&func, allocator);
+    defer dom.deinit();
+    var df = try computeDominanceFrontier(&func, &dom, allocator);
+    defer df.deinit();
+
+    // A def in entry b0 alone → IDF empty (b0's DF is empty).
+    const idf_entry = try iteratedDominanceFrontier(&df, &.{b0}, allocator);
+    defer allocator.free(idf_entry);
+    try std.testing.expectEqual(@as(usize, 0), idf_entry.len);
+
+    // A def in b1 (loop body) → IDF includes b1 itself (loop-header phi site).
+    const idf_loop = try iteratedDominanceFrontier(&df, &.{b1}, allocator);
+    defer allocator.free(idf_loop);
+    try std.testing.expectEqualSlices(ir.BlockId, &.{b1}, idf_loop);
+
+    // A def in {b0, b1} → IDF still {b1} (since DF(b0) is empty and DF(b1) = {b1}).
+    const idf_both = try iteratedDominanceFrontier(&df, &.{ b0, b1 }, allocator);
+    defer allocator.free(idf_both);
+    try std.testing.expectEqualSlices(ir.BlockId, &.{b1}, idf_both);
 }

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -17,17 +17,26 @@ pub fn buildSuccessors(
 
     for (func.blocks.items, 0..) |block, idx| {
         var succs: std.ArrayList(ir.BlockId) = .empty;
+        // Only the FIRST terminator in a block executes at runtime; any
+        // br/br_if/br_table/ret/unreachable that follows is dead code emitted
+        // by the wasm frontend. Tracking dead edges as real CFG edges
+        // confuses downstream analysis (notably ssaPromoteLocals' rename
+        // pass: a dead edge from B → S can make a non-dominator B appear as
+        // a predecessor of S in raw block-id order).
         for (block.instructions.items) |inst| {
             switch (inst.op) {
-                .br => |target| try succs.append(allocator, target),
+                .br => |target| { try succs.append(allocator, target); break; },
                 .br_if => |bi| {
                     try succs.append(allocator, bi.then_block);
                     try succs.append(allocator, bi.else_block);
+                    break;
                 },
                 .br_table => |bt| {
                     for (bt.targets) |t| try succs.append(allocator, t);
                     try succs.append(allocator, bt.default);
+                    break;
                 },
+                .ret, .ret_multi, .@"unreachable" => break,
                 else => {},
             }
         }

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -137,6 +137,9 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
         .local_get, .global_get => {},
         .br, .@"unreachable", .atomic_fence => {},
 
+        // Phi must be lowered before liveness analysis runs (regalloc).
+        .phi => unreachable,
+
         .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
         .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
         .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u,
@@ -345,6 +348,9 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
         .iconst_32, .iconst_64, .fconst_32, .fconst_64 => {},
         .local_get, .global_get => {},
         .br, .@"unreachable", .atomic_fence => {},
+
+        // Phi must be lowered before live-range analysis (regalloc).
+        .phi => unreachable,
 
         .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
         .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -34,6 +34,14 @@ pub const Inst = struct {
         fconst_32: f32,
         fconst_64: f64,
 
+        // SSA phi: `dest` receives the value `incoming[i].value` when
+        // control reaches this block from `incoming[i].block`. Phi
+        // instructions must appear at the head of a block, before any
+        // non-phi instruction. Codegen never sees a phi in practice — the
+        // SSA-promotion pipeline lowers all phis back to synthetic locals
+        // before any backend runs.
+        phi: []const PhiIncoming,
+
         // Binary arithmetic (dest = lhs op rhs)
         add: BinOp,
         sub: BinOp,
@@ -194,6 +202,11 @@ pub const Inst = struct {
     pub const BinOp = struct {
         lhs: VReg,
         rhs: VReg,
+    };
+
+    pub const PhiIncoming = struct {
+        block: BlockId,
+        value: VReg,
     };
 
     pub const AtomicRmwOp = enum { add, sub, @"and", @"or", xor, xchg };

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -228,6 +228,9 @@ pub const BasicBlock = struct {
     }
 
     pub fn deinit(self: *BasicBlock) void {
+        for (self.instructions.items) |inst| {
+            if (inst.op == .phi) self.allocator.free(inst.op.phi);
+        }
         self.instructions.deinit(self.allocator);
         self.predecessors.deinit(self.allocator);
     }

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -3359,6 +3359,221 @@ pub fn inlineSmallFunctions(module: *ir.IrModule, allocator: std.mem.Allocator) 
     return any_inlined;
 }
 
+// ── Loop-Invariant Code Motion (pure ops) ───────────────────────────────────
+
+fn isHoistableOp(op: ir.Inst.Op) bool {
+    return switch (op) {
+        .iconst_32, .iconst_64, .fconst_32, .fconst_64 => true,
+        .add, .sub, .mul,
+        .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
+        .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u,
+        => true,
+        .f_min, .f_max, .f_copysign,
+        .f_eq, .f_ne, .f_lt, .f_gt, .f_le, .f_ge,
+        => true,
+        .clz, .ctz, .popcnt, .eqz,
+        .wrap_i64, .extend_i32_s, .extend_i32_u,
+        .extend8_s, .extend16_s, .extend32_s,
+        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest,
+        .convert_s, .convert_u, .convert_i32_s, .convert_i64_s, .convert_i32_u, .convert_i64_u,
+        .demote_f64, .promote_f32, .reinterpret,
+        .trunc_sat_f32_s, .trunc_sat_f32_u, .trunc_sat_f64_s, .trunc_sat_f64_u,
+        => true,
+        .select => true,
+        // Excluded:
+        // - div_s/div_u/rem_s/rem_u: trap on /0
+        // - trunc_f32_s/u, trunc_f64_s/u (non-saturating): trap on NaN/overflow
+        // - load: may trap on bounds
+        // - all stores/atomics/calls/branches/phi/local_*/global_*/mem_*/table_*: side effects
+        else => false,
+    };
+}
+
+/// Collect operand vregs of a hoistable instruction into `buf`.
+/// Caller must ensure `isHoistableOp(inst.op)`. Returns the populated slice.
+fn collectHoistableOperands(inst: ir.Inst, buf: *[3]ir.VReg) []ir.VReg {
+    var n: usize = 0;
+    switch (inst.op) {
+        .iconst_32, .iconst_64, .fconst_32, .fconst_64 => {},
+        .add, .sub, .mul,
+        .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
+        .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u,
+        .f_min, .f_max, .f_copysign,
+        .f_eq, .f_ne, .f_lt, .f_gt, .f_le, .f_ge,
+        => |bin| {
+            buf[n] = bin.lhs; n += 1;
+            buf[n] = bin.rhs; n += 1;
+        },
+        .clz, .ctz, .popcnt, .eqz,
+        .wrap_i64, .extend_i32_s, .extend_i32_u,
+        .extend8_s, .extend16_s, .extend32_s,
+        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest,
+        .convert_s, .convert_u, .convert_i32_s, .convert_i64_s, .convert_i32_u, .convert_i64_u,
+        .demote_f64, .promote_f32, .reinterpret,
+        .trunc_sat_f32_s, .trunc_sat_f32_u, .trunc_sat_f64_s, .trunc_sat_f64_u,
+        => |v| {
+            buf[n] = v; n += 1;
+        },
+        .select => |sel| {
+            buf[n] = sel.cond; n += 1;
+            buf[n] = sel.if_true; n += 1;
+            buf[n] = sel.if_false; n += 1;
+        },
+        else => unreachable,
+    }
+    return buf[0..n];
+}
+
+/// Hoist loop-invariant pure instructions out of natural loops to their
+/// preheader. A "pure" instruction is one without observable side effects
+/// or traps (see `isHoistableOp`). An instruction is loop-invariant when
+/// all of its operands are defined outside the loop's block set.
+///
+/// Conservative restrictions (each can be relaxed later):
+///   - Skip loops without a unique preheader: we don't insert one.
+///     A preheader is the only predecessor of `loop.header` not in the
+///     loop's blocks.
+///   - Skip loops where `preheader.id >= min(loop.blocks)`: the codegen
+///     iterates blocks in raw block-id order and requires `id(def) ≤
+///     id(use)`. Hoisting moves a def earlier in id-space; this guard
+///     ensures the new def-block id is < every existing in-loop use-block
+///     id. (Loop-output uses have id ≥ min(loop.blocks) ≥ existing
+///     in-loop def, so they remain consistent too.)
+///   - Stop scanning a block at its first terminator: the wasm frontend
+///     can emit dead instructions after a terminator; including those
+///     would make us reason about code outside the executable CFG (and
+///     `buildSuccessors` already ignores them).
+///
+/// Loop nesting: we process loops in ascending `blocks.len` order
+/// (innermost-ish first). Outer loops that become hoistable after an
+/// inner-loop hoist are picked up by the `runPasses` fixpoint loop.
+///
+/// Soundness summary:
+///   - Pure ops have no observable side effects; changing execution
+///     count from N (per iteration) to 1 (per loop entry) is safe.
+///   - Wasm has no observable FP status flags or rounding-mode side
+///     channels, so hoisting f_* ops doesn't change observable behavior.
+///   - For zero-trip loops, hoisting adds one extra execution of the op,
+///     which is OK because the result is unused and the op cannot trap.
+///   - SSA dominance: in a reachable natural loop with a unique
+///     preheader, every operand defined outside the loop already
+///     dominates the original in-loop use; therefore it dominates the
+///     preheader too (every path to the loop goes through the preheader).
+///   - Phi handling: hoisting changes WHERE a vreg is defined, not its
+///     value or vreg id. Phi incoming `(pred, vreg)` selects by edge
+///     identity; the def now in the preheader still dominates every
+///     latch (header dominates latches, preheader dominates header).
+pub fn licmPureOps(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    if (func.blocks.items.len < 2) return false;
+
+    var dom = try analysis.computeDominators(func, allocator);
+    defer dom.deinit();
+
+    var loops = try analysis.computeLoops(func, &dom, allocator);
+    defer loops.deinit();
+
+    if (loops.loops.len == 0) return false;
+
+    var preds = try analysis.buildPredecessors(func, allocator);
+    defer {
+        var pit = preds.iterator();
+        while (pit.next()) |e| allocator.free(e.value_ptr.*);
+        preds.deinit();
+    }
+
+    // Process loops innermost-ish first (smaller block sets first). Outer
+    // loops are revisited by the runPasses fixpoint loop.
+    const order = try allocator.alloc(u32, loops.loops.len);
+    defer allocator.free(order);
+    for (order, 0..) |*o, i| o.* = @intCast(i);
+    const Ctx = struct {
+        forest: *const analysis.LoopForest,
+        fn lessThan(ctx: @This(), a: u32, b: u32) bool {
+            return ctx.forest.loops[a].blocks.len < ctx.forest.loops[b].blocks.len;
+        }
+    };
+    std.sort.pdq(u32, order, Ctx{ .forest = &loops }, Ctx.lessThan);
+
+    var changed = false;
+
+    for (order) |loop_idx| {
+        const loop = &loops.loops[loop_idx];
+
+        // Find unique preheader.
+        const header_preds = preds.get(loop.header) orelse continue;
+        var preheader: ?ir.BlockId = null;
+        var preheader_count: u32 = 0;
+        for (header_preds) |p| {
+            if (loop.containsBlock(p)) continue;
+            preheader = p;
+            preheader_count += 1;
+        }
+        if (preheader_count != 1) continue;
+        const ph = preheader.?;
+
+        // Block-id-order safety: preheader id must precede every loop
+        // block id (loop.blocks is sorted ascending).
+        if (loop.blocks.len == 0) continue;
+        if (ph >= loop.blocks[0]) continue;
+
+        // Build loop_defs: every dest defined in the loop, scanning each
+        // block only up to its first terminator (frontend may emit dead
+        // instructions after a terminator).
+        var loop_defs = std.AutoHashMap(ir.VReg, void).init(allocator);
+        defer loop_defs.deinit();
+        for (loop.blocks) |bid| {
+            const blk = &func.blocks.items[bid];
+            for (blk.instructions.items) |inst| {
+                if (inst.dest) |d| try loop_defs.put(d, {});
+                if (isTerminatorOp(inst.op)) break;
+            }
+        }
+
+        // Insertion point in preheader: just before its first terminator.
+        var insert_idx: usize = func.blocks.items[ph].instructions.items.len;
+        for (func.blocks.items[ph].instructions.items, 0..) |inst, i| {
+            if (isTerminatorOp(inst.op)) { insert_idx = i; break; }
+        }
+
+        // Walk loop blocks, hoisting candidates into the preheader.
+        for (loop.blocks) |bid| {
+            const blk = &func.blocks.items[bid];
+            var i: usize = 0;
+            while (i < blk.instructions.items.len) {
+                const inst = blk.instructions.items[i];
+                if (isTerminatorOp(inst.op)) break; // ignore dead tail
+                if (!isHoistableOp(inst.op)) { i += 1; continue; }
+
+                var op_buf: [3]ir.VReg = undefined;
+                const ops = collectHoistableOperands(inst, &op_buf);
+                var invariant = true;
+                for (ops) |op| {
+                    if (loop_defs.contains(op)) { invariant = false; break; }
+                }
+                if (!invariant) { i += 1; continue; }
+
+                // Hoist: remove from current block, insert before preheader's
+                // terminator. Preserve relative ordering by appending at the
+                // current insert_idx and advancing it.
+                const removed = blk.instructions.orderedRemove(i);
+                try func.blocks.items[ph].instructions.insert(
+                    func.blocks.items[ph].allocator,
+                    insert_idx,
+                    removed,
+                );
+                insert_idx += 1;
+
+                if (removed.dest) |d| _ = loop_defs.remove(d);
+
+                changed = true;
+                // Don't advance `i`: the next instruction shifted into i.
+            }
+        }
+    }
+
+    return changed;
+}
+
 pub fn runPasses(module: *ir.IrModule, passes: []const PassFn, allocator: std.mem.Allocator) !u32 {
     var total_changes: u32 = 0;
     // Module-level: inline small leaf callees before per-function passes.
@@ -3417,6 +3632,7 @@ pub const default_passes: []const PassFn = &.{
     &foldWrapOfExtend,
     &foldLoadStoreOffset,
     &commonSubexprElimination,
+    &licmPureOps,
     &deadCodeElimination,
     &deadLocalSetElimination,
     &elideRedundantBoundsChecks,
@@ -6554,4 +6770,248 @@ test "foldLoadStoreOffset: preserves bounds_known" {
     const ld = func.getBlock(b0).instructions.items[3].op.load;
     try std.testing.expect(ld.bounds_known);
     try std.testing.expectEqual(@as(u32, 4), ld.offset);
+}
+
+test "licmPureOps: hoists invariant add out of single-block loop" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+
+    // CFG: b0 (preheader) -> b1 (header+latch) -> b2 (exit)
+    //                       ^---- back-edge ----+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v_x = func.newVReg();
+    const v_y = func.newVReg();
+    const v_inv = func.newVReg();
+    const v_cond = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_x, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 7 }, .dest = v_y, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    // Header is a self-looping single block.
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v_x, .rhs = v_y } }, .dest = v_inv, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b1, .else_block = b2 } } });
+
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_inv }, .type = .i32 });
+
+    const changed = try licmPureOps(&func, allocator);
+    try std.testing.expect(changed);
+
+    // The add should now be in b0 (preheader); b1 should no longer contain it.
+    var found_in_ph = false;
+    for (func.getBlock(b0).instructions.items) |inst| {
+        if (inst.op == .add and inst.dest == v_inv) found_in_ph = true;
+    }
+    try std.testing.expect(found_in_ph);
+
+    for (func.getBlock(b1).instructions.items) |inst| {
+        try std.testing.expect(!(inst.op == .add and inst.dest == v_inv));
+    }
+}
+
+test "licmPureOps: skips when operand is loop-defined" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v_x = func.newVReg();
+    const v_loaded = func.newVReg();   // loop-defined via load (non-hoistable)
+    const v_use = func.newVReg();
+    const v_cond = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_x, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    // v_loaded is a non-hoistable load; v_use depends on it -> NOT invariant.
+    try func.getBlock(b1).append(.{ .op = .{ .load = .{ .base = v_x, .offset = 0, .size = 4 } }, .dest = v_loaded, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v_x, .rhs = v_loaded } }, .dest = v_use, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .load = .{ .base = v_x, .offset = 4, .size = 4 } }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b1, .else_block = b2 } } });
+
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_use }, .type = .i32 });
+
+    _ = try licmPureOps(&func, allocator);
+
+    // The add depending on v_loaded must NOT be hoisted.
+    var add_in_b1 = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .add and inst.dest == v_use) add_in_b1 = true;
+    }
+    try std.testing.expect(add_in_b1);
+}
+
+test "licmPureOps: does not hoist trapping div" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 2, 2, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v_x = func.newVReg();
+    const v_y = func.newVReg();
+    const v_div = func.newVReg();
+    const v_cond = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_x, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 1 }, .dest = v_y, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    // div_s would trap if v_y == 0 — must NOT speculatively hoist into preheader
+    // because the loop might never execute.
+    try func.getBlock(b1).append(.{ .op = .{ .div_s = .{ .lhs = v_x, .rhs = v_y } }, .dest = v_div, .type = .i32 });
+    // Use a load for the cond so it isn't itself hoisted (would be a noisy
+    // signal; we want to assert specifically about div_s).
+    try func.getBlock(b1).append(.{ .op = .{ .load = .{ .base = v_x, .offset = 0, .size = 4 } }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b1, .else_block = b2 } } });
+
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_div }, .type = .i32 });
+
+    _ = try licmPureOps(&func, allocator);
+
+    // div_s must remain in b1.
+    var div_in_b1 = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .div_s and inst.dest == v_div) div_in_b1 = true;
+    }
+    try std.testing.expect(div_in_b1);
+    for (func.getBlock(b0).instructions.items) |inst| {
+        try std.testing.expect(!(inst.op == .div_s));
+    }
+}
+
+test "licmPureOps: skips loop without unique preheader" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    // b0 -> b1 (header), b2 -> b1 (header). Two preheaders.
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+
+    const v_a = func.newVReg();
+    const v_b = func.newVReg();
+    const v_inv = func.newVReg();
+    const v_cond = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_a, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+    try func.getBlock(b2).append(.{ .op = .{ .iconst_32 = 2 }, .dest = v_b, .type = .i32 });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b1 } });
+
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v_a, .rhs = v_b } }, .dest = v_inv, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b1, .else_block = b3 } } });
+
+    try func.getBlock(b3).append(.{ .op = .{ .ret = v_inv }, .type = .i32 });
+
+    const changed = try licmPureOps(&func, allocator);
+    try std.testing.expect(!changed);
+}
+
+test "licmPureOps: nested loop — single call hoists from inner to outer preheader" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+
+    // CFG (block ids ascending so preheader<header):
+    //   b0 (entry/outer-preheader) -> b1 (outer-header)
+    //   b1 -> b2 (inner-preheader)
+    //   b2 -> b3 (inner-header+latch self-loop) -> b4 (outer-latch)
+    //   b4 -> b1 (outer back-edge), b4 -> b5 (function exit)
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const b4 = try func.newBlock();
+    const b5 = try func.newBlock();
+
+    const v_x = func.newVReg();
+    const v_inner_inv = func.newVReg();
+    const v_one = func.newVReg();
+    const v_cond_inner = func.newVReg();
+    const v_cond_outer = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_x, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    try func.getBlock(b1).append(.{ .op = .{ .br = b2 } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+
+    // Inner-loop body (b3): an add of v_x + 1 — invariant w.r.t. both loops.
+    try func.getBlock(b3).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_one, .type = .i32 });
+    try func.getBlock(b3).append(.{ .op = .{ .add = .{ .lhs = v_x, .rhs = v_one } }, .dest = v_inner_inv, .type = .i32 });
+    // Use a load (non-hoistable) for the inner cond so the test isolates
+    // the visible motion of the add.
+    try func.getBlock(b3).append(.{ .op = .{ .load = .{ .base = v_x, .offset = 0, .size = 4 } }, .dest = v_cond_inner, .type = .i32 });
+    try func.getBlock(b3).append(.{ .op = .{ .br_if = .{ .cond = v_cond_inner, .then_block = b3, .else_block = b4 } } });
+
+    try func.getBlock(b4).append(.{ .op = .{ .load = .{ .base = v_x, .offset = 4, .size = 4 } }, .dest = v_cond_outer, .type = .i32 });
+    try func.getBlock(b4).append(.{ .op = .{ .br_if = .{ .cond = v_cond_outer, .then_block = b1, .else_block = b5 } } });
+
+    try func.getBlock(b5).append(.{ .op = .{ .ret = v_inner_inv }, .type = .i32 });
+
+    // Single call: innermost-first ordering hoists b3→b2 then b2→b0.
+    const c1 = try licmPureOps(&func, allocator);
+    try std.testing.expect(c1);
+
+    // After hoisting, the add must live in b0 (outer preheader).
+    var add_in_b0 = false;
+    for (func.getBlock(b0).instructions.items) |inst| {
+        if (inst.op == .add and inst.dest == v_inner_inv) add_in_b0 = true;
+    }
+    try std.testing.expect(add_in_b0);
+
+    // ...and not in b3.
+    for (func.getBlock(b3).instructions.items) |inst| {
+        try std.testing.expect(!(inst.op == .add and inst.dest == v_inner_inv));
+    }
+}
+
+test "licmPureOps: leaves non-pure load in loop" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v_base = func.newVReg();
+    const v_loaded = func.newVReg();
+    const v_cond = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_base, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    try func.getBlock(b1).append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_loaded, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .load = .{ .base = v_base, .offset = 4, .size = 4 } }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b1, .else_block = b2 } } });
+
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_loaded }, .type = .i32 });
+
+    _ = try licmPureOps(&func, allocator);
+
+    // The load must remain in b1.
+    var load_in_b1 = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .load and inst.dest == v_loaded) load_in_b1 = true;
+    }
+    try std.testing.expect(load_in_b1);
+    // ...and not in b0.
+    for (func.getBlock(b0).instructions.items) |inst| {
+        try std.testing.expect(!(inst.op == .load and inst.dest == v_loaded));
+    }
 }

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -2381,6 +2381,105 @@ pub fn foldConstantBranches(func: *ir.IrFunction, allocator: std.mem.Allocator) 
     return changed;
 }
 
+// ── Address-mode folding (load/store offset) ────────────────────────────────
+
+/// Fold `add base, iconst_32 C` feeding into `load`/`store` by absorbing
+/// C into the load/store's existing immediate offset:
+///
+///     iconst_32 C            ;; const-fold candidate
+///     v_add = add base, C    ;; (or add C, base)
+///     load  v_add, offset=N  =>  load  base, offset=N+C
+///
+/// This is a block-local peephole. The same `add` may have other uses;
+/// we don't remove it — DCE will reap it if all its consumers were
+/// loads/stores that we folded.
+///
+/// Soundness:
+///   - Only fires when the add's IR type is `.i32` (memory32 base).
+///     Memory64 (i64 base) is intentionally skipped: the add could
+///     produce a value > 2^32 and the offset is u32.
+///   - Only fires when C is a non-negative i32 (so its u32 reinterpretation
+///     is < 2^31). Negative consts are mathematically equivalent
+///     (mod 2^32) but mix poorly with the bounds-check end address.
+///   - new_offset = N + C is checked to fit in i32 (≤ 0x7FFFFFFF).
+///     Since the original code already computed `add(base, C)` as i32
+///     wrap arithmetic and the load's runtime address is computed as
+///     `base + N + C` mod 2^32, both old and new produce the same
+///     32-bit effective address. Bounds-check semantics are preserved
+///     because the codegen helper recomputes `addr + size` from the new
+///     base+offset, and the numeric end address is identical.
+///   - We do NOT touch `bounds_known`: that flag was set by
+///     `elideRedundantBoundsChecks` based on the original instruction's
+///     numeric address; that address is unchanged after the fold.
+///
+/// Idempotent and safe inside the `runPasses` fixpoint loop. Composes
+/// with `constantFold` (folds chains of `add base, c1; add ., c2`) and
+/// with `deadCodeElimination` (removes the now-dead add).
+pub fn foldLoadStoreOffset(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    var changed = false;
+    for (func.blocks.items) |*block| {
+        var iconst32 = std.AutoHashMap(ir.VReg, i32).init(allocator);
+        defer iconst32.deinit();
+
+        const AddInfo = struct { other: ir.VReg, c: u32 };
+        var add_info = std.AutoHashMap(ir.VReg, AddInfo).init(allocator);
+        defer add_info.deinit();
+
+        for (block.instructions.items) |*inst| {
+            switch (inst.op) {
+                .iconst_32 => |c| {
+                    if (inst.dest) |d| try iconst32.put(d, c);
+                },
+                .add => |bin| {
+                    if (inst.type != .i32) continue;
+                    const dest = inst.dest orelse continue;
+                    if (iconst32.get(bin.rhs)) |c| {
+                        if (c >= 0) {
+                            try add_info.put(dest, .{ .other = bin.lhs, .c = @as(u32, @intCast(c)) });
+                        }
+                    } else if (iconst32.get(bin.lhs)) |c| {
+                        if (c >= 0) {
+                            try add_info.put(dest, .{ .other = bin.rhs, .c = @as(u32, @intCast(c)) });
+                        }
+                    }
+                },
+                .load => |ld| {
+                    if (add_info.get(ld.base)) |info| {
+                        const new_off: u64 = @as(u64, ld.offset) + @as(u64, info.c);
+                        if (new_off <= std.math.maxInt(i32)) {
+                            inst.op = .{ .load = .{
+                                .base = info.other,
+                                .offset = @as(u32, @intCast(new_off)),
+                                .size = ld.size,
+                                .sign_extend = ld.sign_extend,
+                                .bounds_known = ld.bounds_known,
+                            } };
+                            changed = true;
+                        }
+                    }
+                },
+                .store => |st| {
+                    if (add_info.get(st.base)) |info| {
+                        const new_off: u64 = @as(u64, st.offset) + @as(u64, info.c);
+                        if (new_off <= std.math.maxInt(i32)) {
+                            inst.op = .{ .store = .{
+                                .base = info.other,
+                                .offset = @as(u32, @intCast(new_off)),
+                                .size = st.size,
+                                .val = st.val,
+                                .bounds_known = st.bounds_known,
+                            } };
+                            changed = true;
+                        }
+                    }
+                },
+                else => {},
+            }
+        }
+    }
+    return changed;
+}
+
 // ── Branch-on-Eqz folding ───────────────────────────────────────────────────
 
 /// Collapse `br_if(cond=eqz(x), then=A, else=B)` into
@@ -3316,6 +3415,7 @@ pub const default_passes: []const PassFn = &.{
     &foldSignExtendingLoad,
     &foldFloatUnaryIdempotents,
     &foldWrapOfExtend,
+    &foldLoadStoreOffset,
     &commonSubexprElimination,
     &deadCodeElimination,
     &deadLocalSetElimination,
@@ -6345,4 +6445,113 @@ test "splitCriticalEdges + lowerPhisToLocals: round-trip on critical-edge CFG" {
     // After splitting + lowering: b3's preds are {b2, edge_block_from_b1}
     // and neither should be b1 itself.
     for (b3_preds) |p| try std.testing.expect(p != b1);
+}
+
+test "foldLoadStoreOffset: add base, const into load offset" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const v_base = func.newVReg();
+    const v_c = func.newVReg();
+    const v_addr = func.newVReg();
+    const v_load = func.newVReg();
+    var block = &func.blocks.items[b0];
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = v_base, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 12 }, .dest = v_c, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v_base, .rhs = v_c } }, .dest = v_addr, .type = .i32 });
+    try block.append(.{ .op = .{ .load = .{ .base = v_addr, .offset = 4, .size = 4 } }, .dest = v_load, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v_load }, .type = .i32 });
+
+    const changed = try foldLoadStoreOffset(&func, allocator);
+    try std.testing.expect(changed);
+    const ld = func.getBlock(b0).instructions.items[3].op.load;
+    try std.testing.expectEqual(v_base, ld.base);
+    try std.testing.expectEqual(@as(u32, 16), ld.offset);
+}
+
+test "foldLoadStoreOffset: add const, base (commuted)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const v_base = func.newVReg();
+    const v_c = func.newVReg();
+    const v_addr = func.newVReg();
+    const v_val = func.newVReg();
+    var block = &func.blocks.items[b0];
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = v_base, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 8 }, .dest = v_c, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v_c, .rhs = v_base } }, .dest = v_addr, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 99 }, .dest = v_val, .type = .i32 });
+    try block.append(.{ .op = .{ .store = .{ .base = v_addr, .offset = 0, .size = 4, .val = v_val } } });
+    try block.append(.{ .op = .{ .ret = null } });
+
+    const changed = try foldLoadStoreOffset(&func, allocator);
+    try std.testing.expect(changed);
+    const st = func.getBlock(b0).instructions.items[4].op.store;
+    try std.testing.expectEqual(v_base, st.base);
+    try std.testing.expectEqual(@as(u32, 8), st.offset);
+}
+
+test "foldLoadStoreOffset: skips negative const" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const v_base = func.newVReg();
+    const v_c = func.newVReg();
+    const v_addr = func.newVReg();
+    const v_load = func.newVReg();
+    var block = &func.blocks.items[b0];
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = v_base, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = -4 }, .dest = v_c, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v_base, .rhs = v_c } }, .dest = v_addr, .type = .i32 });
+    try block.append(.{ .op = .{ .load = .{ .base = v_addr, .offset = 0, .size = 4 } }, .dest = v_load, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v_load }, .type = .i32 });
+
+    const changed = try foldLoadStoreOffset(&func, allocator);
+    try std.testing.expect(!changed);
+}
+
+test "foldLoadStoreOffset: skips i64 add (memory64 base)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const v_base = func.newVReg();
+    const v_c = func.newVReg();
+    const v_addr = func.newVReg();
+    const v_load = func.newVReg();
+    var block = &func.blocks.items[b0];
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = v_base, .type = .i64 });
+    try block.append(.{ .op = .{ .iconst_32 = 12 }, .dest = v_c, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v_base, .rhs = v_c } }, .dest = v_addr, .type = .i64 });
+    try block.append(.{ .op = .{ .load = .{ .base = v_addr, .offset = 0, .size = 4 } }, .dest = v_load, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v_load }, .type = .i32 });
+
+    const changed = try foldLoadStoreOffset(&func, allocator);
+    try std.testing.expect(!changed);
+}
+
+test "foldLoadStoreOffset: preserves bounds_known" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const v_base = func.newVReg();
+    const v_c = func.newVReg();
+    const v_addr = func.newVReg();
+    const v_load = func.newVReg();
+    var block = &func.blocks.items[b0];
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = v_base, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 4 }, .dest = v_c, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v_base, .rhs = v_c } }, .dest = v_addr, .type = .i32 });
+    try block.append(.{ .op = .{ .load = .{ .base = v_addr, .offset = 0, .size = 4, .bounds_known = true } }, .dest = v_load, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v_load }, .type = .i32 });
+
+    _ = try foldLoadStoreOffset(&func, allocator);
+    const ld = func.getBlock(b0).instructions.items[3].op.load;
+    try std.testing.expect(ld.bounds_known);
+    try std.testing.expectEqual(@as(u32, 4), ld.offset);
 }

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -1492,6 +1492,135 @@ pub fn forwardLocalGet(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool
     return changed;
 }
 
+/// Promote a wasm local to its single defining VReg across blocks, when
+/// safe. Fires only when ALL of the following hold for a non-parameter
+/// local L:
+///   1. L has exactly one `local_set L = v` instruction in the function,
+///      at block W, instruction index k.
+///   2. Every `local_get L` is in a block U with `id(U) >= id(W)` AND
+///      block W dominates U (so the set always executes first dynamically).
+///      For same-block reads (U == W), the get must come strictly after k.
+///
+/// When fired, every `local_get L → dest` is replaced by `dest := v`
+/// (the get is removed and `dest` rewritten to `v` everywhere); the
+/// single `local_set L` is also removed. This removes the wasm-local
+/// entirely from the IR, exposing `v` to constant-folding, CSE, and
+/// LICM across blocks.
+///
+/// Soundness is conservative: we deliberately reject the case where a
+/// dominator def has higher block-id than the use (the AArch64 codegen
+/// iterates blocks in raw id-order and would reject a backward def→use
+/// span). This is the same constraint that makes the staged SSA
+/// pipeline tricky; here we sidestep it by only promoting forward spans.
+///
+/// Intentionally narrow: this is *not* full SSA construction. It does
+/// not introduce phi nodes and only fires for the simplest common case.
+pub fn promoteSingleDefLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    if (func.local_count == 0) return false;
+    const param_count = func.param_count;
+    if (func.local_count <= param_count) return false;
+
+    const SetSite = struct {
+        block: ir.BlockId,
+        inst_idx: usize,
+        val: ir.VReg,
+        ty: ir.IrType,
+    };
+
+    const set_count = try allocator.alloc(u32, func.local_count);
+    defer allocator.free(set_count);
+    @memset(set_count, 0);
+    const set_site = try allocator.alloc(SetSite, func.local_count);
+    defer allocator.free(set_site);
+
+    for (func.blocks.items, 0..) |block, bidx| {
+        for (block.instructions.items, 0..) |inst, iidx| {
+            if (inst.op != .local_set) continue;
+            const ls = inst.op.local_set;
+            if (ls.idx >= func.local_count) continue;
+            set_count[ls.idx] += 1;
+            set_site[ls.idx] = .{
+                .block = @intCast(bidx),
+                .inst_idx = iidx,
+                .val = ls.val,
+                .ty = inst.type,
+            };
+        }
+    }
+
+    // Identify candidates: non-param locals with exactly one local_set.
+    var any_candidate = false;
+    var L: u32 = param_count;
+    while (L < func.local_count) : (L += 1) {
+        if (set_count[L] == 1) { any_candidate = true; break; }
+    }
+    if (!any_candidate) return false;
+
+    var dom = try analysis.computeDominators(func, allocator);
+    defer dom.deinit();
+
+    // Verify each candidate's gets are all dominated and id-ordered.
+    const safe = try allocator.alloc(bool, func.local_count);
+    defer allocator.free(safe);
+    @memset(safe, false);
+
+    L = param_count;
+    while (L < func.local_count) : (L += 1) {
+        if (set_count[L] != 1) continue;
+        const s = set_site[L];
+        var ok = true;
+        outer: for (func.blocks.items, 0..) |block, bidx| {
+            const u_id: ir.BlockId = @intCast(bidx);
+            for (block.instructions.items, 0..) |inst, iidx| {
+                if (inst.op != .local_get) continue;
+                if (inst.op.local_get != L) continue;
+                if (u_id == s.block) {
+                    if (iidx <= s.inst_idx) { ok = false; break :outer; }
+                } else {
+                    if (u_id < s.block) { ok = false; break :outer; }
+                    if (!dom.dominates(s.block, u_id)) { ok = false; break :outer; }
+                }
+            }
+        }
+        if (ok) safe[L] = true;
+    }
+
+    var changed = false;
+    L = param_count;
+    while (L < func.local_count) : (L += 1) {
+        if (!safe[L]) continue;
+        const s = set_site[L];
+
+        // Replace each get's dest with s.val and remove the get.
+        for (func.blocks.items) |*block| {
+            var i: usize = 0;
+            while (i < block.instructions.items.len) {
+                const inst = &block.instructions.items[i];
+                if (inst.op == .local_get and inst.op.local_get == L) {
+                    if (inst.dest) |d| replaceVReg(func, d, s.val);
+                    _ = block.instructions.orderedRemove(i);
+                    continue;
+                }
+                i += 1;
+            }
+        }
+
+        // Remove the unique local_set.
+        const sblock = func.getBlock(s.block);
+        var j: usize = 0;
+        while (j < sblock.instructions.items.len) : (j += 1) {
+            const inst = sblock.instructions.items[j];
+            if (inst.op == .local_set and inst.op.local_set.idx == L) {
+                _ = sblock.instructions.orderedRemove(j);
+                break;
+            }
+        }
+        changed = true;
+    }
+
+    return changed;
+}
+
 /// Remove `local.set K, v` for any local K that is never read by a
 /// `local.get` anywhere in the function. This is intra-procedural and
 /// trivially sound: wasm locals are frame-scoped; calls never observe
@@ -3618,6 +3747,7 @@ pub fn runPasses(module: *ir.IrModule, passes: []const PassFn, allocator: std.me
 /// The default optimization pipeline.
 pub const default_passes: []const PassFn = &.{
     &forwardLocalGet,
+    &promoteSingleDefLocals,
     &constantFold,
     &algebraicSimplify,
     &strengthReduceMul,

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -73,6 +73,13 @@ pub fn buildUseDef(func: *const ir.IrFunction, allocator: std.mem.Allocator) !st
                         entry.value_ptr.use_count += 1;
                     }
                 },
+                .phi => |incoming| {
+                    for (incoming) |inc| {
+                        const entry = try info.getOrPut(inc.value);
+                        if (!entry.found_existing) entry.value_ptr.* = .{};
+                        entry.value_ptr.use_count += 1;
+                    }
+                },
                 else => {},
             }
         }
@@ -239,6 +246,93 @@ pub fn countUsesOfVReg(func: *const ir.IrFunction, vreg: ir.VReg) u32 {
         }
     }
     return count;
+}
+
+/// Whether an instruction reads `vreg` as one of its operands. Mirrors
+/// the structure of `replaceInInst` so call/call_indirect/call_ref/
+/// ret_multi (which `getUsedVRegs` doesn't enumerate) are also covered.
+fn isTerminatorOp(op: ir.Inst.Op) bool {
+    return switch (op) {
+        .br, .br_if, .br_table, .ret, .ret_multi, .@"unreachable" => true,
+        else => false,
+    };
+}
+
+fn instUsesVReg(inst: ir.Inst, vreg: ir.VReg) bool {
+    switch (inst.op) {
+        .iconst_32, .iconst_64, .fconst_32, .fconst_64,
+        .local_get, .global_get, .br, .@"unreachable",
+        => return false,
+
+        .phi => |incoming| {
+            for (incoming) |inc| if (inc.value == vreg) return true;
+            return false;
+        },
+
+        .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
+        .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
+        .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u,
+        .f_min, .f_max, .f_copysign,
+        .f_eq, .f_ne, .f_lt, .f_gt, .f_le, .f_ge,
+        => |bin| return bin.lhs == vreg or bin.rhs == vreg,
+
+        .clz, .ctz, .popcnt, .eqz, .wrap_i64, .extend_i32_s, .extend_i32_u,
+        .extend8_s, .extend16_s, .extend32_s,
+        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest,
+        .trunc_f32_s, .trunc_f32_u, .trunc_f64_s, .trunc_f64_u,
+        .convert_s, .convert_u, .convert_i32_s, .convert_i64_s, .convert_i32_u, .convert_i64_u, .demote_f64, .promote_f32, .reinterpret,
+        .trunc_sat_f32_s, .trunc_sat_f32_u, .trunc_sat_f64_s, .trunc_sat_f64_u,
+        => |v| return v == vreg,
+
+        .local_set => |ls| return ls.val == vreg,
+        .global_set => |gs| return gs.val == vreg,
+        .load => |ld| return ld.base == vreg,
+        .store => |st| return st.base == vreg or st.val == vreg,
+        .br_if => |bi| return bi.cond == vreg,
+        .br_table => |bt| return bt.index == vreg,
+        .ret => |maybe_vreg| return if (maybe_vreg) |v| v == vreg else false,
+        .ret_multi => |vregs| {
+            for (vregs) |v| if (v == vreg) return true;
+            return false;
+        },
+        .call_result => return false,
+        .call => |cl| {
+            for (cl.args) |a| if (a == vreg) return true;
+            return false;
+        },
+        .call_indirect => |ci| {
+            if (ci.elem_idx == vreg) return true;
+            for (ci.args) |a| if (a == vreg) return true;
+            return false;
+        },
+        .call_ref => |cr| {
+            if (cr.func_ref == vreg) return true;
+            for (cr.args) |a| if (a == vreg) return true;
+            return false;
+        },
+        .select => |sel| return sel.cond == vreg or sel.if_true == vreg or sel.if_false == vreg,
+
+        .atomic_fence => return false,
+        .atomic_load => |al| return al.base == vreg,
+        .atomic_store => |ast| return ast.base == vreg or ast.val == vreg,
+        .atomic_rmw => |ar| return ar.base == vreg or ar.val == vreg,
+        .atomic_cmpxchg => |ac| return ac.base == vreg or ac.expected == vreg or ac.replacement == vreg,
+        .atomic_notify => |an| return an.base == vreg or an.count == vreg,
+        .atomic_wait => |aw| return aw.base == vreg or aw.expected == vreg or aw.timeout == vreg,
+        .memory_copy => |mc| return mc.dst == vreg or mc.src == vreg or mc.len == vreg,
+        .memory_fill => |mf| return mf.dst == vreg or mf.val == vreg or mf.len == vreg,
+        .memory_init => |mi| return mi.dst == vreg or mi.src == vreg or mi.len == vreg,
+        .data_drop => return false,
+        .memory_size => return false,
+        .memory_grow => |pages| return pages == vreg,
+        .table_size => return false,
+        .table_get => |tg| return tg.idx == vreg,
+        .table_set => |ts| return ts.idx == vreg or ts.val == vreg,
+        .table_grow => |tg| return tg.init == vreg or tg.delta == vreg,
+        .table_init => |ti| return ti.dst == vreg or ti.src == vreg or ti.len == vreg,
+        .elem_drop => return false,
+        .ref_func => return false,
+    }
 }
 
 fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
@@ -1538,6 +1632,13 @@ pub fn ssaPromoteLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !boo
     @memset(init_vreg, std.math.maxInt(ir.VReg));
 
     const param_count = func.param_count;
+    // Param promotions are recorded separately and their materialising
+    // `local_get → v_init` is inserted AFTER the rename DFS — otherwise
+    // step 4b would see them as ordinary `local_get`s and mark them for
+    // deletion, leaving v_init undefined.
+    const ParamInit = struct { local: u32, dest: ir.VReg, ty: ir.IrType };
+    var param_inits: std.ArrayList(ParamInit) = .empty;
+    defer param_inits.deinit(allocator);
     {
         var entry_block = func.getBlock(0);
         // Build the prefix as a separate buffer to insert atomically at index 0.
@@ -1546,8 +1647,10 @@ pub fn ssaPromoteLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !boo
 
         for (promotable.items) |L| {
             if (L < param_count) {
-                // Implicit param VReg — no instruction; seed stack later.
-                init_vreg[L] = L;
+                const t = local_type[L].?;
+                const v = func.newVReg();
+                try param_inits.append(allocator, .{ .local = L, .dest = v, .ty = t });
+                init_vreg[L] = v;
                 continue;
             }
             const t = local_type[L].?;
@@ -1585,11 +1688,36 @@ pub fn ssaPromoteLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !boo
     }
     for (phis_per_block) |*list| list.* = .empty;
 
-    // Cache deduped predecessor count per block (for sizing phi incoming).
-    const pred_count = try allocator.alloc(usize, nblocks);
-    defer allocator.free(pred_count);
+    // Cache deduped, reachability-filtered predecessor list per block.
+    // The phi's incoming array is sized to and indexed by this list, so
+    // that unreachable predecessors don't leave uninitialized slots
+    // after the DFS rename pass (the DFS only visits reachable blocks).
+    const reach_preds = try allocator.alloc([]ir.BlockId, nblocks);
+    defer {
+        for (reach_preds) |p| allocator.free(p);
+        allocator.free(reach_preds);
+    }
     for (0..nblocks) |i| {
-        pred_count[i] = if (preds.get(@intCast(i))) |p| p.len else 0;
+        const all = preds.get(@intCast(i)) orelse &[_]ir.BlockId{};
+        var n: usize = 0;
+        for (all) |p| {
+            if (p < nblocks and dom.idom[p] != null) n += 1;
+        }
+        // Entry block is reachable by definition; idom[0] is null but
+        // it's still reachable. (We bail earlier if entry has any preds.)
+        if (i == 0 and all.len > 0) {
+            // Defensive: counted as zero above (idom[0] is null), but the
+            // top-of-function bail-out should have already returned false.
+        }
+        const filtered = try allocator.alloc(ir.BlockId, n);
+        var k: usize = 0;
+        for (all) |p| {
+            if (p < nblocks and dom.idom[p] != null) {
+                filtered[k] = p;
+                k += 1;
+            }
+        }
+        reach_preds[i] = filtered;
     }
 
     for (promotable.items) |L| {
@@ -1618,7 +1746,7 @@ pub fn ssaPromoteLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !boo
             // phi placement at entry would be vacuous; defensive).
             if (B == 0) continue;
 
-            const npreds = pred_count[B];
+            const npreds = reach_preds[B].len;
             if (npreds == 0) continue;
             const incoming = try allocator.alloc(ir.Inst.PhiIncoming, npreds);
             // Fill with sentinels; renaming fills real values.
@@ -1773,8 +1901,8 @@ pub fn ssaPromoteLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !boo
             for (succ_list) |S| {
                 if (S >= nblocks) continue;
                 if (dom.idom[S] == null) continue; // unreachable; should be unreachable from us
-                // Find pred-index of B in preds(S).
-                const pred_list = preds.get(S) orelse continue;
+                // Find pred-index of B in reach_preds(S).
+                const pred_list = reach_preds[S];
                 var pi: ?usize = null;
                 for (pred_list, 0..) |p, k| {
                     if (p == B) { pi = k; break; }
@@ -1812,6 +1940,26 @@ pub fn ssaPromoteLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !boo
             k -= 1;
             _ = block.instructions.orderedRemove(marks.items[k]);
         }
+    }
+
+    // ── 6. Materialise param initial-values via `local_get` at entry. ────
+    // We do this AFTER step 5 so the rename DFS can't mark these
+    // freshly-inserted local_gets for deletion (they didn't exist when
+    // step 4b walked the entry block). The aarch64 backend keeps params
+    // in frame slots, not in v0..v(param_count-1), so we need a real
+    // `local_get` instruction to materialise the value as a VReg.
+    if (param_inits.items.len > 0) {
+        var entry_block = func.getBlock(0);
+        var prefix2: std.ArrayList(ir.Inst) = .empty;
+        defer prefix2.deinit(allocator);
+        for (param_inits.items) |pi| {
+            try prefix2.append(allocator, .{
+                .op = .{ .local_get = pi.local },
+                .dest = pi.dest,
+                .type = pi.ty,
+            });
+        }
+        try entry_block.instructions.insertSlice(entry_block.allocator, 0, prefix2.items);
     }
 
     // The phi insertions and zero-init insertions also count as "changes",
@@ -1926,51 +2074,275 @@ pub fn splitCriticalEdges(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
     return changed;
 }
 
-/// Lower phi instructions back to wasm-style local_set / local_get pairs:
-/// for each `phi(...)` in some block B with destination D and type T,
-/// allocate a fresh local L, replace the phi inst with `local_get L → D`,
-/// and append `local_set L = incoming.value` before the terminator of
-/// each incoming.block.
-///
-/// Requires that critical edges have been split (see `splitCriticalEdges`),
-/// otherwise the inserted `local_set` could execute on a path that does
-/// not reach B.
+/// Lower phi instructions back to wasm-style local_set / local_get pairs.
+/// For each `phi(...)` at block B with destination D and type T:
+///   1. Allocate a fresh local L.
+///   2. Insert `local_set L = incoming.value` before the terminator of
+///      each incoming block (these must be split critical edges — see
+///      `splitCriticalEdges`, or the set would execute on paths that
+///      don't reach B).
+///   3. For every USE of D anywhere in the function, insert a fresh
+///      `local_get L → V'` immediately before the using instruction and
+///      rewrite that operand from D to V'. This rebinding is required
+///      because the AArch64 codegen iterates blocks in raw block-id
+///      order: a use of D in a block whose id is less than B's would
+///      otherwise reach codegen before D's def, producing
+///      `error.UnboundVReg`. Per-use rebinding ensures every def lives
+///      in the same block as its use.
+///   4. Replace the phi inst with `local_get L → D` (D is now dead but
+///      keeping it keeps inst-shapes simple; DCE will remove the
+///      unused def).
 pub fn lowerPhisToLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
-    _ = allocator;
-    var changed = false;
-    for (func.blocks.items) |*block| {
-        for (block.instructions.items) |*inst| {
-            if (inst.op != .phi) continue;
+    const PhiSiteRec = struct {
+        block: ir.BlockId,
+        dest: ir.VReg,
+        ty: ir.IrType,
+        local: u32,
+        incoming: []const ir.Inst.PhiIncoming,
+    };
+    var sites: std.ArrayList(PhiSiteRec) = .empty;
+    defer sites.deinit(allocator);
 
-            const incoming = inst.op.phi;
-            const dest = inst.dest.?;
-            const ty = inst.type;
+    for (func.blocks.items, 0..) |block, bidx| {
+        for (block.instructions.items) |inst| {
+            if (inst.op != .phi) continue;
             const l = func.local_count;
             func.local_count += 1;
-
-            for (incoming) |inc| {
-                const pblock = func.getBlock(inc.block);
-                const pset = ir.Inst{
-                    .op = .{ .local_set = .{ .idx = l, .val = inc.value } },
-                    .type = ty,
-                };
-                // Insert before the terminator (always the last inst).
-                std.debug.assert(pblock.instructions.items.len > 0);
-                const last = pblock.instructions.items.len - 1;
-                try pblock.instructions.insert(pblock.allocator, last, pset);
-            }
-
-            // Replace the phi inst in place. Free the incoming slice now
-            // because BasicBlock.deinit only frees phi-tagged ops.
-            block.allocator.free(incoming);
-            inst.* = .{
-                .op = .{ .local_get = l },
-                .dest = dest,
-                .type = ty,
-            };
-            changed = true;
+            try sites.append(allocator, .{
+                .block = @intCast(bidx),
+                .dest = inst.dest.?,
+                .ty = inst.type,
+                .local = l,
+                .incoming = inst.op.phi,
+            });
         }
     }
+    if (sites.items.len == 0) return false;
+
+    // Build dest→site lookup so we can detect phi-of-phi incoming refs.
+    var dest_to_site: std.AutoHashMap(ir.VReg, usize) = .init(allocator);
+    defer dest_to_site.deinit();
+    for (sites.items, 0..) |site, idx| {
+        try dest_to_site.put(site.dest, idx);
+    }
+
+    // Step 2: insert local_set on each incoming edge, before its FIRST
+    // terminator. (The wasm frontend can emit unreachable instructions after
+    // a terminator within the same block; we must insert before the first
+    // executed control-flow instruction.)
+    //
+    // If `inc.value` is itself another phi's dest (phi-of-phi), the source
+    // value is no longer live as a VReg in the predecessor block — it's
+    // carried via `source_site.local`. Emit a `local_get → fresh_vreg`
+    // first, then set our local from that fresh vreg.
+    for (sites.items) |site| {
+        for (site.incoming) |inc| {
+            const pblock = func.getBlock(inc.block);
+            std.debug.assert(pblock.instructions.items.len > 0);
+            var insert_at: usize = pblock.instructions.items.len;
+            for (pblock.instructions.items, 0..) |pinst, idx| {
+                if (isTerminatorOp(pinst.op)) { insert_at = idx; break; }
+            }
+            var src_val: ir.VReg = inc.value;
+            if (dest_to_site.get(inc.value)) |src_idx| {
+                const src_site = sites.items[src_idx];
+                const fresh = func.newVReg();
+                try pblock.instructions.insert(pblock.allocator, insert_at, .{
+                    .op = .{ .local_get = src_site.local },
+                    .type = src_site.ty,
+                    .dest = fresh,
+                });
+                insert_at += 1;
+                src_val = fresh;
+            }
+            try pblock.instructions.insert(pblock.allocator, insert_at, .{
+                .op = .{ .local_set = .{ .idx = site.local, .val = src_val } },
+                .type = site.ty,
+            });
+        }
+    }
+
+    // Step 3: rebind every use of each phi.dest to a per-use local_get.
+    // Walking is per-site so the inst-uses helper handles one VReg at a time.
+    for (sites.items) |site| {
+        for (func.blocks.items) |*block| {
+            var i: usize = 0;
+            while (i < block.instructions.items.len) {
+                const inst = &block.instructions.items[i];
+                // Skip phi: never observed to use vregs by getUsedVRegs,
+                // and we'd rewrite its incoming via replaceInInst on a
+                // per-block basis — but phis at OTHER blocks may have
+                // incoming.value == site.dest (referring to phi-of-phi).
+                // Handle that explicitly here.
+                if (inst.op == .phi) {
+                    const incoming = @constCast(inst.op.phi);
+                    var any_phi_use = false;
+                    for (incoming) |inc| {
+                        if (inc.value == site.dest) { any_phi_use = true; break; }
+                    }
+                    if (any_phi_use) {
+                        // This is rare (a phi feeds another phi). The
+                        // straightforward rebind is: the local_set on
+                        // the edge feeding *this* phi already wrote
+                        // site.local with the right value, so the
+                        // operand from site.dest needs a fresh local_get
+                        // emitted in the predecessor block. Doing so
+                        // here is awkward; instead, we leave the phi
+                        // operand alone — its `incoming.value` is a
+                        // VReg ref that codegen never sees (phis are
+                        // already lowered for THIS site, but other
+                        // phis are still pending). This works because
+                        // the OTHER phi's lowering will run its own
+                        // step 2 from inc.block, where site.local was
+                        // also set (transitively, if site.dest was
+                        // forwarded via stack-rename through that
+                        // pred). In practice, a phi-of-phi is the
+                        // edge case; for now require the caller's
+                        // pipeline to lower phis in a single sweep,
+                        // which this function does. Just continue.
+                    }
+                    i += 1;
+                    continue;
+                }
+                const used_dest = instUsesVReg(inst.*, site.dest);
+                if (used_dest) {
+                    const fresh = func.newVReg();
+                    try block.instructions.insert(block.allocator, i, .{
+                        .op = .{ .local_get = site.local },
+                        .dest = fresh,
+                        .type = site.ty,
+                    });
+                    // The instruction we want to rewrite is now at i+1.
+                    replaceInInst(&block.instructions.items[i + 1], site.dest, fresh);
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    // Step 4: replace each phi inst with `local_get L → dest`. Indices
+    // have shifted because of the local_set inserts at predecessors and
+    // local_get inserts at use sites, so locate phis by scanning each
+    // block fresh and matching on (dest, op == phi).
+    for (sites.items) |site| {
+        const block_ptr = func.getBlock(site.block);
+        for (block_ptr.instructions.items) |*inst| {
+            if (inst.op != .phi) continue;
+            if (inst.dest.? != site.dest) continue;
+            // Free the incoming slice we own (BasicBlock.deinit only
+            // frees still-tagged phi ops, and we're about to retag).
+            block_ptr.allocator.free(@constCast(inst.op.phi));
+            inst.* = .{
+                .op = .{ .local_get = site.local },
+                .dest = site.dest,
+                .type = site.ty,
+            };
+            break;
+        }
+    }
+    return true;
+}
+
+/// Fix block-id-order liveness violations introduced by ssaPromoteLocals.
+///
+/// The aarch64 backend iterates `func.blocks.items` in raw block-id order
+/// when binding vregs to physical registers/stack slots. A vreg defined in
+/// block W and used in block U requires `id(W) <= id(U)`. SSA promotion
+/// removes the `local_set/local_get` round-trips that previously masked
+/// violations, so any def→use pair that violates the order surfaces as
+/// `error.UnboundVReg` at codegen time.
+///
+/// For each violating (V, use-site U), we:
+///   1. Allocate a synthetic local L_V (once per V).
+///   2. Insert `local_set L_V, V` immediately after V's def in W.
+///   3. Replace the violating use with a fresh `local_get L_V → fresh`
+///      inserted immediately before the using instruction.
+///
+/// Param vregs (0..param_count) are bound by the codegen prologue and
+/// always available; we treat them as defined at block 0.
+pub fn fixCrossBlockLiveness(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    const N = func.next_vreg;
+    if (N == 0) return false;
+
+    const def_block = try allocator.alloc(?ir.BlockId, N);
+    defer allocator.free(def_block);
+    @memset(def_block, null);
+    const def_type = try allocator.alloc(ir.IrType, N);
+    defer allocator.free(def_type);
+
+    var p: u32 = 0;
+    while (p < func.param_count and p < N) : (p += 1) def_block[p] = 0;
+
+    for (func.blocks.items, 0..) |block, bidx| {
+        for (block.instructions.items) |inst| {
+            if (inst.dest) |d| {
+                if (d < N) {
+                    def_block[d] = @intCast(bidx);
+                    def_type[d] = inst.type;
+                }
+            }
+        }
+    }
+
+    var local_for: std.AutoHashMap(ir.VReg, u32) = .init(allocator);
+    defer local_for.deinit();
+
+    var changed = false;
+
+    for (func.blocks.items, 0..) |*ublock, ubidx| {
+        const u_id: ir.BlockId = @intCast(ubidx);
+        var i: usize = 0;
+        while (i < ublock.instructions.items.len) {
+            const inst = &ublock.instructions.items[i];
+            var advanced = false;
+            var v: ir.VReg = 0;
+            while (v < N) : (v += 1) {
+                const w_opt = def_block[v];
+                if (w_opt == null) continue;
+                const w = w_opt.?;
+                if (w <= u_id) continue;
+                if (!instUsesVReg(inst.*, v)) continue;
+
+                const l = blk: {
+                    if (local_for.get(v)) |existing| break :blk existing;
+                    const new_l = func.local_count;
+                    func.local_count += 1;
+                    try local_for.put(v, new_l);
+                    const def_blk = func.getBlock(w);
+                    var ins_at: usize = def_blk.instructions.items.len;
+                    for (def_blk.instructions.items, 0..) |dinst, di| {
+                        if (dinst.dest) |dd| {
+                            if (dd == v) {
+                                ins_at = di + 1;
+                                break;
+                            }
+                        }
+                    }
+                    try def_blk.instructions.insert(def_blk.allocator, ins_at, .{
+                        .op = .{ .local_set = .{ .idx = new_l, .val = v } },
+                        .type = def_type[v],
+                    });
+                    break :blk new_l;
+                };
+
+                const fresh = func.newVReg();
+                try ublock.instructions.insert(ublock.allocator, i, .{
+                    .op = .{ .local_get = l },
+                    .dest = fresh,
+                    .type = def_type[v],
+                });
+                replaceInInst(&ublock.instructions.items[i + 1], v, fresh);
+                i += 1;
+                advanced = true;
+                changed = true;
+                break;
+            }
+            if (!advanced) i += 1;
+        }
+    }
+
     return changed;
 }
 
@@ -2894,6 +3266,17 @@ pub fn runPasses(module: *ir.IrModule, passes: []const PassFn, allocator: std.me
         total_changes += 1;
     }
     for (module.functions.items) |*func| {
+        // SSA-form pipeline integration is staged but disabled pending a
+        // soundness fix: enabling `splitCriticalEdges → ssaPromoteLocals →
+        // ... → lowerPhisToLocals → fixCrossBlockLiveness` produces the
+        // expected register-promoted IR and passes all unit/differential
+        // tests, but CoreMark observes wrong CRCs. The infrastructure is
+        // kept as `pub` functions for individual reuse and unit testing.
+        // Re-enable once the CRC mismatch is root-caused.
+        if (false) {
+            if (try splitCriticalEdges(func, allocator)) total_changes += 1;
+            if (try ssaPromoteLocals(func, allocator)) total_changes += 1;
+        }
         // Iterate the pipeline until fixpoint so that passes can re-expose
         // opportunities for each other (e.g. constantFold → CSE → DCE →
         // more constantFold). Cap iterations as a safety net.
@@ -2907,6 +3290,10 @@ pub fn runPasses(module: *ir.IrModule, passes: []const PassFn, allocator: std.me
                 }
             }
             if (!any_changed) break;
+        }
+        if (false) {
+            if (try lowerPhisToLocals(func, allocator)) total_changes += 1;
+            if (try fixCrossBlockLiveness(func, allocator)) total_changes += 1;
         }
     }
     return total_changes;
@@ -5548,7 +5935,7 @@ fn countOp(func: *const ir.IrFunction, want: std.meta.Tag(ir.Inst.Op)) usize {
     return n;
 }
 
-test "ssaPromoteLocals: single-block param read removes local_get" {
+test "ssaPromoteLocals: single-block param read materialises one local_get" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 1, 1, 1);
     defer func.deinit();
@@ -5564,10 +5951,15 @@ test "ssaPromoteLocals: single-block param read removes local_get" {
     const changed = try ssaPromoteLocals(&func, allocator);
     try std.testing.expect(changed);
 
-    // local_get should be gone; ret should now reference param VReg 0.
-    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .local_get));
-    const ret_inst = func.getBlock(0).instructions.items[func.getBlock(0).instructions.items.len - 1];
-    try std.testing.expectEqual(@as(?ir.VReg, 0), ret_inst.op.ret);
+    // After SSA promotion, the param's value is materialised once via a
+    // single entry `local_get` whose dest is reused by the renamed body.
+    // The original body `local_get` is removed.
+    try std.testing.expectEqual(@as(usize, 1), countOp(&func, .local_get));
+    const block = func.getBlock(0);
+    try std.testing.expect(block.instructions.items[0].op == .local_get);
+    const param_init_dest = block.instructions.items[0].dest.?;
+    const ret_inst = block.instructions.items[block.instructions.items.len - 1];
+    try std.testing.expectEqual(@as(?ir.VReg, param_init_dest), ret_inst.op.ret);
     // No phi inserted (no merge points).
     try std.testing.expectEqual(@as(usize, 0), countOp(&func, .phi));
 }
@@ -5609,10 +6001,10 @@ test "ssaPromoteLocals: diamond merge inserts phi" {
     const changed = try ssaPromoteLocals(&func, allocator);
     try std.testing.expect(changed);
 
-    // local_get / local_set for local 1 should be gone.
+    // local_set should be gone; one entry `local_get` remains for the param's
+    // initial value (aarch64 backend keeps params in frame slots).
     try std.testing.expectEqual(@as(usize, 0), countOp(&func, .local_set));
-    // local_get for param 0 in b0 also removed.
-    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .local_get));
+    try std.testing.expectEqual(@as(usize, 1), countOp(&func, .local_get));
 
     // Exactly one phi inserted at b3.
     try std.testing.expectEqual(@as(usize, 1), countOp(&func, .phi));
@@ -5751,10 +6143,13 @@ test "ssaPromoteLocals: idempotent on already-promoted IR" {
     try func.getBlock(b0).append(.{ .op = .{ .ret = v_get }, .type = .i32 });
 
     _ = try ssaPromoteLocals(&func, allocator);
-    const second = try ssaPromoteLocals(&func, allocator);
-    // After first run there are no local_get/set left, so second run should
-    // see no promotable locals (no local_get observed) and return false.
-    try std.testing.expect(!second);
+    const get_count_after_first = countOp(&func, .local_get);
+    _ = try ssaPromoteLocals(&func, allocator);
+    // The pass may report further changes on a second run (re-materialising
+    // the entry param-init `local_get`), but the resulting IR shape should
+    // be stable: the count of `local_get` does not grow indefinitely.
+    try std.testing.expectEqual(get_count_after_first, countOp(&func, .local_get));
+    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .local_set));
 }
 
 // ── splitCriticalEdges / lowerPhisToLocals tests ───────────────────────────

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -1429,6 +1429,400 @@ pub fn deadLocalSetElimination(func: *ir.IrFunction, allocator: std.mem.Allocato
     return changed;
 }
 
+// ── SSA Promotion of Wasm Locals ───────────────────────────────────────────
+
+/// Promote wasm locals to SSA form: replace `local_get`/`local_set` with
+/// direct value flow, inserting `phi` nodes at iterated dominance frontiers
+/// where multiple def reaching definitions converge.
+///
+/// **Pipeline integration**: this pass produces phi instructions, which
+/// downstream code (`deadCodeElimination`, liveness/regalloc, codegen) is
+/// NOT yet phi-aware. It is therefore intentionally NOT a member of
+/// `default_passes`. A separate `lowerPhisToLocals` pass (Slice 3) must run
+/// before any phi-incompatible pass; until that pass exists this function
+/// is callable for tests only.
+///
+/// **Algorithm** (Cytron / Cooper-Harvey-Kennedy variant):
+///   1. Discover each promotable local's IrType from its `local_get` uses
+///      (`local_set.inst.type` is unreliable — frontend leaves it default).
+///      Locals with no `local_get` are skipped (`deadLocalSetElimination`
+///      already removes their writes).
+///   2. For non-param promotable locals materialise an entry-block
+///      `iconst_*0` / `fconst_*0` defining their wasm-zero initial value.
+///      Param locals (idx < `param_count`) use the implicit param VReg
+///      `idx`; no instruction is inserted.
+///   3. Per-local def_blocks = {entry} ∪ {B : B has `local_set L`}; place a
+///      `phi` at the head of every block in IDF(def_blocks(L)). The phi's
+///      `incoming` is sized to `|preds(B)|` and filled with sentinels;
+///      renaming fills the actual values.
+///   4. Iterative dom-tree DFS renames: per-local stack of "current
+///      reaching def VReg". On entering a block, push each phi.dest; on
+///      seeing `local_get L` rewrite all uses of its dest to stack top
+///      (`replaceVReg`) and mark for deletion; on seeing `local_set L,v`
+///      push `v` and mark for deletion; on each successor edge fill the
+///      successor's phi incoming for that pred from current stack tops.
+///   5. Drop all marked instructions.
+///
+/// **Bail-outs**:
+///   - If the entry block has any predecessors (back-edges to function
+///     start), the seeded-stack scheme cannot encode the implicit
+///     "function-entry" edge for any phi placed at entry. We bail out
+///     (return false, no IR change). This is uncommon in practice; the
+///     frontend's entry block has no preds.
+///   - Unreachable blocks (`dom.idom == null`) are filtered out at every
+///     step.
+///
+/// Returns `true` iff any IR was rewritten.
+pub fn ssaPromoteLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    const nblocks = func.blocks.items.len;
+    if (nblocks == 0 or func.local_count == 0) return false;
+
+    // ── Bail if entry block has any predecessor ──────────────────────────
+    var preds = try analysis.buildPredecessors(func, allocator);
+    defer {
+        var pit = preds.iterator();
+        while (pit.next()) |entry| allocator.free(entry.value_ptr.*);
+        preds.deinit();
+    }
+    if (preds.get(0)) |p0| {
+        if (p0.len != 0) return false;
+    }
+
+    var dom = try analysis.computeDominators(func, allocator);
+    defer dom.deinit();
+
+    // ── 1. Discover promotable locals and their types ────────────────────
+    const local_count = func.local_count;
+    const local_type = try allocator.alloc(?ir.IrType, local_count);
+    defer allocator.free(local_type);
+    @memset(local_type, null);
+    const local_seen_get = try allocator.alloc(bool, local_count);
+    defer allocator.free(local_seen_get);
+    @memset(local_seen_get, false);
+
+    for (func.blocks.items, 0..) |block, bidx| {
+        if (dom.idom[bidx] == null) continue;
+        for (block.instructions.items) |inst| {
+            switch (inst.op) {
+                .local_get => |idx| {
+                    if (idx >= local_count) continue;
+                    local_seen_get[idx] = true;
+                    if (local_type[idx]) |existing| {
+                        // Frontend should be type-consistent across uses
+                        // of one local. If this ever fires we'd silently
+                        // mis-promote; flag in debug builds.
+                        std.debug.assert(existing == inst.type);
+                    } else {
+                        local_type[idx] = inst.type;
+                    }
+                },
+                else => {},
+            }
+        }
+    }
+
+    // Collect promotable indices (any local that has at least one read).
+    var promotable: std.ArrayList(u32) = .empty;
+    defer promotable.deinit(allocator);
+    for (local_seen_get, 0..) |seen, idx| {
+        if (seen) try promotable.append(allocator, @intCast(idx));
+    }
+    if (promotable.items.len == 0) return false;
+
+    // ── 2. Materialise zero-init for non-param promotable locals ─────────
+    // Insert iconst/fconst with value 0 at the head of entry block, in a
+    // stable order (ascending local index), and remember each local's
+    // initial-def VReg.
+    const init_vreg = try allocator.alloc(ir.VReg, local_count);
+    defer allocator.free(init_vreg);
+    @memset(init_vreg, std.math.maxInt(ir.VReg));
+
+    const param_count = func.param_count;
+    {
+        var entry_block = func.getBlock(0);
+        // Build the prefix as a separate buffer to insert atomically at index 0.
+        var prefix: std.ArrayList(ir.Inst) = .empty;
+        defer prefix.deinit(allocator);
+
+        for (promotable.items) |L| {
+            if (L < param_count) {
+                // Implicit param VReg — no instruction; seed stack later.
+                init_vreg[L] = L;
+                continue;
+            }
+            const t = local_type[L].?;
+            const v = func.newVReg();
+            const op: ir.Inst.Op = switch (t) {
+                .i32 => .{ .iconst_32 = 0 },
+                .i64 => .{ .iconst_64 = 0 },
+                .f32 => .{ .fconst_32 = 0.0 },
+                .f64 => .{ .fconst_64 = 0.0 },
+                .void => unreachable,
+            };
+            try prefix.append(allocator, .{ .op = op, .dest = v, .type = t });
+            init_vreg[L] = v;
+        }
+
+        if (prefix.items.len > 0) {
+            // Insert prefix.items at index 0 of entry_block.instructions.
+            try entry_block.instructions.insertSlice(entry_block.allocator, 0, prefix.items);
+        }
+    }
+
+    // ── 3. Compute def_blocks(L), IDF, insert phis ───────────────────────
+    var df = try analysis.computeDominanceFrontier(func, &dom, allocator);
+    defer df.deinit();
+
+    // For each block B and local L promoted-here-as-phi: stores the inst
+    // index of the phi within B and the phi's dest VReg. We use this both
+    // to fill incoming during rename and to push phi.dest onto stack[L]
+    // when entering B.
+    const PhiSite = struct { local: u32, dest: ir.VReg, inst_idx: usize };
+    const phis_per_block = try allocator.alloc(std.ArrayList(PhiSite), nblocks);
+    defer {
+        for (phis_per_block) |*list| list.deinit(allocator);
+        allocator.free(phis_per_block);
+    }
+    for (phis_per_block) |*list| list.* = .empty;
+
+    // Cache deduped predecessor count per block (for sizing phi incoming).
+    const pred_count = try allocator.alloc(usize, nblocks);
+    defer allocator.free(pred_count);
+    for (0..nblocks) |i| {
+        pred_count[i] = if (preds.get(@intCast(i))) |p| p.len else 0;
+    }
+
+    for (promotable.items) |L| {
+        // def_blocks = {entry} ∪ {B reachable : B has local_set L}
+        var def_blocks: std.ArrayList(ir.BlockId) = .empty;
+        defer def_blocks.deinit(allocator);
+        try def_blocks.append(allocator, 0);
+        for (func.blocks.items, 0..) |block, bidx| {
+            if (bidx == 0) continue;
+            if (dom.idom[bidx] == null) continue;
+            for (block.instructions.items) |inst| {
+                if (inst.op == .local_set and inst.op.local_set.idx == L) {
+                    try def_blocks.append(allocator, @intCast(bidx));
+                    break;
+                }
+            }
+        }
+
+        const idf = try analysis.iteratedDominanceFrontier(&df, def_blocks.items, allocator);
+        defer allocator.free(idf);
+
+        for (idf) |B| {
+            // Skip unreachable blocks defensively (shouldn't appear).
+            if (dom.idom[B] == null) continue;
+            // Skip entry block (we bailed earlier if it had preds, so any
+            // phi placement at entry would be vacuous; defensive).
+            if (B == 0) continue;
+
+            const npreds = pred_count[B];
+            if (npreds == 0) continue;
+            const incoming = try allocator.alloc(ir.Inst.PhiIncoming, npreds);
+            // Fill with sentinels; renaming fills real values.
+            for (incoming) |*inc| inc.* = .{ .block = std.math.maxInt(ir.BlockId), .value = std.math.maxInt(ir.VReg) };
+
+            const phi_dest = func.newVReg();
+            const phi_inst: ir.Inst = .{ .op = .{ .phi = incoming }, .dest = phi_dest, .type = local_type[L].? };
+
+            // Insert at head of B (after any phis already placed there
+            // for earlier locals — append to the contiguous phi prefix).
+            const block_ptr = func.getBlock(B);
+            // Find the first non-phi instruction in B; insert before it.
+            var insert_at: usize = 0;
+            while (insert_at < block_ptr.instructions.items.len and block_ptr.instructions.items[insert_at].op == .phi) {
+                insert_at += 1;
+            }
+            try block_ptr.instructions.insert(block_ptr.allocator, insert_at, phi_inst);
+
+            try phis_per_block[B].append(allocator, .{ .local = L, .dest = phi_dest, .inst_idx = insert_at });
+        }
+    }
+
+    // After phi insertion, the recorded `inst_idx` is correct for each
+    // phi at insertion time, but later phi insertions in the same block
+    // shift earlier indices. Recompute by scanning.
+    for (0..nblocks) |bidx| {
+        const block = func.getBlock(@intCast(bidx));
+        var i: usize = 0;
+        var site_idx: usize = 0;
+        // The phis_per_block list was appended in IDF iteration order; the
+        // actual head-of-block scan order is identical (we always inserted
+        // at the end of the existing phi prefix, so IDF order == block
+        // order). Just refresh inst_idx 0..N.
+        while (i < block.instructions.items.len and block.instructions.items[i].op == .phi) : (i += 1) {
+            if (site_idx < phis_per_block[bidx].items.len) {
+                phis_per_block[bidx].items[site_idx].inst_idx = i;
+                site_idx += 1;
+            }
+        }
+    }
+
+    // ── 4. Rename via iterative dom-tree DFS ─────────────────────────────
+    // Build dom-tree children list (invert idom, excluding self-edge of
+    // entry).
+    const dom_children = try allocator.alloc(std.ArrayList(ir.BlockId), nblocks);
+    defer {
+        for (dom_children) |*list| list.deinit(allocator);
+        allocator.free(dom_children);
+    }
+    for (dom_children) |*list| list.* = .empty;
+    for (0..nblocks) |b| {
+        if (dom.idom[b]) |id| {
+            if (id != b) try dom_children[id].append(allocator, @intCast(b));
+        }
+    }
+
+    // Successors (for phi-edge filling at end of each block).
+    var succs = try analysis.buildSuccessors(func, allocator);
+    defer {
+        var sit = succs.iterator();
+        while (sit.next()) |entry| allocator.free(entry.value_ptr.*);
+        succs.deinit();
+    }
+
+    // Per-local stack of current reaching def VReg.
+    const stacks = try allocator.alloc(std.ArrayList(ir.VReg), local_count);
+    defer {
+        for (stacks) |*s| s.deinit(allocator);
+        allocator.free(stacks);
+    }
+    for (stacks) |*s| s.* = .empty;
+
+    // Seed stacks with the initial def for each promotable local.
+    for (promotable.items) |L| {
+        try stacks[L].append(allocator, init_vreg[L]);
+    }
+
+    // Mark instructions for deletion (per block, sorted indices).
+    const deletion_marks = try allocator.alloc(std.ArrayList(usize), nblocks);
+    defer {
+        for (deletion_marks) |*list| list.deinit(allocator);
+        allocator.free(deletion_marks);
+    }
+    for (deletion_marks) |*list| list.* = .empty;
+
+    // Iterative DFS: each stack frame is (block, phase, push_count).
+    // phase 0: process block contents and queue children.
+    // phase 1: pop the recorded number of stack pushes.
+    const Frame = struct {
+        block: ir.BlockId,
+        phase: u8,
+        // Count of (local, vreg) pushes onto each promoted local's stack
+        // performed in this block; used at unwind. Stored as a flat
+        // list of local indices to pop.
+        pop_locals: std.ArrayList(u32),
+    };
+    var dfs_stack: std.ArrayList(Frame) = .empty;
+    defer {
+        for (dfs_stack.items) |*f| f.pop_locals.deinit(allocator);
+        dfs_stack.deinit(allocator);
+    }
+
+    try dfs_stack.append(allocator, .{ .block = 0, .phase = 0, .pop_locals = .empty });
+
+    while (dfs_stack.items.len > 0) {
+        const top = &dfs_stack.items[dfs_stack.items.len - 1];
+        if (top.phase == 1) {
+            // Unwind: pop everything pushed in this block.
+            for (top.pop_locals.items) |L| _ = stacks[L].pop();
+            top.pop_locals.deinit(allocator);
+            _ = dfs_stack.pop();
+            continue;
+        }
+        top.phase = 1;
+
+        const B = top.block;
+        const block_ptr = func.getBlock(B);
+
+        // 4a. Push all phi.dest of this block onto their local stacks.
+        for (phis_per_block[B].items) |site| {
+            try stacks[site.local].append(allocator, site.dest);
+            try top.pop_locals.append(allocator, site.local);
+        }
+
+        // 4b. Walk non-phi instructions, rename uses of local_get and push
+        //     defs of local_set.
+        for (block_ptr.instructions.items, 0..) |*inst, iidx| {
+            switch (inst.op) {
+                .phi => continue,
+                .local_get => |idx| {
+                    if (idx >= local_count) continue;
+                    if (!local_seen_get[idx]) continue; // not promoted (defensive)
+                    const cur_top = stacks[idx].items[stacks[idx].items.len - 1];
+                    if (inst.dest) |d| {
+                        if (d != cur_top) replaceVReg(func, d, cur_top);
+                    }
+                    try deletion_marks[B].append(allocator, iidx);
+                },
+                .local_set => |ls| {
+                    if (ls.idx >= local_count) continue;
+                    if (!local_seen_get[ls.idx]) continue;
+                    try stacks[ls.idx].append(allocator, ls.val);
+                    try top.pop_locals.append(allocator, ls.idx);
+                    try deletion_marks[B].append(allocator, iidx);
+                },
+                else => {},
+            }
+        }
+
+        // 4c. For each successor S, fill its phis' incoming entry for B.
+        if (succs.get(B)) |succ_list| {
+            for (succ_list) |S| {
+                if (S >= nblocks) continue;
+                if (dom.idom[S] == null) continue; // unreachable; should be unreachable from us
+                // Find pred-index of B in preds(S).
+                const pred_list = preds.get(S) orelse continue;
+                var pi: ?usize = null;
+                for (pred_list, 0..) |p, k| {
+                    if (p == B) { pi = k; break; }
+                }
+                const pred_idx = pi orelse continue;
+                for (phis_per_block[S].items) |site| {
+                    const top_v = stacks[site.local].items[stacks[site.local].items.len - 1];
+                    const sblock = func.getBlock(S);
+                    const inst_ptr = &sblock.instructions.items[site.inst_idx];
+                    const incoming = @constCast(inst_ptr.op.phi);
+                    incoming[pred_idx] = .{ .block = B, .value = top_v };
+                }
+            }
+        }
+
+        // 4d. Queue dom-tree children (in reverse so they're processed
+        //     in ascending order — not semantically required but stable).
+        var ci: usize = dom_children[B].items.len;
+        while (ci > 0) {
+            ci -= 1;
+            try dfs_stack.append(allocator, .{ .block = dom_children[B].items[ci], .phase = 0, .pop_locals = .empty });
+        }
+    }
+
+    // ── 5. Remove marked instructions in each block ──────────────────────
+    var changed = false;
+    for (deletion_marks, 0..) |marks, bidx| {
+        if (marks.items.len == 0) continue;
+        changed = true;
+        const block = func.getBlock(@intCast(bidx));
+        // Marks are appended in ascending order during the rename walk;
+        // remove from highest to lowest to keep earlier indices stable.
+        var k: usize = marks.items.len;
+        while (k > 0) {
+            k -= 1;
+            _ = block.instructions.orderedRemove(marks.items[k]);
+        }
+    }
+
+    // The phi insertions and zero-init insertions also count as "changes",
+    // even when no local_get/set was renamed (degenerate case; nothing to
+    // rename, no phi placed → nothing inserted either, so falling through
+    // here is fine). Phi insertion always implies a deletion happened
+    // (the phi'd local must have a get somewhere).
+    if (promotable.items.len > 0) changed = true;
+    return changed;
+}
+
 /// Constant-fold `br_if` whose condition is a known `iconst_32`. If the
 /// condition is zero, rewrite to `br else_block`; otherwise rewrite to
 /// `br then_block`. Uses a per-block iconst_32 map (conditions are
@@ -4989,4 +5383,225 @@ test "foldWrapOfExtend: composes with DCE to drop the extend" {
         try std.testing.expect(inst.op != .extend_i32_s);
         try std.testing.expect(inst.op != .wrap_i64);
     }
+}
+
+// ── ssaPromoteLocals tests ─────────────────────────────────────────────────
+
+fn countOp(func: *const ir.IrFunction, want: std.meta.Tag(ir.Inst.Op)) usize {
+    var n: usize = 0;
+    for (func.blocks.items) |b| {
+        for (b.instructions.items) |inst| {
+            if (@as(std.meta.Tag(ir.Inst.Op), inst.op) == want) n += 1;
+        }
+    }
+    return n;
+}
+
+test "ssaPromoteLocals: single-block param read removes local_get" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 1);
+    defer func.deinit();
+
+    // Param VReg = 0 (param_count = 1).
+    _ = func.newVReg(); // v0 = param 0
+    const b0 = try func.newBlock();
+    const v_get = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_get, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .ret = v_get }, .type = .i32 });
+
+
+    const changed = try ssaPromoteLocals(&func, allocator);
+    try std.testing.expect(changed);
+
+    // local_get should be gone; ret should now reference param VReg 0.
+    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .local_get));
+    const ret_inst = func.getBlock(0).instructions.items[func.getBlock(0).instructions.items.len - 1];
+    try std.testing.expectEqual(@as(?ir.VReg, 0), ret_inst.op.ret);
+    // No phi inserted (no merge points).
+    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .phi));
+}
+
+test "ssaPromoteLocals: diamond merge inserts phi" {
+    const allocator = std.testing.allocator;
+    // 1 param (cond), 1 declared local (val).
+    var func = ir.IrFunction.init(allocator, 1, 1, 2);
+    defer func.deinit();
+    _ = func.newVReg(); // v0 = param 0 (cond)
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+
+    // b0: br_if param0 -> b1, b2
+    const v_cond = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b1, .else_block = b2 } } });
+
+    // b1: local.set 1, 100; br b3
+    const v_c100 = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 100 }, .dest = v_c100, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .local_set = .{ .idx = 1, .val = v_c100 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b3 } });
+
+    // b2: local.set 1, 200; br b3
+    const v_c200 = func.newVReg();
+    try func.getBlock(b2).append(.{ .op = .{ .iconst_32 = 200 }, .dest = v_c200, .type = .i32 });
+    try func.getBlock(b2).append(.{ .op = .{ .local_set = .{ .idx = 1, .val = v_c200 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+
+    // b3: local.get 1; ret
+    const v_get = func.newVReg();
+    try func.getBlock(b3).append(.{ .op = .{ .local_get = 1 }, .dest = v_get, .type = .i32 });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = v_get }, .type = .i32 });
+
+    const changed = try ssaPromoteLocals(&func, allocator);
+    try std.testing.expect(changed);
+
+    // local_get / local_set for local 1 should be gone.
+    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .local_set));
+    // local_get for param 0 in b0 also removed.
+    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .local_get));
+
+    // Exactly one phi inserted at b3.
+    try std.testing.expectEqual(@as(usize, 1), countOp(&func, .phi));
+    const b3_first = func.getBlock(b3).instructions.items[0];
+    try std.testing.expect(b3_first.op == .phi);
+    try std.testing.expectEqual(@as(usize, 2), b3_first.op.phi.len);
+    // Incoming entries: one for b1 with v_c100, one for b2 with v_c200 (order = preds(b3)).
+    var saw_b1 = false;
+    var saw_b2 = false;
+    for (b3_first.op.phi) |inc| {
+        if (inc.block == b1) {
+            try std.testing.expectEqual(v_c100, inc.value);
+            saw_b1 = true;
+        }
+        if (inc.block == b2) {
+            try std.testing.expectEqual(v_c200, inc.value);
+            saw_b2 = true;
+        }
+    }
+    try std.testing.expect(saw_b1 and saw_b2);
+
+    // Ret uses the phi's dest.
+    const ret_inst = func.getBlock(b3).instructions.items[func.getBlock(b3).instructions.items.len - 1];
+    try std.testing.expectEqual(b3_first.dest.?, ret_inst.op.ret.?);
+}
+
+test "ssaPromoteLocals: loop header gets phi (counter-style local)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 1); // 1 declared local (counter)
+    defer func.deinit();
+
+    const b0 = try func.newBlock(); // entry
+    const b1 = try func.newBlock(); // loop header
+    const b2 = try func.newBlock(); // exit
+
+    // b0: local.set 0, 0; br b1
+    const v_zero = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v_zero, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .local_set = .{ .idx = 0, .val = v_zero } } });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    // b1: c = local.get 0; c1 = c + 1; local.set 0, c1; br_if c1 -> b1, b2
+    const v_get = func.newVReg();
+    const v_one = func.newVReg();
+    const v_inc = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .local_get = 0 }, .dest = v_get, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_one, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v_get, .rhs = v_one } }, .dest = v_inc, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .local_set = .{ .idx = 0, .val = v_inc } } });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_inc, .then_block = b1, .else_block = b2 } } });
+
+    // b2: c = local.get 0; ret c
+    const v_final = func.newVReg();
+    try func.getBlock(b2).append(.{ .op = .{ .local_get = 0 }, .dest = v_final, .type = .i32 });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_final }, .type = .i32 });
+
+    const changed = try ssaPromoteLocals(&func, allocator);
+    try std.testing.expect(changed);
+
+    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .local_get));
+    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .local_set));
+    // Phi at loop header b1.
+    try std.testing.expectEqual(@as(usize, 1), countOp(&func, .phi));
+    const phi = func.getBlock(b1).instructions.items[0];
+    try std.testing.expect(phi.op == .phi);
+    try std.testing.expectEqual(@as(usize, 2), phi.op.phi.len);
+    // Incoming: from b0 with v_zero, from b1 with v_inc.
+    var saw_entry = false;
+    var saw_back = false;
+    for (phi.op.phi) |inc| {
+        if (inc.block == b0) {
+            try std.testing.expectEqual(v_zero, inc.value);
+            saw_entry = true;
+        }
+        if (inc.block == b1) {
+            try std.testing.expectEqual(v_inc, inc.value);
+            saw_back = true;
+        }
+    }
+    try std.testing.expect(saw_entry and saw_back);
+
+    // Add inside the loop now reads from phi.dest, not v_get.
+    const add_inst = func.getBlock(b1).instructions.items[2]; // after phi + iconst_1
+    try std.testing.expect(add_inst.op == .add);
+    try std.testing.expectEqual(phi.dest.?, add_inst.op.add.lhs);
+}
+
+test "ssaPromoteLocals: never-set non-param local materialises zero-init" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 1); // 1 declared local, never set
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const v_get = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_get, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .ret = v_get }, .type = .i32 });
+
+    const changed = try ssaPromoteLocals(&func, allocator);
+    try std.testing.expect(changed);
+
+    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .local_get));
+    // An iconst_32 0 was prepended at entry head; ret uses it.
+    const insts = func.getBlock(b0).instructions.items;
+    try std.testing.expect(insts[0].op == .iconst_32);
+    try std.testing.expectEqual(@as(i32, 0), insts[0].op.iconst_32);
+    const ret_inst = insts[insts.len - 1];
+    try std.testing.expectEqual(insts[0].dest.?, ret_inst.op.ret.?);
+}
+
+test "ssaPromoteLocals: bails out when entry has predecessors" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    // b0 ← b1 (back-edge to entry).
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b0 } });
+
+
+    const changed = try ssaPromoteLocals(&func, allocator);
+    // No promotable locals + entry has preds → return false (bail).
+    try std.testing.expect(!changed);
+}
+
+test "ssaPromoteLocals: idempotent on already-promoted IR" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 1);
+    defer func.deinit();
+    _ = func.newVReg();
+
+    const b0 = try func.newBlock();
+    const v_get = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_get, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .ret = v_get }, .type = .i32 });
+
+    _ = try ssaPromoteLocals(&func, allocator);
+    const second = try ssaPromoteLocals(&func, allocator);
+    // After first run there are no local_get/set left, so second run should
+    // see no promotable locals (no local_get observed) and return false.
+    try std.testing.expect(!second);
 }

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -1823,6 +1823,157 @@ pub fn ssaPromoteLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !boo
     return changed;
 }
 
+/// Split critical edges: for every CFG edge B→S where B has multiple
+/// successors and S has multiple predecessors, insert a new empty block
+/// N with a single `br S` terminator and retarget the B→S edge to B→N.
+///
+/// This is a prerequisite for `lowerPhisToLocals`: the lowering of a
+/// phi(...) at S inserts `local_set` instructions at the end of each
+/// predecessor of S. If a predecessor B has multiple successors, those
+/// `local_set`s would also execute on the path that doesn't reach S,
+/// clobbering values used along the other branch.
+///
+/// Also rewrites any existing phi incoming entries at S that reference
+/// B to reference the new edge-block N, so the pass is safe to run
+/// either before or after `ssaPromoteLocals`.
+pub fn splitCriticalEdges(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    var successors = try analysis.buildSuccessors(func, allocator);
+    defer {
+        var sit = successors.iterator();
+        while (sit.next()) |e| allocator.free(e.value_ptr.*);
+        successors.deinit();
+    }
+    var preds = try analysis.buildPredecessors(func, allocator);
+    defer {
+        var pit = preds.iterator();
+        while (pit.next()) |e| allocator.free(e.value_ptr.*);
+        preds.deinit();
+    }
+
+    var changed = false;
+    const orig_len = func.blocks.items.len;
+    var b_idx: u32 = 0;
+    while (b_idx < orig_len) : (b_idx += 1) {
+        const succs_b = successors.get(b_idx) orelse continue;
+        if (succs_b.len < 2) continue;
+
+        // Deduplicate target list while preserving uniqueness, since
+        // br_if with then==else (already a non-critical edge in practice)
+        // and br_table with duplicates shouldn't be split twice.
+        var seen_target = std.AutoHashMap(ir.BlockId, ir.BlockId).init(allocator);
+        defer seen_target.deinit();
+
+        for (succs_b) |s| {
+            if (seen_target.contains(s)) continue;
+            const preds_s = preds.get(s) orelse continue;
+            // preds_s is deduped by buildPredecessors; "multiple preds"
+            // means strictly > 1 distinct predecessor blocks.
+            if (preds_s.len < 2) continue;
+
+            // Critical edge B→S: insert N.
+            const n_id = try func.newBlock();
+            try func.getBlock(n_id).append(.{ .op = .{ .br = s } });
+            try seen_target.put(s, n_id);
+            changed = true;
+        }
+
+        if (seen_target.count() == 0) continue;
+
+        // Retarget B's terminator: rewrite any successor field whose
+        // value matches a key in seen_target to the corresponding new
+        // block. The terminator is the last instruction.
+        const block = func.getBlock(b_idx);
+        const term = &block.instructions.items[block.instructions.items.len - 1];
+        switch (term.op) {
+            .br => |t| if (seen_target.get(t)) |n| {
+                term.op = .{ .br = n };
+            },
+            .br_if => |bi| {
+                var nthen = bi.then_block;
+                var nelse = bi.else_block;
+                if (seen_target.get(bi.then_block)) |n| nthen = n;
+                if (seen_target.get(bi.else_block)) |n| nelse = n;
+                term.op = .{ .br_if = .{ .cond = bi.cond, .then_block = nthen, .else_block = nelse } };
+            },
+            .br_table => |bt| {
+                const new_targets = try allocator.alloc(ir.BlockId, bt.targets.len);
+                for (bt.targets, 0..) |t, i| {
+                    new_targets[i] = if (seen_target.get(t)) |n| n else t;
+                }
+                const new_default = if (seen_target.get(bt.default)) |n| n else bt.default;
+                allocator.free(@constCast(bt.targets));
+                term.op = .{ .br_table = .{ .index = bt.index, .targets = new_targets, .default = new_default } };
+            },
+            else => {},
+        }
+
+        // Rewrite phi incoming entries at S that referenced B → now
+        // reference N. (No-op when ssaPromoteLocals hasn't run yet.)
+        var sit = seen_target.iterator();
+        while (sit.next()) |entry| {
+            const s = entry.key_ptr.*;
+            const n = entry.value_ptr.*;
+            const sblock = func.getBlock(s);
+            for (sblock.instructions.items) |*inst| {
+                if (inst.op != .phi) continue;
+                const incoming = @constCast(inst.op.phi);
+                for (incoming) |*inc| {
+                    if (inc.block == b_idx) inc.block = n;
+                }
+            }
+        }
+    }
+    return changed;
+}
+
+/// Lower phi instructions back to wasm-style local_set / local_get pairs:
+/// for each `phi(...)` in some block B with destination D and type T,
+/// allocate a fresh local L, replace the phi inst with `local_get L → D`,
+/// and append `local_set L = incoming.value` before the terminator of
+/// each incoming.block.
+///
+/// Requires that critical edges have been split (see `splitCriticalEdges`),
+/// otherwise the inserted `local_set` could execute on a path that does
+/// not reach B.
+pub fn lowerPhisToLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    _ = allocator;
+    var changed = false;
+    for (func.blocks.items) |*block| {
+        for (block.instructions.items) |*inst| {
+            if (inst.op != .phi) continue;
+
+            const incoming = inst.op.phi;
+            const dest = inst.dest.?;
+            const ty = inst.type;
+            const l = func.local_count;
+            func.local_count += 1;
+
+            for (incoming) |inc| {
+                const pblock = func.getBlock(inc.block);
+                const pset = ir.Inst{
+                    .op = .{ .local_set = .{ .idx = l, .val = inc.value } },
+                    .type = ty,
+                };
+                // Insert before the terminator (always the last inst).
+                std.debug.assert(pblock.instructions.items.len > 0);
+                const last = pblock.instructions.items.len - 1;
+                try pblock.instructions.insert(pblock.allocator, last, pset);
+            }
+
+            // Replace the phi inst in place. Free the incoming slice now
+            // because BasicBlock.deinit only frees phi-tagged ops.
+            block.allocator.free(incoming);
+            inst.* = .{
+                .op = .{ .local_get = l },
+                .dest = dest,
+                .type = ty,
+            };
+            changed = true;
+        }
+    }
+    return changed;
+}
+
 /// Constant-fold `br_if` whose condition is a known `iconst_32`. If the
 /// condition is zero, rewrite to `br else_block`; otherwise rewrite to
 /// `br then_block`. Uses a per-block iconst_32 map (conditions are
@@ -5604,4 +5755,197 @@ test "ssaPromoteLocals: idempotent on already-promoted IR" {
     // After first run there are no local_get/set left, so second run should
     // see no promotable locals (no local_get observed) and return false.
     try std.testing.expect(!second);
+}
+
+// ── splitCriticalEdges / lowerPhisToLocals tests ───────────────────────────
+
+test "splitCriticalEdges: diamond has no critical edges (single-pred branches)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 1);
+    defer func.deinit();
+    _ = func.newVReg();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const v_cond = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b1, .else_block = b2 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = null }, .type = .i32 });
+
+    const before = func.blocks.items.len;
+    const changed = try splitCriticalEdges(&func, allocator);
+    try std.testing.expect(!changed);
+    try std.testing.expectEqual(before, func.blocks.items.len);
+}
+
+test "splitCriticalEdges: br_if to a multi-pred target splits the edge" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    // CFG:
+    //   b0 -br-> b3
+    //   b1 -br_if-> {b2, b3}     ← b1→b3 is critical (b3 has 2 preds, b1 has 2 succs)
+    //   b2 -br-> b3
+    //   b3 -ret
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const v_cond = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b2, .else_block = b3 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = null } });
+
+    const before = func.blocks.items.len;
+    const changed = try splitCriticalEdges(&func, allocator);
+    try std.testing.expect(changed);
+    // b1→b3 is critical (b1 has 2 succs, b3 has 2 preds). Inserted 1 block.
+    try std.testing.expectEqual(before + 1, func.blocks.items.len);
+
+    // b1's terminator should now point to b2 + new block (not b3 directly).
+    const term = func.getBlock(b1).instructions.items[func.getBlock(b1).instructions.items.len - 1];
+    try std.testing.expect(term.op == .br_if);
+    try std.testing.expect(term.op.br_if.then_block != b3 and term.op.br_if.else_block != b3);
+    // The else target should be the new block, which jumps to b3.
+    const new_id = term.op.br_if.else_block;
+    const new_block = func.getBlock(new_id);
+    try std.testing.expectEqual(@as(usize, 1), new_block.instructions.items.len);
+    try std.testing.expectEqual(b3, new_block.instructions.items[0].op.br);
+}
+
+test "lowerPhisToLocals: round-trips a diamond phi back to local_set/get" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 2);
+    defer func.deinit();
+    _ = func.newVReg();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const v_cond = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .local_get = 0 }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b1, .else_block = b2 } } });
+    const v_c100 = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 100 }, .dest = v_c100, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .local_set = .{ .idx = 1, .val = v_c100 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b3 } });
+    const v_c200 = func.newVReg();
+    try func.getBlock(b2).append(.{ .op = .{ .iconst_32 = 200 }, .dest = v_c200, .type = .i32 });
+    try func.getBlock(b2).append(.{ .op = .{ .local_set = .{ .idx = 1, .val = v_c200 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+    const v_get = func.newVReg();
+    try func.getBlock(b3).append(.{ .op = .{ .local_get = 1 }, .dest = v_get, .type = .i32 });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = v_get }, .type = .i32 });
+
+    _ = try ssaPromoteLocals(&func, allocator);
+    try std.testing.expectEqual(@as(usize, 1), countOp(&func, .phi));
+
+    // Split critical edges before lowering. Diamond is not critical
+    // (b1, b2 each have a single successor), so this is a no-op here.
+    _ = try splitCriticalEdges(&func, allocator);
+
+    const local_count_before = func.local_count;
+    const changed = try lowerPhisToLocals(&func, allocator);
+    try std.testing.expect(changed);
+
+    // No phi remains; one new local was allocated.
+    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .phi));
+    try std.testing.expectEqual(local_count_before + 1, func.local_count);
+    const new_local = local_count_before;
+
+    // b3 starts with `local_get new_local → phi.dest`.
+    const b3_first = func.getBlock(b3).instructions.items[0];
+    try std.testing.expect(b3_first.op == .local_get);
+    try std.testing.expectEqual(new_local, b3_first.op.local_get);
+
+    // b1, b2 each have a `local_set new_local = const` before their terminator.
+    var found_b1_set = false;
+    var found_b2_set = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .local_set and inst.op.local_set.idx == new_local) {
+            try std.testing.expectEqual(v_c100, inst.op.local_set.val);
+            found_b1_set = true;
+        }
+    }
+    for (func.getBlock(b2).instructions.items) |inst| {
+        if (inst.op == .local_set and inst.op.local_set.idx == new_local) {
+            try std.testing.expectEqual(v_c200, inst.op.local_set.val);
+            found_b2_set = true;
+        }
+    }
+    try std.testing.expect(found_b1_set and found_b2_set);
+
+    // Last instruction in b1, b2 is still the br terminator.
+    const b1_last = func.getBlock(b1).instructions.items[func.getBlock(b1).instructions.items.len - 1];
+    const b2_last = func.getBlock(b2).instructions.items[func.getBlock(b2).instructions.items.len - 1];
+    try std.testing.expect(b1_last.op == .br);
+    try std.testing.expect(b2_last.op == .br);
+}
+
+test "splitCriticalEdges + lowerPhisToLocals: round-trip on critical-edge CFG" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 1);
+    defer func.deinit();
+
+    // CFG with a critical edge b1→b3:
+    //   b0 -br-> b1
+    //   b1 -br_if cond-> {b2, b3}    (critical: b1→b3)
+    //   b2 -br-> b3
+    //   b3 -ret get(0)
+    // Set local 0 along both paths so b3 gets a phi.
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+
+    const v_zero_b0 = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v_zero_b0, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .local_set = .{ .idx = 0, .val = v_zero_b0 } } });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    const v_cond = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b2, .else_block = b3 } } });
+
+    const v_c200 = func.newVReg();
+    try func.getBlock(b2).append(.{ .op = .{ .iconst_32 = 200 }, .dest = v_c200, .type = .i32 });
+    try func.getBlock(b2).append(.{ .op = .{ .local_set = .{ .idx = 0, .val = v_c200 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+
+    const v_final = func.newVReg();
+    try func.getBlock(b3).append(.{ .op = .{ .local_get = 0 }, .dest = v_final, .type = .i32 });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = v_final }, .type = .i32 });
+
+    // Run the full pipeline: split → promote → lower.
+    const split_changed = try splitCriticalEdges(&func, allocator);
+    try std.testing.expect(split_changed);
+
+    _ = try ssaPromoteLocals(&func, allocator);
+    try std.testing.expectEqual(@as(usize, 1), countOp(&func, .phi));
+
+    _ = try lowerPhisToLocals(&func, allocator);
+    try std.testing.expectEqual(@as(usize, 0), countOp(&func, .phi));
+
+    // The local_set carrying the phi value must NOT be in b1: that would
+    // execute on the b1→b2 path too. It must be in the inserted edge
+    // block. Find b3's preds.
+    var preds = try analysis.buildPredecessors(&func, allocator);
+    defer {
+        var pit = preds.iterator();
+        while (pit.next()) |e| allocator.free(e.value_ptr.*);
+        preds.deinit();
+    }
+    const b3_preds = preds.get(b3).?;
+    // After splitting + lowering: b3's preds are {b2, edge_block_from_b1}
+    // and neither should be b1 itself.
+    for (b3_preds) |p| try std.testing.expect(p != b1);
 }

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -1872,7 +1872,10 @@ pub fn ssaPromoteLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !boo
         }
 
         // 4b. Walk non-phi instructions, rename uses of local_get and push
-        //     defs of local_set.
+        //     defs of local_set. Stop after the first terminator op so
+        //     unreachable code emitted by the wasm frontend (e.g. dead
+        //     `br`/`local_set` after a real terminator within the same
+        //     block) doesn't pollute the rename stacks.
         for (block_ptr.instructions.items, 0..) |*inst, iidx| {
             switch (inst.op) {
                 .phi => continue,
@@ -1894,6 +1897,7 @@ pub fn ssaPromoteLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !boo
                 },
                 else => {},
             }
+            if (isTerminatorOp(inst.op)) break;
         }
 
         // 4c. For each successor S, fill its phis' incoming entry for B.
@@ -3276,6 +3280,8 @@ pub fn runPasses(module: *ir.IrModule, passes: []const PassFn, allocator: std.me
         if (false) {
             if (try splitCriticalEdges(func, allocator)) total_changes += 1;
             if (try ssaPromoteLocals(func, allocator)) total_changes += 1;
+            if (try lowerPhisToLocals(func, allocator)) total_changes += 1;
+            if (try fixCrossBlockLiveness(func, allocator)) total_changes += 1;
         }
         // Iterate the pipeline until fixpoint so that passes can re-expose
         // opportunities for each other (e.g. constantFold → CSE → DCE →
@@ -3290,10 +3296,6 @@ pub fn runPasses(module: *ir.IrModule, passes: []const PassFn, allocator: std.me
                 }
             }
             if (!any_changed) break;
-        }
-        if (false) {
-            if (try lowerPhisToLocals(func, allocator)) total_changes += 1;
-            if (try fixCrossBlockLiveness(func, allocator)) total_changes += 1;
         }
     }
     return total_changes;

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -2264,34 +2264,68 @@ pub fn lowerPhisToLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !bo
     // a terminator within the same block; we must insert before the first
     // executed control-flow instruction.)
     //
-    // If `inc.value` is itself another phi's dest (phi-of-phi), the source
-    // value is no longer live as a VReg in the predecessor block — it's
-    // carried via `source_site.local`. Emit a `local_get → fresh_vreg`
-    // first, then set our local from that fresh vreg.
-    for (sites.items) |site| {
-        for (site.incoming) |inc| {
-            const pblock = func.getBlock(inc.block);
+    // Parallel-copy lowering: group all (site, inc) pairs by inc.block
+    // and emit ALL local_get reads of phi-of-phi sources BEFORE ANY
+    // local_set writes on the same edge. This avoids the read-after-
+    // write hazard when one phi at S has inc.value = another phi at S
+    // dest, both filled on the same pred edge.
+    {
+        // Build pred -> list of (site_idx, inc.value) groups.
+        var by_pred: std.AutoHashMap(ir.BlockId, std.ArrayList(struct { site_idx: usize, val: ir.VReg })) = .init(allocator);
+        defer {
+            var it = by_pred.iterator();
+            while (it.next()) |e| e.value_ptr.deinit(allocator);
+            by_pred.deinit();
+        }
+        for (sites.items, 0..) |site, sidx| {
+            for (site.incoming) |inc| {
+                const gop = try by_pred.getOrPut(inc.block);
+                if (!gop.found_existing) gop.value_ptr.* = .empty;
+                try gop.value_ptr.append(allocator, .{ .site_idx = sidx, .val = inc.value });
+            }
+        }
+
+        var it = by_pred.iterator();
+        while (it.next()) |entry| {
+            const pred_id = entry.key_ptr.*;
+            const group = entry.value_ptr.items;
+            const pblock = func.getBlock(pred_id);
             std.debug.assert(pblock.instructions.items.len > 0);
             var insert_at: usize = pblock.instructions.items.len;
             for (pblock.instructions.items, 0..) |pinst, idx| {
                 if (isTerminatorOp(pinst.op)) { insert_at = idx; break; }
             }
-            var src_val: ir.VReg = inc.value;
-            if (dest_to_site.get(inc.value)) |src_idx| {
-                const src_site = sites.items[src_idx];
-                const fresh = func.newVReg();
+
+            // Phase A: for each phi-of-phi entry, emit local_get of
+            // source site's local into a fresh vreg. Remember the mapped
+            // value (fresh vreg or inc.value) per group entry.
+            var mapped_vals = try allocator.alloc(ir.VReg, group.len);
+            defer allocator.free(mapped_vals);
+            for (group, 0..) |g, gi| {
+                if (dest_to_site.get(g.val)) |src_idx| {
+                    const src_site = sites.items[src_idx];
+                    const fresh = func.newVReg();
+                    try pblock.instructions.insert(pblock.allocator, insert_at, .{
+                        .op = .{ .local_get = src_site.local },
+                        .type = src_site.ty,
+                        .dest = fresh,
+                    });
+                    insert_at += 1;
+                    mapped_vals[gi] = fresh;
+                } else {
+                    mapped_vals[gi] = g.val;
+                }
+            }
+
+            // Phase B: emit local_sets using mapped values.
+            for (group, 0..) |g, gi| {
+                const site = sites.items[g.site_idx];
                 try pblock.instructions.insert(pblock.allocator, insert_at, .{
-                    .op = .{ .local_get = src_site.local },
-                    .type = src_site.ty,
-                    .dest = fresh,
+                    .op = .{ .local_set = .{ .idx = site.local, .val = mapped_vals[gi] } },
+                    .type = site.ty,
                 });
                 insert_at += 1;
-                src_val = fresh;
             }
-            try pblock.instructions.insert(pblock.allocator, insert_at, .{
-                .op = .{ .local_set = .{ .idx = site.local, .val = src_val } },
-                .type = site.ty,
-            });
         }
     }
 

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -88,6 +88,11 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
         .local_get, .global_get => {},
         .br, .@"unreachable" => {},
 
+        // Phi has unbounded incoming list. Callers that need to walk
+        // phi uses must special-case `.phi`; this helper returns empty
+        // (mirrors how `call`/`call_indirect`/`ret_multi` are handled).
+        .phi => {},
+
         // Binary ops
         .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
         .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
@@ -241,6 +246,12 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
         .iconst_32, .iconst_64, .fconst_32, .fconst_64,
         .local_get, .global_get, .br, .@"unreachable",
         => {},
+
+        .phi => |incoming| {
+            for (@constCast(incoming)) |*inc| {
+                if (inc.value == old) inc.value = new;
+            }
+        },
 
         .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
         .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
@@ -1978,6 +1989,10 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
         .memory_size, .table_size, .ref_func, .data_drop, .elem_drop,
         .atomic_fence, .call_result,
         => {},
+
+        .phi => |incoming| {
+            for (@constCast(incoming)) |*inc| inc.value += offset;
+        },
 
         .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
         .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,


### PR DESCRIPTION
Stack PR 3/3 for the `#136` perf backlog. Lays the SSA-promote infrastructure
that the heavier IR passes (general LICM, value-based cross-block CSE, SROA,
phi-cancellation in front of regalloc) will sit on top of.

**Stack:** #172 (1/3) → #143 (2/3) → this (3/3, draft).

**Draft.** The full pipeline integration (`splitCriticalEdges → ssaPromoteLocals
→ lowerPhisToLocals → fixCrossBlockLiveness`) is **gated under `if (false)`**
in `runPasses`. With it enabled, all unit + differential tests pass but
CoreMark observes wrong CRCs — root cause not yet isolated. The infrastructure
is committed as `pub` functions so individual passes can be exercised by the
unit tests in this PR while the integration remains staged.

The two passes that **are wired into the default pipeline** in this PR
(`promoteSingleDefLocals`, `licmPureOps`, `foldLoadStoreOffset`) are sound
on their own and are independently useful.

## Commits

| # | SHA | Change |
|---|---|---|
| 1 | `fd7180c4` | dominance frontier + iterated DF computation |
| 2 | `e3173d48` | add `phi` op (Slice 1b) |
| 3 | `07b17f34` | `ssaPromoteLocals` (Slice 2) |
| 4 | `d22fdca4` | `splitCriticalEdges` + `lowerPhisToLocals` (Slice 3) |
| 5 | `3e42a00c` | stage SSA-promote pipeline (Slice 4 disabled pending soundness fix) |
| 6 | `eecac732` | stop `ssaPromoteLocals` rename at first terminator |
| 7 | `8b5566a4` | `foldLoadStoreOffset` peephole |
| 8 | `722b9b85` | `licmPureOps` loop-invariant code motion |
| 9 | `c190f68e` | `promoteSingleDefLocals` |
| 10 | `19b836b6` | fix read-after-write hazard in `lowerPhisToLocals` Step 2 (parallel-copy lowering) |

## Validation

- `zig build test -Doptimize=Debug` — **1206/1206 passing**.
- All new passes ship with focused unit tests in `passes.zig`.
- `lowerPhisToLocals` is exercised by parallel-copy stress tests covering
  loop-carry, swaps, and chains (the read-after-write hazard fixed in commit
  `19b836b6`).

## What this PR does NOT do

- Enable the full SSA pipeline in the default flow — that's deferred until
  the CoreMark CRC mismatch is root-caused.
- Re-enable cross-block CSE — still requires the AArch64 codegen to iterate
  blocks in RPO (called out in #143's body).

## Next steps after this lands

1. Root-cause the SSA-pipeline CRC mismatch and flip the gate in `runPasses`.
2. Make AArch64 codegen iterate blocks in RPO, then re-land the dom-CSE that
   #143 reverted in `e38c1577`.
3. Build general LICM on top of `licmPureOps`.

Refs #136.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
