### PR TITLE
perf(aarch64): add i16x8 SIMD lanes

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -559,6 +559,9 @@ fn isSupportedV128Def(inst: ir.Inst) bool {
         .i32x4_shift,
         .i32x4_splat,
         .i32x4_replace_lane,
+        .i16x8_binop,
+        .i16x8_splat,
+        .i16x8_replace_lane,
         => inst.type == .v128,
         else => false,
     };
@@ -582,11 +585,15 @@ fn functionHasUnsupportedV128(func: *const ir.IrFunction, allocator: std.mem.All
                 .i32x4_shift,
                 .i32x4_splat,
                 .i32x4_replace_lane,
+                .i16x8_binop,
+                .i16x8_splat,
+                .i16x8_replace_lane,
                 => {
                     if (!isSupportedV128Def(inst)) return true;
                 },
                 .v128_store,
                 .i32x4_extract_lane,
+                .i16x8_extract_lane,
                 => {},
                 else => {},
             }
@@ -1356,6 +1363,10 @@ fn isV128Inst(inst: ir.Inst) bool {
         .i32x4_splat,
         .i32x4_extract_lane,
         .i32x4_replace_lane,
+        .i16x8_binop,
+        .i16x8_splat,
+        .i16x8_extract_lane,
+        .i16x8_replace_lane,
         => true,
         else => false,
     };
@@ -1507,6 +1518,10 @@ fn compileInst(
         .i32x4_splat => |src| try emitI32x4Splat(code, inst, src, reg_map, v128_map, v128_cache),
         .i32x4_extract_lane => |lane| try emitI32x4ExtractLane(code, inst, lane, reg_map, v128_map, v128_cache),
         .i32x4_replace_lane => |lane| try emitI32x4ReplaceLane(code, inst, lane, reg_map, v128_map, v128_cache, fctx),
+        .i16x8_binop => |bin| try emitI16x8BinOp(code, inst, bin, v128_map, v128_cache, fctx),
+        .i16x8_splat => |src| try emitI16x8Splat(code, inst, src, reg_map, v128_map, v128_cache),
+        .i16x8_extract_lane => |lane| try emitI16x8ExtractLane(code, inst, lane, reg_map, v128_map, v128_cache),
+        .i16x8_replace_lane => |lane| try emitI16x8ReplaceLane(code, inst, lane, reg_map, v128_map, v128_cache, fctx),
 
         .add => |bin| if (inst.type == .f32 or inst.type == .f64)
             try emitFBinOp(code, inst, bin, reg_map, .add)
@@ -2035,6 +2050,97 @@ fn emitI32x4ReplaceLane(
     const dest_reg = try prepareV128UnaryDest(code, inst, lane.vector, vector_reg, v128_map, v128_cache, fctx);
     const val_reg = try useInto(code, reg_map, lane.val, RegMap.tmp0);
     try code.insSFromGp32(dest_reg, lane.lane, val_reg);
+}
+
+fn emitI16x8BinOp(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    bin: ir.Inst.I16x8BinOp,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+    fctx: *const FuncCompileCtx,
+) !void {
+    const lhs_reg = try v128_cache.ensure(code, v128_map, bin.lhs, null);
+    const rhs_reg = if (bin.rhs == bin.lhs)
+        lhs_reg
+    else
+        try v128_cache.ensure(code, v128_map, bin.rhs, lhs_reg);
+    const dest_reg = try prepareV128BinaryDest(
+        code,
+        inst,
+        bin.lhs,
+        lhs_reg,
+        bin.rhs,
+        rhs_reg,
+        v128_map,
+        v128_cache,
+        fctx,
+    );
+    switch (bin.op) {
+        .add => try code.i16x8Op(.add, dest_reg, lhs_reg, rhs_reg),
+        .sub => try code.i16x8Op(.sub, dest_reg, lhs_reg, rhs_reg),
+        .mul => try code.i16x8Op(.mul, dest_reg, lhs_reg, rhs_reg),
+        .eq => try code.i16x8Op(.cmeq, dest_reg, lhs_reg, rhs_reg),
+        .ne => {
+            try code.i16x8Op(.cmeq, dest_reg, lhs_reg, rhs_reg);
+            try code.mvn16b(dest_reg, dest_reg);
+        },
+        .gt_s => try code.i16x8Op(.cmgt, dest_reg, lhs_reg, rhs_reg),
+        .ge_s => try code.i16x8Op(.cmge, dest_reg, lhs_reg, rhs_reg),
+        .lt_s => try code.i16x8Op(.cmgt, dest_reg, rhs_reg, lhs_reg),
+        .le_s => try code.i16x8Op(.cmge, dest_reg, rhs_reg, lhs_reg),
+        .gt_u => try code.i16x8Op(.cmhi, dest_reg, lhs_reg, rhs_reg),
+        .ge_u => try code.i16x8Op(.cmhs, dest_reg, lhs_reg, rhs_reg),
+        .lt_u => try code.i16x8Op(.cmhi, dest_reg, rhs_reg, lhs_reg),
+        .le_u => try code.i16x8Op(.cmhs, dest_reg, rhs_reg, lhs_reg),
+    }
+}
+
+fn emitI16x8Splat(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    src: ir.VReg,
+    reg_map: *const RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+) !void {
+    const dest = inst.dest orelse return;
+    const dest_reg = try v128_cache.defineFresh(code, v128_map, dest, null);
+    const src_reg = try useInto(code, reg_map, src, RegMap.tmp0);
+    try code.dup8hFromGp32(dest_reg, src_reg);
+}
+
+fn emitI16x8ExtractLane(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    lane: ir.Inst.I16x8ExtractLane,
+    reg_map: *RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+) !void {
+    const dest = inst.dest orelse return;
+    const vector_reg = try v128_cache.ensure(code, v128_map, lane.vector, null);
+    const info = try destBegin(reg_map, dest, RegMap.tmp0);
+    switch (lane.sign) {
+        .signed => try code.smovWFromH(info.reg, vector_reg, lane.lane),
+        .unsigned => try code.umovWFromH(info.reg, vector_reg, lane.lane),
+    }
+    try destCommit(code, reg_map, info);
+}
+
+fn emitI16x8ReplaceLane(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    lane: ir.Inst.I16x8ReplaceLane,
+    reg_map: *const RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+    fctx: *const FuncCompileCtx,
+) !void {
+    const vector_reg = try v128_cache.ensure(code, v128_map, lane.vector, null);
+    const dest_reg = try prepareV128UnaryDest(code, inst, lane.vector, vector_reg, v128_map, v128_cache, fctx);
+    const val_reg = try useInto(code, reg_map, lane.val, RegMap.tmp0);
+    try code.insHFromGp32(dest_reg, lane.lane, val_reg);
 }
 
 const ExtendWidth = enum { b, h, w };
@@ -5216,6 +5322,67 @@ test "compile: i32x4 lane ops emit NEON instructions" {
     try std.testing.expect(found_umov);
 }
 
+test "compile: i16x8 lane ops emit NEON instructions" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+
+    const scalar = func.newVReg();
+    const splat = func.newVReg();
+    const replacement = func.newVReg();
+    const replaced = func.newVReg();
+    const signed_lane = func.newVReg();
+    const unsigned_lane = func.newVReg();
+    const sum = func.newVReg();
+
+    try func.getBlock(bid).append(.{ .op = .{ .iconst_32 = -2 }, .dest = scalar, .type = .i32 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_splat = scalar }, .dest = splat, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .iconst_32 = 0x0000_FF80 }, .dest = replacement, .type = .i32 });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i16x8_replace_lane = .{ .vector = splat, .val = replacement, .lane = 5 } },
+        .dest = replaced,
+        .type = .v128,
+    });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i16x8_extract_lane = .{ .vector = replaced, .lane = 5, .sign = .signed } },
+        .dest = signed_lane,
+        .type = .i32,
+    });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i16x8_extract_lane = .{ .vector = replaced, .lane = 5, .sign = .unsigned } },
+        .dest = unsigned_lane,
+        .type = .i32,
+    });
+    try func.getBlock(bid).append(.{
+        .op = .{ .add = .{ .lhs = signed_lane, .rhs = unsigned_lane } },
+        .dest = sum,
+        .type = .i32,
+    });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = sum } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    var found_dup = false;
+    var found_ins = false;
+    var found_smov = false;
+    var found_umov = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFFFFC00) == 0x4E020C00) found_dup = true;
+        if ((w & 0xFFFFFC00) == 0x4E161C00) found_ins = true;
+        if ((w & 0xFFFFFC00) == 0x0E162C00) found_smov = true;
+        if ((w & 0xFFFFFC00) == 0x0E163C00) found_umov = true;
+    }
+
+    try std.testing.expect(found_dup);
+    try std.testing.expect(found_ins);
+    try std.testing.expect(found_smov);
+    try std.testing.expect(found_umov);
+}
+
 test "compile: i32x4 cmp and mul ops emit NEON instructions" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
