### PR TITLE
perf(aarch64): add i64x2 SIMD core lanes

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -567,6 +567,9 @@ fn isSupportedV128Def(inst: ir.Inst) bool {
         .i16x8_shift,
         .i16x8_splat,
         .i16x8_replace_lane,
+        .i64x2_binop,
+        .i64x2_splat,
+        .i64x2_replace_lane,
         => inst.type == .v128,
         else => false,
     };
@@ -598,6 +601,9 @@ fn functionHasUnsupportedV128(func: *const ir.IrFunction, allocator: std.mem.All
                 .i16x8_shift,
                 .i16x8_splat,
                 .i16x8_replace_lane,
+                .i64x2_binop,
+                .i64x2_splat,
+                .i64x2_replace_lane,
                 => {
                     if (!isSupportedV128Def(inst)) return true;
                 },
@@ -605,6 +611,7 @@ fn functionHasUnsupportedV128(func: *const ir.IrFunction, allocator: std.mem.All
                 .i32x4_extract_lane,
                 .i8x16_extract_lane,
                 .i16x8_extract_lane,
+                .i64x2_extract_lane,
                 => {},
                 else => {},
             }
@@ -1384,6 +1391,10 @@ fn isV128Inst(inst: ir.Inst) bool {
         .i16x8_splat,
         .i16x8_extract_lane,
         .i16x8_replace_lane,
+        .i64x2_binop,
+        .i64x2_splat,
+        .i64x2_extract_lane,
+        .i64x2_replace_lane,
         => true,
         else => false,
     };
@@ -1545,6 +1556,10 @@ fn compileInst(
         .i16x8_splat => |src| try emitI16x8Splat(code, inst, src, reg_map, v128_map, v128_cache),
         .i16x8_extract_lane => |lane| try emitI16x8ExtractLane(code, inst, lane, reg_map, v128_map, v128_cache),
         .i16x8_replace_lane => |lane| try emitI16x8ReplaceLane(code, inst, lane, reg_map, v128_map, v128_cache, fctx),
+        .i64x2_binop => |bin| try emitI64x2BinOp(code, inst, bin, v128_map, v128_cache, fctx),
+        .i64x2_splat => |src| try emitI64x2Splat(code, inst, src, reg_map, v128_map, v128_cache),
+        .i64x2_extract_lane => |lane| try emitI64x2ExtractLane(code, inst, lane, reg_map, v128_map, v128_cache),
+        .i64x2_replace_lane => |lane| try emitI64x2ReplaceLane(code, inst, lane, reg_map, v128_map, v128_cache, fctx),
 
         .add => |bin| if (inst.type == .f32 or inst.type == .f64)
             try emitFBinOp(code, inst, bin, reg_map, .add)
@@ -2310,6 +2325,89 @@ fn emitI16x8ReplaceLane(
     const dest_reg = try prepareV128UnaryDest(code, inst, lane.vector, vector_reg, v128_map, v128_cache, fctx);
     const val_reg = try useInto(code, reg_map, lane.val, RegMap.tmp0);
     try code.insHFromGp32(dest_reg, lane.lane, val_reg);
+}
+
+fn emitI64x2BinOp(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    bin: ir.Inst.I64x2BinOp,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+    fctx: *const FuncCompileCtx,
+) !void {
+    const lhs_reg = try v128_cache.ensure(code, v128_map, bin.lhs, null);
+    const rhs_reg = if (bin.rhs == bin.lhs)
+        lhs_reg
+    else
+        try v128_cache.ensure(code, v128_map, bin.rhs, lhs_reg);
+    const dest_reg = try prepareV128BinaryDest(
+        code,
+        inst,
+        bin.lhs,
+        lhs_reg,
+        bin.rhs,
+        rhs_reg,
+        v128_map,
+        v128_cache,
+        fctx,
+    );
+    switch (bin.op) {
+        .add => try code.i64x2Op(.add, dest_reg, lhs_reg, rhs_reg),
+        .sub => try code.i64x2Op(.sub, dest_reg, lhs_reg, rhs_reg),
+        .eq => try code.i64x2Op(.cmeq, dest_reg, lhs_reg, rhs_reg),
+        .ne => {
+            try code.i64x2Op(.cmeq, dest_reg, lhs_reg, rhs_reg);
+            try code.mvn16b(dest_reg, dest_reg);
+        },
+        .gt_s => try code.i64x2Op(.cmgt, dest_reg, lhs_reg, rhs_reg),
+        .ge_s => try code.i64x2Op(.cmge, dest_reg, lhs_reg, rhs_reg),
+        .lt_s => try code.i64x2Op(.cmgt, dest_reg, rhs_reg, lhs_reg),
+        .le_s => try code.i64x2Op(.cmge, dest_reg, rhs_reg, lhs_reg),
+    }
+}
+
+fn emitI64x2Splat(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    src: ir.VReg,
+    reg_map: *const RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+) !void {
+    const dest = inst.dest orelse return;
+    const dest_reg = try v128_cache.defineFresh(code, v128_map, dest, null);
+    const src_reg = try useInto(code, reg_map, src, RegMap.tmp0);
+    try code.dup2dFromGp64(dest_reg, src_reg);
+}
+
+fn emitI64x2ExtractLane(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    lane: ir.Inst.I64x2ExtractLane,
+    reg_map: *RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+) !void {
+    const dest = inst.dest orelse return;
+    const vector_reg = try v128_cache.ensure(code, v128_map, lane.vector, null);
+    const info = try destBegin(reg_map, dest, RegMap.tmp0);
+    try code.umovXFromD(info.reg, vector_reg, lane.lane);
+    try destCommit(code, reg_map, info);
+}
+
+fn emitI64x2ReplaceLane(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    lane: ir.Inst.I64x2ReplaceLane,
+    reg_map: *const RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+    fctx: *const FuncCompileCtx,
+) !void {
+    const vector_reg = try v128_cache.ensure(code, v128_map, lane.vector, null);
+    const dest_reg = try prepareV128UnaryDest(code, inst, lane.vector, vector_reg, v128_map, v128_cache, fctx);
+    const val_reg = try useInto(code, reg_map, lane.val, RegMap.tmp0);
+    try code.insDFromGp64(dest_reg, lane.lane, val_reg);
 }
 
 const ExtendWidth = enum { b, h, w };
@@ -5613,6 +5711,54 @@ test "compile: i16x8 lane ops emit NEON instructions" {
     try std.testing.expect(found_umov);
 }
 
+test "compile: i64x2 lane ops emit NEON instructions" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+
+    const scalar = func.newVReg();
+    const splat = func.newVReg();
+    const replacement = func.newVReg();
+    const replaced = func.newVReg();
+    const lane = func.newVReg();
+    const wrapped = func.newVReg();
+
+    try func.getBlock(bid).append(.{ .op = .{ .iconst_64 = 7 }, .dest = scalar, .type = .i64 });
+    try func.getBlock(bid).append(.{ .op = .{ .i64x2_splat = scalar }, .dest = splat, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .iconst_64 = -128 }, .dest = replacement, .type = .i64 });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i64x2_replace_lane = .{ .vector = splat, .val = replacement, .lane = 1 } },
+        .dest = replaced,
+        .type = .v128,
+    });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i64x2_extract_lane = .{ .vector = replaced, .lane = 1 } },
+        .dest = lane,
+        .type = .i64,
+    });
+    try func.getBlock(bid).append(.{ .op = .{ .wrap_i64 = lane }, .dest = wrapped, .type = .i32 });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = wrapped } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    var found_dup = false;
+    var found_ins = false;
+    var found_umov = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFFFFC00) == 0x4E080C00) found_dup = true;
+        if ((w & 0xFFFFFC00) == 0x4E181C00) found_ins = true;
+        if ((w & 0xFFFFFC00) == 0x4E183C00) found_umov = true;
+    }
+
+    try std.testing.expect(found_dup);
+    try std.testing.expect(found_ins);
+    try std.testing.expect(found_umov);
+}
+
 test "compile: i32x4 cmp and mul ops emit NEON instructions" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
