### PR TITLE
Update security reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,24 @@
 # Security Policy
 
-Please refer to the [Bytecode Alliance security policy](https://bytecodealliance.org/security) for details on how to report security issues in WebAssembly Micro Runtime, our disclosure policy, and how to receive notifications about security issues.
+This repository is an experimental, independent Zig implementation and is not
+affiliated with the Bytecode Alliance or the upstream WebAssembly Micro Runtime
+project.
+
+## Reporting a vulnerability
+
+Please use GitHub Private Vulnerability Reporting for sensitive vulnerability
+reports in this repository. This provides a private channel for sharing details
+with the repository maintainer before public disclosure.
+
+For non-sensitive hardening ideas or bug reports, opening a public GitHub issue
+is fine. Do not include exploit details, proof-of-concept payloads, or other
+sensitive information in a public issue.
+
+## Support expectations
+
+This project is experimental and is not currently production-supported. It does
+not provide a formal security response SLA, long-term support policy, or
+guaranteed CVE process.
+
+Please do not report vulnerabilities in this repository to the Bytecode Alliance
+unless the same issue also affects a Bytecode Alliance project.


### PR DESCRIPTION
## Summary
- replace the Bytecode Alliance security-policy redirect with project-specific guidance
- document that this repository is independent, experimental, and not production-supported
- direct sensitive reports to GitHub Private Vulnerability Reporting
- keep public issues available for non-sensitive hardening and bug reports

Private Vulnerability Reporting has been enabled in the repository settings.

Addresses the disclosure-policy portion of #5.

## Validation
- documentation-only change