### PR TITLE
bench(simd): add v128 benchmark harness

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -329,6 +329,34 @@ pub fn build(b: *std.Build) void {
     coremark_step.dependOn(&run_coremark_nofp.step);
     coremark_step.dependOn(&run_coremark_fp.step);
 
+    // ── SIMD benchmark runner ───────────────────────────────────────────
+    // Builds small in-memory SIMD modules and reports interpreter vs AOT
+    // status/timing.  SIMD AOT is expected to report "unsupported" until the
+    // first native v128 lowering slice lands.
+    const simd_bench_module = b.createModule(.{
+        .root_source_file = b.path("src/tests/simd_bench_runner.zig"),
+        .target = target,
+        .optimize = .ReleaseFast,
+    });
+    simd_bench_module.addImport("wamr", lib_module);
+
+    const simd_bench_exe = b.addExecutable(.{
+        .name = "simd-bench-runner",
+        .root_module = simd_bench_module,
+    });
+    if (aot_executable_target) b.installArtifact(simd_bench_exe);
+
+    const simd_bench_step = b.step(
+        "simd-bench",
+        "Run SIMD interpreter/AOT benchmark status probes",
+    );
+    if (aot_executable_target) {
+        const run_simd_bench = b.addRunArtifact(simd_bench_exe);
+        run_simd_bench.addArg("--iterations");
+        run_simd_bench.addArg("10000");
+        simd_bench_step.dependOn(&run_simd_bench.step);
+    }
+
     const fuzz_step = b.step("fuzz", "Build fuzz harnesses (loader, interp, aot, diff)");
     inline for (.{ "loader", "interp", "aot", "diff" }) |tgt| {
         const fuzz_mod = b.createModule(.{

--- a/scripts/bench_simd.py
+++ b/scripts/bench_simd.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Compare SIMD benchmark status/timing between two git refs.
+
+The script builds a temporary worktree for each ref, overlays the current SIMD
+benchmark harness into that worktree, and runs `simd-bench-runner`.  Overlaying
+the harness lets older refs such as `origin/main` report "unsupported" for SIMD
+AOT rather than failing just because the harness file did not exist yet.
+
+Usage
+-----
+    scripts/bench_simd.py --baseline origin/main --target HEAD --runs 3
+    scripts/bench_simd.py --baseline origin/main --target HEAD --emit github
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+HARNESS_OVERLAY = (
+    "build.zig",
+    "src/tests/aot_harness.zig",
+    "src/tests/simd_bench_runner.zig",
+)
+
+
+@dataclass(frozen=True)
+class Measurement:
+    case: str
+    engine: str
+    status: str
+    result: int | None
+    compile_ns: int | None
+    run_ns: int | None
+    iterations: int
+    code_size: int | None
+    run_index: int
+
+
+def run(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> str:
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return proc.stdout + proc.stderr
+
+
+def make_worktree(repo: Path, ref: str, root: Path, label: str) -> Path:
+    sha = run(["git", "rev-parse", ref], cwd=repo).strip()
+    wt = root / f"{label}-{sha[:12]}"
+    if wt.exists():
+        try:
+            run(["git", "worktree", "remove", "--force", str(wt)], cwd=repo)
+        except subprocess.CalledProcessError:
+            shutil.rmtree(wt)
+    run(["git", "worktree", "add", "--detach", str(wt), sha], cwd=repo)
+    return wt
+
+
+def overlay_harness(source_repo: Path, wt: Path) -> None:
+    for rel in HARNESS_OVERLAY:
+        src = source_repo / rel
+        dst = wt / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+
+def parse_optional_int(value: str) -> int | None:
+    if value == "-":
+        return None
+    return int(value)
+
+
+def parse_runner_output(output: str, run_index: int) -> list[Measurement]:
+    rows: list[Measurement] = []
+    for line in output.splitlines():
+        if not line.startswith("bench\t"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 9:
+            raise RuntimeError(f"malformed simd bench row: {line}")
+        _, case, engine, status, result, compile_ns, run_ns, iterations, code_size = parts
+        rows.append(
+            Measurement(
+                case=case,
+                engine=engine,
+                status=status,
+                result=parse_optional_int(result),
+                compile_ns=parse_optional_int(compile_ns),
+                run_ns=parse_optional_int(run_ns),
+                iterations=int(iterations),
+                code_size=parse_optional_int(code_size),
+                run_index=run_index,
+            )
+        )
+    if not rows:
+        raise RuntimeError(f"simd-bench-runner produced no parseable rows:\n{output}")
+    return rows
+
+
+def build_and_run(
+    wt: Path,
+    source_repo: Path,
+    runs: int,
+    iterations: int,
+) -> list[Measurement]:
+    env = os.environ.copy()
+    overlay_harness(source_repo, wt)
+
+    print(f"[harness] building {wt.name} (ReleaseFast)", file=sys.stderr)
+    run(["zig", "build", "-Doptimize=ReleaseFast"], cwd=wt, env=env)
+
+    runner = wt / "zig-out/bin/simd-bench-runner"
+    if not runner.exists():
+        raise RuntimeError(f"expected runner was not built: {runner}")
+
+    measurements: list[Measurement] = []
+    for i in range(runs):
+        print(
+            f"[harness] running {wt.name} ({i + 1}/{runs}, iterations={iterations})",
+            file=sys.stderr,
+        )
+        out = run([str(runner), "--iterations", str(iterations)], cwd=wt, env=env)
+        measurements.extend(parse_runner_output(out, i + 1))
+    return measurements
+
+
+def fmt_ns(value: float | int | None) -> str:
+    if value is None:
+        return "-"
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.3f} ms"
+    if value >= 1_000:
+        return f"{value / 1_000:.3f} us"
+    return f"{value:.0f} ns"
+
+
+def fmt_value(value: int | None) -> str:
+    return "-" if value is None else str(value)
+
+
+def summarize(rows: list[Measurement]) -> dict[tuple[str, str], dict[str, object]]:
+    grouped: dict[tuple[str, str], list[Measurement]] = {}
+    for row in rows:
+        grouped.setdefault((row.case, row.engine), []).append(row)
+
+    summary: dict[tuple[str, str], dict[str, object]] = {}
+    for key, values in grouped.items():
+        ok_values = [v for v in values if v.status == "ok"]
+        selected = ok_values if ok_values else values
+        run_times = [v.run_ns for v in selected if v.run_ns is not None]
+        compile_times = [v.compile_ns for v in selected if v.compile_ns is not None]
+        code_sizes = [v.code_size for v in selected if v.code_size is not None]
+        results = [v.result for v in selected if v.result is not None]
+        summary[key] = {
+            "status": "ok" if ok_values else selected[0].status,
+            "result": results[0] if results else None,
+            "run_ns": statistics.median(run_times) if run_times else None,
+            "compile_ns": statistics.median(compile_times) if compile_times else None,
+            "iterations": selected[0].iterations,
+            "code_size": code_sizes[0] if code_sizes else None,
+        }
+    return summary
+
+
+def render_table(
+    baseline_ref: str,
+    baseline_rows: list[Measurement],
+    target_ref: str,
+    target_rows: list[Measurement],
+) -> str:
+    baseline = summarize(baseline_rows)
+    target = summarize(target_rows)
+    keys = sorted(set(baseline) | set(target))
+
+    lines = [
+        "### SIMD AOT benchmark comparison",
+        "",
+        "| Case | Engine | Ref | Status | Result | Median run | Median compile | Code size | Iterations |",
+        "|---|---|---|---|---:|---:|---:|---:|---:|",
+    ]
+    for case, engine in keys:
+        for role, ref, table in (
+            ("baseline", baseline_ref, baseline),
+            ("target", target_ref, target),
+        ):
+            row = table.get((case, engine))
+            ref_label = f"{ref} ({role})"
+            if row is None:
+                lines.append(f"| `{case}` | `{engine}` | `{ref_label}` | missing | - | - | - | - | - |")
+                continue
+            lines.append(
+                "| `{case}` | `{engine}` | `{ref}` | {status} | {result} | {run_ns} | {compile_ns} | {code_size} | {iterations} |".format(
+                    case=case,
+                    engine=engine,
+                    ref=ref_label,
+                    status=row["status"],
+                    result=fmt_value(row["result"]),  # type: ignore[arg-type]
+                    run_ns=fmt_ns(row["run_ns"]),  # type: ignore[arg-type]
+                    compile_ns=fmt_ns(row["compile_ns"]),  # type: ignore[arg-type]
+                    code_size=fmt_value(row["code_size"]),  # type: ignore[arg-type]
+                    iterations=row["iterations"],
+                )
+            )
+
+    lines.extend(
+        [
+            "",
+            "AOT rows with `unsupported` are expected for SIMD cases until native v128 lowering lands.",
+            "CoreMark is scalar, so this harness is the SIMD-specific signal for issue #220.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--baseline", default="origin/main", help="git ref for the baseline")
+    p.add_argument("--target", default="HEAD", help="git ref for the target")
+    p.add_argument("--runs", type=int, default=3, help="runner invocations per ref")
+    p.add_argument(
+        "--iterations",
+        type=int,
+        default=10_000,
+        help="function calls per runner invocation",
+    )
+    p.add_argument(
+        "--repo",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="path to wamr repo (default: parent of scripts/)",
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="if given, write the markdown table here as well",
+    )
+    p.add_argument(
+        "--emit",
+        choices=["markdown", "github"],
+        default="markdown",
+        help="`github` also appends to $GITHUB_STEP_SUMMARY when present",
+    )
+    args = p.parse_args()
+
+    if args.runs <= 0:
+        raise ValueError("--runs must be positive")
+    if args.iterations <= 0:
+        raise ValueError("--iterations must be positive")
+
+    repo = args.repo.resolve()
+    with tempfile.TemporaryDirectory(
+        prefix="bench-simd-",
+        dir="/work" if Path("/work").is_dir() else None,
+    ) as tmp:
+        root = Path(tmp)
+        try:
+            wt_b = make_worktree(repo, args.baseline, root, "baseline")
+            wt_t = make_worktree(repo, args.target, root, "target")
+
+            baseline_rows = build_and_run(wt_b, repo, args.runs, args.iterations)
+            target_rows = build_and_run(wt_t, repo, args.runs, args.iterations)
+        finally:
+            run(["git", "worktree", "prune"], cwd=repo)
+
+    table = render_table(args.baseline, baseline_rows, args.target, target_rows)
+    print(table)
+
+    if args.out:
+        args.out.write_text(table + "\n")
+
+    if args.emit == "github":
+        summary = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary:
+            with open(summary, "a", encoding="utf-8") as fh:
+                fh.write(table + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -1,0 +1,460 @@
+//! SIMD benchmark/status runner for the Zig AOT backend.
+//!
+//! The runner builds small in-memory Wasm modules that use SIMD internally and
+//! expose scalar `() -> i32` wrapper functions.  That keeps the benchmark usable
+//! before the AOT runtime grows direct v128 parameter/result support.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const wamr = @import("wamr");
+const loader_mod = wamr.loader;
+const instance_mod = wamr.instance;
+const interp = wamr.interp;
+const ExecEnv = wamr.exec_env.ExecEnv;
+const aot_runtime = wamr.aot_runtime;
+const aot_harness = @import("aot_harness.zig");
+
+const Allocator = std.mem.Allocator;
+
+const BenchBuilder = *const fn (Allocator) anyerror![]u8;
+
+const BenchCase = struct {
+    name: []const u8,
+    simd: bool,
+    build: BenchBuilder,
+};
+
+const RunResult = struct {
+    result: i32,
+    run_ns: u64,
+};
+
+const cases = [_]BenchCase{
+    .{
+        .name = "scalar_i32_add",
+        .simd = false,
+        .build = buildScalarAddModule,
+    },
+    .{
+        .name = "simd_i32x4_add_lane0",
+        .simd = true,
+        .build = buildSimdI32x4AddLane0Module,
+    },
+    .{
+        .name = "simd_v128_xor_lane0",
+        .simd = true,
+        .build = buildSimdV128XorLane0Module,
+    },
+    .{
+        .name = "simd_i32x4_eq_lane0",
+        .simd = true,
+        .build = buildSimdI32x4EqLane0Module,
+    },
+    .{
+        .name = "simd_v128_load_store_lane0",
+        .simd = true,
+        .build = buildSimdLoadStoreLane0Module,
+    },
+};
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    const iterations = parseIterations(args) catch |err| {
+        std.debug.print("simd-bench-runner: invalid arguments: {s}\n", .{@errorName(err)});
+        usage();
+        std.process.exit(2);
+    };
+
+    if (!aot_harness.can_exec_aot) {
+        std.debug.print(
+            "simd-bench-runner: AOT execution is not supported on this target ({s}); interpreter rows will still run.\n",
+            .{@tagName(builtin.cpu.arch)},
+        );
+    }
+
+    for (cases) |case| {
+        try runCase(allocator, case, iterations);
+    }
+}
+
+fn usage() void {
+    std.debug.print(
+        \\usage: simd-bench-runner [--iterations N]
+        \\
+        \\Runs embedded SIMD microbench modules through the interpreter and,
+        \\when supported by the host CPU, through the in-memory AOT pipeline.
+        \\Rows are tab-separated and prefixed with "bench".
+        \\
+    , .{});
+}
+
+fn parseIterations(args: []const []const u8) !u32 {
+    var iterations: u32 = 10_000;
+    var i: usize = 1;
+    while (i < args.len) : (i += 1) {
+        if (std.mem.eql(u8, args[i], "--help") or std.mem.eql(u8, args[i], "-h")) {
+            usage();
+            std.process.exit(0);
+        } else if (std.mem.eql(u8, args[i], "--iterations")) {
+            i += 1;
+            if (i >= args.len) return error.MissingValue;
+            iterations = try std.fmt.parseUnsigned(u32, args[i], 10);
+            if (iterations == 0) return error.InvalidIterationCount;
+        } else {
+            return error.UnknownArgument;
+        }
+    }
+    return iterations;
+}
+
+fn runCase(allocator: Allocator, case: BenchCase, iterations: u32) !void {
+    const wasm = try case.build(allocator);
+    defer allocator.free(wasm);
+
+    const interp_result = runInterpMany(allocator, wasm, "run", iterations) catch |err| {
+        emitRow(case.name, "interp", "trap", null, null, null, iterations, wasm.len);
+        std.debug.print("simd-bench-runner: interpreter failed for {s}: {s}\n", .{ case.name, @errorName(err) });
+        return;
+    };
+    emitRow(case.name, "interp", "ok", interp_result.result, 0, interp_result.run_ns, iterations, wasm.len);
+
+    if (!aot_harness.can_exec_aot) {
+        emitRow(case.name, "aot", "unsupported", null, null, null, iterations, null);
+        return;
+    }
+
+    const compile_start = nowNs();
+    const h = aot_harness.Harness.initWithOptions(
+        allocator,
+        wasm,
+        null,
+        .{ .invoke_start = false },
+    ) catch |err| {
+        const status = if (case.simd and err == error.CompileFailed) "unsupported" else "compile_failed";
+        emitRow(case.name, "aot", status, null, elapsedSince(compile_start), null, iterations, null);
+        return;
+    };
+    const compile_ns = elapsedSince(compile_start);
+    defer h.deinit();
+
+    const aot_result = runAotMany(h, "run", iterations) catch |err| {
+        emitRow(case.name, "aot", "trap", null, compile_ns, null, iterations, h.aot_bin.len);
+        std.debug.print("simd-bench-runner: AOT failed for {s}: {s}\n", .{ case.name, @errorName(err) });
+        return;
+    };
+    const status = if (aot_result.result == interp_result.result) "ok" else "mismatch";
+    emitRow(case.name, "aot", status, aot_result.result, compile_ns, aot_result.run_ns, iterations, h.aot_bin.len);
+}
+
+fn emitRow(
+    case_name: []const u8,
+    engine: []const u8,
+    status: []const u8,
+    result: ?i32,
+    compile_ns: ?u64,
+    run_ns: ?u64,
+    iterations: u32,
+    code_size: ?usize,
+) void {
+    std.debug.print("bench\t{s}\t{s}\t{s}\t", .{ case_name, engine, status });
+    if (result) |v| {
+        std.debug.print("{d}", .{v});
+    } else {
+        std.debug.print("-", .{});
+    }
+    std.debug.print("\t", .{});
+    if (compile_ns) |v| {
+        std.debug.print("{d}", .{v});
+    } else {
+        std.debug.print("-", .{});
+    }
+    std.debug.print("\t", .{});
+    if (run_ns) |v| {
+        std.debug.print("{d}", .{v});
+    } else {
+        std.debug.print("-", .{});
+    }
+    std.debug.print("\t{d}\t", .{iterations});
+    if (code_size) |v| {
+        std.debug.print("{d}", .{v});
+    } else {
+        std.debug.print("-", .{});
+    }
+    std.debug.print("\n", .{});
+}
+
+fn elapsedSince(start: u64) u64 {
+    return nowNs() - start;
+}
+
+fn nowNs() u64 {
+    return wamr.platform.timeGetBootUs() * std.time.ns_per_us;
+}
+
+fn runInterpMany(allocator: Allocator, wasm: []const u8, name: []const u8, iterations: u32) !RunResult {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const module = try loader_mod.load(wasm, arena.allocator());
+
+    const inst = try instance_mod.instantiate(&module, allocator);
+    defer instance_mod.destroy(inst);
+
+    const exp = inst.module.findExport(name, .function) orelse return error.FunctionNotFound;
+
+    var env = try ExecEnv.create(inst, 4096, allocator);
+    defer env.destroy();
+
+    var last: i32 = 0;
+    const start = nowNs();
+    for (0..iterations) |_| {
+        try interp.executeFunction(env, exp.index);
+        last = try env.popI32();
+    }
+    return .{
+        .result = last,
+        .run_ns = elapsedSince(start),
+    };
+}
+
+fn runAotMany(h: *aot_harness.Harness, name: []const u8, iterations: u32) !RunResult {
+    const func_idx = h.findFuncExport(name) orelse return error.FunctionNotFound;
+
+    var results_buf: [1]aot_runtime.ScalarResult = undefined;
+    var last: i32 = 0;
+    const start = nowNs();
+    for (0..iterations) |_| {
+        const results = try h.callScalar(func_idx, &.{}, &results_buf);
+        if (results.len != 1) return error.UnsupportedSignature;
+        last = switch (results[0]) {
+            .i32 => |v| v,
+            else => return error.InvalidResultType,
+        };
+    }
+    return .{
+        .result = last,
+        .run_ns = elapsedSince(start),
+    };
+}
+
+fn buildScalarAddModule(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try instr.append(allocator, 0x41); // i32.const
+    try encodeSLEB128(&instr, allocator, 123);
+    try instr.append(allocator, 0x41); // i32.const
+    try encodeSLEB128(&instr, allocator, 456);
+    try instr.append(allocator, 0x6A); // i32.add
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4AddLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ 1, 2, 3, 4 });
+    try appendV128ConstI32x4(&instr, allocator, .{ 5, 6, 7, 8 });
+    try appendSimdOpcode(&instr, allocator, 0xAE); // i32x4.add
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdV128XorLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ 0x1357_9BDF, 2, 3, 4 });
+    try appendV128ConstI32x4(&instr, allocator, .{ 0x0102_0304, 6, 7, 8 });
+    try appendSimdOpcode(&instr, allocator, 0x51); // v128.xor
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4EqLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ 42, 2, 3, 4 });
+    try appendV128ConstI32x4(&instr, allocator, .{ 42, 0, 3, 5 });
+    try appendSimdOpcode(&instr, allocator, 0x37); // i32x4.eq
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdLoadStoreLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try instr.append(allocator, 0x41); // i32.const destination address
+    try encodeSLEB128(&instr, allocator, 16);
+    try instr.append(allocator, 0x41); // i32.const source address
+    try encodeSLEB128(&instr, allocator, 0);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdMemOpcode(&instr, allocator, 0x0B, 4, 0); // v128.store
+    try instr.append(allocator, 0x41); // i32.const destination address
+    try encodeSLEB128(&instr, allocator, 16);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    var data: [16]u8 = undefined;
+    writeI32Lane(data[0..4], 0x1122_3344);
+    writeI32Lane(data[4..8], 0x5566_7788);
+    writeI32Lane(data[8..12], @bitCast(@as(i32, -7)));
+    writeI32Lane(data[12..16], 0x0102_0304);
+
+    return buildRunI32Module(allocator, instr.items, .{
+        .memory_min = 1,
+        .data = data[0..],
+    });
+}
+
+const ModuleExtras = struct {
+    memory_min: ?u32 = null,
+    data: ?[]const u8 = null,
+};
+
+fn buildRunI32Module(allocator: Allocator, instructions: []const u8, extras: ModuleExtras) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, &[_]u8{ 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00 });
+
+    var type_payload: std.ArrayList(u8) = .empty;
+    defer type_payload.deinit(allocator);
+    try type_payload.appendSlice(allocator, &[_]u8{
+        0x01, // type count
+        0x60, // func
+        0x00, // param count
+        0x01, // result count
+        0x7F, // i32
+    });
+    try appendSection(&out, allocator, 0x01, type_payload.items);
+
+    var func_payload: std.ArrayList(u8) = .empty;
+    defer func_payload.deinit(allocator);
+    try func_payload.appendSlice(allocator, &[_]u8{
+        0x01, // function count
+        0x00, // type index
+    });
+    try appendSection(&out, allocator, 0x03, func_payload.items);
+
+    if (extras.memory_min) |min_pages| {
+        var memory_payload: std.ArrayList(u8) = .empty;
+        defer memory_payload.deinit(allocator);
+        try memory_payload.append(allocator, 0x01); // memory count
+        try memory_payload.append(allocator, 0x00); // limits: min only
+        try encodeULEB128(&memory_payload, allocator, min_pages);
+        try appendSection(&out, allocator, 0x05, memory_payload.items);
+    }
+
+    var export_payload: std.ArrayList(u8) = .empty;
+    defer export_payload.deinit(allocator);
+    try export_payload.append(allocator, 0x01); // export count
+    try export_payload.append(allocator, 0x03); // name length
+    try export_payload.appendSlice(allocator, "run");
+    try export_payload.append(allocator, 0x00); // function export
+    try export_payload.append(allocator, 0x00); // function index
+    try appendSection(&out, allocator, 0x07, export_payload.items);
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(allocator);
+    try body.append(allocator, 0x00); // local decl count
+    try body.appendSlice(allocator, instructions);
+    try body.append(allocator, 0x0B); // end
+
+    var code_payload: std.ArrayList(u8) = .empty;
+    defer code_payload.deinit(allocator);
+    try code_payload.append(allocator, 0x01); // function count
+    try encodeULEB128(&code_payload, allocator, @intCast(body.items.len));
+    try code_payload.appendSlice(allocator, body.items);
+    try appendSection(&out, allocator, 0x0A, code_payload.items);
+
+    if (extras.data) |data| {
+        var data_payload: std.ArrayList(u8) = .empty;
+        defer data_payload.deinit(allocator);
+        try data_payload.append(allocator, 0x01); // segment count
+        try data_payload.append(allocator, 0x00); // active segment for memory 0
+        try data_payload.append(allocator, 0x41); // i32.const
+        try encodeSLEB128(&data_payload, allocator, 0);
+        try data_payload.append(allocator, 0x0B); // end offset expr
+        try encodeULEB128(&data_payload, allocator, @intCast(data.len));
+        try data_payload.appendSlice(allocator, data);
+        try appendSection(&out, allocator, 0x0B, data_payload.items);
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+fn appendSection(out: *std.ArrayList(u8), allocator: Allocator, id: u8, payload: []const u8) !void {
+    try out.append(allocator, id);
+    try encodeULEB128(out, allocator, @intCast(payload.len));
+    try out.appendSlice(allocator, payload);
+}
+
+fn appendV128ConstI32x4(buf: *std.ArrayList(u8), allocator: Allocator, lanes: [4]i32) !void {
+    try appendSimdOpcode(buf, allocator, 0x0C); // v128.const
+    for (lanes) |lane| {
+        var le = std.mem.nativeToLittle(u32, @bitCast(lane));
+        try buf.appendSlice(allocator, std.mem.asBytes(&le));
+    }
+}
+
+fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x1B); // i32x4.extract_lane
+    try buf.append(allocator, lane);
+}
+
+fn appendSimdMemOpcode(
+    buf: *std.ArrayList(u8),
+    allocator: Allocator,
+    opcode: u32,
+    alignment: u32,
+    offset: u32,
+) !void {
+    try appendSimdOpcode(buf, allocator, opcode);
+    try encodeULEB128(buf, allocator, alignment);
+    try encodeULEB128(buf, allocator, offset);
+}
+
+fn appendSimdOpcode(buf: *std.ArrayList(u8), allocator: Allocator, opcode: u32) !void {
+    try buf.append(allocator, 0xFD);
+    try encodeULEB128(buf, allocator, opcode);
+}
+
+fn writeI32Lane(dst: []u8, value: u32) void {
+    var le = std.mem.nativeToLittle(u32, value);
+    @memcpy(dst, std.mem.asBytes(&le));
+}
+
+fn encodeULEB128(buf: *std.ArrayList(u8), allocator: Allocator, value: u32) !void {
+    var v = value;
+    while (true) {
+        var byte: u8 = @intCast(v & 0x7F);
+        v >>= 7;
+        if (v != 0) byte |= 0x80;
+        try buf.append(allocator, byte);
+        if (v == 0) break;
+    }
+}
+
+fn encodeSLEB128(buf: *std.ArrayList(u8), allocator: Allocator, value: i64) !void {
+    var v = value;
+    var more = true;
+    while (more) {
+        const byte: u8 = @as(u8, @truncate(@as(u64, @bitCast(v)))) & 0x7F;
+        v >>= 7;
+        const sign_bit = byte & 0x40;
+        if ((v == 0 and sign_bit == 0) or (v == -1 and sign_bit != 0)) {
+            more = false;
+            try buf.append(allocator, byte);
+        } else {
+            try buf.append(allocator, byte | 0x80);
+        }
+    }
+}