@@ -5826,6 +5972,69 @@ test "compile: i16x8 cmp and mul ops emit NEON instructions" {
     try std.testing.expect(found_cmge);
     try std.testing.expect(found_cmhi);
     try std.testing.expect(found_cmhs);
+}
+
+test "compile: i64x2 cmp and arithmetic ops emit NEON instructions" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+
+    const a = func.newVReg();
+    const b = func.newVReg();
+    const add = func.newVReg();
+    const sub = func.newVReg();
+    const ne = func.newVReg();
+    const lt_s = func.newVReg();
+    const gt_s = func.newVReg();
+    const le_s = func.newVReg();
+    const ge_s = func.newVReg();
+    const lane = func.newVReg();
+    const wrapped = func.newVReg();
+
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0000_0000_0000_0004_ffff_ffff_ffff_ffff }, .dest = a, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0000_0000_0000_0003_0000_0000_0000_0001 }, .dest = b, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i64x2_binop = .{ .op = .add, .lhs = a, .rhs = b } }, .dest = add, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i64x2_binop = .{ .op = .sub, .lhs = add, .rhs = b } }, .dest = sub, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i64x2_binop = .{ .op = .ne, .lhs = sub, .rhs = a } }, .dest = ne, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i64x2_binop = .{ .op = .lt_s, .lhs = a, .rhs = b } }, .dest = lt_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i64x2_binop = .{ .op = .gt_s, .lhs = a, .rhs = b } }, .dest = gt_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i64x2_binop = .{ .op = .le_s, .lhs = a, .rhs = b } }, .dest = le_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i64x2_binop = .{ .op = .ge_s, .lhs = a, .rhs = b } }, .dest = ge_s, .type = .v128 });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i64x2_extract_lane = .{ .vector = ge_s, .lane = 0 } },
+        .dest = lane,
+        .type = .i64,
+    });
+    try func.getBlock(bid).append(.{ .op = .{ .wrap_i64 = lane }, .dest = wrapped, .type = .i32 });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = wrapped } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    var found_add = false;
+    var found_sub = false;
+    var found_cmeq = false;
+    var found_mvn = false;
+    var found_cmgt = false;
+    var found_cmge = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFE0FC00) == 0x4EE08400) found_add = true;
+        if ((w & 0xFFE0FC00) == 0x6EE08400) found_sub = true;
+        if ((w & 0xFFE0FC00) == 0x6EE08C00) found_cmeq = true;
+        if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
+        if ((w & 0xFFE0FC00) == 0x4EE03400) found_cmgt = true;
+        if ((w & 0xFFE0FC00) == 0x4EE03C00) found_cmge = true;
+    }
+
+    try std.testing.expect(found_add);
+    try std.testing.expect(found_sub);
+    try std.testing.expect(found_cmeq);
+    try std.testing.expect(found_mvn);
+    try std.testing.expect(found_cmgt);
+    try std.testing.expect(found_cmge);
 }
 
 test "compile: i8x16 scalar-count shifts emit NEON instructions" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -698,6 +698,11 @@ pub const CodeBuffer = struct {
         try self.emit32(0x4E040C00 | (@as(u32, rn.encoding()) << 5) | vd);
     }
 
+    /// DUP Vd.2D, Xn.
+    pub fn dup2dFromGp64(self: *CodeBuffer, vd: u5, rn: Reg) !void {
+        try self.emit32(0x4E080C00 | (@as(u32, rn.encoding()) << 5) | vd);
+    }
+
     /// DUP Vd.8H, Wn.
     pub fn dup8hFromGp32(self: *CodeBuffer, vd: u5, rn: Reg) !void {
         try self.emit32(0x4E020C00 | (@as(u32, rn.encoding()) << 5) | vd);
@@ -809,6 +814,22 @@ pub const CodeBuffer = struct {
             vd);
     }
 
