### PR TITLE
Add component-loader fuzz coverage

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,8 +1,8 @@
 name: Fuzz
 
-# Scheduled and on-demand fuzzing of the Zig wasm loader, interpreter,
-# AOT compiler, and a differential interp-vs-AOT oracle. Crashes are
-# uploaded as artifacts and — if any — the job fails so the next PR
+# Scheduled and on-demand fuzzing of the Zig core/component loaders,
+# interpreter, AOT compiler, and a differential interp-vs-AOT oracle.
+# Crashes are uploaded as artifacts and — if any — the job fails so the next PR
 # cannot merge until the crasher is triaged.
 on:
   schedule:
@@ -15,14 +15,16 @@ on:
         required: false
         default: "300"
       target:
-        description: "Fuzz target (all, loader, interp, aot, diff)"
+        description: "Fuzz target (all, loader, component-loader, interp, aot, diff)"
         required: false
         default: "all"
   pull_request:
     paths:
       - src/runtime/**
+      - src/component/**
       - src/compiler/**
       - src/tests/fuzz/**
+      - tests/fuzz/**
       - .github/workflows/fuzz.yml
 
 concurrency:
@@ -35,12 +37,13 @@ permissions:
 jobs:
   fuzz:
     name: Fuzz ${{ matrix.target }}
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == matrix.target }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        target: [loader, interp, aot, diff]
+        target: [loader, component-loader, interp, aot, diff]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -75,6 +78,10 @@ jobs:
           fi
           if [ -d tests/spec-json ]; then
             find tests/spec-json -maxdepth 1 -name '*.wasm' -exec cp -n {} .fuzz-corpus/${{ matrix.target }}/ \; || true
+          fi
+          if [ "${{ matrix.target }}" = "component-loader" ]; then
+            # Minimal component: "\0asm" plus version/layer 0x0001000d.
+            printf '\000asm\015\000\001\000' > .fuzz-corpus/${{ matrix.target }}/minimal-component.wasm
           fi
           ls .fuzz-corpus/${{ matrix.target }} | wc -l
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -19,7 +19,7 @@ incorrect canonical ABI lifting/lowering across guest memory.
 
 Out of scope for this checklist: performance-only work, the public security
 advisory process, and broad fuzz-campaign operations. Fuzzing infrastructure is
-tracked separately from this audit checklist.
+tracked in [tests/fuzz/README.md](tests/fuzz/README.md).
 
 ## Review checklist
 
@@ -174,4 +174,4 @@ Potential follow-up audit areas:
 
 - `zig build test`
 - `zig build spec-tests-aot`
-- `zig build fuzz`
+- `zig build fuzz` (see [tests/fuzz/README.md](tests/fuzz/README.md))

--- a/SECURITY_PROCESS.md
+++ b/SECURITY_PROCESS.md
@@ -129,18 +129,19 @@ Existing CI provides these security-relevant signals:
 - ReleaseSafe builds and cross-target jobs provide platform coverage.
 - Spec tests exercise WebAssembly semantic compatibility.
 - The wasm32-wasi smoke job checks the self-hosted WASI build path.
-- The fuzz workflow runs for loader, interpreter, AOT, and differential harness
-  paths on schedule, on demand, and on PRs that touch runtime/compiler/fuzz
-  files.
+- The fuzz workflow runs core-loader, component-loader, interpreter, AOT, and
+  differential harness paths on schedule, on demand, and on PRs that touch
+  runtime, component, compiler, or fuzz files.
 
 Reviewer guidance:
 
 - For interpreter, compiler, runtime, or component boundary changes, expect
   `zig build test` and consider targeted spec, differential, AOT, or fuzz
   coverage.
-- For loader/runtime/compiler/fuzz harness changes, consider `zig build fuzz`
-  or the GitHub fuzz workflow when the change affects input parsing or execution
-  boundaries.
+- For loader/runtime/component/compiler/fuzz harness changes, consider
+  `zig build fuzz` or the GitHub fuzz workflow when the change affects input
+  parsing or execution boundaries. See [tests/fuzz/README.md](tests/fuzz/README.md)
+  for harness-specific oracles.
 - For documentation-only changes, a full Zig build is usually unnecessary; check
   links, wording, and whether the text avoids unsupported support promises.
 

--- a/build.zig
+++ b/build.zig
@@ -290,9 +290,11 @@ pub fn build(b: *std.Build) void {
 
     // ── Fuzz harnesses ────────────────────────────────────────────────
     // CLI binaries that replay corpus inputs through a specific
-    // pipeline (loader / interp / aot / interp-vs-aot diff) and leave
+    // pipeline (core loader / component loader / interp / aot /
+    // interp-vs-aot diff) and leave
     // a reproducer at <crashes>/in-flight.wasm if the process aborts.
-    // See src/tests/fuzz/common.zig and .github/workflows/fuzz.yml.
+    // See src/tests/fuzz/common.zig, tests/fuzz/README.md, and
+    // .github/workflows/fuzz.yml.
     const aot_harness_module = b.createModule(.{
         .root_source_file = b.path("src/tests/aot_harness.zig"),
         .target = target,
@@ -358,21 +360,27 @@ pub fn build(b: *std.Build) void {
         simd_bench_step.dependOn(&run_simd_bench.step);
     }
 
-    const fuzz_step = b.step("fuzz", "Build fuzz harnesses (loader, interp, aot, diff)");
-    inline for (.{ "loader", "interp", "aot", "diff" }) |tgt| {
+    const fuzz_step = b.step("fuzz", "Build fuzz harnesses (loader, component-loader, interp, aot, diff)");
+    inline for (.{
+        .{ .name = "loader", .file = "loader.zig", .needs_aot = false },
+        .{ .name = "component-loader", .file = "component_loader.zig", .needs_aot = false },
+        .{ .name = "interp", .file = "interp.zig", .needs_aot = false },
+        .{ .name = "aot", .file = "aot.zig", .needs_aot = true },
+        .{ .name = "diff", .file = "diff.zig", .needs_aot = true },
+    }) |tgt| {
         const fuzz_mod = b.createModule(.{
-            .root_source_file = b.path("src/tests/fuzz/" ++ tgt ++ ".zig"),
+            .root_source_file = b.path("src/tests/fuzz/" ++ tgt.file),
             .target = target,
             .optimize = optimize,
         });
         fuzz_mod.addImport("config", config_module);
         fuzz_mod.addImport("wamr", lib_module);
-        if (std.mem.eql(u8, tgt, "aot") or std.mem.eql(u8, tgt, "diff")) {
+        if (tgt.needs_aot) {
             fuzz_mod.addImport("aot_harness", aot_harness_module);
         }
 
         const fuzz_exe = b.addExecutable(.{
-            .name = "fuzz-" ++ tgt,
+            .name = "fuzz-" ++ tgt.name,
             .root_module = fuzz_mod,
         });
         const install_fuzz = b.addInstallArtifact(fuzz_exe, .{});

--- a/src/tests/fuzz/common.zig
+++ b/src/tests/fuzz/common.zig
@@ -1,7 +1,8 @@
 //! Shared helpers for the fuzz harness CLIs.
 //!
-//! Each harness (loader, interp, aot, diff) links this module for
-//! argument parsing, corpus iteration, and crash-artifact writing.
+//! Each harness links this module for argument parsing, corpus
+//! iteration, and crash-artifact writing. See tests/fuzz/README.md
+//! for target-specific oracles and triage guidance.
 //!
 //! Crash detection uses a sentinel-file pattern: before each
 //! invocation we write the current input to `<crashes>/in-flight.wasm`.

--- a/src/tests/fuzz/component_loader.zig
+++ b/src/tests/fuzz/component_loader.zig
@@ -1,0 +1,48 @@
+//! fuzz-component-loader — feed arbitrary bytes to the component loader.
+//!
+//! Oracle: the component loader must return either a valid `Component`
+//! or a typed loader error. Any panic, safety-checked overflow, or OOM
+//! on a small input is a bug and leaves the offending input at
+//! `<crashes>/in-flight.wasm` when the process aborts.
+
+const std = @import("std");
+const wamr = @import("wamr");
+const common = @import("common.zig");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
+    const argv = try init.minimal.args.toSlice(init.arena.allocator());
+
+    const args = try common.Args.parse(argv);
+    var corpus = try common.Corpus.load(allocator, io, args.corpus_dir);
+    defer corpus.deinit();
+
+    if (corpus.count() == 0) {
+        std.log.err("empty corpus at {s}", .{args.corpus_dir});
+        return error.EmptyCorpus;
+    }
+
+    const deadline = common.Deadline.init(io, args.duration_ms);
+    var iter: u64 = 0;
+    var idx: usize = 0;
+    while (!deadline.expired(io)) : (iter += 1) {
+        const input = corpus.get(idx);
+        idx +%= 1;
+
+        try common.markInFlight(io, args.crashes_dir, input);
+
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+
+        if (wamr.component_loader.load(input, arena.allocator())) |_| {
+            // Valid component — fine.
+        } else |_| {
+            // Typed loader error — fine.
+        }
+
+        common.clearInFlight(io, args.crashes_dir);
+    }
+
+    std.log.info("fuzz-component-loader: {d} iterations over {d} inputs", .{ iter, corpus.count() });
+}

--- a/src/tests/fuzz/diff.zig
+++ b/src/tests/fuzz/diff.zig
@@ -7,7 +7,7 @@
 //! A true result-comparison oracle requires a shared "invoke export
 //! N, capture typed results" helper that neither interp nor AOT
 //! currently expose uniformly. For v1 the harness only exercises
-//! the compile paths. See plan_fuzz_security.md for the v2 design.
+//! the compile paths. See tests/fuzz/README.md for the v2 scope.
 
 const std = @import("std");
 const wamr = @import("wamr");

--- a/src/tests/fuzz/interp.zig
+++ b/src/tests/fuzz/interp.zig
@@ -4,10 +4,9 @@
 //! Oracle: any panic, safety-checked UB, or unhandled error is a bug.
 //! Runtime traps surface as typed errors and are OK.
 //!
-//! This is a scaffold — the invocation step is best-effort and may
-//! need to be extended once the interp exposes a uniform "invoke
-//! by export and capture results" helper. Until then the value is
-//! mostly in loader + instantiate coverage.
+//! This is a scaffold. Until a bounded execution helper exists, this
+//! target deliberately stays on loader + validation coverage. See
+//! tests/fuzz/README.md for follow-up scope.
 
 const std = @import("std");
 const wamr = @import("wamr");
@@ -48,8 +47,6 @@ fn runOnce(allocator: std.mem.Allocator, bytes: []const u8) !void {
     const a = arena.allocator();
 
     // Just exercise loader + downstream validation for now. A full
-    // invocation path requires setting up ExecEnv + host imports,
-    // which the scaffold leaves as a TODO (tracked in
-    // plan_fuzz_security.md).
+    // invocation path requires bounded execution and host-import setup.
     _ = wamr.loader.load(bytes, a) catch return;
 }

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,0 +1,112 @@
+# Fuzzing security-sensitive boundaries
+
+This directory documents the Zig fuzz harnesses in `src/tests/fuzz`. The
+harnesses are bounded corpus-replay CLIs intended for CI smoke runs, scheduled
+security fuzzing, and local crash reproduction. They complement the sandbox
+review checklist in `SECURITY_AUDIT.md`; they are not a replacement for targeted
+unit tests or private vulnerability triage.
+
+## Goals
+
+Treat all Wasm, component-model binaries, exported arguments, and guest
+linear-memory contents as attacker-controlled. The fuzz harnesses should expose:
+
+- loader panics, safety-checked integer overflows, and malformed-binary crashes;
+- compiler or codegen panics on hostile but bounded inputs;
+- runtime trap handling paths that terminate the host process unexpectedly;
+- component and WASI boundary bugs that corrupt resource or memory isolation.
+
+Typed loader, validation, compile, or runtime errors are expected outcomes for
+malformed inputs. A panic, segfault, safety-check failure, unexplained process
+abort, or small-input OOM is a bug.
+
+## Targets
+
+| Binary | Boundary | Oracle |
+| --- | --- | --- |
+| `fuzz-loader` | Core Wasm loader and validation | A valid module or typed loader error is OK. A panic, abort, or safety-check failure is a bug. |
+| `fuzz-component-loader` | Component-model binary loader | A valid component or typed component loader error is OK. A panic, abort, or safety-check failure is a bug. |
+| `fuzz-interp` | Interpreter loader and validation scaffold | Loader/validation errors are OK. Full bounded export invocation is tracked as follow-up work. |
+| `fuzz-aot` | AOT compile, AOT loader, and instantiate path | Compile/instantiate errors are OK. The harness deliberately sets `invoke_start = false` and does not execute attacker-supplied start functions. |
+| `fuzz-diff` | Interpreter load plus AOT compile/instantiate scaffold | Pipeline errors are OK. Result comparison for supported exports is tracked as follow-up work. |
+
+## Local use
+
+Build all harnesses:
+
+```sh
+zig build fuzz -Doptimize=ReleaseSafe
+```
+
+Run a short smoke over the malformed corpus:
+
+```sh
+rm -rf /tmp/wamr-fuzz-crashes
+mkdir -p /tmp/wamr-fuzz-crashes
+./zig-out/bin/fuzz-loader --corpus tests/malformed/fuzz --crashes /tmp/wamr-fuzz-crashes --duration 5
+./zig-out/bin/fuzz-component-loader --corpus tests/malformed/fuzz --crashes /tmp/wamr-fuzz-crashes --duration 5
+```
+
+For component-loader smoke with at least one valid component seed:
+
+```sh
+rm -rf /tmp/wamr-component-corpus /tmp/wamr-fuzz-crashes
+mkdir -p /tmp/wamr-component-corpus /tmp/wamr-fuzz-crashes
+printf '\000asm\015\000\001\000' > /tmp/wamr-component-corpus/minimal-component.wasm
+./zig-out/bin/fuzz-component-loader --corpus /tmp/wamr-component-corpus --crashes /tmp/wamr-fuzz-crashes --duration 5
+```
+
+The harnesses replay every `.wasm` file under `--corpus` until the duration
+expires. They are not coverage-guided mutators by themselves; use them as stable
+entry points for CI and future mutation/generation infrastructure.
+
+## Crash artifacts and reproduction
+
+Every harness writes the current input to `<crashes>/in-flight.wasm` before
+calling the target and deletes it after a clean return. If the process aborts,
+the file remains as a reproducer. Harnesses may also write named crashers such
+as `<tag>-<hash>.wasm` for explicit oracle failures.
+
+To reproduce a crash:
+
+1. Download the `fuzz-crashes-<target>` artifact from the failed workflow.
+2. Put `in-flight.wasm` or the named crasher in a clean corpus directory.
+3. Re-run the same target locally with a short duration and `-Doptimize=ReleaseSafe`.
+4. Minimize or redact the reproducer before making it public if it may disclose
+   an unfixed security issue. Use the private reporting flow in `SECURITY.md`
+   and `SECURITY_PROCESS.md` for sensitive payloads.
+
+## CI workflow
+
+`.github/workflows/fuzz.yml` runs on a daily schedule, on demand, and on PRs that
+touch runtime/compiler/component/fuzz code. The workflow:
+
+- builds all harnesses with `zig build fuzz -Doptimize=ReleaseSafe`;
+- seeds per-target corpora from `tests/malformed/fuzz` and `tests/spec-json`;
+- adds a generated minimal component seed for `fuzz-component-loader`;
+- uploads `.fuzz-crashes` artifacts with 30-day retention;
+- uploads per-target corpus artifacts with 7-day retention;
+- fails the job when any crash artifact remains.
+
+Manual runs can choose `all`, `loader`, `component-loader`, `interp`, `aot`, or
+`diff` and can set a per-target duration.
+
+## Current limitations and follow-ups
+
+The current targets are intentionally conservative. Do not remove these limits
+without adding bounded execution, subprocess isolation, or another equivalent
+host-protection mechanism.
+
+- `fuzz-interp` does not yet invoke exports (#245). A future target should instantiate
+  safe modules, provide deterministic host imports, and use fuel/timeouts or
+  subprocesses so valid infinite loops cannot hang CI.
+- `fuzz-diff` does not yet compare typed interpreter and AOT results (#246). A future
+  oracle should select supported nullary or bounded-argument scalar exports and
+  handle platform-specific AOT traps outside the test runner.
+- Direct WASI and component-adapter fuzzing needs a deterministic byte-command
+  model for resource tables, paths, descriptors, sockets, HTTP streams, and
+  guest-memory pointer/length pairs (#247).
+- Corpus minimization should preserve a small checked-in seed set while storing
+  larger evolving corpora as workflow artifacts (#248).
+- OSS-Fuzz integration should be evaluated after the local targets are stable,
+  resource usage is bounded, and generated corpora are useful (#249).


### PR DESCRIPTION
## Summary

- add `fuzz-component-loader` for component-model binary parsing without guest execution
- document fuzz harness goals, target oracles, CI artifacts, and reproduction steps in `tests/fuzz/README.md`
- wire the new target into `zig build fuzz` and the scheduled/manual/PR fuzz workflow
- link follow-up fuzz expansion issues: #245, #246, #247, #248, #249

Closes #222.

## Validation

- `zig build test`
- `zig build fuzz -Doptimize=ReleaseSafe`
- `fuzz-loader` short smoke over `tests/malformed/fuzz`
- `fuzz-component-loader` short smoke over malformed seeds plus a generated minimal component
- `git diff --check`