@@ -5275,6 +5442,76 @@ test "compile: i32x4 cmp and mul ops emit NEON instructions" {
         if ((w & 0xFFE0FC00) == 0x4EA03C00) found_cmge = true;
         if ((w & 0xFFE0FC00) == 0x6EA03400) found_cmhi = true;
         if ((w & 0xFFE0FC00) == 0x6EA03C00) found_cmhs = true;
+    }
+
+    try std.testing.expect(found_mul);
+    try std.testing.expect(found_cmeq);
+    try std.testing.expect(found_mvn);
+    try std.testing.expect(found_cmgt);
+    try std.testing.expect(found_cmge);
+    try std.testing.expect(found_cmhi);
+    try std.testing.expect(found_cmhs);
+}
+
+test "compile: i16x8 cmp and mul ops emit NEON instructions" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+
+    const a = func.newVReg();
+    const b = func.newVReg();
+    const mul = func.newVReg();
+    const ne = func.newVReg();
+    const lt_s = func.newVReg();
+    const gt_s = func.newVReg();
+    const le_s = func.newVReg();
+    const ge_s = func.newVReg();
+    const lt_u = func.newVReg();
+    const gt_u = func.newVReg();
+    const le_u = func.newVReg();
+    const ge_u = func.newVReg();
+    const lane = func.newVReg();
+
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0008_0007_0006_0005_8000_FFFF_0002_0001 }, .dest = a, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0007_0008_0005_0006_8000_0001_0003_0001 }, .dest = b, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .mul, .lhs = a, .rhs = b } }, .dest = mul, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .ne, .lhs = a, .rhs = b } }, .dest = ne, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .lt_s, .lhs = a, .rhs = b } }, .dest = lt_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .gt_s, .lhs = a, .rhs = b } }, .dest = gt_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .le_s, .lhs = a, .rhs = b } }, .dest = le_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .ge_s, .lhs = a, .rhs = b } }, .dest = ge_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .lt_u, .lhs = a, .rhs = b } }, .dest = lt_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .gt_u, .lhs = a, .rhs = b } }, .dest = gt_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .le_u, .lhs = a, .rhs = b } }, .dest = le_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .ge_u, .lhs = a, .rhs = b } }, .dest = ge_u, .type = .v128 });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i16x8_extract_lane = .{ .vector = ge_u, .lane = 0, .sign = .unsigned } },
+        .dest = lane,
+        .type = .i32,
+    });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = lane } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    var found_mul = false;
+    var found_cmeq = false;
+    var found_mvn = false;
+    var found_cmgt = false;
+    var found_cmge = false;
+    var found_cmhi = false;
+    var found_cmhs = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFE0FC00) == 0x4E609C00) found_mul = true;
+        if ((w & 0xFFE0FC00) == 0x6E608C00) found_cmeq = true;
+        if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
+        if ((w & 0xFFE0FC00) == 0x4E603400) found_cmgt = true;
+        if ((w & 0xFFE0FC00) == 0x4E603C00) found_cmge = true;
+        if ((w & 0xFFE0FC00) == 0x6E603400) found_cmhi = true;
+        if ((w & 0xFFE0FC00) == 0x6E603C00) found_cmhs = true;
     }
 
     try std.testing.expect(found_mul);

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -688,10 +688,23 @@ pub const CodeBuffer = struct {
         try self.emit32(0x4E040C00 | (@as(u32, rn.encoding()) << 5) | vd);
     }
 
+    /// DUP Vd.8H, Wn.
+    pub fn dup8hFromGp32(self: *CodeBuffer, vd: u5, rn: Reg) !void {
+        try self.emit32(0x4E020C00 | (@as(u32, rn.encoding()) << 5) | vd);
+    }
+
     /// INS Vd.S[lane], Wn (alias: MOV Vd.S[lane], Wn).
     pub fn insSFromGp32(self: *CodeBuffer, vd: u5, lane: u2, rn: Reg) !void {
         try self.emit32(0x4E041C00 |
             (@as(u32, lane) << 19) |
+            (@as(u32, rn.encoding()) << 5) |
+            vd);
+    }
+
+    /// INS Vd.H[lane], Wn (alias: MOV Vd.H[lane], Wn).
+    pub fn insHFromGp32(self: *CodeBuffer, vd: u5, lane: u3, rn: Reg) !void {
+        try self.emit32(0x4E021C00 |
+            (@as(u32, lane) << 18) |
             (@as(u32, rn.encoding()) << 5) |
             vd);
     }
@@ -735,6 +748,25 @@ pub const CodeBuffer = struct {
             vd);
     }
 