+    pub const I64x2Op = enum(u32) {
+        add = 0x4EE08400,
+        sub = 0x6EE08400,
+        cmeq = 0x6EE08C00,
+        cmgt = 0x4EE03400,
+        cmge = 0x4EE03C00,
+    };
+
+    /// Integer 2D binary vector op: ADD/SUB/CMEQ/CMGT/CMGE.
+    pub fn i64x2Op(self: *CodeBuffer, op: I64x2Op, vd: u5, vn: u5, vm: u5) !void {
+        try self.emit32(@intFromEnum(op) |
+            (@as(u32, vm) << 16) |
+            (@as(u32, vn) << 5) |
+            vd);
+    }
+
     /// SSHL Vd.4S, Vn.4S, Vm.4S — signed variable shift.
     pub fn sshl4s(self: *CodeBuffer, vd: u5, vn: u5, vm: u5) !void {
         try self.emit32(0x4EA04400 |
@@ -882,6 +903,14 @@ pub const CodeBuffer = struct {
     pub fn umovWFromS(self: *CodeBuffer, rd: Reg, vn: u5, lane: u2) !void {
         try self.emit32(0x0E043C00 |
             (@as(u32, lane) << 19) |
+            (@as(u32, vn) << 5) |
+            rd.encoding());
+    }
+
+    /// UMOV Xd, Vn.D[lane] (alias: MOV Xd, Vn.D[lane]).
+    pub fn umovXFromD(self: *CodeBuffer, rd: Reg, vn: u5, lane: u1) !void {
+        try self.emit32(0x4E083C00 |
+            (@as(u32, lane) << 20) |
             (@as(u32, vn) << 5) |
             rd.encoding());
     }
@@ -1750,11 +1779,33 @@ test "emit: MOV v0.d[1], x17" {
     try expectWord(0x4E181E20, &code);
 }
 
+test "emit: MOV v20.d lanes from x4" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.insDFromGp64(20, 0, .x4);
+        try expectWord(0x4E081C94, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.insDFromGp64(20, 1, .x4);
+        try expectWord(0x4E181C94, &code);
+    }
+}
+
 test "emit: DUP v0.4s, w1" {
     var code = CodeBuffer.init(std.testing.allocator);
     defer code.deinit();
     try code.dup4sFromGp32(0, .x1);
     try expectWord(0x4E040C20, &code);
+}
+
+test "emit: DUP v0.2d, x3" {
+    var code = CodeBuffer.init(std.testing.allocator);
+    defer code.deinit();
+    try code.dup2dFromGp64(0, .x3);
+    try expectWord(0x4E080C60, &code);
 }
 
 test "emit: DUP v0.8h, w1" {
@@ -1923,6 +1974,39 @@ test "emit: i16x8 vector ops" {
     }
 }
 
+test "emit: i64x2 vector ops" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i64x2Op(.add, 16, 17, 30);
+        try expectWord(0x4EFE8630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i64x2Op(.sub, 16, 17, 30);
+        try expectWord(0x6EFE8630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i64x2Op(.cmeq, 16, 17, 30);
+        try expectWord(0x6EFE8E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i64x2Op(.cmgt, 16, 17, 30);
+        try expectWord(0x4EFE3630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i64x2Op(.cmge, 16, 17, 30);
+        try expectWord(0x4EFE3E30, &code);
+    }
+}
+
 test "emit: i32x4 variable shifts" {
     {
         var code = CodeBuffer.init(std.testing.allocator);
@@ -2021,6 +2105,21 @@ test "emit: UMOV w0, v1.s[3]" {
     defer code.deinit();
     try code.umovWFromS(.x0, 1, 3);
     try expectWord(0x0E1C3C20, &code);
+}
+
+test "emit: UMOV x from d lane" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.umovXFromD(.x5, 6, 0);
+        try expectWord(0x4E083CC5, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.umovXFromD(.x5, 6, 1);
+        try expectWord(0x4E183CC5, &code);
+    }
 }
 
 test "emit: UMOV/SMOV w from h lane" {

--- a/src/compiler/codegen/aarch64/schedule.zig
+++ b/src/compiler/codegen/aarch64/schedule.zig
@@ -249,6 +249,10 @@ pub fn metadata(inst: ir.Inst) Metadata {
         .i16x8_splat,
         .i16x8_extract_lane,
         .i16x8_replace_lane,
+        .i64x2_binop,
+        .i64x2_splat,
+        .i64x2_extract_lane,
+        .i64x2_replace_lane,
         => if (def != null) .alu else .barrier,
 
         .mul => if (def != null and isIntegerType(inst.type)) .mul else .barrier,
@@ -507,6 +511,10 @@ pub fn forEachUse(
             try visit(context, bin.lhs);
             try visit(context, bin.rhs);
         },
+        .i64x2_binop => |bin| {
+            try visit(context, bin.lhs);
+            try visit(context, bin.rhs);
+        },
         .i32x4_shift => |shift| {
             try visit(context, shift.vector);
             try visit(context, shift.count);
@@ -530,6 +538,12 @@ pub fn forEachUse(
         .i16x8_splat => |v| try visit(context, v),
         .i16x8_extract_lane => |lane| try visit(context, lane.vector),
         .i16x8_replace_lane => |lane| {
+            try visit(context, lane.vector);
+            try visit(context, lane.val);
+        },
+        .i64x2_splat => |v| try visit(context, v),
+        .i64x2_extract_lane => |lane| try visit(context, lane.vector),
+        .i64x2_replace_lane => |lane| {
             try visit(context, lane.vector);
             try visit(context, lane.val);
         },

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1267,6 +1267,10 @@ fn compileInst(
         .i16x8_splat,
         .i16x8_extract_lane,
         .i16x8_replace_lane,
+        .i64x2_binop,
+        .i64x2_splat,
+        .i64x2_extract_lane,
+        .i64x2_replace_lane,
         => return error.UnsupportedV128,
         // Phi must be lowered before codegen.
         .phi => unreachable,
@@ -1503,6 +1507,10 @@ fn functionUsesV128(func: *const ir.IrFunction) bool {
                 .i16x8_splat,
                 .i16x8_extract_lane,
                 .i16x8_replace_lane,
+                .i64x2_binop,
+                .i64x2_splat,
+                .i64x2_extract_lane,
+                .i64x2_replace_lane,
                 => return true,
                 else => {},
             }

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -1909,6 +1909,40 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         });
                         try vreg_stack.append(allocator, dest);
                     },
+                    .i64x2_add,
+                    .i64x2_sub,
+                    .i64x2_eq,
+                    .i64x2_ne,
+                    .i64x2_lt_s,
+                    .i64x2_gt_s,
+                    .i64x2_le_s,
+                    .i64x2_ge_s,
+                    => {
+                        const rhs = safePop(&vreg_stack);
+                        const lhs = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        const lane_op: ir.Inst.I64x2Op = switch (simd_op) {
+                            .i64x2_add => .add,
+                            .i64x2_sub => .sub,
+                            .i64x2_eq => .eq,
+                            .i64x2_ne => .ne,
+                            .i64x2_lt_s => .lt_s,
+                            .i64x2_gt_s => .gt_s,
+                            .i64x2_le_s => .le_s,
+                            .i64x2_ge_s => .ge_s,
+                            else => unreachable,
+                        };
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .i64x2_binop = .{
+                                .op = lane_op,
+                                .lhs = lhs,
+                                .rhs = rhs,
+                            } },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
                     .i32x4_shl,
                     .i32x4_shr_s,
                     .i32x4_shr_u,
@@ -2114,6 +2148,48 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         const dest = ir_func.newVReg();
                         try ir_func.getBlock(current_block).append(.{
                             .op = .{ .i16x8_replace_lane = .{
+                                .vector = vector,
+                                .val = val,
+                                .lane = @intCast(lane_raw),
+                            } },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
+                    .i64x2_splat => {
+                        const val = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .i64x2_splat = val },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
+                    .i64x2_extract_lane => {
+                        const lane_raw = try readByte(code, &ip);
+                        if (lane_raw >= 2) return error.InvalidBytecode;
+                        const vector = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .i64x2_extract_lane = .{
+                                .vector = vector,
+                                .lane = @intCast(lane_raw),
+                            } },
+                            .dest = dest,
+                            .type = .i64,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
+                    .i64x2_replace_lane => {
+                        const lane_raw = try readByte(code, &ip);
+                        if (lane_raw >= 2) return error.InvalidBytecode;
+                        const val = safePop(&vreg_stack);
+                        const vector = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .i64x2_replace_lane = .{
                                 .vector = vector,
                                 .val = val,
                                 .lane = @intCast(lane_raw),
@@ -3127,6 +3203,88 @@ test "reject invalid i16x8 lane immediates" {
     try std.testing.expectError(error.InvalidBytecode, lowerModule(&wasm_module, allocator));
 }
 
+test "lower i64x2 dynamic lane opcodes" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i32},
+    };
+    const code = [_]u8{
+        0x42, 0x07, // i64.const 7
+        0xFD, 0x12, // i64x2.splat
+        0x42, 0x80, 0x7F, // i64.const -128
+        0xFD, 0x1E, 0x01, // i64x2.replace_lane 1
+        0xFD, 0x1D, 0x01, // i64x2.extract_lane 1
+        0xA7, // i32.wrap_i64
+        0x0B,
+    };
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &code,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+    try std.testing.expectEqual(@as(usize, 7), insts.len);
+    try std.testing.expectEqual(@as(i64, 7), insts[0].op.iconst_64);
+    try std.testing.expectEqual(ir.IrType.v128, insts[1].type);
+    try std.testing.expectEqual(insts[0].dest.?, insts[1].op.i64x2_splat);
+    try std.testing.expectEqual(@as(i64, -128), insts[2].op.iconst_64);
+    try std.testing.expectEqual(insts[1].dest.?, insts[3].op.i64x2_replace_lane.vector);
+    try std.testing.expectEqual(insts[2].dest.?, insts[3].op.i64x2_replace_lane.val);
+    try std.testing.expectEqual(@as(u1, 1), insts[3].op.i64x2_replace_lane.lane);
+    try std.testing.expectEqual(@as(u1, 1), insts[4].op.i64x2_extract_lane.lane);
+    try std.testing.expectEqual(ir.IrType.i64, insts[4].type);
+    try std.testing.expectEqual(insts[4].dest.?, insts[5].op.wrap_i64);
+    try std.testing.expectEqual(ir.IrType.i32, insts[5].type);
+    try std.testing.expect(insts[6].op.ret != null);
+}
+
+test "reject invalid i64x2 lane immediates" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i64},
+    };
+    const code = [_]u8{
+        0xFD, 0x0C, // v128.const
+        0x01, 0x00,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x02, 0x00,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x00, 0x00,
+        0xFD, 0x1D, 0x02, // i64x2.extract_lane 2
+        0x0B,
+    };
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &code,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    try std.testing.expectError(error.InvalidBytecode, lowerModule(&wasm_module, allocator));
+}
+
 test "lower i32x4 scalar-count shift opcodes" {
     const allocator = std.testing.allocator;
 
@@ -3585,6 +3743,102 @@ test "lower i16x8 cmp and arithmetic opcodes" {
     try std.testing.expectEqual(@as(u3, 0), insts[inst_idx].op.i16x8_extract_lane.lane);
     try std.testing.expectEqual(ir.Inst.I16x8LaneSign.unsigned, insts[inst_idx].op.i16x8_extract_lane.sign);
     try std.testing.expect(insts[inst_idx + 1].op.ret != null);
+}
+
+test "lower i64x2 cmp and arithmetic opcodes" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i32},
+    };
+
+    const Case = struct {
+        opcode: u32,
+        expected: ir.Inst.I64x2Op,
+    };
+    const cases = [_]Case{
+        .{ .opcode = 0xD6, .expected = .eq },
+        .{ .opcode = 0xD7, .expected = .ne },
+        .{ .opcode = 0xD8, .expected = .lt_s },
+        .{ .opcode = 0xD9, .expected = .gt_s },
+        .{ .opcode = 0xDA, .expected = .le_s },
+        .{ .opcode = 0xDB, .expected = .ge_s },
+        .{ .opcode = 0xCE, .expected = .add },
+        .{ .opcode = 0xD1, .expected = .sub },
+    };
+
+    const appendULEB = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, value: u32) !void {
+            var v = value;
+            while (true) {
+                var byte: u8 = @intCast(v & 0x7F);
+                v >>= 7;
+                if (v != 0) byte |= 0x80;
+                try buf.append(alloc, byte);
+                if (v == 0) break;
+            }
+        }
+    }.call;
+    const appendSimd = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, opcode: u32) !void {
+            try buf.append(alloc, 0xFD);
+            try appendULEB(buf, alloc, opcode);
+        }
+    }.call;
+    const appendConst = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, lanes: [2]u64) !void {
+            try appendSimd(buf, alloc, 0x0C);
+            for (lanes) |lane| {
+                var le = std.mem.nativeToLittle(u64, lane);
+                try buf.appendSlice(alloc, std.mem.asBytes(&le));
+            }
+        }
+    }.call;
+
+    var code: std.ArrayList(u8) = .empty;
+    defer code.deinit(allocator);
+    try appendConst(&code, allocator, .{ 0xffff_ffff_ffff_ffff, 2 });
+    try appendConst(&code, allocator, .{ 1, 2 });
+    for (cases, 0..) |case, idx| {
+        if (idx != 0) try appendConst(&code, allocator, .{ 3, 4 });
+        try appendSimd(&code, allocator, case.opcode);
+    }
+    try appendSimd(&code, allocator, 0x1D); // i64x2.extract_lane
+    try code.append(allocator, 0);
+    try code.append(allocator, 0xA7); // i32.wrap_i64
+    try code.append(allocator, 0x0B);
+
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = code.items,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+    try std.testing.expectEqual(@as(usize, 2 + cases.len * 2 + 2), insts.len);
+    var inst_idx: usize = 2;
+    for (cases, 0..) |case, idx| {
+        try std.testing.expectEqual(case.expected, insts[inst_idx].op.i64x2_binop.op);
+        inst_idx += 1;
+        if (idx + 1 < cases.len) {
+            try std.testing.expectEqual(ir.IrType.v128, insts[inst_idx].type);
+            inst_idx += 1;
+        }
+    }
+    try std.testing.expectEqual(@as(u1, 0), insts[inst_idx].op.i64x2_extract_lane.lane);
+    try std.testing.expectEqual(ir.IrType.i64, insts[inst_idx].type);
+    try std.testing.expectEqual(insts[inst_idx].dest.?, insts[inst_idx + 1].op.wrap_i64);
+    try std.testing.expect(insts[inst_idx + 2].op.ret != null);
 }
 
 test "lower unreachable" {

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -196,6 +196,10 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
             live.put(bin.lhs, {}) catch {};
             live.put(bin.rhs, {}) catch {};
         },
