### PR TITLE
Fix CLI version branding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,22 @@ jobs:
       - name: Build
         run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }} -Dstrip=true -Dstack-protector=true "-Dversion=${{ steps.version.outputs.version }}"
 
+      - name: Verify CLI version
+        if: matrix.name == 'linux-x64' || matrix.name == 'linux-arm64' || matrix.name == 'macos-arm64' || matrix.name == 'windows-x64'
+        shell: bash
+        run: |
+          case "${{ matrix.target }}" in
+            *-windows) EXE="zig-out/bin/wamr.exe" ;;
+            *) EXE="zig-out/bin/wamr" ;;
+          esac
+          VERSION_OUTPUT="$("$EXE" --version 2>&1)"
+          EXPECTED="wamr ${{ steps.version.outputs.version }}"
+          if [ "$VERSION_OUTPUT" != "$EXPECTED" ]; then
+            echo "Expected: $EXPECTED"
+            echo "Actual:   $VERSION_OUTPUT"
+            exit 1
+          fi
+
       - name: Azure login (for signing)
         if: endsWith(matrix.target, '-windows')
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0

--- a/build.zig
+++ b/build.zig
@@ -121,7 +121,7 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(lib);
 
-    // ── iwasm executable ───────────────────────────────────────────────
+    // ── wamr executable ────────────────────────────────────────────────
     const exe_module = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,

--- a/src/api/c_api.zig
+++ b/src/api/c_api.zig
@@ -11,6 +11,7 @@ const instance_mod = @import("../runtime/interpreter/instance.zig");
 const types = @import("../runtime/common/types.zig");
 
 const backing_allocator = std.heap.page_allocator;
+const version_cstr = config.version ++ "\x00";
 
 /// Internal wrapper that pairs a WasmModule with its arena.
 const ModuleWrapper = struct {
@@ -86,7 +87,7 @@ export fn wasm_runtime_destroy() void {}
 
 /// Get the version string.
 export fn wasm_runtime_get_version() [*:0]const u8 {
-    return "0.1.0-zig";
+    return version_cstr;
 }
 
 /// Load a module from binary data.
@@ -172,18 +173,20 @@ test "c_api: init and destroy" {
 test "c_api: version string" {
     const ver = wasm_runtime_get_version();
     const slice = std.mem.span(ver);
-    try std.testing.expectEqualStrings("0.1.0-zig", slice);
+    try std.testing.expectEqualStrings(config.version, slice);
 }
 
 /// (func (export "add") (param i32 i32) (result i32) local.get 0 local.get 1 i32.add)
 const add_wasm = [_]u8{
     0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
     // type section: 1 type — (param i32 i32) (result i32)
-    0x01, 0x07, 0x01, 0x60, 0x02, 0x7F, 0x7F, 0x01, 0x7F,
+    0x01, 0x07, 0x01, 0x60, 0x02, 0x7F, 0x7F, 0x01,
+    0x7F,
     // function section: 1 function, type index 0
     0x03, 0x02, 0x01, 0x00,
     // export section: "add" -> func 0
-    0x07, 0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00,
+    0x07, 0x07, 0x01,
+    0x03, 0x61, 0x64, 0x64, 0x00, 0x00,
     // code section: 1 body
     0x0A, 0x09, 0x01, // section id, size, count
     0x07, 0x00, // body size, local decl count

--- a/src/config.zig
+++ b/src/config.zig
@@ -10,6 +10,9 @@
 const builtin = @import("builtin");
 const build_options = @import("config");
 
+/// Product version string supplied by `zig build -Dversion=...`.
+pub const version: []const u8 = if (@hasDecl(build_options, "version")) build_options.version else "dev";
+
 // ---------------------------------------------------------------------------
 // Build mode
 // ---------------------------------------------------------------------------

--- a/src/main.zig
+++ b/src/main.zig
@@ -59,7 +59,7 @@ pub fn main(init: std.process.Init) !void {
     }
 
     if (show_version) {
-        std.debug.print("iwasm (Zig) {s}\n", .{wamr.version.string});
+        printVersion();
         if (wasm_path == null) return;
     }
 
@@ -335,9 +335,17 @@ fn runWasm(
     };
 }
 
+fn versionLine() []const u8 {
+    return "wamr " ++ wamr.version.string ++ "\n";
+}
+
+fn printVersion() void {
+    std.debug.print("{s}", .{versionLine()});
+}
+
 fn printUsage() void {
     std.debug.print(
-        \\iwasm (Zig) - WebAssembly Micro Runtime
+        \\wamr - WebAssembly Micro Runtime
         \\
         \\Usage: wamr [options] <file.wasm> [args...]
         \\
@@ -349,4 +357,8 @@ fn printUsage() void {
         \\  --listen=<ip:port>       Serve a WASI HTTP component on a TCP address
         \\
     , .{});
+}
+
+test "version line uses wamr name and build version" {
+    try std.testing.expectEqualStrings("wamr " ++ wamr.version.string ++ "\n", versionLine());
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -160,10 +160,13 @@ pub const version = .{
     .major = 0,
     .minor = 1,
     .patch = 0,
-    .string = "0.1.0-zig",
+    .string = config.version,
 };
 
 test {
     std.testing.refAllDecls(@This());
 }
 
+test "version string comes from build config" {
+    try std.testing.expectEqualStrings(config.version, version.string);
+}


### PR DESCRIPTION
## Summary

- Uses the build-provided version string for runtime-visible version reporting.
- Changes CLI `--version` and `--help` branding from legacy `iwasm` / `iwasm (Zig)` to `wamr`.
- Makes `wasm_runtime_get_version()` return the same build version.
- Adds release workflow verification that native release binaries print the expected version before packaging.

Closes #228.

## Reference

- https://github.com/microsoft/winget-pkgs/pull/364926#issuecomment-4328296206

## Validation

- `zig build test --summary all`
- `zig build --summary all`
- `zig build -Dversion=3.0.0-dev.8 --summary all`
- `./zig-out/bin/wamr --version` -> `wamr 3.0.0-dev.8`