+    pub const I16x8Op = enum(u32) {
+        add = 0x4E608400,
+        sub = 0x6E608400,
+        mul = 0x4E609C00,
+        cmeq = 0x6E608C00,
+        cmgt = 0x4E603400,
+        cmge = 0x4E603C00,
+        cmhi = 0x6E603400,
+        cmhs = 0x6E603C00,
+    };
+
+    /// Integer 8H binary vector op: ADD/SUB/MUL/CMEQ/CMGT/CMGE/CMHI/CMHS.
+    pub fn i16x8Op(self: *CodeBuffer, op: I16x8Op, vd: u5, vn: u5, vm: u5) !void {
+        try self.emit32(@intFromEnum(op) |
+            (@as(u32, vm) << 16) |
+            (@as(u32, vn) << 5) |
+            vd);
+    }
+
     /// SSHL Vd.4S, Vn.4S, Vm.4S — signed variable shift.
     pub fn sshl4s(self: *CodeBuffer, vd: u5, vn: u5, vm: u5) !void {
         try self.emit32(0x4EA04400 |
@@ -762,6 +794,22 @@ pub const CodeBuffer = struct {
     pub fn umovWFromS(self: *CodeBuffer, rd: Reg, vn: u5, lane: u2) !void {
         try self.emit32(0x0E043C00 |
             (@as(u32, lane) << 19) |
+            (@as(u32, vn) << 5) |
+            rd.encoding());
+    }
+
+    /// UMOV Wd, Vn.H[lane] (alias: MOV Wd, Vn.H[lane]).
+    pub fn umovWFromH(self: *CodeBuffer, rd: Reg, vn: u5, lane: u3) !void {
+        try self.emit32(0x0E023C00 |
+            (@as(u32, lane) << 18) |
+            (@as(u32, vn) << 5) |
+            rd.encoding());
+    }
+
+    /// SMOV Wd, Vn.H[lane].
+    pub fn smovWFromH(self: *CodeBuffer, rd: Reg, vn: u5, lane: u3) !void {
+        try self.emit32(0x0E022C00 |
+            (@as(u32, lane) << 18) |
             (@as(u32, vn) << 5) |
             rd.encoding());
     }
@@ -1589,11 +1637,25 @@ test "emit: DUP v0.4s, w1" {
     try expectWord(0x4E040C20, &code);
 }
 
+test "emit: DUP v0.8h, w1" {
+    var code = CodeBuffer.init(std.testing.allocator);
+    defer code.deinit();
+    try code.dup8hFromGp32(0, .x1);
+    try expectWord(0x4E020C20, &code);
+}
+
 test "emit: MOV v0.s[2], w17" {
     var code = CodeBuffer.init(std.testing.allocator);
     defer code.deinit();
     try code.insSFromGp32(0, 2, .x17);
     try expectWord(0x4E141E20, &code);
+}
+
+test "emit: MOV v0.h[5], w17" {
+    var code = CodeBuffer.init(std.testing.allocator);
+    defer code.deinit();
+    try code.insHFromGp32(0, 5, .x17);
+    try expectWord(0x4E161E20, &code);
 }
 
 test "emit: MVN v0.16b, v1.16b" {
@@ -1629,6 +1691,57 @@ test "emit: MUL v0.4s, v1.4s, v2.4s" {
     defer code.deinit();
     try code.i32x4Op(.mul, 0, 1, 2);
     try expectWord(0x4EA29C20, &code);
+}
+
+test "emit: i16x8 vector ops" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.add, 0, 1, 2);
+        try expectWord(0x4E628420, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.sub, 3, 4, 5);
+        try expectWord(0x6E658483, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.mul, 6, 7, 8);
+        try expectWord(0x4E689CE6, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.cmeq, 9, 10, 11);
+        try expectWord(0x6E6B8D49, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.cmgt, 12, 13, 14);
+        try expectWord(0x4E6E35AC, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.cmge, 15, 16, 17);
+        try expectWord(0x4E713E0F, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.cmhi, 18, 19, 20);
+        try expectWord(0x6E743672, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.cmhs, 21, 22, 23);
+        try expectWord(0x6E773ED5, &code);
+    }
 }
 
 test "emit: i32x4 variable shifts" {
@@ -1687,6 +1800,21 @@ test "emit: UMOV w0, v1.s[3]" {
     defer code.deinit();
     try code.umovWFromS(.x0, 1, 3);
     try expectWord(0x0E1C3C20, &code);
+}
+
+test "emit: UMOV/SMOV w from h lane" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.umovWFromH(.x2, 3, 6);
+        try expectWord(0x0E1A3C62, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.smovWFromH(.x4, 5, 7);
+        try expectWord(0x0E1E2CA4, &code);
+    }
 }
 
 test "emit: DMB ISH" {

--- a/src/compiler/codegen/aarch64/schedule.zig
+++ b/src/compiler/codegen/aarch64/schedule.zig
@@ -239,6 +239,10 @@ pub fn metadata(inst: ir.Inst) Metadata {
         .i32x4_splat,
         .i32x4_extract_lane,
         .i32x4_replace_lane,
+        .i16x8_binop,
+        .i16x8_splat,
+        .i16x8_extract_lane,
+        .i16x8_replace_lane,
         => if (def != null) .alu else .barrier,
 
         .mul => if (def != null and isIntegerType(inst.type)) .mul else .barrier,
@@ -485,6 +489,10 @@ pub fn forEachUse(
             try visit(context, bin.lhs);
             try visit(context, bin.rhs);
         },
+        .i16x8_binop => |bin| {
+            try visit(context, bin.lhs);
+            try visit(context, bin.rhs);
+        },
         .i32x4_shift => |shift| {
             try visit(context, shift.vector);
             try visit(context, shift.count);
@@ -492,6 +500,12 @@ pub fn forEachUse(
         .i32x4_splat => |v| try visit(context, v),
         .i32x4_extract_lane => |lane| try visit(context, lane.vector),
         .i32x4_replace_lane => |lane| {
+            try visit(context, lane.vector);
+            try visit(context, lane.val);
+        },
+        .i16x8_splat => |v| try visit(context, v),
+        .i16x8_extract_lane => |lane| try visit(context, lane.vector),
+        .i16x8_replace_lane => |lane| {
             try visit(context, lane.vector);
             try visit(context, lane.val);
         },
@@ -565,6 +579,14 @@ test "metadata models supported v128 ops as schedulable" {
     const replace = ir.Inst{ .op = .{ .i32x4_replace_lane = .{ .vector = 7, .val = 8, .lane = 1 } }, .dest = 11, .type = .v128 };
     try std.testing.expect(!metadata(replace).barrier);
     try std.testing.expectEqual(Class.alu, metadata(replace).class);
+
+    const i16_binop = ir.Inst{ .op = .{ .i16x8_binop = .{ .op = .add, .lhs = 7, .rhs = 11 } }, .dest = 12, .type = .v128 };
+    try std.testing.expect(!metadata(i16_binop).barrier);
+    try std.testing.expectEqual(Class.alu, metadata(i16_binop).class);
+
+    const i16_extract = ir.Inst{ .op = .{ .i16x8_extract_lane = .{ .vector = 12, .lane = 5, .sign = .unsigned } }, .dest = 13, .type = .i32 };
+    try std.testing.expect(!metadata(i16_extract).barrier);
+    try std.testing.expectEqual(Class.alu, metadata(i16_extract).class);
 }
 
 test "local scheduler prioritizes a long independent multiply chain" {

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1257,6 +1257,10 @@ fn compileInst(
         .i32x4_splat,
         .i32x4_extract_lane,
         .i32x4_replace_lane,
+        .i16x8_binop,
+        .i16x8_splat,
+        .i16x8_extract_lane,
+        .i16x8_replace_lane,
         => return error.UnsupportedV128,
         // Phi must be lowered before codegen.
         .phi => unreachable,
@@ -1483,6 +1487,10 @@ fn functionUsesV128(func: *const ir.IrFunction) bool {
                 .i32x4_splat,
                 .i32x4_extract_lane,
                 .i32x4_replace_lane,
+                .i16x8_binop,
+                .i16x8_splat,
+                .i16x8_extract_lane,
+                .i16x8_replace_lane,
                 => return true,
                 else => {},
             }

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -1823,6 +1823,50 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         });
                         try vreg_stack.append(allocator, dest);
                     },
+                    .i16x8_add,
+                    .i16x8_sub,
+                    .i16x8_eq,
+                    .i16x8_ne,
+                    .i16x8_lt_s,
+                    .i16x8_lt_u,
+                    .i16x8_gt_s,
+                    .i16x8_gt_u,
+                    .i16x8_le_s,
+                    .i16x8_le_u,
+                    .i16x8_ge_s,
+                    .i16x8_ge_u,
+                    .i16x8_mul,
+                    => {
+                        const rhs = safePop(&vreg_stack);
+                        const lhs = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        const lane_op: ir.Inst.I16x8Op = switch (simd_op) {
+                            .i16x8_add => .add,
+                            .i16x8_sub => .sub,
+                            .i16x8_eq => .eq,
+                            .i16x8_ne => .ne,
+                            .i16x8_lt_s => .lt_s,
+                            .i16x8_lt_u => .lt_u,
+                            .i16x8_gt_s => .gt_s,
+                            .i16x8_gt_u => .gt_u,
+                            .i16x8_le_s => .le_s,
+                            .i16x8_le_u => .le_u,
+                            .i16x8_ge_s => .ge_s,
+                            .i16x8_ge_u => .ge_u,
+                            .i16x8_mul => .mul,
+                            else => unreachable,
+                        };
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .i16x8_binop = .{
+                                .op = lane_op,
+                                .lhs = lhs,
+                                .rhs = rhs,
+                            } },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
                     .i32x4_shl,
                     .i32x4_shr_s,
                     .i32x4_shr_u,
@@ -1880,6 +1924,56 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         const dest = ir_func.newVReg();
                         try ir_func.getBlock(current_block).append(.{
                             .op = .{ .i32x4_replace_lane = .{
+                                .vector = vector,
+                                .val = val,
+                                .lane = @intCast(lane_raw),
+                            } },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
+                    .i16x8_splat => {
+                        const val = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .i16x8_splat = val },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
+                    .i16x8_extract_lane_s,
+                    .i16x8_extract_lane_u,
+                    => {
+                        const lane_raw = try readByte(code, &ip);
+                        if (lane_raw >= 8) return error.InvalidBytecode;
+                        const vector = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        const sign: ir.Inst.I16x8LaneSign = switch (simd_op) {
+                            .i16x8_extract_lane_s => .signed,
+                            .i16x8_extract_lane_u => .unsigned,
+                            else => unreachable,
+                        };
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .i16x8_extract_lane = .{
+                                .vector = vector,
+                                .lane = @intCast(lane_raw),
+                                .sign = sign,
+                            } },
+                            .dest = dest,
+                            .type = .i32,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
+                    .i16x8_replace_lane => {
+                        const lane_raw = try readByte(code, &ip);
+                        if (lane_raw >= 8) return error.InvalidBytecode;
+                        const val = safePop(&vreg_stack);
+                        const vector = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .i16x8_replace_lane = .{
                                 .vector = vector,
                                 .val = val,
                                 .lane = @intCast(lane_raw),
@@ -2705,6 +2799,100 @@ test "lower i32x4 dynamic lane opcodes" {
     try std.testing.expect(insts[5].op.ret != null);
 }
 
+test "lower i16x8 dynamic lane opcodes" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i32},
+    };
+    const code = [_]u8{
+        0x41, 0x07, // i32.const 7
+        0xFD, 0x10, // i16x8.splat
+        0x41, 0xE3, 0x00, // i32.const 99
+        0xFD, 0x1A, 0x05, // i16x8.replace_lane 5
+        0xFD, 0x18, 0x05, // i16x8.extract_lane_s 5
+        0xFD, 0x0C, // v128.const
+        0x01, 0x00,
+        0x02, 0x00,
+        0x03, 0x00,
+        0x04, 0x00,
+        0x05, 0x00,
+        0x06, 0x00,
+        0x07, 0x00,
+        0x08, 0x80,
+        0xFD, 0x19, 0x07, // i16x8.extract_lane_u 7
+        0x6A, // i32.add
+        0x0B,
+    };
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &code,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+    try std.testing.expectEqual(@as(usize, 9), insts.len);
+    try std.testing.expectEqual(@as(i32, 7), insts[0].op.iconst_32);
+    try std.testing.expectEqual(ir.IrType.v128, insts[1].type);
+    try std.testing.expectEqual(insts[0].dest.?, insts[1].op.i16x8_splat);
+    try std.testing.expectEqual(@as(i32, 99), insts[2].op.iconst_32);
+    try std.testing.expectEqual(insts[1].dest.?, insts[3].op.i16x8_replace_lane.vector);
+    try std.testing.expectEqual(insts[2].dest.?, insts[3].op.i16x8_replace_lane.val);
+    try std.testing.expectEqual(@as(u3, 5), insts[3].op.i16x8_replace_lane.lane);
+    try std.testing.expectEqual(@as(u3, 5), insts[4].op.i16x8_extract_lane.lane);
+    try std.testing.expectEqual(ir.Inst.I16x8LaneSign.signed, insts[4].op.i16x8_extract_lane.sign);
+    try std.testing.expectEqual(@as(u3, 7), insts[6].op.i16x8_extract_lane.lane);
+    try std.testing.expectEqual(ir.Inst.I16x8LaneSign.unsigned, insts[6].op.i16x8_extract_lane.sign);
+    try std.testing.expectEqual(insts[4].dest.?, insts[7].op.add.lhs);
+    try std.testing.expectEqual(insts[6].dest.?, insts[7].op.add.rhs);
+    try std.testing.expect(insts[8].op.ret != null);
+}
+
+test "reject invalid i16x8 lane immediates" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i32},
+    };
+    const code = [_]u8{
+        0xFD, 0x0C, // v128.const
+        0x01, 0x00,
+        0x02, 0x00,
+        0x03, 0x00,
+        0x04, 0x00,
+        0x05, 0x00,
+        0x06, 0x00,
+        0x07, 0x00,
+        0x08, 0x00,
+        0xFD, 0x19, 0x08, // i16x8.extract_lane_u 8
+        0x0B,
+    };
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &code,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    try std.testing.expectError(error.InvalidBytecode, lowerModule(&wasm_module, allocator));
+}
+
 test "lower i32x4 scalar-count shift opcodes" {
     const allocator = std.testing.allocator;
 
@@ -2853,6 +3041,106 @@ test "lower i32x4 cmp and mul opcodes" {
         }
     }
     try std.testing.expectEqual(@as(u2, 0), insts[inst_idx].op.i32x4_extract_lane.lane);
+    try std.testing.expect(insts[inst_idx + 1].op.ret != null);
+}
+
+test "lower i16x8 cmp and arithmetic opcodes" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i32},
+    };
+
+    const Case = struct {
+        opcode: u32,
+        expected: ir.Inst.I16x8Op,
+    };
+    const cases = [_]Case{
+        .{ .opcode = 0x2D, .expected = .eq },
+        .{ .opcode = 0x2E, .expected = .ne },
+        .{ .opcode = 0x2F, .expected = .lt_s },
+        .{ .opcode = 0x30, .expected = .lt_u },
+        .{ .opcode = 0x31, .expected = .gt_s },
+        .{ .opcode = 0x32, .expected = .gt_u },
+        .{ .opcode = 0x33, .expected = .le_s },
+        .{ .opcode = 0x34, .expected = .le_u },
+        .{ .opcode = 0x35, .expected = .ge_s },
+        .{ .opcode = 0x36, .expected = .ge_u },
+        .{ .opcode = 0x8E, .expected = .add },
+        .{ .opcode = 0x91, .expected = .sub },
+        .{ .opcode = 0x95, .expected = .mul },
+    };
+
+    const appendULEB = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, value: u32) !void {
+            var v = value;
+            while (true) {
+                var byte: u8 = @intCast(v & 0x7F);
+                v >>= 7;
+                if (v != 0) byte |= 0x80;
+                try buf.append(alloc, byte);
+                if (v == 0) break;
+            }
+        }
+    }.call;
+    const appendSimd = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, opcode: u32) !void {
+            try buf.append(alloc, 0xFD);
+            try appendULEB(buf, alloc, opcode);
+        }
+    }.call;
+    const appendConst = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator) !void {
+            try appendSimd(buf, alloc, 0x0C);
+            const lanes = [_]u16{ 1, 2, 3, 4, 5, 6, 7, 8 };
+            for (lanes) |lane| {
+                var le = std.mem.nativeToLittle(u16, lane);
+                try buf.appendSlice(alloc, std.mem.asBytes(&le));
+            }
+        }
+    }.call;
+
+    var code: std.ArrayList(u8) = .empty;
+    defer code.deinit(allocator);
+    try appendConst(&code, allocator);
+    try appendConst(&code, allocator);
+    for (cases, 0..) |case, idx| {
+        if (idx != 0) try appendConst(&code, allocator);
+        try appendSimd(&code, allocator, case.opcode);
+    }
+    try appendSimd(&code, allocator, 0x19); // i16x8.extract_lane_u
+    try code.append(allocator, 0);
+    try code.append(allocator, 0x0B);
+
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = code.items,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+    try std.testing.expectEqual(@as(usize, 2 + cases.len * 2 + 1), insts.len);
+    var inst_idx: usize = 2;
+    for (cases, 0..) |case, idx| {
+        try std.testing.expectEqual(case.expected, insts[inst_idx].op.i16x8_binop.op);
+        inst_idx += 1;
+        if (idx + 1 < cases.len) {
+            try std.testing.expectEqual(ir.IrType.v128, insts[inst_idx].type);
+            inst_idx += 1;
+        }
+    }
+    try std.testing.expectEqual(@as(u3, 0), insts[inst_idx].op.i16x8_extract_lane.lane);
+    try std.testing.expectEqual(ir.Inst.I16x8LaneSign.unsigned, insts[inst_idx].op.i16x8_extract_lane.sign);
     try std.testing.expect(insts[inst_idx + 1].op.ret != null);
 }
 

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -184,6 +184,10 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
             live.put(bin.lhs, {}) catch {};
             live.put(bin.rhs, {}) catch {};
         },