+        .i64x2_binop => |bin| {
+            live.put(bin.lhs, {}) catch {};
+            live.put(bin.rhs, {}) catch {};
+        },
         .i32x4_shift => |shift| {
             live.put(shift.vector, {}) catch {};
             live.put(shift.count, {}) catch {};
@@ -243,10 +247,12 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
         .i32x4_splat,
         .i8x16_splat,
         .i16x8_splat,
+        .i64x2_splat,
         => |vreg| live.put(vreg, {}) catch {},
         .i32x4_extract_lane => |lane| live.put(lane.vector, {}) catch {},
         .i8x16_extract_lane => |lane| live.put(lane.vector, {}) catch {},
         .i16x8_extract_lane => |lane| live.put(lane.vector, {}) catch {},
+        .i64x2_extract_lane => |lane| live.put(lane.vector, {}) catch {},
         .i32x4_replace_lane => |lane| {
             live.put(lane.vector, {}) catch {};
             live.put(lane.val, {}) catch {};
@@ -256,6 +262,10 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
             live.put(lane.val, {}) catch {};
         },
         .i16x8_replace_lane => |lane| {
+            live.put(lane.vector, {}) catch {};
+            live.put(lane.val, {}) catch {};
+        },
+        .i64x2_replace_lane => |lane| {
             live.put(lane.vector, {}) catch {};
             live.put(lane.val, {}) catch {};
         },
@@ -548,6 +558,10 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
             last_use.put(bin.lhs, pos) catch {};
             last_use.put(bin.rhs, pos) catch {};
         },
