### PR TITLE
Invoke interpreter fuzz exports with fuel

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,6 +14,10 @@ on:
         description: "Per-target fuzz duration in seconds"
         required: false
         default: "300"
+      interp_fuel:
+        description: "Per-export interpreter fuel for fuzz-interp"
+        required: false
+        default: "100000"
       target:
         description: "Fuzz target (all, loader, component-loader, interp, aot, diff)"
         required: false
@@ -83,6 +87,10 @@ jobs:
             # Minimal component: "\0asm" plus version/layer 0x0001000d.
             printf '\000asm\015\000\001\000' > .fuzz-corpus/${{ matrix.target }}/minimal-component.wasm
           fi
+          if [ "${{ matrix.target }}" = "interp" ]; then
+            # Minimal core module exporting `run: () -> i32`.
+            printf '\000asm\001\000\000\000\001\005\001\140\000\001\177\003\002\001\000\007\007\001\003run\000\000\012\006\001\004\000\101\052\013' > .fuzz-corpus/${{ matrix.target }}/minimal-interp-run.wasm
+          fi
           ls .fuzz-corpus/${{ matrix.target }} | wc -l
 
       - name: Build fuzz harness
@@ -93,12 +101,18 @@ jobs:
           FUZZ_DURATION: ${{ github.event.inputs.duration_seconds || '600' }}
           FUZZ_TARGET: ${{ matrix.target }}
           FUZZ_CORPUS: .fuzz-corpus/${{ matrix.target }}
+          FUZZ_INTERP_FUEL: ${{ github.event.inputs.interp_fuel || '100000' }}
         run: |
           mkdir -p .fuzz-crashes
+          extra_args=()
+          if [ "$FUZZ_TARGET" = "interp" ]; then
+            extra_args+=(--fuel "$FUZZ_INTERP_FUEL")
+          fi
           ./zig-out/bin/fuzz-${FUZZ_TARGET} \
             --corpus "$FUZZ_CORPUS" \
             --crashes .fuzz-crashes \
-            --duration "$FUZZ_DURATION"
+            --duration "$FUZZ_DURATION" \
+            "${extra_args[@]}"
 
       - name: Upload crashes
         if: always()

