### PR TITLE
compiler: add v128 IR foundation

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -311,6 +311,29 @@ pub fn compileFunctionWithOptions(
     return compileFunctionImpl(func, .{ .allocator = allocator, .options = options }, allocator);
 }
 
+fn functionUsesV128(func: *const ir.IrFunction) bool {
+    if (func.local_types) |local_types| {
+        for (local_types) |ty| if (ty == .v128) return true;
+    }
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |inst| {
+            if (inst.type == .v128) return true;
+            switch (inst.op) {
+                .v128_const,
+                .v128_load,
+                .v128_store,
+                .v128_not,
+                .v128_bitwise,
+                .i32x4_binop,
+                .i32x4_extract_lane,
+                => return true,
+                else => {},
+            }
+        }
+    }
+    return false;
+}
+
 pub fn compileFunctionImpl(
     func: *const ir.IrFunction,
     ctx: FuncCompileCtx,
@@ -318,6 +341,7 @@ pub fn compileFunctionImpl(
 ) ![]u8 {
     // Phase 1b: stack args beyond x7 aren't supported yet.
     if (func.param_count > 7) return error.TooManyParams;
+    if (functionUsesV128(func)) return error.UnsupportedV128;
 
     // Phase 3 of regalloc adoption (issue #100): drive RegMap from a real
     // linear-scan allocation. `RegMap.assign` consults `alloc_result` first;
@@ -752,6 +776,8 @@ fn computeLiveRangesScheduled(
 
     var def_pos = std.AutoHashMap(ir.VReg, u32).init(allocator);
     defer def_pos.deinit();
+    var def_type = std.AutoHashMap(ir.VReg, ir.IrType).init(allocator);
+    defer def_type.deinit();
     var last_use_pos = std.AutoHashMap(ir.VReg, u32).init(allocator);
     defer last_use_pos.deinit();
 
@@ -768,7 +794,10 @@ fn computeLiveRangesScheduled(
 
         for (scheduled.instructions(bid)) |inst| {
             if (inst.dest) |dest| {
-                if (!def_pos.contains(dest)) try def_pos.put(dest, global_idx);
+                if (!def_pos.contains(dest)) {
+                    try def_pos.put(dest, global_idx);
+                    try def_type.put(dest, inst.type);
+                }
             }
             var use_ctx = LastUseCtx{
                 .last_use_pos = &last_use_pos,
@@ -799,6 +828,7 @@ fn computeLiveRangesScheduled(
             .vreg = vreg,
             .start = start,
             .end = @max(start, end),
+            .type = def_type.get(vreg) orelse .i32,
         });
     }
 

--- a/src/compiler/codegen/aarch64/schedule.zig
+++ b/src/compiler/codegen/aarch64/schedule.zig
@@ -227,6 +227,16 @@ pub fn metadata(inst: ir.Inst) Metadata {
     const def = inst.dest;
     const class: Class = switch (inst.op) {
         .iconst_32, .iconst_64 => if (def != null) .constant else .barrier,
+        // SIMD/v128 lowering is intentionally a barrier until the backend has
+        // explicit vector dependency/latency modeling.
+        .v128_const,
+        .v128_load,
+        .v128_store,
+        .v128_not,
+        .v128_bitwise,
+        .i32x4_binop,
+        .i32x4_extract_lane,
+        => .barrier,
 
         .mul => if (def != null and isIntegerType(inst.type)) .mul else .barrier,
 
@@ -455,6 +465,21 @@ pub fn forEachUse(
             try visit(context, tg.delta);
         },
         .phi => |edges| for (edges) |edge| try visit(context, edge.val),
+        .v128_not => |v| try visit(context, v),
+        .v128_load => |ld| try visit(context, ld.base),
+        .v128_store => |st| {
+            try visit(context, st.base);
+            try visit(context, st.val);
+        },
+        .v128_bitwise => |bin| {
+            try visit(context, bin.lhs);
+            try visit(context, bin.rhs);
+        },
+        .i32x4_binop => |bin| {
+            try visit(context, bin.lhs);
+            try visit(context, bin.rhs);
+        },
+        .i32x4_extract_lane => |lane| try visit(context, lane.vector),
         else => {},
     }
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -514,6 +514,8 @@ const CachedStack = struct {
 
 /// Compile an IR function to x86-64 machine code.
 pub fn compileFunction(func: *const ir.IrFunction, allocator: std.mem.Allocator) ![]u8 {
+    if (functionUsesV128(func)) return error.UnsupportedV128;
+
     var code = emit.CodeBuffer.init(allocator);
     errdefer code.deinit();
 
@@ -1005,8 +1007,12 @@ fn compileInst(
         },
 
         // ── Type conversions (pass-through for integer types) ─────────
-        .wrap_i64, .extend_i32_s, .extend_i32_u,
-        .extend8_s, .extend16_s, .extend32_s,
+        .wrap_i64,
+        .extend_i32_s,
+        .extend_i32_u,
+        .extend8_s,
+        .extend16_s,
+        .extend32_s,
         .reinterpret,
         => {
             // Pop, push back (value stays on stack, no-op for now)
@@ -1015,18 +1021,44 @@ fn compileInst(
         },
 
         // ── Float/conversion stubs (pop input, push placeholder) ──────
-        .trunc_f32_s, .trunc_f32_u, .trunc_f64_s, .trunc_f64_u,
-        .convert_s, .convert_u, .convert_i32_s, .convert_i64_s, .convert_i32_u, .convert_i64_u, .demote_f64, .promote_f32,
-        .trunc_sat_f32_s, .trunc_sat_f32_u, .trunc_sat_f64_s, .trunc_sat_f64_u,
-        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest,
+        .trunc_f32_s,
+        .trunc_f32_u,
+        .trunc_f64_s,
+        .trunc_f64_u,
+        .convert_s,
+        .convert_u,
+        .convert_i32_s,
+        .convert_i64_s,
+        .convert_i32_u,
+        .convert_i64_u,
+        .demote_f64,
+        .promote_f32,
+        .trunc_sat_f32_s,
+        .trunc_sat_f32_u,
+        .trunc_sat_f64_s,
+        .trunc_sat_f64_u,
+        .f_neg,
+        .f_abs,
+        .f_sqrt,
+        .f_ceil,
+        .f_floor,
+        .f_trunc,
+        .f_nearest,
         => {
             try stack.pop(code, .rax);
             try stack.push(code, .rax);
         },
 
         // ── Float binary stubs ────────────────────────────────────────
-        .f_min, .f_max, .f_copysign,
-        .f_eq, .f_ne, .f_lt, .f_gt, .f_le, .f_ge,
+        .f_min,
+        .f_max,
+        .f_copysign,
+        .f_eq,
+        .f_ne,
+        .f_lt,
+        .f_gt,
+        .f_le,
+        .f_ge,
         => {
             try stack.pop(code, .rcx);
             try stack.pop(code, .rax);
@@ -1215,6 +1247,14 @@ fn compileInst(
             try code.movRegMem(.rax, .r10, @as(i32, @intCast(fidx * 8)));
             try stack.push(code, .rax);
         },
+        .v128_const,
+        .v128_load,
+        .v128_store,
+        .v128_not,
+        .v128_bitwise,
+        .i32x4_binop,
+        .i32x4_extract_lane,
+        => return error.UnsupportedV128,
         // Phi must be lowered before codegen.
         .phi => unreachable,
     }
@@ -1422,10 +1462,35 @@ fn x86_64_reg_set(local_count: u32) regalloc.RegSet {
     };
 }
 
+fn functionUsesV128(func: *const ir.IrFunction) bool {
+    if (func.local_types) |local_types| {
+        for (local_types) |ty| if (ty == .v128) return true;
+    }
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |inst| {
+            if (inst.type == .v128) return true;
+            switch (inst.op) {
+                .v128_const,
+                .v128_load,
+                .v128_store,
+                .v128_not,
+                .v128_bitwise,
+                .i32x4_binop,
+                .i32x4_extract_lane,
+                => return true,
+                else => {},
+            }
+        }
+    }
+    return false;
+}
+
 /// Compile an IR function using the linear scan register allocator.
 /// VRegs are assigned to physical registers; instructions operate directly
 /// on assigned registers without push/pop through a CachedStack.
 pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocator: std.mem.Allocator) !FuncCompileResult {
+    if (functionUsesV128(func)) return error.UnsupportedV128;
+
     // Compute block emission order ONCE, before anything that uses global
     // instruction numbering. Clobber points, live ranges, and code emission
     // all must use THIS order (same fix as aarch64 — see PR #195 / #203).
@@ -1897,8 +1962,12 @@ fn compileInstRA(
             const dest = inst.dest orelse return;
             const dr = destReg(alloc_result, dest);
             const bin = switch (inst.op) {
-                .add => |b| b, .sub => |b| b, .mul => |b| b,
-                .@"and" => |b| b, .@"or" => |b| b, .xor => |b| b,
+                .add => |b| b,
+                .sub => |b| b,
+                .mul => |b| b,
+                .@"and" => |b| b,
+                .@"or" => |b| b,
+                .xor => |b| b,
                 else => unreachable,
             };
 
@@ -2021,9 +2090,17 @@ fn compileInstRA(
                 try code.cmpRegReg(lhs_reg, rhs_reg);
             }
             const cc: u4 = comptime switch (tag) {
-                .eq => 0x4, .ne => 0x5, .lt_s => 0xC, .lt_u => 0x2,
-                .gt_s => 0xF, .gt_u => 0x7, .le_s => 0xE, .le_u => 0x6,
-                .ge_s => 0xD, .ge_u => 0x3, else => unreachable,
+                .eq => 0x4,
+                .ne => 0x5,
+                .lt_s => 0xC,
+                .lt_u => 0x2,
+                .gt_s => 0xF,
+                .gt_u => 0x7,
+                .le_s => 0xE,
+                .le_u => 0x6,
+                .ge_s => 0xD,
+                .ge_u => 0x3,
+                else => unreachable,
             };
             try code.setcc(cc, dr);
             try code.movzxByte(dr, dr);
@@ -2997,7 +3074,7 @@ fn compileInstRA(
                         var after_patch: usize = 0;
                         if (is_rem) {
                             try code.emitSlice(&.{ 0x31, 0xD2 }); // xor edx, edx
-                            try code.emitSlice(&.{ 0xE9 }); // jmp rel32
+                            try code.emitSlice(&.{0xE9}); // jmp rel32
                             after_patch = code.len();
                             try code.emitI32(0);
                         } else {
@@ -3006,7 +3083,7 @@ fn compileInstRA(
                         const dodiv_off = code.len();
                         code.patchI32(dodiv_patch, @intCast(@as(i64, @intCast(dodiv_off)) - @as(i64, @intCast(dodiv_patch + 4))));
                         code.patchI32(dodiv_patch2, @intCast(@as(i64, @intCast(dodiv_off)) - @as(i64, @intCast(dodiv_patch2 + 4))));
-                        try code.emitSlice(&.{ 0x99 }); // cdq
+                        try code.emitSlice(&.{0x99}); // cdq
                         try code.emitSlice(&.{ 0xF7, 0xF9 }); // idiv ecx
                         if (is_rem) {
                             const after_off = code.len();
@@ -3026,7 +3103,7 @@ fn compileInstRA(
                         var after_patch: usize = 0;
                         if (is_rem) {
                             try code.emitSlice(&.{ 0x31, 0xD2 });
-                            try code.emitSlice(&.{ 0xE9 });
+                            try code.emitSlice(&.{0xE9});
                             after_patch = code.len();
                             try code.emitI32(0);
                         } else {
@@ -3379,24 +3456,24 @@ fn compileInstRA(
                 const minmax_byte: u8 = if (is_min) 0x5D else 0x5F; // MINSS=5D, MAXSS=5F
                 const or_and_byte: u8 = if (is_min) 0x09 else 0x21; // OR=09, AND=21
                 try code.emitSlice(&.{
-                    0x89, 0xC2,                               // mov edx, eax
-                    0x81, 0xE2, 0xFF, 0xFF, 0xFF, 0x7F,       // and edx, 0x7FFFFFFF
-                    0x81, 0xFA, 0x00, 0x00, 0x80, 0x7F,       // cmp edx, 0x7F800000
-                    0x77, 0x2B,                               // ja nan (+43)
-                    0x89, 0xCA,                               // mov edx, ecx
-                    0x81, 0xE2, 0xFF, 0xFF, 0xFF, 0x7F,       // and edx, 0x7FFFFFFF
-                    0x81, 0xFA, 0x00, 0x00, 0x80, 0x7F,       // cmp edx, 0x7F800000
-                    0x77, 0x1B,                               // ja nan (+27)
-                    0x66, 0x0F, 0x6E, 0xC0,                   // movd xmm0, eax
-                    0x66, 0x0F, 0x6E, 0xC9,                   // movd xmm1, ecx
-                    0x0F, 0x2E, 0xC1,                         // ucomiss xmm0, xmm1
-                    0x74, 0x0A,                               // je equal (+10)
-                    0xF3, 0x0F, minmax_byte, 0xC1,            // min/maxss xmm0, xmm1
-                    0x66, 0x0F, 0x7E, 0xC0,                   // movd eax, xmm0
-                    0xEB, 0x09,                               // jmp done (+9)
-                    or_and_byte, 0xC8,                        // or/and eax, ecx
-                    0xEB, 0x05,                               // jmp done (+5)
-                    0xB8, 0x00, 0x00, 0xC0, 0x7F,             // mov eax, 0x7FC00000
+                    0x89, 0xC2, // mov edx, eax
+                    0x81, 0xE2, 0xFF, 0xFF, 0xFF, 0x7F, // and edx, 0x7FFFFFFF
+                    0x81, 0xFA, 0x00, 0x00, 0x80, 0x7F, // cmp edx, 0x7F800000
+                    0x77, 0x2B, // ja nan (+43)
+                    0x89, 0xCA, // mov edx, ecx
+                    0x81, 0xE2, 0xFF, 0xFF, 0xFF, 0x7F, // and edx, 0x7FFFFFFF
+                    0x81, 0xFA, 0x00, 0x00, 0x80, 0x7F, // cmp edx, 0x7F800000
+                    0x77, 0x1B, // ja nan (+27)
+                    0x66, 0x0F, 0x6E, 0xC0, // movd xmm0, eax
+                    0x66, 0x0F, 0x6E, 0xC9, // movd xmm1, ecx
+                    0x0F, 0x2E, 0xC1, // ucomiss xmm0, xmm1
+                    0x74, 0x0A, // je equal (+10)
+                    0xF3, 0x0F, minmax_byte, 0xC1, // min/maxss xmm0, xmm1
+                    0x66, 0x0F, 0x7E, 0xC0, // movd eax, xmm0
+                    0xEB, 0x09, // jmp done (+9)
+                    or_and_byte, 0xC8, // or/and eax, ecx
+                    0xEB, 0x05, // jmp done (+5)
+                    0xB8, 0x00, 0x00, 0xC0, 0x7F, // mov eax, 0x7FC00000
                 });
             } else {
                 // f64: same shape with UCOMISD for IEEE equality.
@@ -3427,28 +3504,28 @@ fn compileInstRA(
                 const minmax_byte: u8 = if (is_min) 0x5D else 0x5F;
                 const or_and_byte: u8 = if (is_min) 0x09 else 0x21;
                 try code.emitSlice(&.{
-                    0x48, 0x89, 0xC2,                                                   // mov rdx, rax
-                    0x49, 0xBB, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F,         // movabs r11, 0x7FFF...FF
-                    0x4C, 0x21, 0xDA,                                                   // and rdx, r11
-                    0x49, 0xBB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F,         // movabs r11, 0x7FF0...00
-                    0x4C, 0x39, 0xDA,                                                   // cmp rdx, r11
-                    0x77, 0x3F,                                                         // ja nan (+63)
-                    0x48, 0x89, 0xCA,                                                   // mov rdx, rcx
-                    0x49, 0xBB, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F,         // movabs r11, 0x7FFF...FF
-                    0x4C, 0x21, 0xDA,                                                   // and rdx, r11
-                    0x49, 0xBB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F,         // movabs r11, 0x7FF0...00
-                    0x4C, 0x39, 0xDA,                                                   // cmp rdx, r11
-                    0x77, 0x20,                                                         // ja nan (+32)
-                    0x66, 0x48, 0x0F, 0x6E, 0xC0,                                       // movq xmm0, rax
-                    0x66, 0x48, 0x0F, 0x6E, 0xC9,                                       // movq xmm1, rcx
-                    0x66, 0x0F, 0x2E, 0xC1,                                             // ucomisd xmm0, xmm1
-                    0x74, 0x0B,                                                         // je equal (+11)
-                    0xF2, 0x0F, minmax_byte, 0xC1,                                      // min/maxsd xmm0, xmm1
-                    0x66, 0x48, 0x0F, 0x7E, 0xC0,                                       // movq rax, xmm0
-                    0xEB, 0x0F,                                                         // jmp done (+15)
-                    0x48, or_and_byte, 0xC8,                                            // or/and rax, rcx
-                    0xEB, 0x0A,                                                         // jmp done (+10)
-                    0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x7F,         // movabs rax, 0x7FF8...00
+                    0x48, 0x89, 0xC2, // mov rdx, rax
+                    0x49, 0xBB, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, // movabs r11, 0x7FFF...FF
+                    0x4C, 0x21, 0xDA, // and rdx, r11
+                    0x49, 0xBB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F, // movabs r11, 0x7FF0...00
+                    0x4C, 0x39, 0xDA, // cmp rdx, r11
+                    0x77, 0x3F, // ja nan (+63)
+                    0x48, 0x89, 0xCA, // mov rdx, rcx
+                    0x49, 0xBB, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, // movabs r11, 0x7FFF...FF
+                    0x4C, 0x21, 0xDA, // and rdx, r11
+                    0x49, 0xBB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F, // movabs r11, 0x7FF0...00
+                    0x4C, 0x39, 0xDA, // cmp rdx, r11
+                    0x77, 0x20, // ja nan (+32)
+                    0x66, 0x48, 0x0F, 0x6E, 0xC0, // movq xmm0, rax
+                    0x66, 0x48, 0x0F, 0x6E, 0xC9, // movq xmm1, rcx
+                    0x66, 0x0F, 0x2E, 0xC1, // ucomisd xmm0, xmm1
+                    0x74, 0x0B, // je equal (+11)
+                    0xF2, 0x0F, minmax_byte, 0xC1, // min/maxsd xmm0, xmm1
+                    0x66, 0x48, 0x0F, 0x7E, 0xC0, // movq rax, xmm0
+                    0xEB, 0x0F, // jmp done (+15)
+                    0x48, or_and_byte, 0xC8, // or/and rax, rcx
+                    0xEB, 0x0A, // jmp done (+10)
+                    0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x7F, // movabs rax, 0x7FF8...00
                 });
             }
             try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
@@ -3779,8 +3856,7 @@ fn compileInstRA(
             // ── Overflow landing: result = MAX_INT ──
             const max_off = code.len();
             if (!is_signed) {
-                if (dst_is_i32) try code.movRegImm32(.rax, @bitCast(@as(u32, 0xFFFFFFFF)))
-                else try code.movRegImm64(.rax, 0xFFFFFFFFFFFFFFFF);
+                if (dst_is_i32) try code.movRegImm32(.rax, @bitCast(@as(u32, 0xFFFFFFFF))) else try code.movRegImm64(.rax, 0xFFFFFFFFFFFFFFFF);
             } else if (dst_is_i32) {
                 try code.movRegImm32(.rax, 0x7FFFFFFF);
             } else {
@@ -4460,7 +4536,10 @@ test "compileFunctionRA: add two constants" {
     // Should use ADD imm32 (0x81) since rhs is a constant
     var found_add_imm = false;
     for (code) |b| {
-        if (b == 0x81) { found_add_imm = true; break; }
+        if (b == 0x81) {
+            found_add_imm = true;
+            break;
+        }
     }
     try std.testing.expect(found_add_imm);
 }
@@ -4505,7 +4584,7 @@ test "compileFunctionRA: wrap_i64 emits mov eax,eax" {
 
     // wrap_i64 emits a 32-bit mov (opcode 0x89) for truncation.
     // The specific register encoding depends on allocation order.
-    try std.testing.expect(containsBytes(code, &.{ 0x89 }));
+    try std.testing.expect(containsBytes(code, &.{0x89}));
     try std.testing.expectEqual(@as(u8, 0xC3), code[code.len - 1]);
 }
 
@@ -4529,7 +4608,7 @@ test "compileFunctionRA: extend_i32_s emits MOVSXD" {
 
     // MOVSXD (opcode 0x63) must be present for sign extension.
     // REX prefix varies by platform (destination register allocation).
-    try std.testing.expect(containsBytes(code, &.{ 0x63 }));
+    try std.testing.expect(containsBytes(code, &.{0x63}));
 }
 
 test "compileFunctionRA: memory_copy emits call via mem_copy_fn" {
@@ -4762,7 +4841,6 @@ test "compileFunctionRA: memory_size loads into allocated dest register" {
     try std.testing.expect(containsBytes(code, &.{ 0x41, 0x8B, 0x92, 0x38, 0x00, 0x00, 0x00 }));
 }
 
-
 test "compileFunctionRA: r12 allocated under register pressure" {
     // Seven simultaneously-live values (6 constants + one op) overflow the
     // first 5 alloc_regs (rdx, rsi, rdi, r8, r9). The 6th and 7th must go to
@@ -4833,7 +4911,6 @@ test "compileFunctionRA: low-pressure function does not save r12" {
     try std.testing.expect(!containsBytes(code, &.{ 0x41, 0x54 }));
     try std.testing.expect(!containsBytes(code, &.{ 0x41, 0x5C }));
 }
-
 
 test "compileFunctionRA: shift does not emit dead r11 save" {
     // Before B1, every shl emitted `mov r11, rax; ...; mov rax, r11` around
@@ -5028,7 +5105,6 @@ test "compileFunctionRA: div does not emit dead r11 save around operand load" {
     try std.testing.expect(!containsBytes(code, &.{ 0x4C, 0x89, 0xD8 }));
 }
 
-
 test "compileFunctionRA: load folds wasm offset into mov disp" {
     // Verifies B2: i32.load with offset=8 no longer emits `add rax, 8`
     // then `mov dst, [rax]`; instead a single `mov dst, [rax+8]`.
@@ -5085,7 +5161,6 @@ test "compileFunctionRA: store folds wasm offset into mov disp and omits r11 sav
     try std.testing.expect(containsBytes(code, &.{ 0x89, 0x88, 0x10, 0x00, 0x00, 0x00 }));
 }
 
-
 test "compileFunctionRA: add of two non-constant values emits LEA" {
     // Two local_get results then add — neither is in const_vals so the LEA
     // path should fire, producing a single `lea dst, [lhs + rhs]` instead
@@ -5110,12 +5185,11 @@ test "compileFunctionRA: add of two non-constant values emits LEA" {
     defer allocator.free(code);
 
     // Expect a LEA (opcode 0x8D). REX prefix varies by platform.
-    try std.testing.expect(containsBytes(code, &.{ 0x8D }));
+    try std.testing.expect(containsBytes(code, &.{0x8D}));
     // ADD reg,reg (opcode 01) must NOT appear — the LEA replaced it.
     // Check no standalone 01 in a REX+01 pattern. Just verify 0x8D is present.
     try std.testing.expectEqual(@as(u8, 0xC3), code[code.len - 1]);
 }
-
 
 test "compileFunctionRA: br to next block is elided (C3 fallthrough)" {
     const allocator = std.testing.allocator;
@@ -5444,8 +5518,6 @@ test "emitCallRegArgMoves: regression — arg[1] source equals arg[0] target (co
         }
     }
 }
-
-
 
 test "compileFunctionRA: i32.load emits inline memory bounds check" {
     // A wasm memory load must emit an inline bounds check before reading,

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const types = @import("../runtime/common/types.zig");
 const ir = @import("ir/ir.zig");
 const Opcode = @import("../runtime/interpreter/opcode.zig").Opcode;
+const SimdOpcode = @import("../runtime/interpreter/opcode.zig").SimdOpcode;
 const MiscOpcode = @import("../runtime/interpreter/opcode.zig").MiscOpcode;
 const AtomicOpcode = @import("../runtime/interpreter/opcode.zig").AtomicOpcode;
 const leb128 = @import("../shared/utils/leb128.zig");
@@ -30,6 +31,7 @@ const ONE_I32: []const ir.IrType = &[_]ir.IrType{.i32};
 const ONE_I64: []const ir.IrType = &[_]ir.IrType{.i64};
 const ONE_F32: []const ir.IrType = &[_]ir.IrType{.f32};
 const ONE_F64: []const ir.IrType = &[_]ir.IrType{.f64};
+const ONE_V128: []const ir.IrType = &[_]ir.IrType{.v128};
 
 fn valTypeToIr(vt: types.ValType) ir.IrType {
     return switch (vt) {
@@ -37,6 +39,7 @@ fn valTypeToIr(vt: types.ValType) ir.IrType {
         .i64 => .i64,
         .f32 => .f32,
         .f64 => .f64,
+        .v128 => .v128,
         else => .i64,
     };
 }
@@ -115,31 +118,18 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
     for (func.locals) |local| total_locals += local.count;
 
     // Build local type table (params first, then declared locals). Used to
-    // give each `.local_get` IR instruction the correct type so codegen can
-    // emit proper zero-extension for i32/f32 and preserve full 64 bits for
-    // i64/f64.
+    // give each `.local_get` IR instruction the correct type so codegen and
+    // analysis never confuse v128 with a scalar i64 slot.
     var local_types = try allocator.alloc(ir.IrType, total_locals);
     errdefer allocator.free(local_types);
     {
         var i: u32 = 0;
         for (func_type.params) |pt| {
-            local_types[i] = switch (pt) {
-                .i32 => .i32,
-                .i64 => .i64,
-                .f32 => .f32,
-                .f64 => .f64,
-                else => .i64,
-            };
+            local_types[i] = valTypeToIr(pt);
             i += 1;
         }
         for (func.locals) |decl| {
-            const ir_t: ir.IrType = switch (decl.val_type) {
-                .i32 => .i32,
-                .i64 => .i64,
-                .f32 => .f32,
-                .f64 => .f64,
-                else => .i64,
-            };
+            const ir_t = valTypeToIr(decl.val_type);
             var n: u32 = 0;
             while (n < decl.count) : (n += 1) {
                 local_types[i] = ir_t;
@@ -258,6 +248,7 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     -2 => .{ .params = NO_TYPES, .results = ONE_I64 }, // -0x02 = i64
                     -3 => .{ .params = NO_TYPES, .results = ONE_F32 }, // -0x03 = f32
                     -4 => .{ .params = NO_TYPES, .results = ONE_F64 }, // -0x04 = f64
+                    -5 => .{ .params = NO_TYPES, .results = ONE_V128 }, // -0x05 = v128
                     else => .{ .params = NO_TYPES, .results = ONE_I64 }, // ref types (funcref/externref/anyref/...) → 64-bit slot
                 };
             }
@@ -840,13 +831,7 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                 const idx = readU32(code, &ip);
                 const dest = ir_func.newVReg();
                 const gt = globalValTypeByIdx(wasm_module, idx) orelse .i32;
-                const ir_ty: ir.IrType = switch (gt) {
-                    .i32 => .i32,
-                    .i64 => .i64,
-                    .f32 => .f32,
-                    .f64 => .f64,
-                    else => .i64,
-                };
+                const ir_ty = valTypeToIr(gt);
                 try ir_func.getBlock(current_block).append(.{ .op = .{ .global_get = idx }, .dest = dest, .type = ir_ty });
                 try vreg_stack.append(allocator, dest);
             },
@@ -856,9 +841,20 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                 try ir_func.getBlock(current_block).append(.{ .op = .{ .global_set = .{ .idx = idx, .val = val } } });
             },
             // ── Load variants ────────────────────────────────────────────
-            .i32_load, .i32_load8_s, .i32_load8_u, .i32_load16_s, .i32_load16_u,
-            .i64_load, .i64_load8_s, .i64_load8_u, .i64_load16_s, .i64_load16_u, .i64_load32_s, .i64_load32_u,
-            .f32_load, .f64_load,
+            .i32_load,
+            .i32_load8_s,
+            .i32_load8_u,
+            .i32_load16_s,
+            .i32_load16_u,
+            .i64_load,
+            .i64_load8_s,
+            .i64_load8_u,
+            .i64_load16_s,
+            .i64_load16_u,
+            .i64_load32_s,
+            .i64_load32_u,
+            .f32_load,
+            .f64_load,
             => {
                 _ = readU32(code, &ip); // alignment
                 const offset = readU32(code, &ip);
@@ -872,8 +868,11 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     else => unreachable,
                 };
                 const sign_extend: bool = switch (op) {
-                    .i32_load8_s, .i32_load16_s,
-                    .i64_load8_s, .i64_load16_s, .i64_load32_s,
+                    .i32_load8_s,
+                    .i32_load16_s,
+                    .i64_load8_s,
+                    .i64_load16_s,
+                    .i64_load32_s,
                     => true,
                     else => false,
                 };
@@ -887,9 +886,15 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                 try vreg_stack.append(allocator, dest);
             },
             // ── Store variants ───────────────────────────────────────────
-            .i32_store, .i32_store8, .i32_store16,
-            .i64_store, .i64_store8, .i64_store16, .i64_store32,
-            .f32_store, .f64_store,
+            .i32_store,
+            .i32_store8,
+            .i32_store16,
+            .i64_store,
+            .i64_store8,
+            .i64_store16,
+            .i64_store32,
+            .f32_store,
+            .f64_store,
             => {
                 _ = readU32(code, &ip); // alignment
                 const offset = readU32(code, &ip);
@@ -1256,8 +1261,14 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
             },
 
             // ── Float arithmetic (stub: lower to IR but codegen not yet) ──
-            .f32_add, .f32_sub, .f32_mul, .f32_div,
-            .f64_add, .f64_sub, .f64_mul, .f64_div,
+            .f32_add,
+            .f32_sub,
+            .f32_mul,
+            .f32_div,
+            .f64_add,
+            .f64_sub,
+            .f64_mul,
+            .f64_div,
             => {
                 const rhs = safePop(&vreg_stack);
                 const lhs = safePop(&vreg_stack);
@@ -1296,10 +1307,14 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
             },
 
             // ── Truncation (float → int) ──────────────────────────────
-            .i32_trunc_f32_s, .i32_trunc_f32_u,
-            .i32_trunc_f64_s, .i32_trunc_f64_u,
-            .i64_trunc_f32_s, .i64_trunc_f32_u,
-            .i64_trunc_f64_s, .i64_trunc_f64_u,
+            .i32_trunc_f32_s,
+            .i32_trunc_f32_u,
+            .i32_trunc_f64_s,
+            .i32_trunc_f64_u,
+            .i64_trunc_f32_s,
+            .i64_trunc_f32_u,
+            .i64_trunc_f64_s,
+            .i64_trunc_f64_u,
             => {
                 const val = safePop(&vreg_stack);
                 const dest = ir_func.newVReg();
@@ -1319,8 +1334,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
             },
 
             // ── Conversion (int → float) ──────────────────────────────
-            .f32_convert_i32_s, .f32_convert_i64_s,
-            .f64_convert_i32_s, .f64_convert_i64_s,
+            .f32_convert_i32_s,
+            .f32_convert_i64_s,
+            .f64_convert_i32_s,
+            .f64_convert_i64_s,
             => {
                 const val = safePop(&vreg_stack);
                 const dest = ir_func.newVReg();
@@ -1335,8 +1352,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                 try ir_func.getBlock(current_block).append(.{ .op = ir_op, .dest = dest, .type = ir_type });
                 try vreg_stack.append(allocator, dest);
             },
-            .f32_convert_i32_u, .f32_convert_i64_u,
-            .f64_convert_i32_u, .f64_convert_i64_u,
+            .f32_convert_i32_u,
+            .f32_convert_i64_u,
+            .f64_convert_i32_u,
+            .f64_convert_i64_u,
             => {
                 const val = safePop(&vreg_stack);
                 const dest = ir_func.newVReg();
@@ -1396,10 +1415,14 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
             .misc_prefix => {
                 const sub_opcode: MiscOpcode = @enumFromInt(readU32(code, &ip));
                 switch (sub_opcode) {
-                    .i32_trunc_sat_f32_s, .i32_trunc_sat_f32_u,
-                    .i32_trunc_sat_f64_s, .i32_trunc_sat_f64_u,
-                    .i64_trunc_sat_f32_s, .i64_trunc_sat_f32_u,
-                    .i64_trunc_sat_f64_s, .i64_trunc_sat_f64_u,
+                    .i32_trunc_sat_f32_s,
+                    .i32_trunc_sat_f32_u,
+                    .i32_trunc_sat_f64_s,
+                    .i32_trunc_sat_f64_u,
+                    .i64_trunc_sat_f32_s,
+                    .i64_trunc_sat_f32_u,
+                    .i64_trunc_sat_f64_s,
+                    .i64_trunc_sat_f64_u,
                     => {
                         const val = safePop(&vreg_stack);
                         const dest = ir_func.newVReg();
@@ -1411,8 +1434,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                             else => unreachable,
                         };
                         const ir_type: ir.IrType = switch (sub_opcode) {
-                            .i32_trunc_sat_f32_s, .i32_trunc_sat_f32_u,
-                            .i32_trunc_sat_f64_s, .i32_trunc_sat_f64_u,
+                            .i32_trunc_sat_f32_s,
+                            .i32_trunc_sat_f32_u,
+                            .i32_trunc_sat_f64_s,
+                            .i32_trunc_sat_f64_u,
                             => .i32,
                             else => .i64,
                         };
@@ -1514,9 +1539,13 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         try vreg_stack.append(allocator, dest);
                     },
 
-                    .i32_atomic_load, .i64_atomic_load,
-                    .i32_atomic_load8_u, .i32_atomic_load16_u,
-                    .i64_atomic_load8_u, .i64_atomic_load16_u, .i64_atomic_load32_u,
+                    .i32_atomic_load,
+                    .i64_atomic_load,
+                    .i32_atomic_load8_u,
+                    .i32_atomic_load16_u,
+                    .i64_atomic_load8_u,
+                    .i64_atomic_load16_u,
+                    .i64_atomic_load32_u,
                     => {
                         _ = readU32(code, &ip);
                         const offset = readU32(code, &ip);
@@ -1538,9 +1567,13 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         try vreg_stack.append(allocator, dest);
                     },
 
-                    .i32_atomic_store, .i64_atomic_store,
-                    .i32_atomic_store8, .i32_atomic_store16,
-                    .i64_atomic_store8, .i64_atomic_store16, .i64_atomic_store32,
+                    .i32_atomic_store,
+                    .i64_atomic_store,
+                    .i32_atomic_store8,
+                    .i32_atomic_store16,
+                    .i64_atomic_store8,
+                    .i64_atomic_store16,
+                    .i64_atomic_store32,
                     => {
                         _ = readU32(code, &ip);
                         const offset = readU32(code, &ip);
@@ -1557,24 +1590,48 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         try ir_func.getBlock(current_block).append(.{ .op = .{ .atomic_store = .{ .base = base, .offset = offset, .size = size, .val = val } } });
                     },
 
-                    .i32_atomic_rmw_add, .i64_atomic_rmw_add,
-                    .i32_atomic_rmw8_add_u, .i32_atomic_rmw16_add_u,
-                    .i64_atomic_rmw8_add_u, .i64_atomic_rmw16_add_u, .i64_atomic_rmw32_add_u,
-                    .i32_atomic_rmw_sub, .i64_atomic_rmw_sub,
-                    .i32_atomic_rmw8_sub_u, .i32_atomic_rmw16_sub_u,
-                    .i64_atomic_rmw8_sub_u, .i64_atomic_rmw16_sub_u, .i64_atomic_rmw32_sub_u,
-                    .i32_atomic_rmw_and, .i64_atomic_rmw_and,
-                    .i32_atomic_rmw8_and_u, .i32_atomic_rmw16_and_u,
-                    .i64_atomic_rmw8_and_u, .i64_atomic_rmw16_and_u, .i64_atomic_rmw32_and_u,
-                    .i32_atomic_rmw_or, .i64_atomic_rmw_or,
-                    .i32_atomic_rmw8_or_u, .i32_atomic_rmw16_or_u,
-                    .i64_atomic_rmw8_or_u, .i64_atomic_rmw16_or_u, .i64_atomic_rmw32_or_u,
-                    .i32_atomic_rmw_xor, .i64_atomic_rmw_xor,
-                    .i32_atomic_rmw8_xor_u, .i32_atomic_rmw16_xor_u,
-                    .i64_atomic_rmw8_xor_u, .i64_atomic_rmw16_xor_u, .i64_atomic_rmw32_xor_u,
-                    .i32_atomic_rmw_xchg, .i64_atomic_rmw_xchg,
-                    .i32_atomic_rmw8_xchg_u, .i32_atomic_rmw16_xchg_u,
-                    .i64_atomic_rmw8_xchg_u, .i64_atomic_rmw16_xchg_u, .i64_atomic_rmw32_xchg_u,
+                    .i32_atomic_rmw_add,
+                    .i64_atomic_rmw_add,
+                    .i32_atomic_rmw8_add_u,
+                    .i32_atomic_rmw16_add_u,
+                    .i64_atomic_rmw8_add_u,
+                    .i64_atomic_rmw16_add_u,
+                    .i64_atomic_rmw32_add_u,
+                    .i32_atomic_rmw_sub,
+                    .i64_atomic_rmw_sub,
+                    .i32_atomic_rmw8_sub_u,
+                    .i32_atomic_rmw16_sub_u,
+                    .i64_atomic_rmw8_sub_u,
+                    .i64_atomic_rmw16_sub_u,
+                    .i64_atomic_rmw32_sub_u,
+                    .i32_atomic_rmw_and,
+                    .i64_atomic_rmw_and,
+                    .i32_atomic_rmw8_and_u,
+                    .i32_atomic_rmw16_and_u,
+                    .i64_atomic_rmw8_and_u,
+                    .i64_atomic_rmw16_and_u,
+                    .i64_atomic_rmw32_and_u,
+                    .i32_atomic_rmw_or,
+                    .i64_atomic_rmw_or,
+                    .i32_atomic_rmw8_or_u,
+                    .i32_atomic_rmw16_or_u,
+                    .i64_atomic_rmw8_or_u,
+                    .i64_atomic_rmw16_or_u,
+                    .i64_atomic_rmw32_or_u,
+                    .i32_atomic_rmw_xor,
+                    .i64_atomic_rmw_xor,
+                    .i32_atomic_rmw8_xor_u,
+                    .i32_atomic_rmw16_xor_u,
+                    .i64_atomic_rmw8_xor_u,
+                    .i64_atomic_rmw16_xor_u,
+                    .i64_atomic_rmw32_xor_u,
+                    .i32_atomic_rmw_xchg,
+                    .i64_atomic_rmw_xchg,
+                    .i32_atomic_rmw8_xchg_u,
+                    .i32_atomic_rmw16_xchg_u,
+                    .i64_atomic_rmw8_xchg_u,
+                    .i64_atomic_rmw16_xchg_u,
+                    .i64_atomic_rmw32_xchg_u,
                     => {
                         _ = readU32(code, &ip);
                         const offset = readU32(code, &ip);
@@ -1606,9 +1663,13 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         try vreg_stack.append(allocator, dest);
                     },
 
-                    .i32_atomic_rmw_cmpxchg, .i64_atomic_rmw_cmpxchg,
-                    .i32_atomic_rmw8_cmpxchg_u, .i32_atomic_rmw16_cmpxchg_u,
-                    .i64_atomic_rmw8_cmpxchg_u, .i64_atomic_rmw16_cmpxchg_u, .i64_atomic_rmw32_cmpxchg_u,
+                    .i32_atomic_rmw_cmpxchg,
+                    .i64_atomic_rmw_cmpxchg,
+                    .i32_atomic_rmw8_cmpxchg_u,
+                    .i32_atomic_rmw16_cmpxchg_u,
+                    .i64_atomic_rmw8_cmpxchg_u,
+                    .i64_atomic_rmw16_cmpxchg_u,
+                    .i64_atomic_rmw32_cmpxchg_u,
                     => {
                         _ = readU32(code, &ip);
                         const offset = readU32(code, &ip);
@@ -1638,10 +1699,19 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     },
                 }
             },
+            .simd_prefix => {
+                const sub = readU32(code, &ip);
+                const simd_op: SimdOpcode = @enumFromInt(sub);
+                std.debug.print("wamrc: unsupported SIMD opcode 0x{X}\n", .{@intFromEnum(simd_op)});
+                return error.UnsupportedOpcode;
+            },
 
             // ── Sign-extension ops ─────────────────────────────────────
-            .i32_extend8_s, .i32_extend16_s,
-            .i64_extend8_s, .i64_extend16_s, .i64_extend32_s,
+            .i32_extend8_s,
+            .i32_extend16_s,
+            .i64_extend8_s,
+            .i64_extend16_s,
+            .i64_extend32_s,
             => {
                 const val = safePop(&vreg_stack);
                 const dest = ir_func.newVReg();
@@ -1660,8 +1730,18 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
             },
 
             // ── Float comparisons ──────────────────────────────────────
-            .f32_eq, .f32_ne, .f32_lt, .f32_gt, .f32_le, .f32_ge,
-            .f64_eq, .f64_ne, .f64_lt, .f64_gt, .f64_le, .f64_ge,
+            .f32_eq,
+            .f32_ne,
+            .f32_lt,
+            .f32_gt,
+            .f32_le,
+            .f32_ge,
+            .f64_eq,
+            .f64_ne,
+            .f64_lt,
+            .f64_gt,
+            .f64_le,
+            .f64_ge,
             => {
                 const rhs = safePop(&vreg_stack);
                 const lhs = safePop(&vreg_stack);
@@ -1685,8 +1765,20 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
             },
 
             // ── Float unary math ───────────────────────────────────────
-            .f32_abs, .f32_neg, .f32_sqrt, .f32_ceil, .f32_floor, .f32_trunc, .f32_nearest,
-            .f64_abs, .f64_neg, .f64_sqrt, .f64_ceil, .f64_floor, .f64_trunc, .f64_nearest,
+            .f32_abs,
+            .f32_neg,
+            .f32_sqrt,
+            .f32_ceil,
+            .f32_floor,
+            .f32_trunc,
+            .f32_nearest,
+            .f64_abs,
+            .f64_neg,
+            .f64_sqrt,
+            .f64_ceil,
+            .f64_floor,
+            .f64_trunc,
+            .f64_nearest,
             => {
                 const val = safePop(&vreg_stack);
                 const dest = ir_func.newVReg();
@@ -1709,8 +1801,12 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
             },
 
             // ── Float binary math ──────────────────────────────────────
-            .f32_min, .f32_max, .f32_copysign,
-            .f64_min, .f64_max, .f64_copysign,
+            .f32_min,
+            .f32_max,
+            .f32_copysign,
+            .f64_min,
+            .f64_max,
+            .f64_copysign,
             => {
                 const rhs = safePop(&vreg_stack);
                 const lhs = safePop(&vreg_stack);
@@ -2023,18 +2119,36 @@ fn skipOperands(code: []const u8, ip: *usize, op: Opcode) void {
             while (i <= count) : (i += 1) _ = readU32(code, ip);
         },
         // Load/store ops have align + offset
-        .i32_load, .i64_load, .f32_load, .f64_load,
-        .i32_load8_s, .i32_load8_u, .i32_load16_s, .i32_load16_u,
-        .i64_load8_s, .i64_load8_u, .i64_load16_s, .i64_load16_u,
-        .i64_load32_s, .i64_load32_u,
-        .i32_store, .i64_store, .f32_store, .f64_store,
-        .i32_store8, .i32_store16, .i64_store8, .i64_store16, .i64_store32,
+        .i32_load,
+        .i64_load,
+        .f32_load,
+        .f64_load,
+        .i32_load8_s,
+        .i32_load8_u,
+        .i32_load16_s,
+        .i32_load16_u,
+        .i64_load8_s,
+        .i64_load8_u,
+        .i64_load16_s,
+        .i64_load16_u,
+        .i64_load32_s,
+        .i64_load32_u,
+        .i32_store,
+        .i64_store,
+        .f32_store,
+        .f64_store,
+        .i32_store8,
+        .i32_store16,
+        .i64_store8,
+        .i64_store16,
+        .i64_store32,
         => {
             _ = readU32(code, ip); // align
             _ = readU32(code, ip); // offset
         },
         // Prefix opcodes
         .misc_prefix => _ = readU32(code, ip),
+        .simd_prefix => skipSimdOperands(code, ip),
         .atomic_prefix => {
             _ = readU32(code, ip); // sub-opcode
             _ = readU32(code, ip); // align
@@ -2051,6 +2165,64 @@ fn skipOperands(code: []const u8, ip: *usize, op: Opcode) void {
         .call_ref, .return_call_ref => _ = readU32(code, ip), // typeidx
         // ref_as_non_null has no operands
         // No operands
+        else => {},
+    }
+}
+
+fn skipSimdOperands(code: []const u8, ip: *usize) void {
+    const sub = readU32(code, ip);
+    const simd_op: SimdOpcode = @enumFromInt(sub);
+    switch (simd_op) {
+        .v128_load,
+        .v128_load8x8_s,
+        .v128_load8x8_u,
+        .v128_load16x4_s,
+        .v128_load16x4_u,
+        .v128_load32x2_s,
+        .v128_load32x2_u,
+        .v128_load8_splat,
+        .v128_load16_splat,
+        .v128_load32_splat,
+        .v128_load64_splat,
+        .v128_store,
+        .v128_load32_zero,
+        .v128_load64_zero,
+        => {
+            _ = readU32(code, ip); // alignment
+            _ = readU32(code, ip); // offset
+        },
+        .v128_const => ip.* += @min(@as(usize, 16), code.len -| ip.*),
+        .i8x16_shuffle => ip.* += @min(@as(usize, 16), code.len -| ip.*),
+        .i8x16_extract_lane_s,
+        .i8x16_extract_lane_u,
+        .i8x16_replace_lane,
+        .i16x8_extract_lane_s,
+        .i16x8_extract_lane_u,
+        .i16x8_replace_lane,
+        .i32x4_extract_lane,
+        .i32x4_replace_lane,
+        .i64x2_extract_lane,
+        .i64x2_replace_lane,
+        .f32x4_extract_lane,
+        .f32x4_replace_lane,
+        .f64x2_extract_lane,
+        .f64x2_replace_lane,
+        => {
+            if (ip.* < code.len) ip.* += 1;
+        },
+        .v128_load8_lane,
+        .v128_load16_lane,
+        .v128_load32_lane,
+        .v128_load64_lane,
+        .v128_store8_lane,
+        .v128_store16_lane,
+        .v128_store32_lane,
+        .v128_store64_lane,
+        => {
+            _ = readU32(code, ip); // alignment
+            _ = readU32(code, ip); // offset
+            if (ip.* < code.len) ip.* += 1; // lane
+        },
         else => {},
     }
 }
@@ -2186,6 +2358,39 @@ test "lower local.get 0; local.get 1; i32.add; end" {
     try std.testing.expect(insts[3].op.ret != null);
 }
 
+test "lower v128 local type is not treated as i64" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{.v128},
+        .results = &.{.v128},
+    };
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 1,
+        .locals = &.{},
+        // local.get 0, end
+        .code = &[_]u8{ 0x20, 0x00, 0x0B },
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    const ir_func = &ir_module.functions.items[0];
+    try std.testing.expect(ir_func.local_types != null);
+    try std.testing.expectEqual(ir.IrType.v128, ir_func.local_types.?[0]);
+
+    const insts = ir_func.blocks.items[0].instructions.items;
+    try std.testing.expectEqual(@as(u32, 0), insts[0].op.local_get);
+    try std.testing.expectEqual(ir.IrType.v128, insts[0].type);
+    try std.testing.expect(insts[1].op.ret != null);
+}
+
 test "lower unreachable" {
     const allocator = std.testing.allocator;
 
@@ -2268,13 +2473,20 @@ test "lower: dead code after br is skipped" {
     // The i32.const 99 after br is dead code and should be skipped
     var bytecode: [20]u8 = undefined;
     var pos: usize = 0;
-    bytecode[pos] = 0x41; pos += 1; // i32.const
-    bytecode[pos] = 42; pos += 1; // 42
-    bytecode[pos] = 0x0C; pos += 1; // br
-    bytecode[pos] = 0; pos += 1; // depth 0
-    bytecode[pos] = 0x41; pos += 1; // i32.const (dead)
-    bytecode[pos] = 99; pos += 1; // 99 (dead)
-    bytecode[pos] = 0x0B; pos += 1; // end
+    bytecode[pos] = 0x41;
+    pos += 1; // i32.const
+    bytecode[pos] = 42;
+    pos += 1; // 42
+    bytecode[pos] = 0x0C;
+    pos += 1; // br
+    bytecode[pos] = 0;
+    pos += 1; // depth 0
+    bytecode[pos] = 0x41;
+    pos += 1; // i32.const (dead)
+    bytecode[pos] = 99;
+    pos += 1; // 99 (dead)
+    bytecode[pos] = 0x0B;
+    pos += 1; // end
 
     const func_type = types.FuncType{ .params = &.{}, .results = &.{} };
     const func = types.WasmFunction{

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -133,32 +133,105 @@ pub fn computeLiveness(
 /// Add all VReg uses of an instruction to a live set.
 fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
     switch (inst.op) {
-        .iconst_32, .iconst_64, .fconst_32, .fconst_64 => {},
+        .iconst_32, .iconst_64, .fconst_32, .fconst_64, .v128_const => {},
         .local_get, .global_get => {},
         .br, .@"unreachable", .atomic_fence => {},
 
-        .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
-        .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
-        .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u,
-        .f_min, .f_max, .f_copysign,
-        .f_eq, .f_ne, .f_lt, .f_gt, .f_le, .f_ge,
+        .add,
+        .sub,
+        .mul,
+        .div_s,
+        .div_u,
+        .rem_s,
+        .rem_u,
+        .@"and",
+        .@"or",
+        .xor,
+        .shl,
+        .shr_s,
+        .shr_u,
+        .rotl,
+        .rotr,
+        .eq,
+        .ne,
+        .lt_s,
+        .lt_u,
+        .gt_s,
+        .gt_u,
+        .le_s,
+        .le_u,
+        .ge_s,
+        .ge_u,
+        .f_min,
+        .f_max,
+        .f_copysign,
+        .f_eq,
+        .f_ne,
+        .f_lt,
+        .f_gt,
+        .f_le,
+        .f_ge,
         => |bin| {
             live.put(bin.lhs, {}) catch {};
             live.put(bin.rhs, {}) catch {};
         },
 
-        .clz, .ctz, .popcnt, .eqz, .wrap_i64, .extend_i32_s, .extend_i32_u,
-        .extend8_s, .extend16_s, .extend32_s,
-        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest,
-        .trunc_f32_s, .trunc_f32_u, .trunc_f64_s, .trunc_f64_u,
-        .convert_s, .convert_u, .convert_i32_s, .convert_i64_s, .convert_i32_u, .convert_i64_u, .demote_f64, .promote_f32, .reinterpret,
-        .trunc_sat_f32_s, .trunc_sat_f32_u, .trunc_sat_f64_s, .trunc_sat_f64_u,
+        .v128_bitwise => |bin| {
+            live.put(bin.lhs, {}) catch {};
+            live.put(bin.rhs, {}) catch {};
+        },
+        .i32x4_binop => |bin| {
+            live.put(bin.lhs, {}) catch {};
+            live.put(bin.rhs, {}) catch {};
+        },
+
+        .clz,
+        .ctz,
+        .popcnt,
+        .eqz,
+        .wrap_i64,
+        .extend_i32_s,
+        .extend_i32_u,
+        .extend8_s,
+        .extend16_s,
+        .extend32_s,
+        .f_neg,
+        .f_abs,
+        .f_sqrt,
+        .f_ceil,
+        .f_floor,
+        .f_trunc,
+        .f_nearest,
+        .trunc_f32_s,
+        .trunc_f32_u,
+        .trunc_f64_s,
+        .trunc_f64_u,
+        .convert_s,
+        .convert_u,
+        .convert_i32_s,
+        .convert_i64_s,
+        .convert_i32_u,
+        .convert_i64_u,
+        .demote_f64,
+        .promote_f32,
+        .reinterpret,
+        .trunc_sat_f32_s,
+        .trunc_sat_f32_u,
+        .trunc_sat_f64_s,
+        .trunc_sat_f64_u,
+        .v128_not,
         => |vreg| live.put(vreg, {}) catch {},
+        .i32x4_extract_lane => |lane| live.put(lane.vector, {}) catch {},
 
         .local_set => |ls| live.put(ls.val, {}) catch {},
         .global_set => |gs| live.put(gs.val, {}) catch {},
         .load => |ld| live.put(ld.base, {}) catch {},
+        .v128_load => |ld| live.put(ld.base, {}) catch {},
         .store => |st| {
+            live.put(st.base, {}) catch {};
+            live.put(st.val, {}) catch {};
+        },
+        .v128_store => |st| {
             live.put(st.base, {}) catch {};
             live.put(st.val, {}) catch {};
         },
@@ -259,6 +332,7 @@ pub const LiveRange = struct {
     vreg: ir.VReg,
     start: u32, // global instruction index of definition
     end: u32, // global instruction index of last use
+    type: ir.IrType,
 };
 
 /// Compute live ranges for all VRegs in a function.
@@ -292,6 +366,8 @@ pub fn computeLiveRangesWithOrder(
     // Global instruction numbering — follows block_order if provided.
     var def_pos = std.AutoHashMap(ir.VReg, u32).init(allocator);
     defer def_pos.deinit();
+    var def_type = std.AutoHashMap(ir.VReg, ir.IrType).init(allocator);
+    defer def_type.deinit();
     var last_use_pos = std.AutoHashMap(ir.VReg, u32).init(allocator);
     defer last_use_pos.deinit();
 
@@ -326,6 +402,7 @@ pub fn computeLiveRangesWithOrder(
             if (inst.dest) |dest| {
                 if (!def_pos.contains(dest)) {
                     try def_pos.put(dest, global_idx);
+                    try def_type.put(dest, inst.type);
                 }
             }
             // Record last use position
@@ -351,7 +428,12 @@ pub fn computeLiveRangesWithOrder(
         const vreg = entry.key_ptr.*;
         const start = entry.value_ptr.*;
         const end = last_use_pos.get(vreg) orelse start;
-        try ranges.append(allocator, .{ .vreg = vreg, .start = start, .end = @max(start, end) });
+        try ranges.append(allocator, .{
+            .vreg = vreg,
+            .start = start,
+            .end = @max(start, end),
+            .type = def_type.get(vreg) orelse .i32,
+        });
     }
 
     // Sort by start position
@@ -366,32 +448,105 @@ pub fn computeLiveRangesWithOrder(
 
 fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u32) void {
     switch (inst.op) {
-        .iconst_32, .iconst_64, .fconst_32, .fconst_64 => {},
+        .iconst_32, .iconst_64, .fconst_32, .fconst_64, .v128_const => {},
         .local_get, .global_get => {},
         .br, .@"unreachable", .atomic_fence => {},
 
-        .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
-        .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
-        .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u,
-        .f_min, .f_max, .f_copysign,
-        .f_eq, .f_ne, .f_lt, .f_gt, .f_le, .f_ge,
+        .add,
+        .sub,
+        .mul,
+        .div_s,
+        .div_u,
+        .rem_s,
+        .rem_u,
+        .@"and",
+        .@"or",
+        .xor,
+        .shl,
+        .shr_s,
+        .shr_u,
+        .rotl,
+        .rotr,
+        .eq,
+        .ne,
+        .lt_s,
+        .lt_u,
+        .gt_s,
+        .gt_u,
+        .le_s,
+        .le_u,
+        .ge_s,
+        .ge_u,
+        .f_min,
+        .f_max,
+        .f_copysign,
+        .f_eq,
+        .f_ne,
+        .f_lt,
+        .f_gt,
+        .f_le,
+        .f_ge,
         => |bin| {
             last_use.put(bin.lhs, pos) catch {};
             last_use.put(bin.rhs, pos) catch {};
         },
 
-        .clz, .ctz, .popcnt, .eqz, .wrap_i64, .extend_i32_s, .extend_i32_u,
-        .extend8_s, .extend16_s, .extend32_s,
-        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest,
-        .trunc_f32_s, .trunc_f32_u, .trunc_f64_s, .trunc_f64_u,
-        .convert_s, .convert_u, .convert_i32_s, .convert_i64_s, .convert_i32_u, .convert_i64_u, .demote_f64, .promote_f32, .reinterpret,
-        .trunc_sat_f32_s, .trunc_sat_f32_u, .trunc_sat_f64_s, .trunc_sat_f64_u,
+        .v128_bitwise => |bin| {
+            last_use.put(bin.lhs, pos) catch {};
+            last_use.put(bin.rhs, pos) catch {};
+        },
+        .i32x4_binop => |bin| {
+            last_use.put(bin.lhs, pos) catch {};
+            last_use.put(bin.rhs, pos) catch {};
+        },
+
+        .clz,
+        .ctz,
+        .popcnt,
+        .eqz,
+        .wrap_i64,
+        .extend_i32_s,
+        .extend_i32_u,
+        .extend8_s,
+        .extend16_s,
+        .extend32_s,
+        .f_neg,
+        .f_abs,
+        .f_sqrt,
+        .f_ceil,
+        .f_floor,
+        .f_trunc,
+        .f_nearest,
+        .trunc_f32_s,
+        .trunc_f32_u,
+        .trunc_f64_s,
+        .trunc_f64_u,
+        .convert_s,
+        .convert_u,
+        .convert_i32_s,
+        .convert_i64_s,
+        .convert_i32_u,
+        .convert_i64_u,
+        .demote_f64,
+        .promote_f32,
+        .reinterpret,
+        .trunc_sat_f32_s,
+        .trunc_sat_f32_u,
+        .trunc_sat_f64_s,
+        .trunc_sat_f64_u,
+        .v128_not,
         => |vreg| last_use.put(vreg, pos) catch {},
+        .i32x4_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
 
         .local_set => |ls| last_use.put(ls.val, pos) catch {},
         .global_set => |gs| last_use.put(gs.val, pos) catch {},
         .load => |ld| last_use.put(ld.base, pos) catch {},
+        .v128_load => |ld| last_use.put(ld.base, pos) catch {},
         .store => |st| {
+            last_use.put(st.base, pos) catch {};
+            last_use.put(st.val, pos) catch {};
+        },
+        .v128_store => |st| {
             last_use.put(st.base, pos) catch {};
             last_use.put(st.val, pos) catch {};
         },
@@ -1075,6 +1230,32 @@ test "computeLiveRanges: basic ranges" {
     try std.testing.expectEqual(@as(u32, 2), ranges[1].end); // v1 used at pos 2 (add)
     try std.testing.expectEqual(@as(u32, 2), ranges[2].start);
     try std.testing.expectEqual(@as(u32, 3), ranges[2].end); // v2 used at pos 3 (ret)
+}
+
+test "computeLiveRanges: v128 ranges retain type" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const block0 = func.getBlock(b0);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try block0.append(.{ .op = .{ .v128_const = 0xFFFF }, .dest = v0, .type = .v128 });
+    try block0.append(.{ .op = .{ .v128_not = v0 }, .dest = v1, .type = .v128 });
+    try block0.append(.{ .op = .{ .i32x4_extract_lane = .{ .vector = v1, .lane = 0 } }, .dest = v2, .type = .i32 });
+    try block0.append(.{ .op = .{ .ret = v2 } });
+
+    const ranges = try computeLiveRanges(&func, allocator);
+    defer allocator.free(ranges);
+
+    try std.testing.expectEqual(@as(usize, 3), ranges.len);
+    try std.testing.expectEqual(ir.IrType.v128, ranges[0].type);
+    try std.testing.expectEqual(ir.IrType.v128, ranges[1].type);
+    try std.testing.expectEqual(ir.IrType.i32, ranges[2].type);
+    try std.testing.expectEqual(@as(u32, 1), ranges[0].end);
+    try std.testing.expectEqual(@as(u32, 2), ranges[1].end);
 }
 
 test "computeLiveRanges: call with explicit args" {

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -18,7 +18,35 @@ pub const IrType = enum {
     i64,
     f32,
     f64,
+    v128,
     void,
+
+    pub fn byteSize(self: IrType) u8 {
+        return switch (self) {
+            .i32, .f32 => 4,
+            .i64, .f64 => 8,
+            .v128 => 16,
+            .void => 0,
+        };
+    }
+
+    /// Number of 8-byte frame slots needed to spill this value.
+    pub fn spillSlots64(self: IrType) u8 {
+        return switch (self) {
+            .v128 => 2,
+            .void => 0,
+            else => 1,
+        };
+    }
+
+    /// Alignment required for stack storage, in 8-byte frame slots.
+    pub fn spillAlignSlots64(self: IrType) u8 {
+        return switch (self) {
+            .v128 => 2,
+            .void => 1,
+            else => 1,
+        };
+    }
 };
 
 /// An IR instruction.
@@ -33,6 +61,17 @@ pub const Inst = struct {
         iconst_64: i64,
         fconst_32: f32,
         fconst_64: f64,
+
+        // SIMD/v128 foundation. These IR forms are intentionally narrow:
+        // they cover the first AArch64 NEON slice without implying full
+        // wasm SIMD coverage or exported v128 ABI support.
+        v128_const: u128,
+        v128_load: V128Mem,
+        v128_store: V128Store,
+        v128_not: VReg,
+        v128_bitwise: V128Bitwise,
+        i32x4_binop: I32x4BinOp,
+        i32x4_extract_lane: I32x4ExtractLane,
 
         // Binary arithmetic (dest = lhs op rhs)
         add: BinOp,
@@ -205,6 +244,44 @@ pub const Inst = struct {
 
     pub const AtomicRmwOp = enum { add, sub, @"and", @"or", xor, xchg };
 
+    pub const V128BitwiseOp = enum { @"and", andnot, @"or", xor };
+
+    pub const I32x4Op = enum { add, sub, eq };
+
+    pub const V128Mem = struct {
+        base: VReg,
+        offset: u32,
+        alignment: u32,
+        bounds_known: bool = false,
+        checked_end: u64 = 0,
+    };
+
+    pub const V128Store = struct {
+        base: VReg,
+        offset: u32,
+        alignment: u32,
+        val: VReg,
+        bounds_known: bool = false,
+        checked_end: u64 = 0,
+    };
+
+    pub const V128Bitwise = struct {
+        op: V128BitwiseOp,
+        lhs: VReg,
+        rhs: VReg,
+    };
+
+    pub const I32x4BinOp = struct {
+        op: I32x4Op,
+        lhs: VReg,
+        rhs: VReg,
+    };
+
+    pub const I32x4ExtractLane = struct {
+        vector: VReg,
+        lane: u2,
+    };
+
     pub const PhiEdge = struct {
         block: BlockId,
         val: VReg,
@@ -350,6 +427,34 @@ test "IrFunction: newVReg returns sequential values" {
     try std.testing.expectEqual(@as(VReg, 2), func.newVReg());
     try std.testing.expectEqual(@as(VReg, 3), func.newVReg());
     try std.testing.expectEqual(@as(VReg, 4), func.next_vreg);
+}
+
+test "IrType: v128 uses 16 bytes and two spill slots" {
+    try std.testing.expectEqual(@as(u8, 16), IrType.v128.byteSize());
+    try std.testing.expectEqual(@as(u8, 2), IrType.v128.spillSlots64());
+    try std.testing.expectEqual(@as(u8, 2), IrType.v128.spillAlignSlots64());
+    try std.testing.expectEqual(@as(u8, 1), IrType.i64.spillSlots64());
+}
+
+test "Inst: first v128 op family preserves operand shape" {
+    const c = Inst{ .op = .{ .v128_const = 0x0011_2233_4455_6677_8899_AABB_CCDD_EEFF }, .dest = 1, .type = .v128 };
+    try std.testing.expectEqual(IrType.v128, c.type);
+    try std.testing.expectEqual(@as(u128, 0x0011_2233_4455_6677_8899_AABB_CCDD_EEFF), c.op.v128_const);
+
+    const bit = Inst{
+        .op = .{ .v128_bitwise = .{ .op = .xor, .lhs = 1, .rhs = 2 } },
+        .dest = 3,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(Inst.V128BitwiseOp.xor, bit.op.v128_bitwise.op);
+    try std.testing.expectEqual(@as(VReg, 1), bit.op.v128_bitwise.lhs);
+
+    const lane = Inst{
+        .op = .{ .i32x4_extract_lane = .{ .vector = 3, .lane = 2 } },
+        .dest = 4,
+        .type = .i32,
+    };
+    try std.testing.expectEqual(@as(u2, 2), lane.op.i32x4_extract_lane.lane);
 }
 
 test "IrModule: add multiple functions" {

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -91,34 +91,107 @@ pub fn buildUseDef(func: *const ir.IrFunction, allocator: std.mem.Allocator) !st
 fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
     var list = BoundedVRegList{};
     switch (inst.op) {
-        .iconst_32, .iconst_64, .fconst_32, .fconst_64 => {},
+        .iconst_32, .iconst_64, .fconst_32, .fconst_64, .v128_const => {},
         .local_get, .global_get => {},
         .br, .@"unreachable" => {},
 
         // Binary ops
-        .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
-        .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
-        .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u,
-        .f_min, .f_max, .f_copysign,
-        .f_eq, .f_ne, .f_lt, .f_gt, .f_le, .f_ge,
+        .add,
+        .sub,
+        .mul,
+        .div_s,
+        .div_u,
+        .rem_s,
+        .rem_u,
+        .@"and",
+        .@"or",
+        .xor,
+        .shl,
+        .shr_s,
+        .shr_u,
+        .rotl,
+        .rotr,
+        .eq,
+        .ne,
+        .lt_s,
+        .lt_u,
+        .gt_s,
+        .gt_u,
+        .le_s,
+        .le_u,
+        .ge_s,
+        .ge_u,
+        .f_min,
+        .f_max,
+        .f_copysign,
+        .f_eq,
+        .f_ne,
+        .f_lt,
+        .f_gt,
+        .f_le,
+        .f_ge,
         => |bin| {
             list.append(bin.lhs);
             list.append(bin.rhs);
         },
 
+        .v128_bitwise => |bin| {
+            list.append(bin.lhs);
+            list.append(bin.rhs);
+        },
+        .i32x4_binop => |bin| {
+            list.append(bin.lhs);
+            list.append(bin.rhs);
+        },
+
         // Unary ops
-        .clz, .ctz, .popcnt, .eqz, .wrap_i64, .extend_i32_s, .extend_i32_u,
-        .extend8_s, .extend16_s, .extend32_s,
-        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest,
-        .trunc_f32_s, .trunc_f32_u, .trunc_f64_s, .trunc_f64_u,
-        .convert_s, .convert_u, .convert_i32_s, .convert_i64_s, .convert_i32_u, .convert_i64_u, .demote_f64, .promote_f32, .reinterpret,
-        .trunc_sat_f32_s, .trunc_sat_f32_u, .trunc_sat_f64_s, .trunc_sat_f64_u,
+        .clz,
+        .ctz,
+        .popcnt,
+        .eqz,
+        .wrap_i64,
+        .extend_i32_s,
+        .extend_i32_u,
+        .extend8_s,
+        .extend16_s,
+        .extend32_s,
+        .f_neg,
+        .f_abs,
+        .f_sqrt,
+        .f_ceil,
+        .f_floor,
+        .f_trunc,
+        .f_nearest,
+        .trunc_f32_s,
+        .trunc_f32_u,
+        .trunc_f64_s,
+        .trunc_f64_u,
+        .convert_s,
+        .convert_u,
+        .convert_i32_s,
+        .convert_i64_s,
+        .convert_i32_u,
+        .convert_i64_u,
+        .demote_f64,
+        .promote_f32,
+        .reinterpret,
+        .trunc_sat_f32_s,
+        .trunc_sat_f32_u,
+        .trunc_sat_f64_s,
+        .trunc_sat_f64_u,
+        .v128_not,
         => |vreg| list.append(vreg),
+        .i32x4_extract_lane => |lane| list.append(lane.vector),
 
         .local_set => |ls| list.append(ls.val),
         .global_set => |gs| list.append(gs.val),
         .load => |ld| list.append(ld.base),
+        .v128_load => |ld| list.append(ld.base),
         .store => |st| {
+            list.append(st.base);
+            list.append(st.val);
+        },
+        .v128_store => |st| {
             list.append(st.base);
             list.append(st.val);
         },
@@ -247,38 +320,136 @@ pub fn countUsesOfVReg(func: *const ir.IrFunction, vreg: ir.VReg) u32 {
 
 fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
     switch (inst.op) {
-        .iconst_32, .iconst_64, .fconst_32, .fconst_64,
-        .local_get, .global_get, .br, .@"unreachable",
+        .iconst_32,
+        .iconst_64,
+        .fconst_32,
+        .fconst_64,
+        .v128_const,
+        .local_get,
+        .global_get,
+        .br,
+        .@"unreachable",
         => {},
 
-        .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
-        .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
-        .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u,
-        .f_min, .f_max, .f_copysign,
-        .f_eq, .f_ne, .f_lt, .f_gt, .f_le, .f_ge,
+        .add,
+        .sub,
+        .mul,
+        .div_s,
+        .div_u,
+        .rem_s,
+        .rem_u,
+        .@"and",
+        .@"or",
+        .xor,
+        .shl,
+        .shr_s,
+        .shr_u,
+        .rotl,
+        .rotr,
+        .eq,
+        .ne,
+        .lt_s,
+        .lt_u,
+        .gt_s,
+        .gt_u,
+        .le_s,
+        .le_u,
+        .ge_s,
+        .ge_u,
+        .f_min,
+        .f_max,
+        .f_copysign,
+        .f_eq,
+        .f_ne,
+        .f_lt,
+        .f_gt,
+        .f_le,
+        .f_ge,
         => |*bin| {
             if (bin.lhs == old) bin.lhs = new;
             if (bin.rhs == old) bin.rhs = new;
         },
 
-        .clz, .ctz, .popcnt, .eqz, .wrap_i64, .extend_i32_s, .extend_i32_u,
-        .extend8_s, .extend16_s, .extend32_s,
-        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest,
-        .trunc_f32_s, .trunc_f32_u, .trunc_f64_s, .trunc_f64_u,
-        .convert_s, .convert_u, .convert_i32_s, .convert_i64_s, .convert_i32_u, .convert_i64_u, .demote_f64, .promote_f32, .reinterpret,
-        .trunc_sat_f32_s, .trunc_sat_f32_u, .trunc_sat_f64_s, .trunc_sat_f64_u,
-        => |*vreg| if (vreg.* == old) { vreg.* = new; },
+        .v128_bitwise => |*bin| {
+            if (bin.lhs == old) bin.lhs = new;
+            if (bin.rhs == old) bin.rhs = new;
+        },
+        .i32x4_binop => |*bin| {
+            if (bin.lhs == old) bin.lhs = new;
+            if (bin.rhs == old) bin.rhs = new;
+        },
 
-        .local_set => |*ls| if (ls.val == old) { ls.val = new; },
-        .global_set => |*gs| if (gs.val == old) { gs.val = new; },
-        .load => |*ld| if (ld.base == old) { ld.base = new; },
+        .clz,
+        .ctz,
+        .popcnt,
+        .eqz,
+        .wrap_i64,
+        .extend_i32_s,
+        .extend_i32_u,
+        .extend8_s,
+        .extend16_s,
+        .extend32_s,
+        .f_neg,
+        .f_abs,
+        .f_sqrt,
+        .f_ceil,
+        .f_floor,
+        .f_trunc,
+        .f_nearest,
+        .trunc_f32_s,
+        .trunc_f32_u,
+        .trunc_f64_s,
+        .trunc_f64_u,
+        .convert_s,
+        .convert_u,
+        .convert_i32_s,
+        .convert_i64_s,
+        .convert_i32_u,
+        .convert_i64_u,
+        .demote_f64,
+        .promote_f32,
+        .reinterpret,
+        .trunc_sat_f32_s,
+        .trunc_sat_f32_u,
+        .trunc_sat_f64_s,
+        .trunc_sat_f64_u,
+        .v128_not,
+        => |*vreg| if (vreg.* == old) {
+            vreg.* = new;
+        },
+        .i32x4_extract_lane => |*lane| if (lane.vector == old) {
+            lane.vector = new;
+        },
+
+        .local_set => |*ls| if (ls.val == old) {
+            ls.val = new;
+        },
+        .global_set => |*gs| if (gs.val == old) {
+            gs.val = new;
+        },
+        .load => |*ld| if (ld.base == old) {
+            ld.base = new;
+        },
+        .v128_load => |*ld| if (ld.base == old) {
+            ld.base = new;
+        },
         .store => |*st| {
             if (st.base == old) st.base = new;
             if (st.val == old) st.val = new;
         },
-        .br_if => |*bi| if (bi.cond == old) { bi.cond = new; },
-        .br_table => |*bt| if (bt.index == old) { bt.index = new; },
-        .ret => |*maybe_vreg| if (maybe_vreg.*) |v| { if (v == old) maybe_vreg.* = new; },
+        .v128_store => |*st| {
+            if (st.base == old) st.base = new;
+            if (st.val == old) st.val = new;
+        },
+        .br_if => |*bi| if (bi.cond == old) {
+            bi.cond = new;
+        },
+        .br_table => |*bt| if (bt.index == old) {
+            bt.index = new;
+        },
+        .ret => |*maybe_vreg| if (maybe_vreg.*) |v| {
+            if (v == old) maybe_vreg.* = new;
+        },
         .ret_multi => |vregs| {
             for (@constCast(vregs)) |*v| {
                 if (v.* == old) v.* = new;
@@ -310,7 +481,9 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
 
         // Atomic operations
         .atomic_fence => {},
-        .atomic_load => |*al| if (al.base == old) { al.base = new; },
+        .atomic_load => |*al| if (al.base == old) {
+            al.base = new;
+        },
         .atomic_store => |*ast| {
             if (ast.base == old) ast.base = new;
             if (ast.val == old) ast.val = new;
@@ -397,11 +570,31 @@ pub fn constantFold(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
                 .iconst_64 => |v| if (inst.dest) |d| {
                     try constants.put(d, v);
                 },
-                .add, .sub, .mul, .@"and", .@"or", .xor,
-                .shl, .shr_s, .shr_u, .rotl, .rotr,
-                .eq, .ne, .lt_s, .gt_s, .le_s, .ge_s,
-                .lt_u, .gt_u, .le_u, .ge_u,
-                .div_s, .div_u, .rem_s, .rem_u,
+                .add,
+                .sub,
+                .mul,
+                .@"and",
+                .@"or",
+                .xor,
+                .shl,
+                .shr_s,
+                .shr_u,
+                .rotl,
+                .rotr,
+                .eq,
+                .ne,
+                .lt_s,
+                .gt_s,
+                .le_s,
+                .ge_s,
+                .lt_u,
+                .gt_u,
+                .le_u,
+                .ge_u,
+                .div_s,
+                .div_u,
+                .rem_s,
+                .rem_u,
                 => |bin| {
                     const dest = inst.dest orelse continue;
                     const maybe_lhs = constants.get(bin.lhs);
@@ -537,22 +730,14 @@ fn evalBinOp(op: ir.Inst.Op, lhs: i64, rhs: i64, ty: ir.IrType) ?i64 {
         },
         .eq => @intFromBool(lhs == rhs),
         .ne => @intFromBool(lhs != rhs),
-        .lt_s => if (ty == .i64) @intFromBool(lhs < rhs)
-            else @intFromBool(@as(i32, @truncate(lhs)) < @as(i32, @truncate(rhs))),
-        .gt_s => if (ty == .i64) @intFromBool(lhs > rhs)
-            else @intFromBool(@as(i32, @truncate(lhs)) > @as(i32, @truncate(rhs))),
-        .le_s => if (ty == .i64) @intFromBool(lhs <= rhs)
-            else @intFromBool(@as(i32, @truncate(lhs)) <= @as(i32, @truncate(rhs))),
-        .ge_s => if (ty == .i64) @intFromBool(lhs >= rhs)
-            else @intFromBool(@as(i32, @truncate(lhs)) >= @as(i32, @truncate(rhs))),
-        .lt_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) < @as(u64, @bitCast(rhs)))
-            else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) < @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
-        .gt_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) > @as(u64, @bitCast(rhs)))
-            else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) > @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
-        .le_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) <= @as(u64, @bitCast(rhs)))
-            else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) <= @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
-        .ge_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) >= @as(u64, @bitCast(rhs)))
-            else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) >= @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
+        .lt_s => if (ty == .i64) @intFromBool(lhs < rhs) else @intFromBool(@as(i32, @truncate(lhs)) < @as(i32, @truncate(rhs))),
+        .gt_s => if (ty == .i64) @intFromBool(lhs > rhs) else @intFromBool(@as(i32, @truncate(lhs)) > @as(i32, @truncate(rhs))),
+        .le_s => if (ty == .i64) @intFromBool(lhs <= rhs) else @intFromBool(@as(i32, @truncate(lhs)) <= @as(i32, @truncate(rhs))),
+        .ge_s => if (ty == .i64) @intFromBool(lhs >= rhs) else @intFromBool(@as(i32, @truncate(lhs)) >= @as(i32, @truncate(rhs))),
+        .lt_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) < @as(u64, @bitCast(rhs))) else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) < @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
+        .gt_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) > @as(u64, @bitCast(rhs))) else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) > @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
+        .le_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) <= @as(u64, @bitCast(rhs))) else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) <= @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
+        .ge_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) >= @as(u64, @bitCast(rhs))) else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) >= @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
         .div_s => blk: {
             if (rhs == 0) break :blk null;
             if (ty == .i64) {
@@ -908,11 +1093,13 @@ pub fn strengthReduceDivRem(func: *ir.IrFunction, allocator: std.mem.Allocator) 
                         else
                             .{ .iconst_32 = @intCast(k) };
                         try block.instructions.insert(
-                            block.allocator, i,
+                            block.allocator,
+                            i,
                             .{ .op = shift_op, .dest = shift_vreg, .type = inst.type },
                         );
                         block.instructions.items[i + 1].op = .{ .shr_u = .{
-                            .lhs = bin.lhs, .rhs = shift_vreg,
+                            .lhs = bin.lhs,
+                            .rhs = shift_vreg,
                         } };
                         block.instructions.items[i + 1].dest = dest;
                         try constants.put(shift_vreg, @intCast(k));
@@ -968,11 +1155,13 @@ pub fn strengthReduceDivRem(func: *ir.IrFunction, allocator: std.mem.Allocator) 
                         else
                             .{ .iconst_32 = @bitCast(@as(u32, @truncate(mask_u))) };
                         try block.instructions.insert(
-                            block.allocator, i,
+                            block.allocator,
+                            i,
                             .{ .op = mask_op, .dest = mask_vreg, .type = inst.type },
                         );
                         block.instructions.items[i + 1].op = .{ .@"and" = .{
-                            .lhs = bin.lhs, .rhs = mask_vreg,
+                            .lhs = bin.lhs,
+                            .rhs = mask_vreg,
                         } };
                         block.instructions.items[i + 1].dest = dest;
                         try constants.put(mask_vreg, @as(i64, @bitCast(mask_u)));
@@ -1010,7 +1199,8 @@ pub fn strengthReduceDivRem(func: *ir.IrFunction, allocator: std.mem.Allocator) 
                         }
                         // Replace rem_u with sub(x, q*d).
                         block.instructions.items[i].op = .{ .sub = .{
-                            .lhs = bin.lhs, .rhs = v_qd,
+                            .lhs = bin.lhs,
+                            .rhs = v_qd,
                         } };
                         block.instructions.items[i].dest = dest;
                         block.instructions.items[i].type = .i32;
@@ -1055,7 +1245,10 @@ fn computeMagicU32(d: u32) ?struct { magic: u64, shift: u6 } {
             // Compute (x * m) >> (32 + s) using 128-bit arithmetic via two 64-bit muls.
             const prod = @as(u128, x) * @as(u128, m);
             const result = @as(u64, @truncate(prod >> shift_amt));
-            if (result != expected) { ok = false; break; }
+            if (result != expected) {
+                ok = false;
+                break;
+            }
         }
         if (ok) return .{ .magic = m, .shift = s };
     }
@@ -1178,15 +1371,46 @@ pub fn algebraicSimplify(func: *ir.IrFunction, allocator: std.mem.Allocator) !bo
 
 fn hasSideEffect(inst: ir.Inst) bool {
     return switch (inst.op) {
-        .store, .local_set, .global_set, .call, .call_indirect, .call_ref, .ret, .ret_multi, .br, .br_if, .br_table, .@"unreachable",
-        .atomic_fence, .atomic_load, .atomic_store, .atomic_rmw, .atomic_cmpxchg,
-        .atomic_notify, .atomic_wait, .memory_copy, .memory_fill, .memory_grow,
-        .memory_init, .data_drop, .table_init, .elem_drop, .table_set, .table_grow,
+        .store,
+        .v128_store,
+        .local_set,
+        .global_set,
+        .call,
+        .call_indirect,
+        .call_ref,
+        .ret,
+        .ret_multi,
+        .br,
+        .br_if,
+        .br_table,
+        .@"unreachable",
+        .atomic_fence,
+        .atomic_load,
+        .atomic_store,
+        .atomic_rmw,
+        .atomic_cmpxchg,
+        .atomic_notify,
+        .atomic_wait,
+        .memory_copy,
+        .memory_fill,
+        .memory_grow,
+        .memory_init,
+        .data_drop,
+        .table_init,
+        .elem_drop,
+        .table_set,
+        .table_grow,
         => true,
         // Trapping ops: must not be removed even if result is unused.
-        .load, .table_get,
-        .div_u, .rem_u,
-        .trunc_f32_s, .trunc_f32_u, .trunc_f64_s, .trunc_f64_u,
+        .load,
+        .v128_load,
+        .table_get,
+        .div_u,
+        .rem_u,
+        .trunc_f32_s,
+        .trunc_f32_u,
+        .trunc_f64_s,
+        .trunc_f64_u,
         => true,
         // div_s/rem_s trap for integers but not floats (float div produces NaN/Inf).
         .div_s, .rem_s => inst.type != .f32 and inst.type != .f64,
@@ -1306,19 +1530,83 @@ pub fn commonSubexprElimination(func: *ir.IrFunction, allocator: std.mem.Allocat
 
 fn isPure(inst: ir.Inst) bool {
     return switch (inst.op) {
-        .iconst_32, .iconst_64, .fconst_32, .fconst_64,
-        .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
-        .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
-        .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u,
-        .clz, .ctz, .popcnt, .eqz,
-        .wrap_i64, .extend_i32_s, .extend_i32_u,
-        .extend8_s, .extend16_s, .extend32_s,
-        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest,
-        .f_min, .f_max, .f_copysign,
-        .f_eq, .f_ne, .f_lt, .f_gt, .f_le, .f_ge,
-        .trunc_f32_s, .trunc_f32_u, .trunc_f64_s, .trunc_f64_u,
-        .convert_s, .convert_u, .convert_i32_s, .convert_i64_s, .convert_i32_u, .convert_i64_u, .demote_f64, .promote_f32, .reinterpret,
-        .trunc_sat_f32_s, .trunc_sat_f32_u, .trunc_sat_f64_s, .trunc_sat_f64_u,
+        .iconst_32,
+        .iconst_64,
+        .fconst_32,
+        .fconst_64,
+        .v128_const,
+        .add,
+        .sub,
+        .mul,
+        .div_s,
+        .div_u,
+        .rem_s,
+        .rem_u,
+        .@"and",
+        .@"or",
+        .xor,
+        .shl,
+        .shr_s,
+        .shr_u,
+        .rotl,
+        .rotr,
+        .eq,
+        .ne,
+        .lt_s,
+        .lt_u,
+        .gt_s,
+        .gt_u,
+        .le_s,
+        .le_u,
+        .ge_s,
+        .ge_u,
+        .clz,
+        .ctz,
+        .popcnt,
+        .eqz,
+        .wrap_i64,
+        .extend_i32_s,
+        .extend_i32_u,
+        .extend8_s,
+        .extend16_s,
+        .extend32_s,
+        .f_neg,
+        .f_abs,
+        .f_sqrt,
+        .f_ceil,
+        .f_floor,
+        .f_trunc,
+        .f_nearest,
+        .f_min,
+        .f_max,
+        .f_copysign,
+        .f_eq,
+        .f_ne,
+        .f_lt,
+        .f_gt,
+        .f_le,
+        .f_ge,
+        .trunc_f32_s,
+        .trunc_f32_u,
+        .trunc_f64_s,
+        .trunc_f64_u,
+        .convert_s,
+        .convert_u,
+        .convert_i32_s,
+        .convert_i64_s,
+        .convert_i32_u,
+        .convert_i64_u,
+        .demote_f64,
+        .promote_f32,
+        .reinterpret,
+        .trunc_sat_f32_s,
+        .trunc_sat_f32_u,
+        .trunc_sat_f64_s,
+        .trunc_sat_f64_u,
+        .v128_not,
+        .v128_bitwise,
+        .i32x4_binop,
+        .i32x4_extract_lane,
         => true,
         else => false,
     };
@@ -1333,6 +1621,7 @@ fn sameOp(a: ir.Inst, b: ir.Inst) bool {
         .iconst_64 => |v| v == b.op.iconst_64,
         .fconst_32 => |v| @as(u32, @bitCast(v)) == @as(u32, @bitCast(b.op.fconst_32)),
         .fconst_64 => |v| @as(u64, @bitCast(v)) == @as(u64, @bitCast(b.op.fconst_64)),
+        .v128_const => |v| v == b.op.v128_const,
         // Binary integer arithmetic / logic / shifts / rotations
         .add => |bin| bin.lhs == b.op.add.lhs and bin.rhs == b.op.add.rhs,
         .sub => |bin| bin.lhs == b.op.sub.lhs and bin.rhs == b.op.sub.rhs,
@@ -1405,6 +1694,10 @@ fn sameOp(a: ir.Inst, b: ir.Inst) bool {
         .trunc_sat_f32_u => |v| v == b.op.trunc_sat_f32_u,
         .trunc_sat_f64_s => |v| v == b.op.trunc_sat_f64_s,
         .trunc_sat_f64_u => |v| v == b.op.trunc_sat_f64_u,
+        .v128_not => |v| v == b.op.v128_not,
+        .v128_bitwise => |bin| bin.op == b.op.v128_bitwise.op and bin.lhs == b.op.v128_bitwise.lhs and bin.rhs == b.op.v128_bitwise.rhs,
+        .i32x4_binop => |bin| bin.op == b.op.i32x4_binop.op and bin.lhs == b.op.i32x4_binop.lhs and bin.rhs == b.op.i32x4_binop.rhs,
+        .i32x4_extract_lane => |lane| lane.vector == b.op.i32x4_extract_lane.vector and lane.lane == b.op.i32x4_extract_lane.lane,
         // div/rem: covered by isPure+hasSideEffect guard; float variants
         // (side-effect-free) reach here.
         .div_s => |bin| bin.lhs == b.op.div_s.lhs and bin.rhs == b.op.div_s.rhs,
@@ -1600,10 +1893,16 @@ pub fn hoistLoopBoundsChecks(func: *ir.IrFunction, allocator: std.mem.Allocator)
             // Fence: stop scanning.
             switch (inst.op) {
                 .memory_grow,
-                .call, .call_indirect, .call_ref,
-                .memory_copy, .memory_fill, .memory_init,
-                .table_grow, .table_init,
-                .atomic_notify, .atomic_wait,
+                .call,
+                .call_indirect,
+                .call_ref,
+                .memory_copy,
+                .memory_fill,
+                .memory_init,
+                .table_grow,
+                .table_init,
+                .atomic_notify,
+                .atomic_wait,
                 => break,
                 else => {},
             }
@@ -1614,8 +1913,7 @@ pub fn hoistLoopBoundsChecks(func: *ir.IrFunction, allocator: std.mem.Allocator)
                     if (loop.containsBlock(db)) continue; // not loop-invariant
                     const end: u64 = @as(u64, ld.offset) + @as(u64, ld.size);
                     const gop = try base_max.getOrPut(ld.base);
-                    if (!gop.found_existing) gop.value_ptr.* = end
-                    else if (end > gop.value_ptr.*) gop.value_ptr.* = end;
+                    if (!gop.found_existing) gop.value_ptr.* = end else if (end > gop.value_ptr.*) gop.value_ptr.* = end;
                 },
                 .store => |st| {
                     if (st.bounds_known) continue;
@@ -1623,8 +1921,7 @@ pub fn hoistLoopBoundsChecks(func: *ir.IrFunction, allocator: std.mem.Allocator)
                     if (loop.containsBlock(db)) continue;
                     const end: u64 = @as(u64, st.offset) + @as(u64, st.size);
                     const gop = try base_max.getOrPut(st.base);
-                    if (!gop.found_existing) gop.value_ptr.* = end
-                    else if (end > gop.value_ptr.*) gop.value_ptr.* = end;
+                    if (!gop.found_existing) gop.value_ptr.* = end else if (end > gop.value_ptr.*) gop.value_ptr.* = end;
                 },
                 else => {},
             }
@@ -1721,7 +2018,10 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
         var preheader: ?ir.BlockId = null;
         for (header_preds) |p| {
             if (!loop.containsBlock(p)) {
-                if (preheader != null) { preheader = null; break; }
+                if (preheader != null) {
+                    preheader = null;
+                    break;
+                }
                 preheader = p;
             }
         }
@@ -1729,7 +2029,9 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
         const ph_insts = func.blocks.items[ph].instructions.items;
         if (ph_insts.len == 0) continue;
         switch (ph_insts[ph_insts.len - 1].op) {
-            .br => |t| { if (t != loop.header) continue; },
+            .br => |t| {
+                if (t != loop.header) continue;
+            },
             else => continue,
         }
         if (!dom.dominates(ph, loop.header)) continue;
@@ -1750,10 +2052,16 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
                     var ok = true;
                     for (used.slice()) |v| {
                         if (def_block.get(v)) |db| {
-                            if (loop.containsBlock(db)) { ok = false; break; }
+                            if (loop.containsBlock(db)) {
+                                ok = false;
+                                break;
+                            }
                         }
                     }
-                    if (!ok) { i += 1; continue; }
+                    if (!ok) {
+                        i += 1;
+                        continue;
+                    }
 
                     const ph_block = &func.blocks.items[ph];
                     try ph_block.instructions.insert(ph_block.allocator, ph_block.instructions.items.len - 1, inst);
@@ -1913,10 +2221,16 @@ pub fn elideRedundantBoundsChecks(func: *ir.IrFunction, allocator: std.mem.Alloc
                 // on first accesses) then hide all dominator entries
                 // from post-fence instructions and dom-tree descendants.
                 .memory_grow,
-                .call, .call_indirect, .call_ref,
-                .memory_copy, .memory_fill, .memory_init,
-                .table_grow, .table_init,
-                .atomic_notify, .atomic_wait,
+                .call,
+                .call_indirect,
+                .call_ref,
+                .memory_copy,
+                .memory_fill,
+                .memory_init,
+                .table_grow,
+                .table_init,
+                .atomic_notify,
+                .atomic_wait,
                 => {
                     changed = patchSegment(&seg_first) or changed;
                     seg_first.clearRetainingCapacity();
@@ -2117,10 +2431,16 @@ pub fn foldLoadStoreOffset(func: *ir.IrFunction, allocator: std.mem.Allocator) !
                     }
                 },
                 .memory_grow,
-                .call, .call_indirect, .call_ref,
-                .memory_copy, .memory_fill, .memory_init,
-                .table_grow, .table_init,
-                .atomic_notify, .atomic_wait,
+                .call,
+                .call_indirect,
+                .call_ref,
+                .memory_copy,
+                .memory_fill,
+                .memory_init,
+                .table_grow,
+                .table_init,
+                .atomic_notify,
+                .atomic_wait,
                 => {
                     block_checked.clearRetainingCapacity();
                     valid_start = table.items.len;
@@ -2768,40 +3088,127 @@ pub fn foldInverseCompareEqz(func: *ir.IrFunction, allocator: std.mem.Allocator)
 fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
     if (inst.dest) |d| inst.dest = d + offset;
     switch (inst.op) {
-        .iconst_32, .iconst_64, .fconst_32, .fconst_64,
-        .local_get, .global_get, .br, .@"unreachable",
-        .memory_size, .table_size, .ref_func, .data_drop, .elem_drop,
-        .atomic_fence, .call_result,
+        .iconst_32,
+        .iconst_64,
+        .fconst_32,
+        .fconst_64,
+        .v128_const,
+        .local_get,
+        .global_get,
+        .br,
+        .@"unreachable",
+        .memory_size,
+        .table_size,
+        .ref_func,
+        .data_drop,
+        .elem_drop,
+        .atomic_fence,
+        .call_result,
         => {},
 
-        .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u,
-        .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr,
-        .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u,
-        .f_min, .f_max, .f_copysign,
-        .f_eq, .f_ne, .f_lt, .f_gt, .f_le, .f_ge,
+        .add,
+        .sub,
+        .mul,
+        .div_s,
+        .div_u,
+        .rem_s,
+        .rem_u,
+        .@"and",
+        .@"or",
+        .xor,
+        .shl,
+        .shr_s,
+        .shr_u,
+        .rotl,
+        .rotr,
+        .eq,
+        .ne,
+        .lt_s,
+        .lt_u,
+        .gt_s,
+        .gt_u,
+        .le_s,
+        .le_u,
+        .ge_s,
+        .ge_u,
+        .f_min,
+        .f_max,
+        .f_copysign,
+        .f_eq,
+        .f_ne,
+        .f_lt,
+        .f_gt,
+        .f_le,
+        .f_ge,
         => |*bin| {
             bin.lhs += offset;
             bin.rhs += offset;
         },
 
-        .clz, .ctz, .popcnt, .eqz, .wrap_i64, .extend_i32_s, .extend_i32_u,
-        .extend8_s, .extend16_s, .extend32_s,
-        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest,
-        .trunc_f32_s, .trunc_f32_u, .trunc_f64_s, .trunc_f64_u,
-        .convert_s, .convert_u, .convert_i32_s, .convert_i64_s, .convert_i32_u, .convert_i64_u, .demote_f64, .promote_f32, .reinterpret,
-        .trunc_sat_f32_s, .trunc_sat_f32_u, .trunc_sat_f64_s, .trunc_sat_f64_u,
+        .v128_bitwise => |*bin| {
+            bin.lhs += offset;
+            bin.rhs += offset;
+        },
+        .i32x4_binop => |*bin| {
+            bin.lhs += offset;
+            bin.rhs += offset;
+        },
+
+        .clz,
+        .ctz,
+        .popcnt,
+        .eqz,
+        .wrap_i64,
+        .extend_i32_s,
+        .extend_i32_u,
+        .extend8_s,
+        .extend16_s,
+        .extend32_s,
+        .f_neg,
+        .f_abs,
+        .f_sqrt,
+        .f_ceil,
+        .f_floor,
+        .f_trunc,
+        .f_nearest,
+        .trunc_f32_s,
+        .trunc_f32_u,
+        .trunc_f64_s,
+        .trunc_f64_u,
+        .convert_s,
+        .convert_u,
+        .convert_i32_s,
+        .convert_i64_s,
+        .convert_i32_u,
+        .convert_i64_u,
+        .demote_f64,
+        .promote_f32,
+        .reinterpret,
+        .trunc_sat_f32_s,
+        .trunc_sat_f32_u,
+        .trunc_sat_f64_s,
+        .trunc_sat_f64_u,
+        .v128_not,
         => |*vreg| vreg.* += offset,
+        .i32x4_extract_lane => |*lane| lane.vector += offset,
 
         .local_set => |*ls| ls.val += offset,
         .global_set => |*gs| gs.val += offset,
         .load => |*ld| ld.base += offset,
+        .v128_load => |*ld| ld.base += offset,
         .store => |*st| {
+            st.base += offset;
+            st.val += offset;
+        },
+        .v128_store => |*st| {
             st.base += offset;
             st.val += offset;
         },
         .br_if => |*bi| bi.cond += offset,
         .br_table => |*bt| bt.index += offset,
-        .ret => |*maybe_vreg| if (maybe_vreg.*) |v| { maybe_vreg.* = v + offset; },
+        .ret => |*maybe_vreg| if (maybe_vreg.*) |v| {
+            maybe_vreg.* = v + offset;
+        },
         .ret_multi => |vregs| {
             for (@constCast(vregs)) |*v| v.* += offset;
         },
@@ -2912,12 +3319,25 @@ fn isInlinable(callee: *const ir.IrFunction, max_insts: u32, max_blocks: u32) bo
 
         for (blk.instructions.items) |inst| {
             switch (inst.op) {
-                .call, .call_indirect, .call_ref, .call_result,
+                .call,
+                .call_indirect,
+                .call_ref,
+                .call_result,
                 .memory_grow,
-                .atomic_fence, .atomic_load, .atomic_store, .atomic_rmw,
-                .atomic_cmpxchg, .atomic_notify, .atomic_wait,
-                .memory_copy, .memory_fill, .memory_init, .table_init,
-                .table_grow, .data_drop, .elem_drop,
+                .atomic_fence,
+                .atomic_load,
+                .atomic_store,
+                .atomic_rmw,
+                .atomic_cmpxchg,
+                .atomic_notify,
+                .atomic_wait,
+                .memory_copy,
+                .memory_fill,
+                .memory_init,
+                .table_init,
+                .table_grow,
+                .data_drop,
+                .elem_drop,
                 .br_table,
                 .ret_multi,
                 .local_set,
@@ -3207,7 +3627,10 @@ pub fn promoteLocalsToSSA(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
                     // Deduplicate.
                     var dup = false;
                     for (def_blocks[idx].items) |existing| {
-                        if (existing == bid) { dup = true; break; }
+                        if (existing == bid) {
+                            dup = true;
+                            break;
+                        }
                     }
                     if (!dup) try def_blocks[idx].append(allocator, bid);
                 }
@@ -3314,6 +3737,7 @@ pub fn promoteLocalsToSSA(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
                 .i64 => .{ .iconst_64 = 0 },
                 .f32 => .{ .fconst_32 = 0 },
                 .f64 => .{ .fconst_64 = 0 },
+                .v128 => .{ .v128_const = 0 },
                 .void => .{ .iconst_32 = 0 },
             };
             // Insert at start of entry block (block 0) before phis.
@@ -3458,7 +3882,10 @@ pub fn promoteLocalsToSSA(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
                     if (ls.idx < nlocals) {
                         // Rewrite the value operand, chasing rename chains.
                         var val = ls.val;
-                        while (rename_map.get(val)) |r| { if (r == val) break; val = r; }
+                        while (rename_map.get(val)) |r| {
+                            if (r == val) break;
+                            val = r;
+                        }
                         try stacks[ls.idx].append(allocator, val);
                         inst.op = .{ .iconst_32 = 0 };
                         inst.dest = null;
@@ -3549,9 +3976,15 @@ pub fn lowerPhisToLocals(func: *ir.IrFunction, allocator: std.mem.Allocator) !bo
     for (func.blocks.items) |*block| {
         var i: usize = 0;
         while (i < block.instructions.items.len) {
-            if (block.instructions.items[i].op != .phi) { i += 1; continue; }
+            if (block.instructions.items[i].op != .phi) {
+                i += 1;
+                continue;
+            }
 
-            const dest = block.instructions.items[i].dest orelse { i += 1; continue; };
+            const dest = block.instructions.items[i].dest orelse {
+                i += 1;
+                continue;
+            };
             const edges = block.instructions.items[i].op.phi;
             const phi_type = block.instructions.items[i].type;
             const synth_idx = next_synth_local;
@@ -4798,12 +5231,18 @@ test "hoistLoopInvariantCode: pure add with invariant operands hoisted" {
     try std.testing.expect(changed);
     var found_add = false;
     for (func.getBlock(b0).instructions.items) |inst| {
-        if (inst.op == .add) { found_add = true; break; }
+        if (inst.op == .add) {
+            found_add = true;
+            break;
+        }
     }
     try std.testing.expect(found_add);
     var hdr_has_add = false;
     for (func.getBlock(b1).instructions.items) |inst| {
-        if (inst.op == .add) { hdr_has_add = true; break; }
+        if (inst.op == .add) {
+            hdr_has_add = true;
+            break;
+        }
     }
     try std.testing.expect(!hdr_has_add);
 }
@@ -4833,7 +5272,10 @@ test "hoistLoopInvariantCode: cascading hoist" {
     try std.testing.expect(changed);
     var ph_has_add = false;
     for (func.getBlock(b0).instructions.items) |inst| {
-        if (inst.op == .add) { ph_has_add = true; break; }
+        if (inst.op == .add) {
+            ph_has_add = true;
+            break;
+        }
     }
     try std.testing.expect(ph_has_add);
 }
@@ -6252,8 +6694,8 @@ test "foldInverseCompareEqz: all 10 mappings" {
         src: ir.Inst.Op,
         expect_tag: std.meta.Tag(ir.Inst.Op),
     }{
-        .{ .src = .{ .eq   = .{ .lhs = 0, .rhs = 0 } }, .expect_tag = .ne   },
-        .{ .src = .{ .ne   = .{ .lhs = 0, .rhs = 0 } }, .expect_tag = .eq   },
+        .{ .src = .{ .eq = .{ .lhs = 0, .rhs = 0 } }, .expect_tag = .ne },
+        .{ .src = .{ .ne = .{ .lhs = 0, .rhs = 0 } }, .expect_tag = .eq },
         .{ .src = .{ .lt_s = .{ .lhs = 0, .rhs = 0 } }, .expect_tag = .ge_s },
         .{ .src = .{ .ge_s = .{ .lhs = 0, .rhs = 0 } }, .expect_tag = .lt_s },
         .{ .src = .{ .le_s = .{ .lhs = 0, .rhs = 0 } }, .expect_tag = .gt_s },
@@ -6274,8 +6716,16 @@ test "foldInverseCompareEqz: all 10 mappings" {
         const v_neg = func.newVReg();
         var src = c.src;
         switch (src) {
-            .eq, .ne, .lt_s, .ge_s, .le_s, .gt_s,
-            .lt_u, .ge_u, .le_u, .gt_u,
+            .eq,
+            .ne,
+            .lt_s,
+            .ge_s,
+            .le_s,
+            .gt_s,
+            .lt_u,
+            .ge_u,
+            .le_u,
+            .gt_u,
             => |*b| {
                 b.lhs = v0;
                 b.rhs = v1;

--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -28,7 +28,7 @@ pub const max_alloc_regs: usize = 64;
 /// Physical register or stack slot assignment.
 pub const Allocation = union(enum) {
     reg: PhysReg,
-    /// Byte offset of the spill slot from the frame pointer. Sign and
+    /// Byte offset of the first spill byte from the frame pointer. Sign and
     /// stride come from `RegSet.spill_base`/`spill_stride`.
     stack: i32,
 };
@@ -61,7 +61,8 @@ pub const RegSet = struct {
 pub const AllocResult = struct {
     /// VReg → physical location mapping.
     assignments: std.AutoHashMap(ir.VReg, Allocation),
-    /// Number of spill slots used.
+    /// Number of 8-byte spill slots used. v128 values consume two slots and
+    /// are aligned to a 16-byte FP-relative offset.
     spill_count: u32,
 
     pub fn deinit(self: *AllocResult) void {
@@ -122,7 +123,7 @@ pub fn allocateFromRanges(
     var active: std.ArrayList(ActiveInterval) = .empty;
     defer active.deinit(allocator);
 
-    var spill_count: u32 = 0;
+    var spill_slots_used: u32 = 0;
 
     for (ranges) |range| {
         // Expire old intervals that ended before this one starts
@@ -136,6 +137,7 @@ pub fn allocateFromRanges(
                 .vreg = range.vreg,
                 .end = range.end,
                 .reg_idx = reg_idx,
+                .type = range.type,
             });
         } else {
             // No safe free register — try to evict an active interval
@@ -154,36 +156,55 @@ pub fn allocateFromRanges(
             if (best_evict) |evict_idx| {
                 const evicted = active.orderedRemove(evict_idx);
                 const stolen_reg = evicted.reg_idx;
-                const spill_offset = reg_set.spill_base +
-                    @as(i32, @intCast(spill_count)) * reg_set.spill_stride;
+                const spill_offset = allocateSpill(&spill_slots_used, reg_set, evicted.type);
                 try assignments.put(evicted.vreg, .{ .stack = spill_offset });
-                spill_count += 1;
                 try assignments.put(range.vreg, .{ .reg = reg_set.alloc_regs[stolen_reg] });
                 try insertActive(&active, allocator, .{
                     .vreg = range.vreg,
                     .end = range.end,
                     .reg_idx = stolen_reg,
+                    .type = range.type,
                 });
             } else {
                 // No safe eviction candidate — spill the new interval
-                const spill_offset = reg_set.spill_base +
-                    @as(i32, @intCast(spill_count)) * reg_set.spill_stride;
+                const spill_offset = allocateSpill(&spill_slots_used, reg_set, range.type);
                 try assignments.put(range.vreg, .{ .stack = spill_offset });
-                spill_count += 1;
             }
         }
     }
 
     return .{
         .assignments = assignments,
-        .spill_count = spill_count,
+        .spill_count = spill_slots_used,
     };
+}
+
+fn allocateSpill(spill_slots_used: *u32, reg_set: RegSet, ty: ir.IrType) i32 {
+    const align_slots = @as(u32, ty.spillAlignSlots64());
+    const needed_slots = @as(u32, ty.spillSlots64());
+    while (!spillSlotAligned(reg_set, spill_slots_used.*, align_slots)) {
+        spill_slots_used.* += 1;
+    }
+    const offset = reg_set.spill_base +
+        @as(i32, @intCast(spill_slots_used.*)) * reg_set.spill_stride;
+    spill_slots_used.* += needed_slots;
+    return offset;
+}
+
+fn spillSlotAligned(reg_set: RegSet, slot_index: u32, align_slots: u32) bool {
+    if (align_slots <= 1) return true;
+    const offset = reg_set.spill_base +
+        @as(i32, @intCast(slot_index)) * reg_set.spill_stride;
+    const align_bytes = @as(i32, @intCast(align_slots * 8));
+    const abs_offset = if (offset < 0) -offset else offset;
+    return @mod(abs_offset, align_bytes) == 0;
 }
 
 const ActiveInterval = struct {
     vreg: ir.VReg,
     end: u32,
     reg_idx: u8,
+    type: ir.IrType,
 };
 
 /// Remove intervals from `active` whose end position is <= `pos`.
@@ -363,3 +384,26 @@ test "allocate: spills when pressure exceeds registers" {
     }
 }
 
+test "allocateFromRanges: v128 spills consume two aligned slots" {
+    const allocator = std.testing.allocator;
+    const one_reg_set: RegSet = .{
+        .alloc_regs = &.{0},
+        .callee_saved_indices = &.{},
+        .caller_saved_indices = &.{0},
+        .spill_base = 8,
+        .spill_stride = 8,
+    };
+    const ranges = [_]analysis.LiveRange{
+        .{ .vreg = 0, .start = 0, .end = 10, .type = .v128 },
+        .{ .vreg = 1, .start = 1, .end = 9, .type = .i64 },
+        .{ .vreg = 2, .start = 2, .end = 8, .type = .v128 },
+    };
+
+    var result = try allocateFromRanges(allocator, one_reg_set, &.{}, &ranges);
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(u32, 4), result.spill_count);
+    try std.testing.expectEqual(Allocation{ .stack = 16 }, result.get(0).?);
+    try std.testing.expectEqual(Allocation{ .stack = 32 }, result.get(1).?);
+    try std.testing.expectEqual(Allocation{ .reg = 0 }, result.get(2).?);
+}


### PR DESCRIPTION
## Summary
- add .v128 as a first-class compiler IR type with byte/spill sizing helpers
- define initial SIMD IR op shapes and preserve v128 through frontend type mapping, liveness/use-def helpers, and regalloc metadata
- keep AArch64 and x86_64 codegen conservative by rejecting v128 before scalar paths can truncate it

Refs #220

## Validation
- zig build test
- zig build simd-bench
- scripts/bench_simd.py --baseline HEAD --target HEAD --runs 1 --iterations 10

SIMD AOT remains unsupported by design in this foundation slice; native NEON lowering is the next PR.