+        .i64x2_binop => |bin| {
+            last_use.put(bin.lhs, pos) catch {};
+            last_use.put(bin.rhs, pos) catch {};
+        },
         .i32x4_shift => |shift| {
             last_use.put(shift.vector, pos) catch {};
             last_use.put(shift.count, pos) catch {};
@@ -595,10 +609,12 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
         .i32x4_splat,
         .i8x16_splat,
         .i16x8_splat,
+        .i64x2_splat,
         => |vreg| last_use.put(vreg, pos) catch {},
         .i32x4_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
         .i8x16_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
         .i16x8_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
+        .i64x2_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
         .i32x4_replace_lane => |lane| {
             last_use.put(lane.vector, pos) catch {};
             last_use.put(lane.val, pos) catch {};
@@ -608,6 +624,10 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
             last_use.put(lane.val, pos) catch {};
         },
         .i16x8_replace_lane => |lane| {
+            last_use.put(lane.vector, pos) catch {};
+            last_use.put(lane.val, pos) catch {};
+        },
+        .i64x2_replace_lane => |lane| {
             last_use.put(lane.vector, pos) catch {};
             last_use.put(lane.val, pos) catch {};
         },

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -85,6 +85,10 @@ pub const Inst = struct {
         i16x8_splat: VReg,
         i16x8_extract_lane: I16x8ExtractLane,
         i16x8_replace_lane: I16x8ReplaceLane,
+        i64x2_binop: I64x2BinOp,
+        i64x2_splat: VReg,
+        i64x2_extract_lane: I64x2ExtractLane,
+        i64x2_replace_lane: I64x2ReplaceLane,
 
         // Binary arithmetic (dest = lhs op rhs)
         add: BinOp,
@@ -306,6 +310,17 @@ pub const Inst = struct {
         mul,
     };
 
+    pub const I64x2Op = enum {
+        add,
+        sub,
+        eq,
+        ne,
+        lt_s,
+        gt_s,
+        le_s,
+        ge_s,
+    };
+
     pub const I32x4ShiftOp = enum {
         shl,
         shr_s,
@@ -365,6 +380,12 @@ pub const Inst = struct {
         rhs: VReg,
     };
 
+    pub const I64x2BinOp = struct {
+        op: I64x2Op,
+        lhs: VReg,
+        rhs: VReg,
+    };
+
     pub const I32x4Shift = struct {
         op: I32x4ShiftOp,
         vector: VReg,
@@ -404,6 +425,11 @@ pub const Inst = struct {
         sign: I16x8LaneSign,
     };
 
+    pub const I64x2ExtractLane = struct {
+        vector: VReg,
+        lane: u1,
+    };
+
     pub const I32x4ReplaceLane = struct {
         vector: VReg,
         val: VReg,
@@ -420,6 +446,12 @@ pub const Inst = struct {
         vector: VReg,
         val: VReg,
         lane: u3,
+    };
+
+    pub const I64x2ReplaceLane = struct {
+        vector: VReg,
+        val: VReg,
+        lane: u1,
     };
 
     pub const PhiEdge = struct {
@@ -688,6 +720,37 @@ test "Inst: first v128 op family preserves operand shape" {
     try std.testing.expectEqual(@as(VReg, 18), i16_replace.op.i16x8_replace_lane.vector);
     try std.testing.expectEqual(@as(VReg, 21), i16_replace.op.i16x8_replace_lane.val);
     try std.testing.expectEqual(@as(u3, 7), i16_replace.op.i16x8_replace_lane.lane);
+
+    const i64_bin = Inst{
+        .op = .{ .i64x2_binop = .{ .op = .gt_s, .lhs = 23, .rhs = 24 } },
+        .dest = 25,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(Inst.I64x2Op.gt_s, i64_bin.op.i64x2_binop.op);
+    try std.testing.expectEqual(@as(VReg, 23), i64_bin.op.i64x2_binop.lhs);
+
+    const i64_splat = Inst{
+        .op = .{ .i64x2_splat = 26 },
+        .dest = 27,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(@as(VReg, 26), i64_splat.op.i64x2_splat);
+
+    const i64_extract = Inst{
+        .op = .{ .i64x2_extract_lane = .{ .vector = 27, .lane = 1 } },
+        .dest = 28,
+        .type = .i64,
+    };
+    try std.testing.expectEqual(@as(u1, 1), i64_extract.op.i64x2_extract_lane.lane);
+
+    const i64_replace = Inst{
+        .op = .{ .i64x2_replace_lane = .{ .vector = 27, .val = 28, .lane = 1 } },
+        .dest = 29,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(@as(VReg, 27), i64_replace.op.i64x2_replace_lane.vector);
+    try std.testing.expectEqual(@as(VReg, 28), i64_replace.op.i64x2_replace_lane.val);
+    try std.testing.expectEqual(@as(u1, 1), i64_replace.op.i64x2_replace_lane.lane);
 }
 
 test "IrModule: add multiple functions" {

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -155,6 +155,10 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
             list.append(bin.lhs);
             list.append(bin.rhs);
         },
+        .i64x2_binop => |bin| {
+            list.append(bin.lhs);
+            list.append(bin.rhs);
+        },
         .i32x4_shift => |shift| {
             list.append(shift.vector);
             list.append(shift.count);
@@ -203,10 +207,12 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
         .i32x4_splat,
         .i8x16_splat,
         .i16x8_splat,
+        .i64x2_splat,
         => |vreg| list.append(vreg),
         .i32x4_extract_lane => |lane| list.append(lane.vector),
         .i8x16_extract_lane => |lane| list.append(lane.vector),
         .i16x8_extract_lane => |lane| list.append(lane.vector),
+        .i64x2_extract_lane => |lane| list.append(lane.vector),
         .i32x4_replace_lane => |lane| {
             list.append(lane.vector);
             list.append(lane.val);
@@ -216,6 +222,10 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
             list.append(lane.val);
         },
         .i16x8_replace_lane => |lane| {
+            list.append(lane.vector);
+            list.append(lane.val);
+        },
+        .i64x2_replace_lane => |lane| {
             list.append(lane.vector);
             list.append(lane.val);
         },
@@ -427,6 +437,10 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
             if (bin.lhs == old) bin.lhs = new;
             if (bin.rhs == old) bin.rhs = new;
         },
+        .i64x2_binop => |*bin| {
+            if (bin.lhs == old) bin.lhs = new;
+            if (bin.rhs == old) bin.rhs = new;
+        },
         .i32x4_shift => |*shift| {
             if (shift.vector == old) shift.vector = new;
             if (shift.count == old) shift.count = new;
@@ -474,6 +488,7 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
         .i32x4_splat,
         .i8x16_splat,
         .i16x8_splat,
+        .i64x2_splat,
         => |*vreg| if (vreg.* == old) {
             vreg.* = new;
         },
@@ -486,6 +501,9 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
         .i16x8_extract_lane => |*lane| if (lane.vector == old) {
             lane.vector = new;
         },
+        .i64x2_extract_lane => |*lane| if (lane.vector == old) {
+            lane.vector = new;
+        },
         .i32x4_replace_lane => |*lane| {
             if (lane.vector == old) lane.vector = new;
             if (lane.val == old) lane.val = new;
@@ -495,6 +513,10 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
             if (lane.val == old) lane.val = new;
         },
         .i16x8_replace_lane => |*lane| {
+            if (lane.vector == old) lane.vector = new;
+            if (lane.val == old) lane.val = new;
+        },
+        .i64x2_replace_lane => |*lane| {
             if (lane.vector == old) lane.vector = new;
             if (lane.val == old) lane.val = new;
         },
@@ -1698,6 +1720,10 @@ fn isPure(inst: ir.Inst) bool {
         .i16x8_splat,
         .i16x8_extract_lane,
         .i16x8_replace_lane,
+        .i64x2_binop,
+        .i64x2_splat,
+        .i64x2_extract_lane,
+        .i64x2_replace_lane,
         => true,
         else => false,
     };
@@ -1802,6 +1828,10 @@ fn sameOp(a: ir.Inst, b: ir.Inst) bool {
         .i16x8_splat => |v| v == b.op.i16x8_splat,
         .i16x8_extract_lane => |lane| lane.vector == b.op.i16x8_extract_lane.vector and lane.lane == b.op.i16x8_extract_lane.lane and lane.sign == b.op.i16x8_extract_lane.sign,
         .i16x8_replace_lane => |lane| lane.vector == b.op.i16x8_replace_lane.vector and lane.val == b.op.i16x8_replace_lane.val and lane.lane == b.op.i16x8_replace_lane.lane,
+        .i64x2_binop => |bin| bin.op == b.op.i64x2_binop.op and bin.lhs == b.op.i64x2_binop.lhs and bin.rhs == b.op.i64x2_binop.rhs,
+        .i64x2_splat => |v| v == b.op.i64x2_splat,
+        .i64x2_extract_lane => |lane| lane.vector == b.op.i64x2_extract_lane.vector and lane.lane == b.op.i64x2_extract_lane.lane,
+        .i64x2_replace_lane => |lane| lane.vector == b.op.i64x2_replace_lane.vector and lane.val == b.op.i64x2_replace_lane.val and lane.lane == b.op.i64x2_replace_lane.lane,
         // div/rem: covered by isPure+hasSideEffect guard; float variants
         // (side-effect-free) reach here.
         .div_s => |bin| bin.lhs == b.op.div_s.lhs and bin.rhs == b.op.div_s.rhs,
@@ -3269,6 +3299,10 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
             bin.lhs += offset;
             bin.rhs += offset;
         },
+        .i64x2_binop => |*bin| {
+            bin.lhs += offset;
+            bin.rhs += offset;
+        },
         .i32x4_shift => |*shift| {
             shift.vector += offset;
             shift.count += offset;
@@ -3316,10 +3350,12 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
         .i32x4_splat,
         .i8x16_splat,
         .i16x8_splat,
+        .i64x2_splat,
         => |*vreg| vreg.* += offset,
         .i32x4_extract_lane => |*lane| lane.vector += offset,
         .i8x16_extract_lane => |*lane| lane.vector += offset,
         .i16x8_extract_lane => |*lane| lane.vector += offset,
+        .i64x2_extract_lane => |*lane| lane.vector += offset,
         .i32x4_replace_lane => |*lane| {
             lane.vector += offset;
             lane.val += offset;
@@ -3329,6 +3365,10 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
             lane.val += offset;
         },
         .i16x8_replace_lane => |*lane| {
+            lane.vector += offset;
+            lane.val += offset;
+        },
+        .i64x2_replace_lane => |*lane| {
             lane.vector += offset;
             lane.val += offset;
         },

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -199,6 +199,36 @@ const cases = [_]BenchCase{
         .build = buildSimdI8x16ShrULane0Module,
     },
     .{
+        .name = "simd_i64x2_add_lane0",
+        .simd = true,
+        .build = buildSimdI64x2AddLane0Module,
+    },
+    .{
+        .name = "simd_i64x2_sub_lane0",
+        .simd = true,
+        .build = buildSimdI64x2SubLane0Module,
+    },
+    .{
+        .name = "simd_i64x2_eq_lane0",
+        .simd = true,
+        .build = buildSimdI64x2EqLane0Module,
+    },
+    .{
+        .name = "simd_i64x2_gt_s_lane0",
+        .simd = true,
+        .build = buildSimdI64x2GtSLane0Module,
+    },
+    .{
+        .name = "simd_i64x2_splat_lane0",
+        .simd = true,
+        .build = buildSimdI64x2SplatLane0Module,
+    },
+    .{
+        .name = "simd_i64x2_replace_lane1",
+        .simd = true,
+        .build = buildSimdI64x2ReplaceLane1Module,
+    },
+    .{
         .name = "simd_v128_load_store_lane0",
         .simd = true,
         .build = buildSimdLoadStoreLane0Module,
@@ -242,6 +272,11 @@ const cases = [_]BenchCase{
         .name = "simd_i8x16_shift_mix_4k_loop",
         .simd = true,
         .build = buildSimdI8x16ShiftMix4kLoopModule,
+    },
+    .{
+        .name = "simd_i64x2_mem_add_4k_loop",
+        .simd = true,
+        .build = buildSimdI64x2MemoryAdd4kLoopModule,
     },
 };
 
@@ -881,6 +916,83 @@ fn buildSimdI8x16ShiftLane0Module(
     return buildRunI32Module(allocator, instr.items, .{});
 }
 
+fn buildSimdI64x2AddLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI64x2(&instr, allocator, .{ 1, 2 });
+    try appendV128ConstI64x2(&instr, allocator, .{ 5, 6 });
+    try appendSimdOpcode(&instr, allocator, 0xCE); // i64x2.add
+    try appendI64x2ExtractLane(&instr, allocator, 0);
+    try appendI32WrapI64(&instr, allocator);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI64x2SubLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI64x2(&instr, allocator, .{ 3, 2 });
+    try appendV128ConstI64x2(&instr, allocator, .{ 7, 6 });
+    try appendSimdOpcode(&instr, allocator, 0xD1); // i64x2.sub
+    try appendI64x2ExtractLane(&instr, allocator, 0);
+    try appendI32WrapI64(&instr, allocator);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI64x2EqLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI64x2(&instr, allocator, .{ 42, 2 });
+    try appendV128ConstI64x2(&instr, allocator, .{ 42, 0 });
+    try appendSimdOpcode(&instr, allocator, 0xD6); // i64x2.eq
+    try appendI64x2ExtractLane(&instr, allocator, 0);
+    try appendI32WrapI64(&instr, allocator);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI64x2GtSLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI64x2(&instr, allocator, .{ 0xffff_ffff_ffff_ffff, 4 });
+    try appendV128ConstI64x2(&instr, allocator, .{ 0xffff_ffff_ffff_fffe, 5 });
+    try appendSimdOpcode(&instr, allocator, 0xD9); // i64x2.gt_s
+    try appendI64x2ExtractLane(&instr, allocator, 0);
+    try appendI32WrapI64(&instr, allocator);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI64x2SplatLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendI64Const(&instr, allocator, 77);
+    try appendI64x2Splat(&instr, allocator);
+    try appendI64x2ExtractLane(&instr, allocator, 0);
+    try appendI32WrapI64(&instr, allocator);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI64x2ReplaceLane1Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI64x2(&instr, allocator, .{ 1, 2 });
+    try appendI64Const(&instr, allocator, -128);
+    try appendI64x2ReplaceLane(&instr, allocator, 1);
+    try appendI64x2ExtractLane(&instr, allocator, 1);
+    try appendI32WrapI64(&instr, allocator);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
 fn buildSimdLoadStoreLane0Module(allocator: Allocator) ![]u8 {
     var instr: std.ArrayList(u8) = .empty;
     defer instr.deinit(allocator);
@@ -1383,6 +1495,60 @@ fn buildSimdI8x16ShiftMix4kLoopModule(allocator: Allocator) ![]u8 {
     });
 }
 
+fn buildSimdI64x2MemoryAdd4kLoopModule(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendI32Const(&instr, allocator, 0);
+    try appendLocalSet(&instr, allocator, 0);
+    try appendBlock(&instr, allocator);
+    try appendLoop(&instr, allocator);
+
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Const(&instr, allocator, memory_loop_bytes);
+    try appendI32GeU(&instr, allocator);
+    try appendBrIf(&instr, allocator, 1);
+
+    try appendI32Const(&instr, allocator, memory_loop_dst_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendSimdOpcode(&instr, allocator, 0xCE); // i64x2.add
+    try appendSimdMemOpcode(&instr, allocator, 0x0B, 4, 0); // v128.store
+
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Const(&instr, allocator, 16);
+    try appendI32Add(&instr, allocator);
+    try appendLocalSet(&instr, allocator, 0);
+    try appendBr(&instr, allocator, 0);
+
+    try appendEnd(&instr, allocator);
+    try appendEnd(&instr, allocator);
+
+    try appendI32Const(&instr, allocator, memory_loop_dst_base + memory_loop_bytes - 16);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendI64x2ExtractLane(&instr, allocator, 1);
+    try appendI32WrapI64(&instr, allocator);
+
+    const data = try buildMemoryLoopDataI64(allocator);
+    defer allocator.free(data);
+    return buildRunI32Module(allocator, instr.items, .{
+        .memory_min = 1,
+        .data = data,
+        .local_i32_count = 1,
+    });
+}
+
 fn buildMemoryLoopData(allocator: Allocator) ![]u8 {
     const data_len = memory_loop_b_base + memory_loop_bytes;
     const data = try allocator.alloc(u8, data_len);
@@ -1425,6 +1591,24 @@ fn buildMemoryLoopDataI8(allocator: Allocator) ![]u8 {
     for (0..memory_loop_bytes) |offset| {
         data[memory_loop_a_base + offset] = @intCast((offset * 3 + 5) & 0xFF);
         data[memory_loop_b_base + offset] = @intCast((offset * 7 + 11) & 0xFF);
+    }
+
+    return data;
+}
+
+fn buildMemoryLoopDataI64(allocator: Allocator) ![]u8 {
+    const data_len = memory_loop_b_base + memory_loop_bytes;
+    const data = try allocator.alloc(u8, data_len);
+    @memset(data, 0);
+
+    var lane: u32 = 0;
+    while (lane < memory_loop_bytes / @sizeOf(u64)) : (lane += 1) {
+        const lane_offset = lane * @sizeOf(u64);
+        const a_pos: usize = @intCast(memory_loop_a_base + lane_offset);
+        const b_pos: usize = @intCast(memory_loop_b_base + lane_offset);
+        const lane64: u64 = lane;
+        writeI64Lane(data[a_pos..][0..8], lane64 * 3 + 5);
+        writeI64Lane(data[b_pos..][0..8], lane64 * 7 + 11);
     }
 
     return data;
@@ -1528,6 +1712,14 @@ fn appendV128ConstI32x4(buf: *std.ArrayList(u8), allocator: Allocator, lanes: [4
     }
 }
 
+fn appendV128ConstI64x2(buf: *std.ArrayList(u8), allocator: Allocator, lanes: [2]u64) !void {
+    try appendSimdOpcode(buf, allocator, 0x0C); // v128.const
+    for (lanes) |lane| {
+        var le = std.mem.nativeToLittle(u64, lane);
+        try buf.appendSlice(allocator, std.mem.asBytes(&le));
+    }
+}
+
 fn appendV128ConstI16x8(buf: *std.ArrayList(u8), allocator: Allocator, lanes: [8]u16) !void {
     try appendSimdOpcode(buf, allocator, 0x0C); // v128.const
     for (lanes) |lane| {
@@ -1545,6 +1737,10 @@ fn appendI32x4Splat(buf: *std.ArrayList(u8), allocator: Allocator) !void {
     try appendSimdOpcode(buf, allocator, 0x11); // i32x4.splat
 }
 
+fn appendI64x2Splat(buf: *std.ArrayList(u8), allocator: Allocator) !void {
+    try appendSimdOpcode(buf, allocator, 0x12); // i64x2.splat
+}
+
 fn appendI16x8Splat(buf: *std.ArrayList(u8), allocator: Allocator) !void {
     try appendSimdOpcode(buf, allocator, 0x10); // i16x8.splat
 }
@@ -1555,6 +1751,11 @@ fn appendI8x16Splat(buf: *std.ArrayList(u8), allocator: Allocator) !void {
 
 fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x1B); // i32x4.extract_lane
+    try buf.append(allocator, lane);
+}
+
+fn appendI64x2ExtractLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x1D); // i64x2.extract_lane
     try buf.append(allocator, lane);
 }
 
@@ -1583,6 +1784,11 @@ fn appendI32x4ReplaceLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u
     try buf.append(allocator, lane);
 }
 
+fn appendI64x2ReplaceLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x1E); // i64x2.replace_lane
+    try buf.append(allocator, lane);
+}
+
 fn appendI16x8ReplaceLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x1A); // i16x8.replace_lane
     try buf.append(allocator, lane);
@@ -1596,6 +1802,15 @@ fn appendI8x16ReplaceLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u
 fn appendI32Const(buf: *std.ArrayList(u8), allocator: Allocator, value: i64) !void {
     try buf.append(allocator, 0x41); // i32.const
     try encodeSLEB128(buf, allocator, value);
+}
+
+fn appendI64Const(buf: *std.ArrayList(u8), allocator: Allocator, value: i64) !void {
+    try buf.append(allocator, 0x42); // i64.const
+    try encodeSLEB128(buf, allocator, value);
+}
+
+fn appendI32WrapI64(buf: *std.ArrayList(u8), allocator: Allocator) !void {
+    try buf.append(allocator, 0xA7); // i32.wrap_i64
 }
 
 fn appendLocalGet(buf: *std.ArrayList(u8), allocator: Allocator, index: u32) !void {
@@ -1683,6 +1898,11 @@ fn appendSimdOpcode(buf: *std.ArrayList(u8), allocator: Allocator, opcode: u32) 
 
 fn writeI32Lane(dst: []u8, value: u32) void {
     var le = std.mem.nativeToLittle(u32, value);
+    @memcpy(dst, std.mem.asBytes(&le));
+}
+
+fn writeI64Lane(dst: []u8, value: u64) void {
+    var le = std.mem.nativeToLittle(u64, value);
     @memcpy(dst, std.mem.asBytes(&le));
 }
 

--- a/tests/benchmarks/simd/README.md
+++ b/tests/benchmarks/simd/README.md
@@ -33,7 +33,9 @@ The `simd_i8x16_mem_add_4k_loop` row is the byte-lane memory-add probe. It walks
 
 The `simd_i8x16_shift_mix_4k_loop` row is the byte-lane dynamic-shift counterpart to the i16/i32 shift probes. Each loop iteration derives scalar counts from the vector index, exercises `i8x16.shl`, `i8x16.shr_u`, and `i8x16.shr_s`, stores a vector result, and returns one unsigned byte checksum lane. The derived counts intentionally exceed 8 so AOT modulo-8 count masking is covered.
 
-The small `simd_i32x4_*_lane0`, `simd_i16x8_*_lane0`, and `simd_i8x16_*` rows are coverage/status probes for individual opcode families. They intentionally return one scalar lane so interpreter, AOT, and optional Wasmtime rows can be compared before the runtime supports direct exported v128 values. The i16x8 and i8x16 comparison and replace-lane rows also cover signed vs unsigned extraction of all-ones masks and high-bit lane values.
+The `simd_i64x2_mem_add_4k_loop` row is the 64-bit lane counterpart to the integer memory-add probes. It walks the same 4 KiB input shape as packed 64-bit lanes with `v128.load`, wrapping `i64x2.add`, and `v128.store`, then extracts an `i64` checksum lane and returns it via `i32.wrap_i64`.
+
+The small `simd_i32x4_*_lane0`, `simd_i16x8_*_lane0`, `simd_i8x16_*`, and `simd_i64x2_*` rows are coverage/status probes for individual opcode families. They intentionally return one scalar lane so interpreter, AOT, and optional Wasmtime rows can be compared before the runtime supports direct exported v128 values. The i16x8 and i8x16 comparison and replace-lane rows cover signed vs unsigned extraction of all-ones masks and high-bit lane values; the i64x2 rows wrap extracted i64 lanes to i32 for the exported checksum.
 
 Wasmtime can be included as an external baseline:
 


### PR DESCRIPTION
## Summary
- add IR/frontend/AArch64 lowering for i64x2 splat, extract/replace lane, add/sub, eq/ne, and signed comparisons
- add exact AArch64 .2D encoding tests plus compile-level coverage
- add i64x2 SIMD status rows and a 4 KiB memory-add loop benchmark

## Validation
- zig build test
- zig build simd-bench -- --iterations 1000
- zig build simd-bench -- --iterations 10000
- zig build simd-bench -- --iterations 100 --wasmtime --wasmtime-iterations 3
- scripts/bench_simd.py --baseline origin/main --target HEAD --runs 3 --iterations 10000

New i64x2 AOT rows move from unsupported on origin/main to ok on HEAD.