### PR TITLE
compiler: add AArch64 i32x4 cmp and mul

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -1838,12 +1838,24 @@ fn emitI32x4BinOp(
         v128_cache,
         fctx,
     );
-    const op: emit.CodeBuffer.I32x4Op = switch (bin.op) {
-        .add => .add,
-        .sub => .sub,
-        .eq => .cmeq,
-    };
-    try code.i32x4Op(op, dest_reg, lhs_reg, rhs_reg);
+    switch (bin.op) {
+        .add => try code.i32x4Op(.add, dest_reg, lhs_reg, rhs_reg),
+        .sub => try code.i32x4Op(.sub, dest_reg, lhs_reg, rhs_reg),
+        .mul => try code.i32x4Op(.mul, dest_reg, lhs_reg, rhs_reg),
+        .eq => try code.i32x4Op(.cmeq, dest_reg, lhs_reg, rhs_reg),
+        .ne => {
+            try code.i32x4Op(.cmeq, dest_reg, lhs_reg, rhs_reg);
+            try code.mvn16b(dest_reg, dest_reg);
+        },
+        .gt_s => try code.i32x4Op(.cmgt, dest_reg, lhs_reg, rhs_reg),
+        .ge_s => try code.i32x4Op(.cmge, dest_reg, lhs_reg, rhs_reg),
+        .lt_s => try code.i32x4Op(.cmgt, dest_reg, rhs_reg, lhs_reg),
+        .le_s => try code.i32x4Op(.cmge, dest_reg, rhs_reg, lhs_reg),
+        .gt_u => try code.i32x4Op(.cmhi, dest_reg, lhs_reg, rhs_reg),
+        .ge_u => try code.i32x4Op(.cmhs, dest_reg, lhs_reg, rhs_reg),
+        .lt_u => try code.i32x4Op(.cmhi, dest_reg, rhs_reg, lhs_reg),
+        .le_u => try code.i32x4Op(.cmhs, dest_reg, rhs_reg, lhs_reg),
+    }
 }
 
 fn emitI32x4Splat(
@@ -5067,6 +5079,76 @@ test "compile: i32x4 lane ops emit NEON instructions" {
     try std.testing.expect(found_dup);
     try std.testing.expect(found_ins);
     try std.testing.expect(found_umov);
+}
+
+test "compile: i32x4 cmp and mul ops emit NEON instructions" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+
+    const a = func.newVReg();
+    const b = func.newVReg();
+    const mul = func.newVReg();
+    const ne = func.newVReg();
+    const lt_s = func.newVReg();
+    const gt_s = func.newVReg();
+    const le_s = func.newVReg();
+    const ge_s = func.newVReg();
+    const lt_u = func.newVReg();
+    const gt_u = func.newVReg();
+    const le_u = func.newVReg();
+    const ge_u = func.newVReg();
+    const lane = func.newVReg();
+
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0000_0004_8000_0000_FFFF_FFFF_0000_0002 }, .dest = a, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0000_0003_8000_0000_0000_0001_0000_0003 }, .dest = b, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .mul, .lhs = a, .rhs = b } }, .dest = mul, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .ne, .lhs = a, .rhs = b } }, .dest = ne, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .lt_s, .lhs = a, .rhs = b } }, .dest = lt_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .gt_s, .lhs = a, .rhs = b } }, .dest = gt_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .le_s, .lhs = a, .rhs = b } }, .dest = le_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .ge_s, .lhs = a, .rhs = b } }, .dest = ge_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .lt_u, .lhs = a, .rhs = b } }, .dest = lt_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .gt_u, .lhs = a, .rhs = b } }, .dest = gt_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .le_u, .lhs = a, .rhs = b } }, .dest = le_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .ge_u, .lhs = a, .rhs = b } }, .dest = ge_u, .type = .v128 });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i32x4_extract_lane = .{ .vector = ge_u, .lane = 0 } },
+        .dest = lane,
+        .type = .i32,
+    });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = lane } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    var found_mul = false;
+    var found_cmeq = false;
+    var found_mvn = false;
+    var found_cmgt = false;
+    var found_cmge = false;
+    var found_cmhi = false;
+    var found_cmhs = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFE0FC00) == 0x4EA09C00) found_mul = true;
+        if ((w & 0xFFE0FC00) == 0x6EA08C00) found_cmeq = true;
+        if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
+        if ((w & 0xFFE0FC00) == 0x4EA03400) found_cmgt = true;
+        if ((w & 0xFFE0FC00) == 0x4EA03C00) found_cmge = true;
+        if ((w & 0xFFE0FC00) == 0x6EA03400) found_cmhi = true;
+        if ((w & 0xFFE0FC00) == 0x6EA03C00) found_cmhs = true;
+    }
+
+    try std.testing.expect(found_mul);
+    try std.testing.expect(found_cmeq);
+    try std.testing.expect(found_mvn);
+    try std.testing.expect(found_cmgt);
+    try std.testing.expect(found_cmge);
+    try std.testing.expect(found_cmhi);
+    try std.testing.expect(found_cmhs);
 }
 
 test "compile: v128 locals remain unsupported before ABI support" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -714,10 +714,15 @@ pub const CodeBuffer = struct {
     pub const I32x4Op = enum(u32) {
         add = 0x4EA08400,
         sub = 0x6EA08400,
+        mul = 0x4EA09C00,
         cmeq = 0x6EA08C00,
+        cmgt = 0x4EA03400,
+        cmge = 0x4EA03C00,
+        cmhi = 0x6EA03400,
+        cmhs = 0x6EA03C00,
     };
 
-    /// ADD/SUB/CMEQ Vd.4S, Vn.4S, Vm.4S.
+    /// Integer 4S binary vector op: ADD/SUB/MUL/CMEQ/CMGT/CMGE/CMHI/CMHS.
     pub fn i32x4Op(self: *CodeBuffer, op: I32x4Op, vd: u5, vn: u5, vm: u5) !void {
         try self.emit32(@intFromEnum(op) |
             (@as(u32, vm) << 16) |
@@ -1582,6 +1587,43 @@ test "emit: CMEQ v0.4s, v1.4s, v2.4s" {
     defer code.deinit();
     try code.i32x4Op(.cmeq, 0, 1, 2);
     try expectWord(0x6EA28C20, &code);
+}
+
+test "emit: MUL v0.4s, v1.4s, v2.4s" {
+    var code = CodeBuffer.init(std.testing.allocator);
+    defer code.deinit();
+    try code.i32x4Op(.mul, 0, 1, 2);
+    try expectWord(0x4EA29C20, &code);
+}
+
+test "emit: signed i32x4 comparisons" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i32x4Op(.cmgt, 0, 1, 2);
+        try expectWord(0x4EA23420, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i32x4Op(.cmge, 0, 1, 2);
+        try expectWord(0x4EA23C20, &code);
+    }
+}
+
+test "emit: unsigned i32x4 comparisons" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i32x4Op(.cmhi, 0, 1, 2);
+        try expectWord(0x6EA23420, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i32x4Op(.cmhs, 0, 1, 2);
+        try expectWord(0x6EA23C20, &code);
+    }
 }
 
 test "emit: UMOV w0, v1.s[3]" {

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -1782,6 +1782,16 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .i32x4_add,
                     .i32x4_sub,
                     .i32x4_eq,
+                    .i32x4_ne,
+                    .i32x4_lt_s,
+                    .i32x4_lt_u,
+                    .i32x4_gt_s,
+                    .i32x4_gt_u,
+                    .i32x4_le_s,
+                    .i32x4_le_u,
+                    .i32x4_ge_s,
+                    .i32x4_ge_u,
+                    .i32x4_mul,
                     => {
                         const rhs = safePop(&vreg_stack);
                         const lhs = safePop(&vreg_stack);
@@ -1790,6 +1800,16 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                             .i32x4_add => .add,
                             .i32x4_sub => .sub,
                             .i32x4_eq => .eq,
+                            .i32x4_ne => .ne,
+                            .i32x4_lt_s => .lt_s,
+                            .i32x4_lt_u => .lt_u,
+                            .i32x4_gt_s => .gt_s,
+                            .i32x4_gt_u => .gt_u,
+                            .i32x4_le_s => .le_s,
+                            .i32x4_le_u => .le_u,
+                            .i32x4_ge_s => .ge_s,
+                            .i32x4_ge_u => .ge_u,
+                            .i32x4_mul => .mul,
                             else => unreachable,
                         };
                         try ir_func.getBlock(current_block).append(.{
@@ -2659,6 +2679,101 @@ test "lower i32x4 dynamic lane opcodes" {
     try std.testing.expectEqual(@as(u2, 2), insts[3].op.i32x4_replace_lane.lane);
     try std.testing.expectEqual(@as(u2, 2), insts[4].op.i32x4_extract_lane.lane);
     try std.testing.expect(insts[5].op.ret != null);
+}
+
+test "lower i32x4 cmp and mul opcodes" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i32},
+    };
+
+    const Case = struct {
+        opcode: u32,
+        expected: ir.Inst.I32x4Op,
+    };
+    const cases = [_]Case{
+        .{ .opcode = 0x38, .expected = .ne },
+        .{ .opcode = 0x39, .expected = .lt_s },
+        .{ .opcode = 0x3A, .expected = .lt_u },
+        .{ .opcode = 0x3B, .expected = .gt_s },
+        .{ .opcode = 0x3C, .expected = .gt_u },
+        .{ .opcode = 0x3D, .expected = .le_s },
+        .{ .opcode = 0x3E, .expected = .le_u },
+        .{ .opcode = 0x3F, .expected = .ge_s },
+        .{ .opcode = 0x40, .expected = .ge_u },
+        .{ .opcode = 0xB5, .expected = .mul },
+    };
+
+    const appendULEB = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, value: u32) !void {
+            var v = value;
+            while (true) {
+                var byte: u8 = @intCast(v & 0x7F);
+                v >>= 7;
+                if (v != 0) byte |= 0x80;
+                try buf.append(alloc, byte);
+                if (v == 0) break;
+            }
+        }
+    }.call;
+    const appendSimd = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, opcode: u32) !void {
+            try buf.append(alloc, 0xFD);
+            try appendULEB(buf, alloc, opcode);
+        }
+    }.call;
+    const appendConst = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, lanes: [4]i32) !void {
+            try appendSimd(buf, alloc, 0x0C);
+            for (lanes) |lane| {
+                var le = std.mem.nativeToLittle(u32, @bitCast(lane));
+                try buf.appendSlice(alloc, std.mem.asBytes(&le));
+            }
+        }
+    }.call;
+
+    var code: std.ArrayList(u8) = .empty;
+    defer code.deinit(allocator);
+    try appendConst(&code, allocator, .{ -1, 1, -2, 2 });
+    try appendConst(&code, allocator, .{ 1, -1, 2, -2 });
+    for (cases, 0..) |case, idx| {
+        if (idx != 0) try appendConst(&code, allocator, .{ 2, 3, 4, 5 });
+        try appendSimd(&code, allocator, case.opcode);
+    }
+    try appendSimd(&code, allocator, 0x1B); // i32x4.extract_lane
+    try code.append(allocator, 0);
+    try code.append(allocator, 0x0B);
+
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = code.items,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+    try std.testing.expectEqual(@as(usize, 2 + cases.len * 2 + 1), insts.len);
+    var inst_idx: usize = 2;
+    for (cases, 0..) |case, idx| {
+        try std.testing.expectEqual(case.expected, insts[inst_idx].op.i32x4_binop.op);
+        inst_idx += 1;
+        if (idx + 1 < cases.len) {
+            try std.testing.expectEqual(ir.IrType.v128, insts[inst_idx].type);
+            inst_idx += 1;
+        }
+    }
+    try std.testing.expectEqual(@as(u2, 0), insts[inst_idx].op.i32x4_extract_lane.lane);
+    try std.testing.expect(insts[inst_idx + 1].op.ret != null);
 }
 
 test "lower unreachable" {

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -248,7 +248,21 @@ pub const Inst = struct {
 
     pub const V128BitwiseOp = enum { @"and", andnot, @"or", xor };
 
-    pub const I32x4Op = enum { add, sub, eq };
+    pub const I32x4Op = enum {
+        add,
+        sub,
+        eq,
+        ne,
+        lt_s,
+        lt_u,
+        gt_s,
+        gt_u,
+        le_s,
+        le_u,
+        ge_s,
+        ge_u,
+        mul,
+    };
 
     pub const V128Mem = struct {
         base: VReg,

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -59,6 +59,26 @@ const cases = [_]BenchCase{
         .build = buildSimdI32x4EqLane0Module,
     },
     .{
+        .name = "simd_i32x4_mul_lane0",
+        .simd = true,
+        .build = buildSimdI32x4MulLane0Module,
+    },
+    .{
+        .name = "simd_i32x4_ne_lane0",
+        .simd = true,
+        .build = buildSimdI32x4NeLane0Module,
+    },
+    .{
+        .name = "simd_i32x4_gt_s_lane0",
+        .simd = true,
+        .build = buildSimdI32x4GtSLane0Module,
+    },
+    .{
+        .name = "simd_i32x4_gt_u_lane0",
+        .simd = true,
+        .build = buildSimdI32x4GtULane0Module,
+    },
+    .{
         .name = "simd_i32x4_splat_lane0",
         .simd = true,
         .build = buildSimdI32x4SplatLane0Module,
@@ -385,6 +405,54 @@ fn buildSimdI32x4EqLane0Module(allocator: Allocator) ![]u8 {
     try appendV128ConstI32x4(&instr, allocator, .{ 42, 2, 3, 4 });
     try appendV128ConstI32x4(&instr, allocator, .{ 42, 0, 3, 5 });
     try appendSimdOpcode(&instr, allocator, 0x37); // i32x4.eq
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4MulLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ 50_000, -7, 3, 4 });
+    try appendV128ConstI32x4(&instr, allocator, .{ 50_000, 6, 7, 8 });
+    try appendSimdOpcode(&instr, allocator, 0xB5); // i32x4.mul
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4NeLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ 42, 2, 3, 4 });
+    try appendV128ConstI32x4(&instr, allocator, .{ 7, 2, 0, 4 });
+    try appendSimdOpcode(&instr, allocator, 0x38); // i32x4.ne
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4GtSLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ -1, 10, -5, 4 });
+    try appendV128ConstI32x4(&instr, allocator, .{ 1, 9, -6, 4 });
+    try appendSimdOpcode(&instr, allocator, 0x3B); // i32x4.gt_s
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4GtULane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ -1, 10, -5, 4 });
+    try appendV128ConstI32x4(&instr, allocator, .{ 1, 9, -6, 4 });
+    try appendSimdOpcode(&instr, allocator, 0x3C); // i32x4.gt_u
     try appendI32x4ExtractLane(&instr, allocator, 0);
 
     return buildRunI32Module(allocator, instr.items, .{});