--- a/src/runtime/interpreter/interp.zig
+++ b/src/runtime/interpreter/interp.zig
@@ -65,6 +65,7 @@ const simd = @import("simd.zig");
 const leb128 = @import("../../shared/utils/leb128.zig");
 
 pub const TrapError = error{
+    OutOfFuel,
     Unreachable,
     IntegerOverflow,
     IntegerDivisionByZero,
@@ -81,6 +82,21 @@ pub const TrapError = error{
     UnknownOpcode,
     UnalignedAtomicAccess,
     UncaughtException,
+};
+
+pub const default_fuel: u32 = 100_000_000;
+
+pub const ExecuteOptions = struct {
+    fuel: u32 = default_fuel,
+};
+
+const FuelBudget = struct {
+    remaining: u32,
+
+    fn consume(self: *FuelBudget) TrapError!void {
+        if (self.remaining == 0) return error.OutOfFuel;
+        self.remaining -= 1;
+    }
 };
 
 /// Sentinel type_idx for GC objects that wrap externref values via any.convert_extern.
@@ -772,6 +788,16 @@ fn prepareTailCall(env: *ExecEnv, func_idx: u32) TrapError!void {
 
 /// Execute a function by index within the module instance.
 pub fn executeFunction(env: *ExecEnv, func_idx: u32) TrapError!void {
+    return executeFunctionWithOptions(env, func_idx, .{});
+}
+
+/// Execute a function with caller-supplied limits.
+pub fn executeFunctionWithOptions(env: *ExecEnv, func_idx: u32, options: ExecuteOptions) TrapError!void {
+    var fuel = FuelBudget{ .remaining = options.fuel };
+    return executeFunctionWithFuel(env, func_idx, &fuel);
+}
+
+fn executeFunctionWithFuel(env: *ExecEnv, func_idx: u32, fuel: *FuelBudget) TrapError!void {
     var current_func_idx = func_idx;
 
     while (true) {
@@ -797,7 +823,7 @@ pub fn executeFunction(env: *ExecEnv, func_idx: u32) TrapError!void {
                 const saved_module_inst = env.module_inst;
                 env.module_inst = imported.module_inst;
                 defer env.module_inst = saved_module_inst;
-                try executeFunction(env, imported.func_idx);
+                try executeFunctionWithFuel(env, imported.func_idx, fuel);
                 return;
             }
             // Fallback: no-op stub for unresolved imports (pop args, push zero results)
@@ -874,7 +900,7 @@ pub fn executeFunction(env: *ExecEnv, func_idx: u32) TrapError!void {
         }
 
         var tail_call_target: u32 = 0;
-        const result = dispatchLoop(env, func.code, &tail_call_target) catch |err| {
+        const result = dispatchLoopWithFuel(env, func.code, &tail_call_target, fuel) catch |err| {
             if (err == error.UncaughtException) {
                 // Pop the callee's frame and restore the caller's stack
                 const frame = env.popFrame() catch return err;
@@ -1414,10 +1440,14 @@ fn funcTypesEqual(a: types.FuncType, b: types.FuncType) bool {
 // ── Dispatch loop ────────────────────────────────────────────────────────
 
 fn dispatchLoop(env: *ExecEnv, code: []const u8, tail_call_target: *u32) TrapError!DispatchResult {
+    var fuel = FuelBudget{ .remaining = default_fuel };
+    return dispatchLoopWithFuel(env, code, tail_call_target, &fuel);
+}
+
+fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32, fuel: *FuelBudget) TrapError!DispatchResult {
     var ip: usize = 0;
     var labels: [MAX_LABELS]Label = undefined;
     var label_sp: u32 = 0;
-    var fuel: u32 = 100_000_000;
 
     // Push implicit function-body label so br/br_if/br_table can target the function.
     const return_arity: u32 = if (env.currentFrame()) |frame| frame.return_arity else 0;
@@ -1430,10 +1460,9 @@ fn dispatchLoop(env: *ExecEnv, code: []const u8, tail_call_target: *u32) TrapErr
     label_sp = 1;
 
     while (ip < code.len) {
-        fuel -|= 1;
-        if (fuel == 0) return error.Unreachable;
+        try fuel.consume();
         // Check for cross-thread trap (every 4096 iterations to minimize overhead)
-        if (fuel % 4096 == 0) {
+        if (fuel.remaining % 4096 == 0) {
             if (env.thread_manager) |tm| {
                 if (tm.hasTrap()) return error.Unreachable;
             }
@@ -1750,7 +1779,7 @@ fn dispatchLoop(env: *ExecEnv, code: []const u8, tail_call_target: *u32) TrapErr
                 const func_idx = readU32(code, &ip);
                 const frame = env.currentFrameMut() orelse return error.CallStackUnderflow;
                 frame.ip = @intCast(ip);
-                executeFunction(env, func_idx) catch |err| {
+                executeFunctionWithFuel(env, func_idx, fuel) catch |err| {
                     if (err == error.UncaughtException) {
                         if (try handleUncaughtException(env, labels[0..label_sp], code, &label_sp, &ip)) continue;
                     }
@@ -1799,7 +1828,7 @@ fn dispatchLoop(env: *ExecEnv, code: []const u8, tail_call_target: *u32) TrapErr
                 if (funcref.module_inst != env.module_inst) {
                     const saved = env.module_inst;
                     env.module_inst = funcref.module_inst;
-                    executeFunction(env, funcref.func_idx) catch |err| {
+                    executeFunctionWithFuel(env, funcref.func_idx, fuel) catch |err| {
                         env.module_inst = saved;
                         if (err == error.UncaughtException) {
                             if (try handleUncaughtException(env, labels[0..label_sp], code, &label_sp, &ip)) continue;
@@ -1808,7 +1837,7 @@ fn dispatchLoop(env: *ExecEnv, code: []const u8, tail_call_target: *u32) TrapErr
                     };
                     env.module_inst = saved;
                 } else {
-                    executeFunction(env, funcref.func_idx) catch |err| {
+                    executeFunctionWithFuel(env, funcref.func_idx, fuel) catch |err| {
                         if (err == error.UncaughtException) {
                             if (try handleUncaughtException(env, labels[0..label_sp], code, &label_sp, &ip)) continue;
                         }
@@ -2783,7 +2812,7 @@ fn dispatchLoop(env: *ExecEnv, code: []const u8, tail_call_target: *u32) TrapErr
                 };
                 _ = type_idx;
                 // Call the function by index (same as call)
-                try executeFunction(env, func_idx);
+                try executeFunctionWithFuel(env, func_idx, fuel);
             },
             .return_call_ref => {
                 const type_idx = readU32(code, &ip);
@@ -3600,6 +3629,30 @@ fn runCode(code: []const u8) !i32 {
 fn runCodeExpectTrap(code: []const u8, expected: TrapError) !void {
     const result = runCode(code);
     try testing.expectError(expected, result);
+}
+
+test "interp: dispatch fuel exhaustion reports OutOfFuel" {
+    const alloc = testing.allocator;
+    var inst = types.ModuleInstance{
+        .module = &.{},
+        .memories = &.{},
+        .tables = &.{},
+        .globals = &.{},
+        .allocator = alloc,
+    };
+    var env = ExecEnv{
+        .module_inst = &inst,
+        .operand_stack = try alloc.alloc(types.Value, 16),
+        .call_stack = try alloc.alloc(CallFrame, 16),
+        .allocator = alloc,
+    };
+    defer alloc.free(env.operand_stack);
+    defer alloc.free(env.call_stack);
+
+    try env.pushFrame(.{ .func_idx = 0, .ip = 0, .stack_base = 0, .local_count = 0, .return_arity = 1, .prev_sp = 0 });
+    var dummy_target: u32 = 0;
+    var fuel = FuelBudget{ .remaining = 1 };
+    try testing.expectError(error.OutOfFuel, dispatchLoopWithFuel(&env, &.{ 0x41, 42, 0x0B }, &dummy_target, &fuel));
 }
 
 test "interp: i32.const" {

--- a/src/tests/fuzz/common.zig
+++ b/src/tests/fuzz/common.zig
@@ -16,11 +16,13 @@ pub const Args = struct {
     corpus_dir: []const u8,
     crashes_dir: []const u8,
     duration_ms: u64,
+    fuel: ?u32,
 
     pub fn parse(argv: []const []const u8) !Args {
         var corpus: ?[]const u8 = null;
         var crashes: ?[]const u8 = null;
         var duration_s: u64 = 60;
+        var fuel: ?u32 = null;
 
         var i: usize = 1;
         while (i < argv.len) : (i += 1) {
@@ -34,6 +36,9 @@ pub const Args = struct {
             } else if (std.mem.eql(u8, a, "--duration") and i + 1 < argv.len) {
                 i += 1;
                 duration_s = try std.fmt.parseInt(u64, argv[i], 10);
+            } else if (std.mem.eql(u8, a, "--fuel") and i + 1 < argv.len) {
+                i += 1;
+                fuel = try std.fmt.parseInt(u32, argv[i], 10);
             } else if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
                 printUsage();
                 std.process.exit(0);
@@ -48,16 +53,18 @@ pub const Args = struct {
             .corpus_dir = corpus orelse return error.MissingCorpus,
             .crashes_dir = crashes orelse return error.MissingCrashesDir,
             .duration_ms = duration_s * std.time.ms_per_s,
+            .fuel = fuel,
         };
     }
 
     fn printUsage() void {
         std.debug.print(
-            \\usage: fuzz-<target> --corpus <dir> --crashes <dir> [--duration <seconds>]
+            \\usage: fuzz-<target> --corpus <dir> --crashes <dir> [--duration <seconds>] [--fuel <instructions>]
             \\
             \\Replays every .wasm file under <corpus> through the target until
             \\<duration> seconds have elapsed. A crashing input is left at
             \\<crashes>/in-flight.wasm when the process aborts.
+            \\The optional --fuel limit is currently used by fuzz-interp.
             \\
         , .{});
     }

--- a/src/tests/fuzz/interp.zig
+++ b/src/tests/fuzz/interp.zig
@@ -1,16 +1,19 @@
-//! fuzz-interp — load + instantiate + invoke every nullary export
-//! through the interpreter.
+//! fuzz-interp — load, instantiate, and invoke safe nullary exports
+//! through the interpreter under a fuel budget.
 //!
-//! Oracle: any panic, safety-checked UB, or unhandled error is a bug.
-//! Runtime traps surface as typed errors and are OK.
-//!
-//! This is a scaffold. Until a bounded execution helper exists, this
-//! target deliberately stays on loader + validation coverage. See
-//! tests/fuzz/README.md for follow-up scope.
+//! Oracle: loader/instantiation errors, guest traps, fuel exhaustion,
+//! and unsupported signatures are expected outcomes. Any panic,
+//! safety-checked UB, or process abort is a bug.
 
 const std = @import("std");
 const wamr = @import("wamr");
 const common = @import("common.zig");
+const types = wamr.types;
+const ExecEnv = wamr.exec_env.ExecEnv;
+
+const default_fuel_per_export: u32 = 100_000;
+const exec_stack_size: u32 = 4096;
+const max_exports_per_input: usize = 8;
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
@@ -34,19 +37,72 @@ pub fn main(init: std.process.Init) !void {
         idx +%= 1;
 
         try common.markInFlight(io, args.crashes_dir, input);
-        runOnce(allocator, input) catch {};
+        try runOnce(allocator, input, args.fuel orelse default_fuel_per_export);
         common.clearInFlight(io, args.crashes_dir);
     }
 
     std.log.info("fuzz-interp: {d} iterations over {d} inputs", .{ iter, corpus.count() });
 }
 
-fn runOnce(allocator: std.mem.Allocator, bytes: []const u8) !void {
+fn runOnce(allocator: std.mem.Allocator, bytes: []const u8, fuel_per_export: u32) !void {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const a = arena.allocator();
 
-    // Just exercise loader + downstream validation for now. A full
-    // invocation path requires bounded execution and host-import setup.
-    _ = wamr.loader.load(bytes, a) catch return;
+    const module = wamr.loader.load(bytes, a) catch return;
+    if (module.imports.len != 0 or module.start_function != null) return;
+
+    const inst = wamr.instance.instantiate(&module, allocator) catch return;
+    defer wamr.instance.destroy(inst);
+
+    var invoked: usize = 0;
+    for (module.exports) |exp| {
+        if (invoked >= max_exports_per_input) break;
+        if (exp.kind != .function) continue;
+        if (exp.index < module.import_function_count) continue;
+        const func_type = module.getFuncType(exp.index) orelse continue;
+        if (!supportedFuncType(func_type)) continue;
+
+        try invokeExport(allocator, inst, exp.index, func_type, fuel_per_export);
+        invoked += 1;
+    }
+}
+
+fn supportedFuncType(func_type: types.FuncType) bool {
+    if (func_type.params.len != 0) return false;
+    if (func_type.results.len > 1) return false;
+    for (func_type.results) |result| {
+        switch (result) {
+            .i32, .i64, .f32, .f64 => {},
+            else => return false,
+        }
+    }
+    return true;
+}
+
+fn invokeExport(
+    allocator: std.mem.Allocator,
+    inst: *types.ModuleInstance,
+    func_idx: u32,
+    func_type: types.FuncType,
+    fuel_per_export: u32,
+) !void {
+    var env = try ExecEnv.create(inst, exec_stack_size, allocator);
+    defer env.destroy();
+
+    wamr.interp.executeFunctionWithOptions(env, func_idx, .{ .fuel = fuel_per_export }) catch return;
+    try validateResults(env, func_type.results);
+}
+
+fn validateResults(env: *ExecEnv, results: []const types.ValType) !void {
+    if (@as(usize, @intCast(env.sp)) != results.len) return error.InvalidResultStack;
+
+    var i = results.len;
+    while (i > 0) {
+        i -= 1;
+        const value = try env.pop();
+        if (std.meta.activeTag(value) != results[i]) return error.InvalidResultStack;
+    }
+
+    if (env.sp != 0) return error.InvalidResultStack;
 }

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -26,7 +26,7 @@ abort, or small-input OOM is a bug.
 | --- | --- | --- |
 | `fuzz-loader` | Core Wasm loader and validation | A valid module or typed loader error is OK. A panic, abort, or safety-check failure is a bug. |
 | `fuzz-component-loader` | Component-model binary loader | A valid component or typed component loader error is OK. A panic, abort, or safety-check failure is a bug. |
-| `fuzz-interp` | Interpreter loader and validation scaffold | Loader/validation errors are OK. Full bounded export invocation is tracked as follow-up work. |
+| `fuzz-interp` | Interpreter load, instantiate, and bounded nullary export invocation | Loader/validation/instantiation errors, guest traps, fuel exhaustion, and unsupported signatures are OK. Panics, aborts, or result-stack shape mismatches are bugs. |
 | `fuzz-aot` | AOT compile, AOT loader, and instantiate path | Compile/instantiate errors are OK. The harness deliberately sets `invoke_start = false` and does not execute attacker-supplied start functions. |
 | `fuzz-diff` | Interpreter load plus AOT compile/instantiate scaffold | Pipeline errors are OK. Result comparison for supported exports is tracked as follow-up work. |
 
@@ -56,9 +56,22 @@ printf '\000asm\015\000\001\000' > /tmp/wamr-component-corpus/minimal-component.
 ./zig-out/bin/fuzz-component-loader --corpus /tmp/wamr-component-corpus --crashes /tmp/wamr-fuzz-crashes --duration 5
 ```
 
+For interpreter invocation smoke with at least one valid nullary export:
+
+```sh
+rm -rf /tmp/wamr-interp-corpus /tmp/wamr-fuzz-crashes
+mkdir -p /tmp/wamr-interp-corpus /tmp/wamr-fuzz-crashes
+printf '\000asm\001\000\000\000\001\005\001\140\000\001\177\003\002\001\000\007\007\001\003run\000\000\012\006\001\004\000\101\052\013' > /tmp/wamr-interp-corpus/minimal-interp-run.wasm
+./zig-out/bin/fuzz-interp --corpus /tmp/wamr-interp-corpus --crashes /tmp/wamr-fuzz-crashes --duration 5 --fuel 100000
+```
+
 The harnesses replay every `.wasm` file under `--corpus` until the duration
 expires. They are not coverage-guided mutators by themselves; use them as stable
 entry points for CI and future mutation/generation infrastructure.
+
+`fuzz-interp` uses `--fuel <instructions>` as a per-export interpreter instruction
+budget. Fuel exhaustion is an expected outcome and is reported separately from a
+guest `unreachable` trap.
 
 ## Crash artifacts and reproduction
 
@@ -84,12 +97,14 @@ touch runtime/compiler/component/fuzz code. The workflow:
 - builds all harnesses with `zig build fuzz -Doptimize=ReleaseSafe`;
 - seeds per-target corpora from `tests/malformed/fuzz` and `tests/spec-json`;
 - adds a generated minimal component seed for `fuzz-component-loader`;
+- adds a generated nullary scalar export seed for `fuzz-interp`;
 - uploads `.fuzz-crashes` artifacts with 30-day retention;
 - uploads per-target corpus artifacts with 7-day retention;
 - fails the job when any crash artifact remains.
 
 Manual runs can choose `all`, `loader`, `component-loader`, `interp`, `aot`, or
-`diff` and can set a per-target duration.
+`diff`, set a per-target duration, and set the per-export `fuzz-interp` fuel
+budget.
 
 ## Current limitations and follow-ups
 
@@ -97,9 +112,11 @@ The current targets are intentionally conservative. Do not remove these limits
 without adding bounded execution, subprocess isolation, or another equivalent
 host-protection mechanism.
 
-- `fuzz-interp` does not yet invoke exports (#245). A future target should instantiate
-  safe modules, provide deterministic host imports, and use fuel/timeouts or
-  subprocesses so valid infinite loops cannot hang CI.
+- `fuzz-interp` skips modules with imports or start functions, then invokes at
+  most eight exported local functions whose signatures are `() -> ()`,
+  `() -> i32`, `() -> i64`, `() -> f32`, or `() -> f64`. Parameterized,
+  reference-typed, `v128`, imported-function, and multi-result exports remain
+  out of scope until a deterministic input and host-import policy is designed.
 - `fuzz-diff` does not yet compare typed interpreter and AOT results (#246). A future
   oracle should select supported nullary or bounded-argument scalar exports and
   handle platform-specific AOT traps outside the test runner.


### PR DESCRIPTION
## Summary

- add a fuel-aware interpreter execution API with explicit `OutOfFuel` reporting while preserving `executeFunction` defaults
- update `fuzz-interp` to instantiate import-free modules and invoke selected nullary scalar exports under a bounded fuel budget
- seed the fuzz workflow with a tiny valid interpreter module and expose manual `interp_fuel`
- document the bounded interpreter fuzz policy and remaining out-of-scope coverage

Closes #245.

## Validation

- `zig build test`
- `zig build fuzz -Doptimize=ReleaseSafe`
- `fuzz-interp` short smoke over malformed seeds plus a generated nullary-export module
- `fuzz-loader` short smoke over `tests/malformed/fuzz`
- `git diff --check`