--- a/tests/benchmarks/simd/README.md
+++ b/tests/benchmarks/simd/README.md
@@ -1,0 +1,20 @@
+# SIMD benchmark harness
+
+Issue #220 tracks native AArch64 AOT lowering for Wasm SIMD/v128 operations. Standard CoreMark is scalar, so it is not expected to move materially for this work. This harness provides SIMD-specific status and timing probes.
+
+Run the embedded benchmark runner directly:
+
+```sh
+zig build simd-bench
+./zig-out/bin/simd-bench-runner --iterations 10000
+```
+
+Compare two git refs:
+
+```sh
+scripts/bench_simd.py --baseline origin/main --target HEAD --runs 3 --iterations 10000
+```
+
+`scripts/bench_simd.py` creates temporary worktrees under `/work`, overlays the current harness into each worktree, and builds each ref in `ReleaseFast`. Overlaying the harness lets older refs report SIMD AOT as `unsupported` instead of failing because the harness did not exist.
+
+The runner emits tab-separated rows for interpreter and AOT engines. It records status, scalar checksum result, compile time, run time, iteration count, and code size. SIMD AOT rows are expected to be `unsupported` until the first v128 IR/frontend/backend lowering slice lands.


### PR DESCRIPTION
## Summary
- add `simd-bench-runner` and `zig build simd-bench` for embedded SIMD interpreter/AOT status probes
- add `scripts/bench_simd.py` for baseline-vs-target comparisons using temporary `/work` worktrees
- document the SIMD harness and expected `unsupported` AOT status before native v128 lowering

## Validation
- `zig build simd-bench`
- `scripts/bench_simd.py --baseline HEAD --target HEAD --runs 1 --iterations 10`
- `zig build test`

Closes #220 only partially; this is the measurement harness foundation for the native SIMD work.