--- a/tests/benchmarks/simd/README.md
+++ b/tests/benchmarks/simd/README.md
@@ -21,6 +21,8 @@ The runner emits tab-separated rows for interpreter and AOT engines. It records 
 
 The `scalar_i32_mem_add_4k_loop` and `simd_i32x4_mem_add_4k_loop` rows are the first throughput-oriented probes. Each exported call walks two 4 KiB input arrays in linear memory, writes an output array, and returns a scalar checksum from the last element. The SIMD row processes the same data with `v128.load`, `i32x4.add`, and `v128.store`, making it a better signal for vector memory-loop quality than one-instruction microbenchmarks.
 
+The small `simd_i32x4_*_lane0` rows are coverage/status probes for individual opcode families. They intentionally return one scalar lane so interpreter, AOT, and optional Wasmtime rows can be compared before the runtime supports direct exported v128 values.
+
 Wasmtime can be included as an external baseline:
 
 ```sh


### PR DESCRIPTION
## Summary

- extend the supported `i32x4_binop` family with `mul`, `ne`, signed comparisons, and unsigned comparisons
- map the new Wasm SIMD opcodes in the frontend while leaving unselected SIMD opcodes unsupported
- add AArch64 NEON lowering for `MUL`, `CMEQ`+`MVN`, signed `CMGT/CMGE`, and unsigned `CMHI/CMHS`
- add frontend, emit, and compile tests for the expanded op family
- add SIMD benchmark/status rows for `mul`, `ne`, `gt_s`, and `gt_u`

## Validation

- `zig build test`
- `zig build simd-bench`
- `scripts/bench_simd.py --baseline origin/main --target HEAD --runs 3 --iterations 10000`

New AOT rows transition from baseline unsupported to target ok:
- `simd_i32x4_mul_lane0`: unsupported -> ok, result `-1794967296`
- `simd_i32x4_ne_lane0`: unsupported -> ok, result `-1`
- `simd_i32x4_gt_s_lane0`: unsupported -> ok, result `0`
- `simd_i32x4_gt_u_lane0`: unsupported -> ok, result `-1`

Existing throughput row remained neutral: `simd_i32x4_mem_add_4k_loop` AOT median was `9.938 ms` on `origin/main` vs `9.950 ms` on this branch for 10000 calls.

Closes part of #220.
