### PR TITLE
Document lightweight security review process

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,14 @@ assignees: ""
 ---
 
 **Is it a security vulnerability?**
-If it results in a crash or hang, please refer to [a quick checklist](../../doc/security_need_to_know.md#is-this-bug-considered-a-security-vulnerability) to determine if it is a security vulnerability. If you are still unsure, please report it through [a security advisor](https://github.com/bytecodealliance/wasm-micro-runtime/security/advisories) and allow the maintainer to make a decision. Thank you.
+If this may expose host memory, bypass a sandbox or WASI/component capability,
+mis-handle a private vulnerability report, or includes sensitive proof-of-concept
+details, do not file it publicly. Use this repository's private vulnerability
+reporting instead:
+https://github.com/cataggar/wamr/security/advisories/new
+
+Public issues are fine for non-sensitive bugs, crashes without exploit details,
+and hardening ideas.
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -18,10 +25,10 @@ Information like tags, release version, commits.
 **To Reproduce**
 Steps to reproduce the behavior:
 
-1. Compile iwasm with flags like '...'
-2. (Optional) Compile wamrc with flags like '....'
-3. (Optional) Run wamrc with CLI options like '...' to generate .aot
-4. Run iwasm with CLI options like '...'
+1. Build `wamr` with flags like '...'
+2. (Optional) Build `wamrc` with flags like '....'
+3. (Optional) Run `wamrc` with CLI options like '...' to generate AOT output
+4. Run `wamr` with CLI options like '...'
 5. See error
 
 **Expected behavior**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: true
+contact_links:
+  - name: Private vulnerability report
+    url: https://github.com/cataggar/wamr/security/advisories/new
+    about: Report sensitive vulnerabilities privately to this repository maintainer.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+-
+
+## Security review
+
+- [ ] This PR does not touch sandbox-critical code or security process docs.
+- [ ] This PR touches a sandbox-critical boundary; boundary:
+- [ ] Guest-memory range checks use overflow-safe arithmetic before slicing or
+      native memory access.
+- [ ] Interpreter/AOT trap semantics and differential or spec coverage were
+      considered.
+- [ ] WASI/component resource capability and ownership/lifetime rules were
+      considered.
+- [ ] Security reporting/process wording keeps the project's experimental,
+      independent, no-SLA status clear.
+
+## Validation
+
+-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,3 +25,6 @@ unless the same issue also affects a Bytecode Alliance project.
 
 For proactive review scope and sandbox-critical audit checklists, see
 [SECURITY_AUDIT.md](SECURITY_AUDIT.md).
+
+For maintainer triage, advisory decisions, upstream advisory tracking, and
+security-review expectations, see [SECURITY_PROCESS.md](SECURITY_PROCESS.md).

--- a/SECURITY_PROCESS.md
+++ b/SECURITY_PROCESS.md
@@ -1,0 +1,152 @@
+# Security Review and Advisory Process
+
+This is a maintainer checklist for lightweight security handling in this
+repository. It complements the public reporting instructions in
+[SECURITY.md](SECURITY.md) and the sandbox-critical review checklist in
+[SECURITY_AUDIT.md](SECURITY_AUDIT.md).
+
+This project is experimental, independently maintained, and not
+production-supported. The process below is best-effort guidance; it is not a
+formal security response SLA, long-term support policy, embargo guarantee, or
+CVE commitment.
+
+## Private vulnerability report triage
+
+Use GitHub Private Vulnerability Reporting for sensitive reports. Keep report
+details, payloads, and reproducers private until a public fix or advisory plan is
+chosen.
+
+1. Acknowledge the report in the private thread and ask for any missing
+   non-sensitive reproduction context.
+2. Reproduce or narrow the issue without moving exploit details into public
+   issues, public PRs, logs, or docs.
+3. Classify the affected boundary:
+   - loader or validation
+   - interpreter runtime
+   - AOT compiler, codegen, or runtime
+   - component canonical ABI
+   - WASI or component host resources
+   - build, release, dependency, or supply chain
+   - documentation or process only
+4. Assess impact in repository terms:
+   - host memory access or sandbox escape
+   - guest isolation break
+   - WASI/component capability bypass
+   - denial of service
+   - incorrect trap behavior or AOT/interpreter mismatch
+   - build, release, or supply-chain exposure
+   - non-security correctness bug
+5. Decide whether the fix should happen in a private security fork/branch or in
+   a normal public PR with minimal disclosure.
+6. Keep reproducers attached to the private report when needed. Public
+   regression tests should be minimized or redacted if the full reproducer would
+   reveal an unfixed vulnerability.
+7. After a fix is public, cross-link the private report, public issue or PR, and
+   any advisory record that applies.
+
+## Advisory and CVE decisions
+
+Use a GitHub Security Advisory when a report is a confirmed vulnerability in this
+repository and private coordination is useful before public disclosure.
+
+Consider requesting a CVE only when all of the following are true:
+
+- the issue has a confirmed security impact in this repository;
+- released artifacts or real users are plausibly affected;
+- ecosystem-wide tracking would help downstream users or distributors.
+
+Use a normal public issue or PR for:
+
+- non-sensitive hardening ideas;
+- already-public bugs;
+- test or checklist gaps;
+- correctness bugs without a plausible security impact;
+- issues that only affect unsupported local experiments.
+
+If an issue only affects upstream C/C++ WAMR, Wasmtime, or another project, link
+to the upstream advisory and record this Zig implementation as unaffected or
+under review instead of creating a misleading advisory here.
+
+## Upstream advisory tracking
+
+Periodically review upstream advisories and releases that could overlap this
+runtime's threat model:
+
+- upstream `bytecodealliance/wasm-micro-runtime` security advisories, releases,
+  and issues;
+- relevant `bytecodealliance/wasmtime` advisories and releases;
+- GitHub Security Advisories for WebAssembly runtimes or dependencies used by
+  this repository.
+
+For each relevant advisory, record a short public note in the tracking issue or
+follow-up PR. Use this format:
+
+| Field | Expected content |
+| --- | --- |
+| Source | Project and advisory or release link |
+| Reviewed | Date reviewed |
+| Area | Loader, interpreter, AOT, component, WASI, release, dependency, etc. |
+| Status | `unaffected`, `affected`, `under-review`, or `not-applicable` |
+| Rationale | Short reason without exploit details |
+| Follow-up | Issue or PR link, if any |
+
+Do not copy exploit payloads, embargoed details, or sensitive reproducer material
+into public tracking notes.
+
+## PR review expectations
+
+Use [SECURITY_AUDIT.md](SECURITY_AUDIT.md) for the detailed sandbox-critical
+checklist. For everyday PR review, first decide whether a change touches one of
+these boundaries:
+
+- WebAssembly loader or validation;
+- interpreter dispatch, memory, table, or trap handling;
+- compiler frontend, IR passes, register allocation, AOT codegen, or AOT
+  runtime;
+- component canonical ABI lifting/lowering or guest-memory access;
+- WASI/component host capabilities, resource tables, or resource lifetimes;
+- build, release, dependency, or workflow behavior.
+
+If a PR touches a boundary, reviewers should look for:
+
+- overflow-safe `ptr + len`, `addr + offset + width`, and element-count
+  calculations before slicing host memory;
+- trap semantics preserved across interpreter and AOT paths;
+- explicit table, function, signature, null-reference, and dropped-segment
+  checks before dispatch;
+- host-resource ownership and drop behavior that cannot double-free, leak
+  capabilities, or reuse stale handles incorrectly;
+- tests or documented rationale for boundary cases, especially when the change
+  intentionally shifts behavior.
+
+## CI and validation expectations
+
+Existing CI provides these security-relevant signals:
+
+- `zig build test` is the baseline for normal code changes.
+- Debug builds keep Zig safety checks visible, which helps catch bounds and
+  overflow mistakes.
+- ReleaseSafe builds and cross-target jobs provide platform coverage.
+- Spec tests exercise WebAssembly semantic compatibility.
+- The wasm32-wasi smoke job checks the self-hosted WASI build path.
+- The fuzz workflow runs for loader, interpreter, AOT, and differential harness
+  paths on schedule, on demand, and on PRs that touch runtime/compiler/fuzz
+  files.
+
+Reviewer guidance:
+
+- For interpreter, compiler, runtime, or component boundary changes, expect
+  `zig build test` and consider targeted spec, differential, AOT, or fuzz
+  coverage.
+- For loader/runtime/compiler/fuzz harness changes, consider `zig build fuzz`
+  or the GitHub fuzz workflow when the change affects input parsing or execution
+  boundaries.
+- For documentation-only changes, a full Zig build is usually unnecessary; check
+  links, wording, and whether the text avoids unsupported support promises.
+
+## Public communication
+
+Keep public issues and PRs factual and minimal until any sensitive fix is
+available. Public notes should describe impact, affected area, and fixed version
+or commit when appropriate, but should not include exploit instructions or
+unredacted payloads for an unresolved vulnerability.


### PR DESCRIPTION
## Summary

- Add SECURITY_PROCESS.md with private report triage, advisory/CVE decision guidance, upstream advisory tracking, PR review expectations, and CI/security validation notes.
- Link the process from SECURITY.md while preserving the experimental/no-SLA positioning.
- Add a PR template security checklist and update issue templates to route sensitive reports to this repository's private vulnerability reporting.

## Security review

- This is documentation/template-only process work.
- The wording preserves the project's experimental, independent, no-SLA status.
- Sensitive vulnerability reports are routed to this repository's private vulnerability reporting path.

## Validation

- git diff --check

Closes #224.