+        .i16x8_binop => |bin| {
+            live.put(bin.lhs, {}) catch {};
+            live.put(bin.rhs, {}) catch {};
+        },
         .i32x4_shift => |shift| {
             live.put(shift.vector, {}) catch {};
             live.put(shift.count, {}) catch {};
@@ -225,9 +229,15 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
         .trunc_sat_f64_u,
         .v128_not,
         .i32x4_splat,
+        .i16x8_splat,
         => |vreg| live.put(vreg, {}) catch {},
         .i32x4_extract_lane => |lane| live.put(lane.vector, {}) catch {},
+        .i16x8_extract_lane => |lane| live.put(lane.vector, {}) catch {},
         .i32x4_replace_lane => |lane| {
+            live.put(lane.vector, {}) catch {};
+            live.put(lane.val, {}) catch {};
+        },
+        .i16x8_replace_lane => |lane| {
             live.put(lane.vector, {}) catch {};
             live.put(lane.val, {}) catch {};
         },
@@ -508,6 +518,10 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
             last_use.put(bin.lhs, pos) catch {};
             last_use.put(bin.rhs, pos) catch {};
         },
+        .i16x8_binop => |bin| {
+            last_use.put(bin.lhs, pos) catch {};
+            last_use.put(bin.rhs, pos) catch {};
+        },
         .i32x4_shift => |shift| {
             last_use.put(shift.vector, pos) catch {};
             last_use.put(shift.count, pos) catch {};
@@ -549,9 +563,15 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
         .trunc_sat_f64_u,
         .v128_not,
         .i32x4_splat,
+        .i16x8_splat,
         => |vreg| last_use.put(vreg, pos) catch {},
         .i32x4_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
+        .i16x8_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
         .i32x4_replace_lane => |lane| {
+            last_use.put(lane.vector, pos) catch {};
+            last_use.put(lane.val, pos) catch {};
+        },
+        .i16x8_replace_lane => |lane| {
             last_use.put(lane.vector, pos) catch {};
             last_use.put(lane.val, pos) catch {};
         },

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -75,6 +75,10 @@ pub const Inst = struct {
         i32x4_splat: VReg,
         i32x4_extract_lane: I32x4ExtractLane,
         i32x4_replace_lane: I32x4ReplaceLane,
+        i16x8_binop: I16x8BinOp,
+        i16x8_splat: VReg,
+        i16x8_extract_lane: I16x8ExtractLane,
+        i16x8_replace_lane: I16x8ReplaceLane,
 
         // Binary arithmetic (dest = lhs op rhs)
         add: BinOp,
@@ -265,6 +269,22 @@ pub const Inst = struct {
         mul,
     };
 
+    pub const I16x8Op = enum {
+        add,
+        sub,
+        eq,
+        ne,
+        lt_s,
+        lt_u,
+        gt_s,
+        gt_u,
+        le_s,
+        le_u,
+        ge_s,
+        ge_u,
+        mul,
+    };
+
     pub const I32x4ShiftOp = enum {
         shl,
         shr_s,
@@ -300,6 +320,12 @@ pub const Inst = struct {
         rhs: VReg,
     };
 
+    pub const I16x8BinOp = struct {
+        op: I16x8Op,
+        lhs: VReg,
+        rhs: VReg,
+    };
+
     pub const I32x4Shift = struct {
         op: I32x4ShiftOp,
         vector: VReg,
@@ -311,10 +337,24 @@ pub const Inst = struct {
         lane: u2,
     };
 
+    pub const I16x8LaneSign = enum { signed, unsigned };
+
+    pub const I16x8ExtractLane = struct {
+        vector: VReg,
+        lane: u3,
+        sign: I16x8LaneSign,
+    };
+
     pub const I32x4ReplaceLane = struct {
         vector: VReg,
         val: VReg,
         lane: u2,
+    };
+
+    pub const I16x8ReplaceLane = struct {
+        vector: VReg,
+        val: VReg,
+        lane: u3,
     };
 
     pub const PhiEdge = struct {
@@ -515,6 +555,31 @@ test "Inst: first v128 op family preserves operand shape" {
     try std.testing.expectEqual(Inst.I32x4ShiftOp.shr_u, shift.op.i32x4_shift.op);
     try std.testing.expectEqual(@as(VReg, 8), shift.op.i32x4_shift.vector);
     try std.testing.expectEqual(@as(VReg, 9), shift.op.i32x4_shift.count);
+
+    const i16_bin = Inst{
+        .op = .{ .i16x8_binop = .{ .op = .mul, .lhs = 11, .rhs = 12 } },
+        .dest = 13,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(Inst.I16x8Op.mul, i16_bin.op.i16x8_binop.op);
+    try std.testing.expectEqual(@as(VReg, 11), i16_bin.op.i16x8_binop.lhs);
+
+    const i16_extract = Inst{
+        .op = .{ .i16x8_extract_lane = .{ .vector = 13, .lane = 5, .sign = .signed } },
+        .dest = 14,
+        .type = .i32,
+    };
+    try std.testing.expectEqual(@as(u3, 5), i16_extract.op.i16x8_extract_lane.lane);
+    try std.testing.expectEqual(Inst.I16x8LaneSign.signed, i16_extract.op.i16x8_extract_lane.sign);
+
+    const i16_replace = Inst{
+        .op = .{ .i16x8_replace_lane = .{ .vector = 13, .val = 14, .lane = 7 } },
+        .dest = 15,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(@as(VReg, 13), i16_replace.op.i16x8_replace_lane.vector);
+    try std.testing.expectEqual(@as(VReg, 14), i16_replace.op.i16x8_replace_lane.val);
+    try std.testing.expectEqual(@as(u3, 7), i16_replace.op.i16x8_replace_lane.lane);
 }
 
 test "IrModule: add multiple functions" {

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -143,6 +143,10 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
             list.append(bin.lhs);
             list.append(bin.rhs);
         },
+        .i16x8_binop => |bin| {
+            list.append(bin.lhs);
+            list.append(bin.rhs);
+        },
         .i32x4_shift => |shift| {
             list.append(shift.vector);
             list.append(shift.count);
@@ -185,9 +189,15 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
         .trunc_sat_f64_u,
         .v128_not,
         .i32x4_splat,
+        .i16x8_splat,
         => |vreg| list.append(vreg),
         .i32x4_extract_lane => |lane| list.append(lane.vector),
+        .i16x8_extract_lane => |lane| list.append(lane.vector),
         .i32x4_replace_lane => |lane| {
+            list.append(lane.vector);
+            list.append(lane.val);
+        },
+        .i16x8_replace_lane => |lane| {
             list.append(lane.vector);
             list.append(lane.val);
         },
@@ -387,6 +397,10 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
             if (bin.lhs == old) bin.lhs = new;
             if (bin.rhs == old) bin.rhs = new;
         },
+        .i16x8_binop => |*bin| {
+            if (bin.lhs == old) bin.lhs = new;
+            if (bin.rhs == old) bin.rhs = new;
+        },
         .i32x4_shift => |*shift| {
             if (shift.vector == old) shift.vector = new;
             if (shift.count == old) shift.count = new;
@@ -428,13 +442,21 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
         .trunc_sat_f64_u,
         .v128_not,
         .i32x4_splat,
+        .i16x8_splat,
         => |*vreg| if (vreg.* == old) {
             vreg.* = new;
         },
         .i32x4_extract_lane => |*lane| if (lane.vector == old) {
             lane.vector = new;
         },
+        .i16x8_extract_lane => |*lane| if (lane.vector == old) {
+            lane.vector = new;
+        },
         .i32x4_replace_lane => |*lane| {
+            if (lane.vector == old) lane.vector = new;
+            if (lane.val == old) lane.val = new;
+        },
+        .i16x8_replace_lane => |*lane| {
             if (lane.vector == old) lane.vector = new;
             if (lane.val == old) lane.val = new;
         },
@@ -1628,6 +1650,10 @@ fn isPure(inst: ir.Inst) bool {
         .i32x4_splat,
         .i32x4_extract_lane,
         .i32x4_replace_lane,
+        .i16x8_binop,
+        .i16x8_splat,
+        .i16x8_extract_lane,
+        .i16x8_replace_lane,
         => true,
         else => false,
     };
@@ -1722,6 +1748,10 @@ fn sameOp(a: ir.Inst, b: ir.Inst) bool {
         .i32x4_splat => |v| v == b.op.i32x4_splat,
         .i32x4_extract_lane => |lane| lane.vector == b.op.i32x4_extract_lane.vector and lane.lane == b.op.i32x4_extract_lane.lane,
         .i32x4_replace_lane => |lane| lane.vector == b.op.i32x4_replace_lane.vector and lane.val == b.op.i32x4_replace_lane.val and lane.lane == b.op.i32x4_replace_lane.lane,
+        .i16x8_binop => |bin| bin.op == b.op.i16x8_binop.op and bin.lhs == b.op.i16x8_binop.lhs and bin.rhs == b.op.i16x8_binop.rhs,
+        .i16x8_splat => |v| v == b.op.i16x8_splat,
+        .i16x8_extract_lane => |lane| lane.vector == b.op.i16x8_extract_lane.vector and lane.lane == b.op.i16x8_extract_lane.lane and lane.sign == b.op.i16x8_extract_lane.sign,
+        .i16x8_replace_lane => |lane| lane.vector == b.op.i16x8_replace_lane.vector and lane.val == b.op.i16x8_replace_lane.val and lane.lane == b.op.i16x8_replace_lane.lane,
         // div/rem: covered by isPure+hasSideEffect guard; float variants
         // (side-effect-free) reach here.
         .div_s => |bin| bin.lhs == b.op.div_s.lhs and bin.rhs == b.op.div_s.rhs,
@@ -3177,6 +3207,10 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
             bin.lhs += offset;
             bin.rhs += offset;
         },
+        .i16x8_binop => |*bin| {
+            bin.lhs += offset;
+            bin.rhs += offset;
+        },
         .i32x4_shift => |*shift| {
             shift.vector += offset;
             shift.count += offset;
@@ -3218,9 +3252,15 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
         .trunc_sat_f64_u,
         .v128_not,
         .i32x4_splat,
+        .i16x8_splat,
         => |*vreg| vreg.* += offset,
         .i32x4_extract_lane => |*lane| lane.vector += offset,
+        .i16x8_extract_lane => |*lane| lane.vector += offset,
         .i32x4_replace_lane => |*lane| {
+            lane.vector += offset;
+            lane.val += offset;
+        },
+        .i16x8_replace_lane => |*lane| {
             lane.vector += offset;
             lane.val += offset;
         },

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -104,6 +104,36 @@ const cases = [_]BenchCase{
         .build = buildSimdI32x4ReplaceLane2Module,
     },
     .{
+        .name = "simd_i16x8_add_lane0",
+        .simd = true,
+        .build = buildSimdI16x8AddLane0Module,
+    },
+    .{
+        .name = "simd_i16x8_mul_lane0",
+        .simd = true,
+        .build = buildSimdI16x8MulLane0Module,
+    },
+    .{
+        .name = "simd_i16x8_gt_s_lane0",
+        .simd = true,
+        .build = buildSimdI16x8GtSLane0Module,
+    },
+    .{
+        .name = "simd_i16x8_gt_u_lane0",
+        .simd = true,
+        .build = buildSimdI16x8GtULane0Module,
+    },
+    .{
+        .name = "simd_i16x8_splat_lane0",
+        .simd = true,
+        .build = buildSimdI16x8SplatLane0Module,
+    },
+    .{
+        .name = "simd_i16x8_replace_lane5",
+        .simd = true,
+        .build = buildSimdI16x8ReplaceLane5Module,
+    },
+    .{
         .name = "simd_v128_load_store_lane0",
         .simd = true,
         .build = buildSimdLoadStoreLane0Module,
@@ -127,6 +157,11 @@ const cases = [_]BenchCase{
         .name = "simd_i32x4_shift_mix_4k_loop",
         .simd = true,
         .build = buildSimdI32x4ShiftMix4kLoopModule,
+    },
+    .{
+        .name = "simd_i16x8_mem_add_4k_loop",
+        .simd = true,
+        .build = buildSimdI16x8MemoryAdd4kLoopModule,
     },
 };
 
@@ -536,6 +571,77 @@ fn buildSimdI32x4ReplaceLane2Module(allocator: Allocator) ![]u8 {
     return buildRunI32Module(allocator, instr.items, .{});
 }
 
+fn buildSimdI16x8AddLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI16x8(&instr, allocator, .{ 1200, 2, 3, 4, 5, 6, 7, 8 });
+    try appendV128ConstI16x8(&instr, allocator, .{ 3400, 6, 7, 8, 9, 10, 11, 12 });
+    try appendSimdOpcode(&instr, allocator, 0x8E); // i16x8.add
+    try appendI16x8ExtractLaneU(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI16x8MulLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI16x8(&instr, allocator, .{ 300, 2, 3, 4, 5, 6, 7, 8 });
+    try appendV128ConstI16x8(&instr, allocator, .{ 300, 6, 7, 8, 9, 10, 11, 12 });
+    try appendSimdOpcode(&instr, allocator, 0x95); // i16x8.mul
+    try appendI16x8ExtractLaneU(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI16x8GtSLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI16x8(&instr, allocator, .{ 0xFFFF, 10, 0x8000, 4, 5, 6, 7, 8 });
+    try appendV128ConstI16x8(&instr, allocator, .{ 0xFFFE, 9, 0x7FFF, 4, 5, 6, 7, 8 });
+    try appendSimdOpcode(&instr, allocator, 0x31); // i16x8.gt_s
+    try appendI16x8ExtractLaneS(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI16x8GtULane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI16x8(&instr, allocator, .{ 0xFFFF, 10, 0x8000, 4, 5, 6, 7, 8 });
+    try appendV128ConstI16x8(&instr, allocator, .{ 0xFFFE, 9, 0x7FFF, 4, 5, 6, 7, 8 });
+    try appendSimdOpcode(&instr, allocator, 0x32); // i16x8.gt_u
+    try appendI16x8ExtractLaneU(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI16x8SplatLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendI32Const(&instr, allocator, 0x1_2345);
+    try appendI16x8Splat(&instr, allocator);
+    try appendI16x8ExtractLaneU(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI16x8ReplaceLane5Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI16x8(&instr, allocator, .{ 1, 2, 3, 4, 5, 6, 7, 8 });
+    try appendI32Const(&instr, allocator, 0x0000_FF80);
+    try appendI16x8ReplaceLane(&instr, allocator, 5);
+    try appendI16x8ExtractLaneS(&instr, allocator, 5);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
 fn buildSimdLoadStoreLane0Module(allocator: Allocator) ![]u8 {
     var instr: std.ArrayList(u8) = .empty;
     defer instr.deinit(allocator);
@@ -790,6 +896,59 @@ fn buildSimdI32x4ShiftMix4kLoopModule(allocator: Allocator) ![]u8 {
     });
 }
 
+fn buildSimdI16x8MemoryAdd4kLoopModule(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendI32Const(&instr, allocator, 0);
+    try appendLocalSet(&instr, allocator, 0);
+    try appendBlock(&instr, allocator);
+    try appendLoop(&instr, allocator);
+
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Const(&instr, allocator, memory_loop_bytes);
+    try appendI32GeU(&instr, allocator);
+    try appendBrIf(&instr, allocator, 1);
+
+    try appendI32Const(&instr, allocator, memory_loop_dst_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendSimdOpcode(&instr, allocator, 0x8E); // i16x8.add
+    try appendSimdMemOpcode(&instr, allocator, 0x0B, 4, 0); // v128.store
+
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Const(&instr, allocator, 16);
+    try appendI32Add(&instr, allocator);
+    try appendLocalSet(&instr, allocator, 0);
+    try appendBr(&instr, allocator, 0);
+
+    try appendEnd(&instr, allocator);
+    try appendEnd(&instr, allocator);
+
+    try appendI32Const(&instr, allocator, memory_loop_dst_base + memory_loop_bytes - 16);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendI16x8ExtractLaneU(&instr, allocator, 7);
+
+    const data = try buildMemoryLoopDataI16(allocator);
+    defer allocator.free(data);
+    return buildRunI32Module(allocator, instr.items, .{
+        .memory_min = 1,
+        .data = data,
+        .local_i32_count = 1,
+    });
+}
+
 fn buildMemoryLoopData(allocator: Allocator) ![]u8 {
     const data_len = memory_loop_b_base + memory_loop_bytes;
     const data = try allocator.alloc(u8, data_len);
@@ -802,6 +961,23 @@ fn buildMemoryLoopData(allocator: Allocator) ![]u8 {
         const b_pos: usize = @intCast(memory_loop_b_base + lane_offset);
         writeI32Lane(data[a_pos..][0..4], lane * 3 + 5);
         writeI32Lane(data[b_pos..][0..4], lane * 7 + 11);
+    }
+
+    return data;
+}
+
+fn buildMemoryLoopDataI16(allocator: Allocator) ![]u8 {
+    const data_len = memory_loop_b_base + memory_loop_bytes;
+    const data = try allocator.alloc(u8, data_len);
+    @memset(data, 0);
+
+    var lane: u32 = 0;
+    while (lane < memory_loop_bytes / @sizeOf(u16)) : (lane += 1) {
+        const lane_offset = lane * @sizeOf(u16);
+        const a_pos: usize = @intCast(memory_loop_a_base + lane_offset);
+        const b_pos: usize = @intCast(memory_loop_b_base + lane_offset);
+        writeI16Lane(data[a_pos..][0..2], @intCast((lane * 3 + 5) & 0xFFFF));
+        writeI16Lane(data[b_pos..][0..2], @intCast((lane * 7 + 11) & 0xFFFF));
     }
 
     return data;
@@ -905,8 +1081,20 @@ fn appendV128ConstI32x4(buf: *std.ArrayList(u8), allocator: Allocator, lanes: [4
     }
 }
 
+fn appendV128ConstI16x8(buf: *std.ArrayList(u8), allocator: Allocator, lanes: [8]u16) !void {
+    try appendSimdOpcode(buf, allocator, 0x0C); // v128.const
+    for (lanes) |lane| {
+        var le = std.mem.nativeToLittle(u16, lane);
+        try buf.appendSlice(allocator, std.mem.asBytes(&le));
+    }
+}
+
 fn appendI32x4Splat(buf: *std.ArrayList(u8), allocator: Allocator) !void {
     try appendSimdOpcode(buf, allocator, 0x11); // i32x4.splat
+}
+
+fn appendI16x8Splat(buf: *std.ArrayList(u8), allocator: Allocator) !void {
+    try appendSimdOpcode(buf, allocator, 0x10); // i16x8.splat
 }
 
 fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
@@ -914,8 +1102,23 @@ fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u
     try buf.append(allocator, lane);
 }
 
+fn appendI16x8ExtractLaneS(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x18); // i16x8.extract_lane_s
+    try buf.append(allocator, lane);
+}
+
+fn appendI16x8ExtractLaneU(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x19); // i16x8.extract_lane_u
+    try buf.append(allocator, lane);
+}
+
 fn appendI32x4ReplaceLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x1C); // i32x4.replace_lane
+    try buf.append(allocator, lane);
+}
+
+fn appendI16x8ReplaceLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x1A); // i16x8.replace_lane
     try buf.append(allocator, lane);
 }
 
@@ -1005,6 +1208,11 @@ fn appendSimdOpcode(buf: *std.ArrayList(u8), allocator: Allocator, opcode: u32) 
 
 fn writeI32Lane(dst: []u8, value: u32) void {
     var le = std.mem.nativeToLittle(u32, value);
+    @memcpy(dst, std.mem.asBytes(&le));
+}
+
+fn writeI16Lane(dst: []u8, value: u16) void {
+    var le = std.mem.nativeToLittle(u16, value);
     @memcpy(dst, std.mem.asBytes(&le));
 }
 

--- a/tests/benchmarks/simd/README.md
+++ b/tests/benchmarks/simd/README.md
@@ -25,7 +25,9 @@ The `simd_i32x4_mem_sum8_4k_loop` row is a v128 register-pressure probe. Each lo
 
 The `simd_i32x4_shift_mix_4k_loop` row is a dynamic-shift throughput probe. Each loop iteration derives the scalar shift count from the loop index, exercises `i32x4.shl`, `i32x4.shr_u`, and `i32x4.shr_s`, stores a vector result, and returns one scalar checksum lane. This keeps shift counts data-dependent and above the lane width so modulo masking is covered in the AOT path.
 
-The small `simd_i32x4_*_lane0` rows are coverage/status probes for individual opcode families. They intentionally return one scalar lane so interpreter, AOT, and optional Wasmtime rows can be compared before the runtime supports direct exported v128 values.
+The `simd_i16x8_mem_add_4k_loop` row is the 16-bit lane counterpart to the i32x4 memory-add loop. It walks two 4 KiB arrays as packed 16-bit lanes with `v128.load`, `i16x8.add`, and `v128.store`, then returns the final unsigned 16-bit lane as a scalar checksum.
+
+The small `simd_i32x4_*_lane0` and `simd_i16x8_*_lane0` rows are coverage/status probes for individual opcode families. They intentionally return one scalar lane so interpreter, AOT, and optional Wasmtime rows can be compared before the runtime supports direct exported v128 values. The i16x8 comparison and replace-lane rows also cover signed vs unsigned 16-bit extraction of all-ones masks and high-bit lane values.
 
 Wasmtime can be included as an external baseline:
 


### PR DESCRIPTION
## Summary
- add IR/frontend/AArch64 AOT lowering for scoped i16x8 splat, extract_lane_s/u, replace_lane, add/sub/mul, eq/ne, and signed/unsigned comparisons
- add NEON .8H emit helpers plus scheduler/liveness/pass/x86_64 unsupported handling for the new IR shapes
- add i16x8 status rows and simd_i16x8_mem_add_4k_loop benchmark coverage

Part of #220.

## Validation
- zig build test
- zig build simd-bench -- --iterations 10000
- zig build simd-bench -- --iterations 100 --wasmtime --wasmtime-iterations 3
- scripts/bench_simd.py --baseline origin/main --target HEAD --runs 3 --iterations 10000

## Benchmark signal
- new i16x8 AOT rows are unsupported on origin/main and ok on this branch
- simd_i16x8_mem_add_4k_loop: ok, result 20486, median 9.950 ms per 10000 AOT calls, code size 8830
- existing i32x4 throughput/status rows remain effectively neutral