### PR TITLE
compiler: lower AArch64 i32x4 lane ops

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -331,8 +331,8 @@ pub fn build(b: *std.Build) void {
 
     // ── SIMD benchmark runner ───────────────────────────────────────────
     // Builds small in-memory SIMD modules and reports interpreter vs AOT
-    // status/timing.  SIMD AOT is expected to report "unsupported" until the
-    // first native v128 lowering slice lands.
+    // status/timing. Optional runner args after `--` can enable external
+    // baselines such as Wasmtime.
     const simd_bench_module = b.createModule(.{
         .root_source_file = b.path("src/tests/simd_bench_runner.zig"),
         .target = target,
@@ -354,6 +354,7 @@ pub fn build(b: *std.Build) void {
         const run_simd_bench = b.addRunArtifact(simd_bench_exe);
         run_simd_bench.addArg("--iterations");
         run_simd_bench.addArg("10000");
+        if (b.args) |args| run_simd_bench.addArgs(args);
         simd_bench_step.dependOn(&run_simd_bench.step);
     }
 

--- a/scripts/bench_simd.py
+++ b/scripts/bench_simd.py
@@ -114,6 +114,9 @@ def build_and_run(
     source_repo: Path,
     runs: int,
     iterations: int,
+    wasmtime: bool,
+    wasmtime_path: str,
+    wasmtime_iterations: int | None,
 ) -> list[Measurement]:
     env = os.environ.copy()
     overlay_harness(source_repo, wt)
@@ -131,7 +134,13 @@ def build_and_run(
             f"[harness] running {wt.name} ({i + 1}/{runs}, iterations={iterations})",
             file=sys.stderr,
         )
-        out = run([str(runner), "--iterations", str(iterations)], cwd=wt, env=env)
+        runner_args = [str(runner), "--iterations", str(iterations)]
+        if wasmtime:
+            runner_args.append("--wasmtime")
+            runner_args.extend(["--wasmtime-path", wasmtime_path])
+            if wasmtime_iterations is not None:
+                runner_args.extend(["--wasmtime-iterations", str(wasmtime_iterations)])
+        out = run(runner_args, cwd=wt, env=env)
         measurements.extend(parse_runner_output(out, i + 1))
     return measurements
 
@@ -236,6 +245,22 @@ def main() -> int:
         help="function calls per runner invocation",
     )
     p.add_argument(
+        "--wasmtime",
+        action="store_true",
+        help="include Wasmtime CLI rows as an external baseline",
+    )
+    p.add_argument(
+        "--wasmtime-path",
+        default="wasmtime",
+        help="Wasmtime executable to use with --wasmtime",
+    )
+    p.add_argument(
+        "--wasmtime-iterations",
+        type=int,
+        default=None,
+        help="Wasmtime CLI invocations per run; defaults to min(iterations, 10)",
+    )
+    p.add_argument(
         "--repo",
         type=Path,
         default=Path(__file__).resolve().parents[1],
@@ -259,6 +284,8 @@ def main() -> int:
         raise ValueError("--runs must be positive")
     if args.iterations <= 0:
         raise ValueError("--iterations must be positive")
+    if args.wasmtime_iterations is not None and args.wasmtime_iterations <= 0:
+        raise ValueError("--wasmtime-iterations must be positive")
 
     repo = args.repo.resolve()
     with tempfile.TemporaryDirectory(
@@ -270,8 +297,24 @@ def main() -> int:
             wt_b = make_worktree(repo, args.baseline, root, "baseline")
             wt_t = make_worktree(repo, args.target, root, "target")
 
-            baseline_rows = build_and_run(wt_b, repo, args.runs, args.iterations)
-            target_rows = build_and_run(wt_t, repo, args.runs, args.iterations)
+            baseline_rows = build_and_run(
+                wt_b,
+                repo,
+                args.runs,
+                args.iterations,
+                args.wasmtime,
+                args.wasmtime_path,
+                args.wasmtime_iterations,
+            )
+            target_rows = build_and_run(
+                wt_t,
+                repo,
+                args.runs,
+                args.iterations,
+                args.wasmtime,
+                args.wasmtime_path,
+                args.wasmtime_iterations,
+            )
         finally:
             run(["git", "worktree", "prune"], cwd=repo)
 

--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -355,6 +355,8 @@ fn isSupportedV128Def(inst: ir.Inst) bool {
         .v128_not,
         .v128_bitwise,
         .i32x4_binop,
+        .i32x4_splat,
+        .i32x4_replace_lane,
         => inst.type == .v128,
         else => false,
     };
@@ -375,6 +377,8 @@ fn functionHasUnsupportedV128(func: *const ir.IrFunction, allocator: std.mem.All
                 .v128_not,
                 .v128_bitwise,
                 .i32x4_binop,
+                .i32x4_splat,
+                .i32x4_replace_lane,
                 => {
                     if (!isSupportedV128Def(inst)) return true;
                 },
@@ -1172,7 +1176,9 @@ fn compileInst(
         .v128_not => |src| try emitV128Not(code, inst, src, v128_map),
         .v128_bitwise => |bin| try emitV128Bitwise(code, inst, bin, v128_map),
         .i32x4_binop => |bin| try emitI32x4BinOp(code, inst, bin, v128_map),
+        .i32x4_splat => |src| try emitI32x4Splat(code, inst, src, reg_map, v128_map),
         .i32x4_extract_lane => |lane| try emitI32x4ExtractLane(code, inst, lane, reg_map, v128_map),
+        .i32x4_replace_lane => |lane| try emitI32x4ReplaceLane(code, inst, lane, reg_map, v128_map),
 
         .add => |bin| if (inst.type == .f32 or inst.type == .f64)
             try emitFBinOp(code, inst, bin, reg_map, .add)
@@ -1561,6 +1567,18 @@ fn emitI32x4BinOp(
     try storeV128Dest(code, inst, v128_map, v128_tmp0);
 }
 
+fn emitI32x4Splat(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    src: ir.VReg,
+    reg_map: *const RegMap,
+    v128_map: *V128StackMap,
+) !void {
+    const src_reg = try useInto(code, reg_map, src, RegMap.tmp0);
+    try code.dup4sFromGp32(v128_tmp0, src_reg);
+    try storeV128Dest(code, inst, v128_map, v128_tmp0);
+}
+
 fn emitI32x4ExtractLane(
     code: *emit.CodeBuffer,
     inst: ir.Inst,
@@ -1573,6 +1591,19 @@ fn emitI32x4ExtractLane(
     const info = try destBegin(reg_map, dest, RegMap.tmp0);
     try code.umovWFromS(info.reg, v128_tmp0, lane.lane);
     try destCommit(code, reg_map, info);
+}
+
+fn emitI32x4ReplaceLane(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    lane: ir.Inst.I32x4ReplaceLane,
+    reg_map: *const RegMap,
+    v128_map: *V128StackMap,
+) !void {
+    try loadV128Slot(code, v128_map, lane.vector, v128_tmp0);
+    const val_reg = try useInto(code, reg_map, lane.val, RegMap.tmp0);
+    try code.insSFromGp32(v128_tmp0, lane.lane, val_reg);
+    try storeV128Dest(code, inst, v128_map, v128_tmp0);
 }
 
 const ExtendWidth = enum { b, h, w };
@@ -4705,6 +4736,52 @@ test "compile: v128 first-family ops emit NEON instructions" {
 
     try std.testing.expect(found_eor);
     try std.testing.expect(found_add4s);
+    try std.testing.expect(found_umov);
+}
+
+test "compile: i32x4 lane ops emit NEON instructions" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+
+    const scalar = func.newVReg();
+    const splat = func.newVReg();
+    const replacement = func.newVReg();
+    const replaced = func.newVReg();
+    const lane = func.newVReg();
+
+    try func.getBlock(bid).append(.{ .op = .{ .iconst_32 = 7 }, .dest = scalar, .type = .i32 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_splat = scalar }, .dest = splat, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .iconst_32 = 99 }, .dest = replacement, .type = .i32 });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i32x4_replace_lane = .{ .vector = splat, .val = replacement, .lane = 2 } },
+        .dest = replaced,
+        .type = .v128,
+    });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i32x4_extract_lane = .{ .vector = replaced, .lane = 2 } },
+        .dest = lane,
+        .type = .i32,
+    });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = lane } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    var found_dup = false;
+    var found_ins = false;
+    var found_umov = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFFFFC00) == 0x4E040C00) found_dup = true;
+        if ((w & 0xFFFFFC00) == 0x4E141C00) found_ins = true;
+        if ((w & 0x0FE0FC00) == 0x0E003C00) found_umov = true;
+    }
+
+    try std.testing.expect(found_dup);
+    try std.testing.expect(found_ins);
     try std.testing.expect(found_umov);
 }
 

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -8,13 +8,34 @@ const std = @import("std");
 
 /// AArch64 general-purpose registers (64-bit X registers).
 pub const Reg = enum(u5) {
-    x0 = 0, x1 = 1, x2 = 2, x3 = 3,
-    x4 = 4, x5 = 5, x6 = 6, x7 = 7,
-    x8 = 8, x9 = 9, x10 = 10, x11 = 11,
-    x12 = 12, x13 = 13, x14 = 14, x15 = 15,
-    x16 = 16, x17 = 17, x18 = 18, x19 = 19,
-    x20 = 20, x21 = 21, x22 = 22, x23 = 23,
-    x24 = 24, x25 = 25, x26 = 26, x27 = 27,
+    x0 = 0,
+    x1 = 1,
+    x2 = 2,
+    x3 = 3,
+    x4 = 4,
+    x5 = 5,
+    x6 = 6,
+    x7 = 7,
+    x8 = 8,
+    x9 = 9,
+    x10 = 10,
+    x11 = 11,
+    x12 = 12,
+    x13 = 13,
+    x14 = 14,
+    x15 = 15,
+    x16 = 16,
+    x17 = 17,
+    x18 = 18,
+    x19 = 19,
+    x20 = 20,
+    x21 = 21,
+    x22 = 22,
+    x23 = 23,
+    x24 = 24,
+    x25 = 25,
+    x26 = 26,
+    x27 = 27,
     x28 = 28,
     fp = 29, // frame pointer (x29)
     lr = 30, // link register (x30)
@@ -421,7 +442,12 @@ pub const CodeBuffer = struct {
     /// LSLV/LSRV/ASRV/RORV Xd, Xn, Xm (variable shift, 64-bit)
     pub fn shiftRegReg(self: *CodeBuffer, rd: Reg, rn: Reg, rm: Reg, op: ShiftOp) !void {
         // 1|0|0|11010110|Rm|0010|op|Rn|Rd
-        const opc: u2 = switch (op) { .lsl => 0b00, .lsr => 0b01, .asr => 0b10, .ror => 0b11 };
+        const opc: u2 = switch (op) {
+            .lsl => 0b00,
+            .lsr => 0b01,
+            .asr => 0b10,
+            .ror => 0b11,
+        };
         try self.emit32(0x9AC02000 | (@as(u32, rm.encoding()) << 16) |
             (@as(u32, opc) << 10) |
             (@as(u32, rn.encoding()) << 5) | rd.encoding());
@@ -429,7 +455,12 @@ pub const CodeBuffer = struct {
 
     /// 32-bit variable shift (mask count by 5 per AArch64 semantics — matches wasm i32).
     pub fn shiftRegReg32(self: *CodeBuffer, rd: Reg, rn: Reg, rm: Reg, op: ShiftOp) !void {
-        const opc: u2 = switch (op) { .lsl => 0b00, .lsr => 0b01, .asr => 0b10, .ror => 0b11 };
+        const opc: u2 = switch (op) {
+            .lsl => 0b00,
+            .lsr => 0b01,
+            .asr => 0b10,
+            .ror => 0b11,
+        };
         try self.emit32(0x1AC02000 | (@as(u32, rm.encoding()) << 16) |
             (@as(u32, opc) << 10) |
             (@as(u32, rn.encoding()) << 5) | rd.encoding());
@@ -647,6 +678,19 @@ pub const CodeBuffer = struct {
             vd);
     }
 
+    /// DUP Vd.4S, Wn.
+    pub fn dup4sFromGp32(self: *CodeBuffer, vd: u5, rn: Reg) !void {
+        try self.emit32(0x4E040C00 | (@as(u32, rn.encoding()) << 5) | vd);
+    }
+
+    /// INS Vd.S[lane], Wn (alias: MOV Vd.S[lane], Wn).
+    pub fn insSFromGp32(self: *CodeBuffer, vd: u5, lane: u2, rn: Reg) !void {
+        try self.emit32(0x4E041C00 |
+            (@as(u32, lane) << 19) |
+            (@as(u32, rn.encoding()) << 5) |
+            vd);
+    }
+
     /// MVN Vd.16B, Vn.16B (alias for NOT).
     pub fn mvn16b(self: *CodeBuffer, vd: u5, vn: u5) !void {
         try self.emit32(0x6E205800 | (@as(u32, vn) << 5) | vd);
@@ -767,11 +811,11 @@ pub const CodeBuffer = struct {
     /// Size selects the base opcode (byte/half/word/dword); opcode12 is
     /// the operation selector in bits [15:12].
     pub const LseOp = enum(u32) {
-        add = 0x0000,   // LDADD  — new = old + Rs
-        clr = 0x1000,   // LDCLR  — new = old & ~Rs
-        eor = 0x2000,   // LDEOR  — new = old ^ Rs
-        set = 0x3000,   // LDSET  — new = old | Rs
-        swp = 0x8000,   // SWP    — new = Rs
+        add = 0x0000, // LDADD  — new = old + Rs
+        clr = 0x1000, // LDCLR  — new = old & ~Rs
+        eor = 0x2000, // LDEOR  — new = old ^ Rs
+        set = 0x3000, // LDSET  — new = old | Rs
+        swp = 0x8000, // SWP    — new = Rs
     };
 
     pub fn lseAtomic(
@@ -1496,6 +1540,20 @@ test "emit: MOV v0.d[1], x17" {
     defer code.deinit();
     try code.insDFromGp64(0, 1, .x17);
     try expectWord(0x4E181E20, &code);
+}
+
+test "emit: DUP v0.4s, w1" {
+    var code = CodeBuffer.init(std.testing.allocator);
+    defer code.deinit();
+    try code.dup4sFromGp32(0, .x1);
+    try expectWord(0x4E040C20, &code);
+}
+
+test "emit: MOV v0.s[2], w17" {
+    var code = CodeBuffer.init(std.testing.allocator);
+    defer code.deinit();
+    try code.insSFromGp32(0, 2, .x17);
+    try expectWord(0x4E141E20, &code);
 }
 
 test "emit: MVN v0.16b, v1.16b" {

--- a/src/compiler/codegen/aarch64/schedule.zig
+++ b/src/compiler/codegen/aarch64/schedule.zig
@@ -235,7 +235,9 @@ pub fn metadata(inst: ir.Inst) Metadata {
         .v128_not,
         .v128_bitwise,
         .i32x4_binop,
+        .i32x4_splat,
         .i32x4_extract_lane,
+        .i32x4_replace_lane,
         => .barrier,
 
         .mul => if (def != null and isIntegerType(inst.type)) .mul else .barrier,
@@ -479,7 +481,12 @@ pub fn forEachUse(
             try visit(context, bin.lhs);
             try visit(context, bin.rhs);
         },
+        .i32x4_splat => |v| try visit(context, v),
         .i32x4_extract_lane => |lane| try visit(context, lane.vector),
+        .i32x4_replace_lane => |lane| {
+            try visit(context, lane.vector);
+            try visit(context, lane.val);
+        },
         else => {},
     }
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1253,7 +1253,9 @@ fn compileInst(
         .v128_not,
         .v128_bitwise,
         .i32x4_binop,
+        .i32x4_splat,
         .i32x4_extract_lane,
+        .i32x4_replace_lane,
         => return error.UnsupportedV128,
         // Phi must be lowered before codegen.
         .phi => unreachable,
@@ -1476,7 +1478,9 @@ fn functionUsesV128(func: *const ir.IrFunction) bool {
                 .v128_not,
                 .v128_bitwise,
                 .i32x4_binop,
+                .i32x4_splat,
                 .i32x4_extract_lane,
+                .i32x4_replace_lane,
                 => return true,
                 else => {},
             }

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -1803,6 +1803,16 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         });
                         try vreg_stack.append(allocator, dest);
                     },
+                    .i32x4_splat => {
+                        const val = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .i32x4_splat = val },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
                     .i32x4_extract_lane => {
                         const lane_raw = try readByte(code, &ip);
                         if (lane_raw >= 4) return error.InvalidBytecode;
@@ -1815,6 +1825,23 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                             } },
                             .dest = dest,
                             .type = .i32,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
+                    .i32x4_replace_lane => {
+                        const lane_raw = try readByte(code, &ip);
+                        if (lane_raw >= 4) return error.InvalidBytecode;
+                        const val = safePop(&vreg_stack);
+                        const vector = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .i32x4_replace_lane = .{
+                                .vector = vector,
+                                .val = val,
+                                .lane = @intCast(lane_raw),
+                            } },
+                            .dest = dest,
+                            .type = .v128,
                         });
                         try vreg_stack.append(allocator, dest);
                     },
@@ -2588,6 +2615,50 @@ test "lower selected SIMD first-family opcodes" {
     try std.testing.expectEqual(ir.Inst.I32x4Op.add, insts[4].op.i32x4_binop.op);
     try std.testing.expectEqual(@as(u2, 0), insts[5].op.i32x4_extract_lane.lane);
     try std.testing.expect(insts[6].op.ret != null);
+}
+
+test "lower i32x4 dynamic lane opcodes" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i32},
+    };
+    const code = [_]u8{
+        0x41, 0x07, // i32.const 7
+        0xFD, 0x11, // i32x4.splat
+        0x41, 0xE3, 0x00, // i32.const 99
+        0xFD, 0x1C, 0x02, // i32x4.replace_lane 2
+        0xFD, 0x1B, 0x02, // i32x4.extract_lane 2
+        0x0B,
+    };
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &code,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+    try std.testing.expectEqual(@as(usize, 6), insts.len);
+    try std.testing.expectEqual(@as(i32, 7), insts[0].op.iconst_32);
+    try std.testing.expectEqual(ir.IrType.v128, insts[1].type);
+    try std.testing.expectEqual(insts[0].dest.?, insts[1].op.i32x4_splat);
+    try std.testing.expectEqual(@as(i32, 99), insts[2].op.iconst_32);
+    try std.testing.expectEqual(ir.IrType.v128, insts[3].type);
+    try std.testing.expectEqual(insts[1].dest.?, insts[3].op.i32x4_replace_lane.vector);
+    try std.testing.expectEqual(insts[2].dest.?, insts[3].op.i32x4_replace_lane.val);
+    try std.testing.expectEqual(@as(u2, 2), insts[3].op.i32x4_replace_lane.lane);
+    try std.testing.expectEqual(@as(u2, 2), insts[4].op.i32x4_extract_lane.lane);
+    try std.testing.expect(insts[5].op.ret != null);
 }
 
 test "lower unreachable" {

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -220,8 +220,13 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
         .trunc_sat_f64_s,
         .trunc_sat_f64_u,
         .v128_not,
+        .i32x4_splat,
         => |vreg| live.put(vreg, {}) catch {},
         .i32x4_extract_lane => |lane| live.put(lane.vector, {}) catch {},
+        .i32x4_replace_lane => |lane| {
+            live.put(lane.vector, {}) catch {};
+            live.put(lane.val, {}) catch {};
+        },
 
         .local_set => |ls| live.put(ls.val, {}) catch {},
         .global_set => |gs| live.put(gs.val, {}) catch {},
@@ -535,8 +540,13 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
         .trunc_sat_f64_s,
         .trunc_sat_f64_u,
         .v128_not,
+        .i32x4_splat,
         => |vreg| last_use.put(vreg, pos) catch {},
         .i32x4_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
+        .i32x4_replace_lane => |lane| {
+            last_use.put(lane.vector, pos) catch {};
+            last_use.put(lane.val, pos) catch {};
+        },
 
         .local_set => |ls| last_use.put(ls.val, pos) catch {},
         .global_set => |gs| last_use.put(gs.val, pos) catch {},

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -71,7 +71,9 @@ pub const Inst = struct {
         v128_not: VReg,
         v128_bitwise: V128Bitwise,
         i32x4_binop: I32x4BinOp,
+        i32x4_splat: VReg,
         i32x4_extract_lane: I32x4ExtractLane,
+        i32x4_replace_lane: I32x4ReplaceLane,
 
         // Binary arithmetic (dest = lhs op rhs)
         add: BinOp,
@@ -282,6 +284,12 @@ pub const Inst = struct {
         lane: u2,
     };
 
+    pub const I32x4ReplaceLane = struct {
+        vector: VReg,
+        val: VReg,
+        lane: u2,
+    };
+
     pub const PhiEdge = struct {
         block: BlockId,
         val: VReg,
@@ -455,6 +463,22 @@ test "Inst: first v128 op family preserves operand shape" {
         .type = .i32,
     };
     try std.testing.expectEqual(@as(u2, 2), lane.op.i32x4_extract_lane.lane);
+
+    const splat = Inst{
+        .op = .{ .i32x4_splat = 5 },
+        .dest = 6,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(@as(VReg, 5), splat.op.i32x4_splat);
+
+    const replace = Inst{
+        .op = .{ .i32x4_replace_lane = .{ .vector = 6, .val = 7, .lane = 1 } },
+        .dest = 8,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(@as(VReg, 6), replace.op.i32x4_replace_lane.vector);
+    try std.testing.expectEqual(@as(VReg, 7), replace.op.i32x4_replace_lane.val);
+    try std.testing.expectEqual(@as(u2, 1), replace.op.i32x4_replace_lane.lane);
 }
 
 test "IrModule: add multiple functions" {

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -180,8 +180,13 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
         .trunc_sat_f64_s,
         .trunc_sat_f64_u,
         .v128_not,
+        .i32x4_splat,
         => |vreg| list.append(vreg),
         .i32x4_extract_lane => |lane| list.append(lane.vector),
+        .i32x4_replace_lane => |lane| {
+            list.append(lane.vector);
+            list.append(lane.val);
+        },
 
         .local_set => |ls| list.append(ls.val),
         .global_set => |gs| list.append(gs.val),
@@ -414,11 +419,16 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
         .trunc_sat_f64_s,
         .trunc_sat_f64_u,
         .v128_not,
+        .i32x4_splat,
         => |*vreg| if (vreg.* == old) {
             vreg.* = new;
         },
         .i32x4_extract_lane => |*lane| if (lane.vector == old) {
             lane.vector = new;
+        },
+        .i32x4_replace_lane => |*lane| {
+            if (lane.vector == old) lane.vector = new;
+            if (lane.val == old) lane.val = new;
         },
 
         .local_set => |*ls| if (ls.val == old) {
@@ -1606,7 +1616,9 @@ fn isPure(inst: ir.Inst) bool {
         .v128_not,
         .v128_bitwise,
         .i32x4_binop,
+        .i32x4_splat,
         .i32x4_extract_lane,
+        .i32x4_replace_lane,
         => true,
         else => false,
     };
@@ -1697,7 +1709,9 @@ fn sameOp(a: ir.Inst, b: ir.Inst) bool {
         .v128_not => |v| v == b.op.v128_not,
         .v128_bitwise => |bin| bin.op == b.op.v128_bitwise.op and bin.lhs == b.op.v128_bitwise.lhs and bin.rhs == b.op.v128_bitwise.rhs,
         .i32x4_binop => |bin| bin.op == b.op.i32x4_binop.op and bin.lhs == b.op.i32x4_binop.lhs and bin.rhs == b.op.i32x4_binop.rhs,
+        .i32x4_splat => |v| v == b.op.i32x4_splat,
         .i32x4_extract_lane => |lane| lane.vector == b.op.i32x4_extract_lane.vector and lane.lane == b.op.i32x4_extract_lane.lane,
+        .i32x4_replace_lane => |lane| lane.vector == b.op.i32x4_replace_lane.vector and lane.val == b.op.i32x4_replace_lane.val and lane.lane == b.op.i32x4_replace_lane.lane,
         // div/rem: covered by isPure+hasSideEffect guard; float variants
         // (side-effect-free) reach here.
         .div_s => |bin| bin.lhs == b.op.div_s.lhs and bin.rhs == b.op.div_s.rhs,
@@ -3189,8 +3203,13 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
         .trunc_sat_f64_s,
         .trunc_sat_f64_u,
         .v128_not,
+        .i32x4_splat,
         => |*vreg| vreg.* += offset,
         .i32x4_extract_lane => |*lane| lane.vector += offset,
+        .i32x4_replace_lane => |*lane| {
+            lane.vector += offset;
+            lane.val += offset;
+        },
 
         .local_set => |*ls| ls.val += offset,
         .global_set => |*gs| gs.val += offset,

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -328,6 +328,70 @@ test "differential SIMD: i32x4.eq extracts all-ones lane" {
     try expectSimdDiffI32(wasm, "f", -1);
 }
 
+test "differential SIMD: i32x4.splat extracts lane 3" {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try body.append(testing.allocator, 0x41);
+    try encodeSLEB128(&body, testing.allocator, -123);
+    try appendI32x4Splat(&body, testing.allocator);
+    try appendI32x4ExtractLane(&body, testing.allocator, 3);
+    try body.append(testing.allocator, 0x0B);
+
+    const wasm = try buildCustomModule(testing.allocator, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", -123);
+}
+
+test "differential SIMD: i32x4.replace_lane updates selected lane" {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendV128ConstI32x4(&body, testing.allocator, .{ 1, 2, 3, 4 });
+    try body.append(testing.allocator, 0x41);
+    try encodeSLEB128(&body, testing.allocator, 99);
+    try appendI32x4ReplaceLane(&body, testing.allocator, 2);
+    try appendI32x4ExtractLane(&body, testing.allocator, 2);
+    try body.append(testing.allocator, 0x0B);
+
+    const wasm = try buildCustomModule(testing.allocator, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", 99);
+}
+
+test "differential SIMD: i32x4.replace_lane preserves untouched lanes" {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendV128ConstI32x4(&body, testing.allocator, .{ 10, 20, 30, 40 });
+    try body.append(testing.allocator, 0x41);
+    try encodeSLEB128(&body, testing.allocator, 99);
+    try appendI32x4ReplaceLane(&body, testing.allocator, 2);
+    try appendI32x4ExtractLane(&body, testing.allocator, 0);
+    try body.append(testing.allocator, 0x0B);
+
+    const wasm = try buildCustomModule(testing.allocator, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", 10);
+}
+
+test "differential SIMD: i32x4.splat feeds i32x4.add" {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try body.append(testing.allocator, 0x41);
+    try encodeSLEB128(&body, testing.allocator, 3);
+    try appendI32x4Splat(&body, testing.allocator);
+    try appendV128ConstI32x4(&body, testing.allocator, .{ 4, 5, 6, 7 });
+    try appendSimdOpcode(&body, testing.allocator, 0xAE);
+    try appendI32x4ExtractLane(&body, testing.allocator, 2);
+    try body.append(testing.allocator, 0x0B);
+
+    const wasm = try buildCustomModule(testing.allocator, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", 9);
+}
+
 test "differential SIMD: v128 bitwise xor extracts lane 0" {
     var body: std.ArrayList(u8) = .empty;
     defer body.deinit(testing.allocator);
@@ -515,8 +579,17 @@ fn appendV128ConstI32x4(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, l
     }
 }
 
+fn appendI32x4Splat(buf: *std.ArrayList(u8), allocator: std.mem.Allocator) !void {
+    try appendSimdOpcode(buf, allocator, 0x11);
+}
+
 fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x1B);
+    try buf.append(allocator, lane);
+}
+
+fn appendI32x4ReplaceLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x1C);
     try buf.append(allocator, lane);
 }
 

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -30,6 +30,13 @@ const RunResult = struct {
     run_ns: u64,
 };
 
+const BenchOptions = struct {
+    iterations: u32 = 10_000,
+    run_wasmtime: bool = false,
+    wasmtime_path: []const u8 = "wasmtime",
+    wasmtime_iterations: ?u32 = null,
+};
+
 const cases = [_]BenchCase{
     .{
         .name = "scalar_i32_add",
@@ -52,6 +59,16 @@ const cases = [_]BenchCase{
         .build = buildSimdI32x4EqLane0Module,
     },
     .{
+        .name = "simd_i32x4_splat_lane0",
+        .simd = true,
+        .build = buildSimdI32x4SplatLane0Module,
+    },
+    .{
+        .name = "simd_i32x4_replace_lane2",
+        .simd = true,
+        .build = buildSimdI32x4ReplaceLane2Module,
+    },
+    .{
         .name = "simd_v128_load_store_lane0",
         .simd = true,
         .build = buildSimdLoadStoreLane0Module,
@@ -61,7 +78,7 @@ const cases = [_]BenchCase{
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const args = try init.minimal.args.toSlice(init.arena.allocator());
-    const iterations = parseIterations(args) catch |err| {
+    const options = parseOptions(args) catch |err| {
         std.debug.print("simd-bench-runner: invalid arguments: {s}\n", .{@errorName(err)});
         usage();
         std.process.exit(2);
@@ -75,23 +92,25 @@ pub fn main(init: std.process.Init) !void {
     }
 
     for (cases) |case| {
-        try runCase(allocator, case, iterations);
+        try runCase(allocator, init.io, case, options);
     }
 }
 
 fn usage() void {
     std.debug.print(
-        \\usage: simd-bench-runner [--iterations N]
+        \\usage: simd-bench-runner [--iterations N] [--wasmtime] [--wasmtime-path PATH] [--wasmtime-iterations N]
         \\
         \\Runs embedded SIMD microbench modules through the interpreter and,
         \\when supported by the host CPU, through the in-memory AOT pipeline.
+        \\With --wasmtime, also invokes the Wasmtime CLI for a small external
+        \\baseline. Wasmtime timings include CLI startup and compilation.
         \\Rows are tab-separated and prefixed with "bench".
         \\
     , .{});
 }
 
-fn parseIterations(args: []const []const u8) !u32 {
-    var iterations: u32 = 10_000;
+fn parseOptions(args: []const []const u8) !BenchOptions {
+    var options = BenchOptions{};
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         if (std.mem.eql(u8, args[i], "--help") or std.mem.eql(u8, args[i], "-h")) {
@@ -100,28 +119,59 @@ fn parseIterations(args: []const []const u8) !u32 {
         } else if (std.mem.eql(u8, args[i], "--iterations")) {
             i += 1;
             if (i >= args.len) return error.MissingValue;
-            iterations = try std.fmt.parseUnsigned(u32, args[i], 10);
-            if (iterations == 0) return error.InvalidIterationCount;
+            options.iterations = try std.fmt.parseUnsigned(u32, args[i], 10);
+            if (options.iterations == 0) return error.InvalidIterationCount;
+        } else if (std.mem.eql(u8, args[i], "--wasmtime")) {
+            options.run_wasmtime = true;
+        } else if (std.mem.eql(u8, args[i], "--wasmtime-path")) {
+            i += 1;
+            if (i >= args.len) return error.MissingValue;
+            options.wasmtime_path = args[i];
+        } else if (std.mem.eql(u8, args[i], "--wasmtime-iterations")) {
+            i += 1;
+            if (i >= args.len) return error.MissingValue;
+            options.wasmtime_iterations = try std.fmt.parseUnsigned(u32, args[i], 10);
+            if (options.wasmtime_iterations.? == 0) return error.InvalidIterationCount;
         } else {
             return error.UnknownArgument;
         }
     }
-    return iterations;
+    return options;
 }
 
-fn runCase(allocator: Allocator, case: BenchCase, iterations: u32) !void {
+fn runCase(allocator: Allocator, io: std.Io, case: BenchCase, options: BenchOptions) !void {
     const wasm = try case.build(allocator);
     defer allocator.free(wasm);
 
-    const interp_result = runInterpMany(allocator, wasm, "run", iterations) catch |err| {
-        emitRow(case.name, "interp", "trap", null, null, null, iterations, wasm.len);
+    const interp_result = runInterpMany(allocator, wasm, "run", options.iterations) catch |err| {
+        emitRow(case.name, "interp", "trap", null, null, null, options.iterations, wasm.len);
         std.debug.print("simd-bench-runner: interpreter failed for {s}: {s}\n", .{ case.name, @errorName(err) });
         return;
     };
-    emitRow(case.name, "interp", "ok", interp_result.result, 0, interp_result.run_ns, iterations, wasm.len);
+    emitRow(case.name, "interp", "ok", interp_result.result, 0, interp_result.run_ns, options.iterations, wasm.len);
+
+    if (options.run_wasmtime) {
+        const wasmtime_iterations = options.wasmtime_iterations orelse @min(options.iterations, 10);
+        const wasmtime_result = runWasmtimeMany(
+            allocator,
+            io,
+            wasm,
+            "run",
+            case.name,
+            wasmtime_iterations,
+            options.wasmtime_path,
+        ) catch |err| {
+            const status = if (err == error.FileNotFound) "unsupported" else "trap";
+            emitRow(case.name, "wasmtime", status, null, null, null, wasmtime_iterations, wasm.len);
+            std.debug.print("simd-bench-runner: Wasmtime failed for {s}: {s}\n", .{ case.name, @errorName(err) });
+            return;
+        };
+        const status = if (wasmtime_result.result == interp_result.result) "ok" else "mismatch";
+        emitRow(case.name, "wasmtime", status, wasmtime_result.result, null, wasmtime_result.run_ns, wasmtime_iterations, wasm.len);
+    }
 
     if (!aot_harness.can_exec_aot) {
-        emitRow(case.name, "aot", "unsupported", null, null, null, iterations, null);
+        emitRow(case.name, "aot", "unsupported", null, null, null, options.iterations, null);
         return;
     }
 
@@ -133,19 +183,19 @@ fn runCase(allocator: Allocator, case: BenchCase, iterations: u32) !void {
         .{ .invoke_start = false },
     ) catch |err| {
         const status = if (case.simd and err == error.CompileFailed) "unsupported" else "compile_failed";
-        emitRow(case.name, "aot", status, null, elapsedSince(compile_start), null, iterations, null);
+        emitRow(case.name, "aot", status, null, elapsedSince(compile_start), null, options.iterations, null);
         return;
     };
     const compile_ns = elapsedSince(compile_start);
     defer h.deinit();
 
-    const aot_result = runAotMany(h, "run", iterations) catch |err| {
-        emitRow(case.name, "aot", "trap", null, compile_ns, null, iterations, h.aot_bin.len);
+    const aot_result = runAotMany(h, "run", options.iterations) catch |err| {
+        emitRow(case.name, "aot", "trap", null, compile_ns, null, options.iterations, h.aot_bin.len);
         std.debug.print("simd-bench-runner: AOT failed for {s}: {s}\n", .{ case.name, @errorName(err) });
         return;
     };
     const status = if (aot_result.result == interp_result.result) "ok" else "mismatch";
-    emitRow(case.name, "aot", status, aot_result.result, compile_ns, aot_result.run_ns, iterations, h.aot_bin.len);
+    emitRow(case.name, "aot", status, aot_result.result, compile_ns, aot_result.run_ns, options.iterations, h.aot_bin.len);
 }
 
 fn emitRow(
@@ -238,6 +288,49 @@ fn runAotMany(h: *aot_harness.Harness, name: []const u8, iterations: u32) !RunRe
     };
 }
 
+fn runWasmtimeMany(
+    allocator: Allocator,
+    io: std.Io,
+    wasm: []const u8,
+    name: []const u8,
+    case_name: []const u8,
+    iterations: u32,
+    wasmtime_path: []const u8,
+) !RunResult {
+    const cwd = std.Io.Dir.cwd();
+    try cwd.createDirPath(io, ".zig-cache/simd-bench-wasmtime");
+    const wasm_path = try std.fmt.allocPrint(allocator, ".zig-cache/simd-bench-wasmtime/{s}.wasm", .{case_name});
+    defer allocator.free(wasm_path);
+    defer cwd.deleteFile(io, wasm_path) catch {};
+
+    try cwd.writeFile(io, .{ .sub_path = wasm_path, .data = wasm });
+
+    var last: i32 = 0;
+    const start = nowNs();
+    var i: u32 = 0;
+    while (i < iterations) : (i += 1) {
+        const argv = [_][]const u8{ wasmtime_path, "--invoke", name, wasm_path };
+        const result = try std.process.run(allocator, io, .{
+            .argv = &argv,
+            .stdout_limit = .limited(4096),
+            .stderr_limit = .limited(4096),
+        });
+        defer allocator.free(result.stdout);
+        defer allocator.free(result.stderr);
+
+        switch (result.term) {
+            .exited => |code| if (code != 0) return error.WasmtimeFailed,
+            else => return error.WasmtimeFailed,
+        }
+        const trimmed = std.mem.trim(u8, result.stdout, " \t\r\n");
+        last = try std.fmt.parseInt(i32, trimmed, 10);
+    }
+    return .{
+        .result = last,
+        .run_ns = elapsedSince(start),
+    };
+}
+
 fn buildScalarAddModule(allocator: Allocator) ![]u8 {
     var instr: std.ArrayList(u8) = .empty;
     defer instr.deinit(allocator);
@@ -283,6 +376,31 @@ fn buildSimdI32x4EqLane0Module(allocator: Allocator) ![]u8 {
     try appendV128ConstI32x4(&instr, allocator, .{ 42, 0, 3, 5 });
     try appendSimdOpcode(&instr, allocator, 0x37); // i32x4.eq
     try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4SplatLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try instr.append(allocator, 0x41); // i32.const
+    try encodeSLEB128(&instr, allocator, 77);
+    try appendI32x4Splat(&instr, allocator);
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4ReplaceLane2Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ 1, 2, 3, 4 });
+    try instr.append(allocator, 0x41); // i32.const
+    try encodeSLEB128(&instr, allocator, 99);
+    try appendI32x4ReplaceLane(&instr, allocator, 2);
+    try appendI32x4ExtractLane(&instr, allocator, 2);
 
     return buildRunI32Module(allocator, instr.items, .{});
 }
@@ -405,8 +523,17 @@ fn appendV128ConstI32x4(buf: *std.ArrayList(u8), allocator: Allocator, lanes: [4
     }
 }
 
+fn appendI32x4Splat(buf: *std.ArrayList(u8), allocator: Allocator) !void {
+    try appendSimdOpcode(buf, allocator, 0x11); // i32x4.splat
+}
+
 fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x1B); // i32x4.extract_lane
+    try buf.append(allocator, lane);
+}
+
+fn appendI32x4ReplaceLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x1C); // i32x4.replace_lane
     try buf.append(allocator, lane);
 }
 


### PR DESCRIPTION
## Summary
- add IR/frontend/AArch64 NEON lowering for `i32x4.splat` and `i32x4.replace_lane`
- keep current stack-resident v128 storage policy and x86-64/v128 ABI paths explicitly unsupported
- add scalar-wrapper differential tests plus new SIMD bench rows for splat/replace
- add opt-in Wasmtime CLI baseline rows to `simd-bench-runner` and `scripts/bench_simd.py`

## Validation
- `zig build test`
- `zig build simd-bench`
- `zig build simd-bench -- --wasmtime --wasmtime-iterations 3 --iterations 100`
- `scripts/bench_simd.py --baseline origin/main --target HEAD --runs 1 --iterations 10 --wasmtime --wasmtime-iterations 3`

The committed comparison shows `origin/main` AOT unsupported for the new splat/replace rows and target AOT ok; Wasmtime rows are ok for both refs and include CLI startup/compile time.

Refs #220