### PR TITLE
Compare interpreter and AOT results in fuzz-diff

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -87,7 +87,7 @@ jobs:
             # Minimal component: "\0asm" plus version/layer 0x0001000d.
             printf '\000asm\015\000\001\000' > .fuzz-corpus/${{ matrix.target }}/minimal-component.wasm
           fi
-          if [ "${{ matrix.target }}" = "interp" ]; then
+          if [ "${{ matrix.target }}" = "interp" ] || [ "${{ matrix.target }}" = "diff" ]; then
             # Minimal core module exporting `run: () -> i32`.
             printf '\000asm\001\000\000\000\001\005\001\140\000\001\177\003\002\001\000\007\007\001\003run\000\000\012\006\001\004\000\101\052\013' > .fuzz-corpus/${{ matrix.target }}/minimal-interp-run.wasm
           fi
@@ -105,7 +105,7 @@ jobs:
         run: |
           mkdir -p .fuzz-crashes
           extra_args=()
-          if [ "$FUZZ_TARGET" = "interp" ]; then
+          if [ "$FUZZ_TARGET" = "interp" ] || [ "$FUZZ_TARGET" = "diff" ]; then
             extra_args+=(--fuel "$FUZZ_INTERP_FUEL")
           fi
           ./zig-out/bin/fuzz-${FUZZ_TARGET} \

--- a/src/tests/fuzz/common.zig
+++ b/src/tests/fuzz/common.zig
@@ -64,7 +64,7 @@ pub const Args = struct {
             \\Replays every .wasm file under <corpus> through the target until
             \\<duration> seconds have elapsed. A crashing input is left at
             \\<crashes>/in-flight.wasm when the process aborts.
-            \\The optional --fuel limit is currently used by fuzz-interp.
+            \\The optional --fuel limit is currently used by fuzz-interp and fuzz-diff.
             \\
         , .{});
     }

--- a/src/tests/fuzz/diff.zig
+++ b/src/tests/fuzz/diff.zig
@@ -1,17 +1,14 @@
-//! fuzz-diff — interp vs AOT differential oracle (SCAFFOLD).
+//! fuzz-diff — interp vs AOT differential oracle.
 //!
-//! For each valid wasm input, drive BOTH the interpreter load path
-//! and the full AOT compile+instantiate path. Crashes / panics in
-//! either pipeline surface via the sentinel-file mechanism.
-//!
-//! A true result-comparison oracle requires a shared "invoke export
-//! N, capture typed results" helper that neither interp nor AOT
-//! currently expose uniformly. For v1 the harness only exercises
-//! the compile paths. See tests/fuzz/README.md for the v2 scope.
+//! For each valid import-free module, compare interpreter and AOT
+//! results for a conservative subset of nullary scalar exports. Typed
+//! load/compile/trap outcomes are expected; result mismatches are saved
+//! as named crashers.
 
 const std = @import("std");
 const wamr = @import("wamr");
 const common = @import("common.zig");
+const invoke = @import("invoke.zig");
 const aot_harness = @import("aot_harness");
 
 pub fn main(init: std.process.Init) !void {
@@ -40,21 +37,71 @@ pub fn main(init: std.process.Init) !void {
         idx +%= 1;
 
         try common.markInFlight(io, args.crashes_dir, input);
-        runOnce(allocator, input) catch {};
+        try runOnce(allocator, io, args.crashes_dir, input, args.fuel orelse invoke.default_fuel_per_export);
         common.clearInFlight(io, args.crashes_dir);
     }
 
     std.log.info("fuzz-diff: {d} iterations over {d} inputs", .{ iter, corpus.count() });
 }
 
-fn runOnce(allocator: std.mem.Allocator, bytes: []const u8) !void {
-    // Interp side — loader only for v1.
-    var iarena = std.heap.ArenaAllocator.init(allocator);
-    defer iarena.deinit();
-    _ = wamr.loader.load(bytes, iarena.allocator()) catch return;
+fn runOnce(allocator: std.mem.Allocator, io: std.Io, crashes_dir: []const u8, bytes: []const u8, fuel_per_export: u32) !void {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const module = wamr.loader.load(bytes, arena.allocator()) catch return;
+    if (!invoke.modulePolicyAllows(&module)) return;
 
-    // AOT side — full compile + instantiate, but do NOT invoke start:
-    // attacker-supplied start functions can SEGV on OOB access.
+    var targets: [invoke.max_exports_per_input]invoke.ExportTarget = undefined;
+    var target_count: usize = 0;
+    for (module.exports) |exp| {
+        const target = invoke.selectExport(&module, exp) orelse continue;
+        if (!invoke.isAotSafeExport(&module, target.func_idx)) continue;
+        targets[target_count] = target;
+        target_count += 1;
+        if (target_count >= targets.len) break;
+    }
+    if (target_count == 0) return;
+
+    const interp_inst = wamr.instance.instantiate(&module, allocator) catch return;
+    defer wamr.instance.destroy(interp_inst);
+
+    // Full AOT compile + instantiate, but do NOT invoke start. Native AOT
+    // invocation below is limited to the statically safe subset selected above.
     const h = aot_harness.Harness.initWithOptions(allocator, bytes, null, .{ .invoke_start = false }) catch return;
     defer h.deinit();
+
+    for (targets[0..target_count]) |target| {
+        var interp_buf: [invoke.max_results]invoke.ScalarValue = undefined;
+        const interp_results = invoke.invokeInterpExport(
+            allocator,
+            interp_inst,
+            target.func_idx,
+            target.func_type,
+            fuel_per_export,
+            &interp_buf,
+        ) catch |err| switch (err) {
+            error.ExpectedTrap, error.OutOfFuel => continue,
+            else => return err,
+        };
+
+        var aot_raw_buf: [wamr.aot_runtime.MaxScalarResults]wamr.aot_runtime.ScalarResult = undefined;
+        const aot_raw = h.callScalar(target.func_idx, &.{}, &aot_raw_buf) catch continue;
+        if (aot_raw.len > invoke.max_results) {
+            try common.saveCrasher(io, crashes_dir, bytes, "diff-mismatch");
+            return;
+        }
+
+        var aot_buf: [invoke.max_results]invoke.ScalarValue = undefined;
+        for (aot_raw, 0..) |raw, i| {
+            aot_buf[i] = invoke.scalarFromAot(raw) orelse {
+                try common.saveCrasher(io, crashes_dir, bytes, "diff-mismatch");
+                return;
+            };
+        }
+        const aot_results = aot_buf[0..aot_raw.len];
+
+        if (!invoke.scalarSlicesEqual(interp_results, aot_results)) {
+            try common.saveCrasher(io, crashes_dir, bytes, "diff-mismatch");
+            return;
+        }
+    }
 }

--- a/src/tests/fuzz/interp.zig
+++ b/src/tests/fuzz/interp.zig
@@ -6,14 +6,8 @@
 //! safety-checked UB, or process abort is a bug.
 
 const std = @import("std");
-const wamr = @import("wamr");
 const common = @import("common.zig");
-const types = wamr.types;
-const ExecEnv = wamr.exec_env.ExecEnv;
-
-const default_fuel_per_export: u32 = 100_000;
-const exec_stack_size: u32 = 4096;
-const max_exports_per_input: usize = 8;
+const invoke = @import("invoke.zig");
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
@@ -37,72 +31,9 @@ pub fn main(init: std.process.Init) !void {
         idx +%= 1;
 
         try common.markInFlight(io, args.crashes_dir, input);
-        try runOnce(allocator, input, args.fuel orelse default_fuel_per_export);
+        try invoke.runInterpModule(allocator, input, args.fuel orelse invoke.default_fuel_per_export);
         common.clearInFlight(io, args.crashes_dir);
     }
 
     std.log.info("fuzz-interp: {d} iterations over {d} inputs", .{ iter, corpus.count() });
-}
-
-fn runOnce(allocator: std.mem.Allocator, bytes: []const u8, fuel_per_export: u32) !void {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-
-    const module = wamr.loader.load(bytes, a) catch return;
-    if (module.imports.len != 0 or module.start_function != null) return;
-
-    const inst = wamr.instance.instantiate(&module, allocator) catch return;
-    defer wamr.instance.destroy(inst);
-
-    var invoked: usize = 0;
-    for (module.exports) |exp| {
-        if (invoked >= max_exports_per_input) break;
-        if (exp.kind != .function) continue;
-        if (exp.index < module.import_function_count) continue;
-        const func_type = module.getFuncType(exp.index) orelse continue;
-        if (!supportedFuncType(func_type)) continue;
-
-        try invokeExport(allocator, inst, exp.index, func_type, fuel_per_export);
-        invoked += 1;
-    }
-}
-
-fn supportedFuncType(func_type: types.FuncType) bool {
-    if (func_type.params.len != 0) return false;
-    if (func_type.results.len > 1) return false;
-    for (func_type.results) |result| {
-        switch (result) {
-            .i32, .i64, .f32, .f64 => {},
-            else => return false,
-        }
-    }
-    return true;
-}
-
-fn invokeExport(
-    allocator: std.mem.Allocator,
-    inst: *types.ModuleInstance,
-    func_idx: u32,
-    func_type: types.FuncType,
-    fuel_per_export: u32,
-) !void {
-    var env = try ExecEnv.create(inst, exec_stack_size, allocator);
-    defer env.destroy();
-
-    wamr.interp.executeFunctionWithOptions(env, func_idx, .{ .fuel = fuel_per_export }) catch return;
-    try validateResults(env, func_type.results);
-}
-
-fn validateResults(env: *ExecEnv, results: []const types.ValType) !void {
-    if (@as(usize, @intCast(env.sp)) != results.len) return error.InvalidResultStack;
-
-    var i = results.len;
-    while (i > 0) {
-        i -= 1;
-        const value = try env.pop();
-        if (std.meta.activeTag(value) != results[i]) return error.InvalidResultStack;
-    }
-
-    if (env.sp != 0) return error.InvalidResultStack;
 }

--- a/src/tests/fuzz/invoke.zig
+++ b/src/tests/fuzz/invoke.zig
@@ -1,0 +1,337 @@
+//! Shared safe invocation policy for fuzz-interp and fuzz-diff.
+
+const std = @import("std");
+const wamr = @import("wamr");
+const types = wamr.types;
+const ExecEnv = wamr.exec_env.ExecEnv;
+const Opcode = wamr.opcode.Opcode;
+
+pub const default_fuel_per_export: u32 = 100_000;
+pub const exec_stack_size: u32 = 4096;
+pub const max_exports_per_input: usize = 8;
+pub const max_results: usize = 1;
+
+pub const ExportTarget = struct {
+    name: []const u8,
+    func_idx: u32,
+    func_type: types.FuncType,
+};
+
+pub const ScalarValue = union(enum) {
+    i32: i32,
+    i64: i64,
+    f32_bits: u32,
+    f64_bits: u64,
+};
+
+pub fn runInterpModule(allocator: std.mem.Allocator, bytes: []const u8, fuel_per_export: u32) !void {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const module = wamr.loader.load(bytes, a) catch return;
+    if (!modulePolicyAllows(&module)) return;
+
+    const inst = wamr.instance.instantiate(&module, allocator) catch return;
+    defer wamr.instance.destroy(inst);
+
+    var invoked: usize = 0;
+    for (module.exports) |exp| {
+        if (invoked >= max_exports_per_input) break;
+        const target = selectExport(&module, exp) orelse continue;
+
+        var result_buf: [max_results]ScalarValue = undefined;
+        _ = invokeInterpExport(allocator, inst, target.func_idx, target.func_type, fuel_per_export, &result_buf) catch |err| switch (err) {
+            error.ExpectedTrap, error.OutOfFuel => {},
+            else => return err,
+        };
+        invoked += 1;
+    }
+}
+
+pub fn modulePolicyAllows(module: *const types.WasmModule) bool {
+    return module.imports.len == 0 and module.start_function == null;
+}
+
+pub fn selectExport(module: *const types.WasmModule, exp: types.ExportDesc) ?ExportTarget {
+    if (exp.kind != .function) return null;
+    if (exp.index < module.import_function_count) return null;
+    const func_type = module.getFuncType(exp.index) orelse return null;
+    if (!supportedFuncType(func_type)) return null;
+    return .{ .name = exp.name, .func_idx = exp.index, .func_type = func_type };
+}
+
+pub fn supportedFuncType(func_type: types.FuncType) bool {
+    if (func_type.params.len != 0) return false;
+    if (func_type.results.len > max_results) return false;
+    for (func_type.results) |result| {
+        switch (result) {
+            .i32, .i64, .f32, .f64 => {},
+            else => return false,
+        }
+    }
+    return true;
+}
+
+pub fn invokeInterpExport(
+    allocator: std.mem.Allocator,
+    inst: *types.ModuleInstance,
+    func_idx: u32,
+    func_type: types.FuncType,
+    fuel_per_export: u32,
+    results_out: []ScalarValue,
+) ![]const ScalarValue {
+    if (!supportedFuncType(func_type) or results_out.len < func_type.results.len)
+        return error.UnsupportedSignature;
+
+    var env = try ExecEnv.create(inst, exec_stack_size, allocator);
+    defer env.destroy();
+
+    wamr.interp.executeFunctionWithOptions(env, func_idx, .{ .fuel = fuel_per_export }) catch |err| switch (err) {
+        error.OutOfFuel => return error.OutOfFuel,
+        else => return error.ExpectedTrap,
+    };
+
+    return captureResults(env, func_type.results, results_out);
+}
+
+pub fn captureResults(env: *ExecEnv, result_types: []const types.ValType, results_out: []ScalarValue) ![]const ScalarValue {
+    if (result_types.len > results_out.len) return error.UnsupportedSignature;
+    if (@as(usize, @intCast(env.sp)) != result_types.len) return error.InvalidResultStack;
+
+    var i = result_types.len;
+    while (i > 0) {
+        i -= 1;
+        const value = try env.pop();
+        results_out[i] = scalarFromValue(result_types[i], value) orelse return error.InvalidResultStack;
+    }
+
+    if (env.sp != 0) return error.InvalidResultStack;
+    return results_out[0..result_types.len];
+}
+
+fn scalarFromValue(result_type: types.ValType, value: types.Value) ?ScalarValue {
+    return switch (result_type) {
+        .i32 => switch (value) {
+            .i32 => |v| .{ .i32 = v },
+            else => null,
+        },
+        .i64 => switch (value) {
+            .i64 => |v| .{ .i64 = v },
+            else => null,
+        },
+        .f32 => switch (value) {
+            .f32 => |v| .{ .f32_bits = @as(u32, @bitCast(v)) },
+            else => null,
+        },
+        .f64 => switch (value) {
+            .f64 => |v| .{ .f64_bits = @as(u64, @bitCast(v)) },
+            else => null,
+        },
+        else => null,
+    };
+}
+
+pub fn scalarFromAot(result: wamr.aot_runtime.ScalarResult) ?ScalarValue {
+    return switch (result) {
+        .i32 => |v| .{ .i32 = v },
+        .i64 => |v| .{ .i64 = v },
+        .f32 => |v| .{ .f32_bits = @as(u32, @bitCast(v)) },
+        .f64 => |v| .{ .f64_bits = @as(u64, @bitCast(v)) },
+        else => null,
+    };
+}
+
+pub fn scalarSlicesEqual(a: []const ScalarValue, b: []const ScalarValue) bool {
+    if (a.len != b.len) return false;
+    for (a, b) |av, bv| {
+        if (!scalarEqual(av, bv)) return false;
+    }
+    return true;
+}
+
+fn scalarEqual(a: ScalarValue, b: ScalarValue) bool {
+    return switch (a) {
+        .i32 => |av| switch (b) {
+            .i32 => |bv| av == bv,
+            else => false,
+        },
+        .i64 => |av| switch (b) {
+            .i64 => |bv| av == bv,
+            else => false,
+        },
+        .f32_bits => |av| switch (b) {
+            .f32_bits => |bv| av == bv or (isNanF32(av) and isNanF32(bv)),
+            else => false,
+        },
+        .f64_bits => |av| switch (b) {
+            .f64_bits => |bv| av == bv or (isNanF64(av) and isNanF64(bv)),
+            else => false,
+        },
+    };
+}
+
+fn isNanF32(bits: u32) bool {
+    const value: f32 = @bitCast(bits);
+    return std.math.isNan(value);
+}
+
+fn isNanF64(bits: u64) bool {
+    const value: f64 = @bitCast(bits);
+    return std.math.isNan(value);
+}
+
+pub fn isAotSafeExport(module: *const types.WasmModule, func_idx: u32) bool {
+    const code = functionCode(module, func_idx) orelse return false;
+    return isAotSafeStraightLineCode(code);
+}
+
+pub fn functionCode(module: *const types.WasmModule, func_idx: u32) ?[]const u8 {
+    if (func_idx < module.import_function_count) return null;
+    const local_idx: usize = @intCast(func_idx - module.import_function_count);
+    if (local_idx >= module.functions.len) return null;
+    return module.functions[local_idx].code;
+}
+
+fn isAotSafeStraightLineCode(code: []const u8) bool {
+    var ip: usize = 0;
+    while (ip < code.len) {
+        const op: Opcode = @enumFromInt(code[ip]);
+        ip += 1;
+        switch (op) {
+            .end => return ip == code.len,
+            .nop,
+            .drop,
+            .select,
+            .i32_eqz,
+            .i32_eq,
+            .i32_ne,
+            .i32_lt_s,
+            .i32_lt_u,
+            .i32_gt_s,
+            .i32_gt_u,
+            .i32_le_s,
+            .i32_le_u,
+            .i32_ge_s,
+            .i32_ge_u,
+            .i64_eqz,
+            .i64_eq,
+            .i64_ne,
+            .i64_lt_s,
+            .i64_lt_u,
+            .i64_gt_s,
+            .i64_gt_u,
+            .i64_le_s,
+            .i64_le_u,
+            .i64_ge_s,
+            .i64_ge_u,
+            .f32_eq,
+            .f32_ne,
+            .f32_lt,
+            .f32_gt,
+            .f32_le,
+            .f32_ge,
+            .f64_eq,
+            .f64_ne,
+            .f64_lt,
+            .f64_gt,
+            .f64_le,
+            .f64_ge,
+            .i32_clz,
+            .i32_ctz,
+            .i32_popcnt,
+            .i32_add,
+            .i32_sub,
+            .i32_mul,
+            .i32_and,
+            .i32_or,
+            .i32_xor,
+            .i32_shl,
+            .i32_shr_s,
+            .i32_shr_u,
+            .i32_rotl,
+            .i32_rotr,
+            .i64_clz,
+            .i64_ctz,
+            .i64_popcnt,
+            .i64_add,
+            .i64_sub,
+            .i64_mul,
+            .i64_and,
+            .i64_or,
+            .i64_xor,
+            .i64_shl,
+            .i64_shr_s,
+            .i64_shr_u,
+            .i64_rotl,
+            .i64_rotr,
+            .f32_abs,
+            .f32_neg,
+            .f32_add,
+            .f32_sub,
+            .f32_mul,
+            .f32_min,
+            .f32_max,
+            .f32_copysign,
+            .f64_abs,
+            .f64_neg,
+            .f64_add,
+            .f64_sub,
+            .f64_mul,
+            .f64_min,
+            .f64_max,
+            .f64_copysign,
+            .i32_wrap_i64,
+            .i64_extend_i32_s,
+            .i64_extend_i32_u,
+            .f32_convert_i32_s,
+            .f32_convert_i32_u,
+            .f32_convert_i64_s,
+            .f32_convert_i64_u,
+            .f32_demote_f64,
+            .f64_convert_i32_s,
+            .f64_convert_i32_u,
+            .f64_convert_i64_s,
+            .f64_convert_i64_u,
+            .f64_promote_f32,
+            .i32_reinterpret_f32,
+            .i64_reinterpret_f64,
+            .f32_reinterpret_i32,
+            .f64_reinterpret_i64,
+            .i32_extend8_s,
+            .i32_extend16_s,
+            .i64_extend8_s,
+            .i64_extend16_s,
+            .i64_extend32_s,
+            => {},
+
+            .local_get,
+            .local_set,
+            .local_tee,
+            .i32_const,
+            .i64_const,
+            => if (!skipLeb(code, &ip)) return false,
+
+            .f32_const => if (!skipFixed(code, &ip, 4)) return false,
+            .f64_const => if (!skipFixed(code, &ip, 8)) return false,
+            else => return false,
+        }
+    }
+    return false;
+}
+
+fn skipLeb(code: []const u8, ip: *usize) bool {
+    var n: usize = 0;
+    while (n < 10 and ip.* < code.len) : (n += 1) {
+        const b = code[ip.*];
+        ip.* += 1;
+        if ((b & 0x80) == 0) return true;
+    }
+    return false;
+}
+
+fn skipFixed(code: []const u8, ip: *usize, len: usize) bool {
+    if (ip.* + len > code.len) return false;
+    ip.* += len;
+    return true;
+}

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -28,7 +28,7 @@ abort, or small-input OOM is a bug.
 | `fuzz-component-loader` | Component-model binary loader | A valid component or typed component loader error is OK. A panic, abort, or safety-check failure is a bug. |
 | `fuzz-interp` | Interpreter load, instantiate, and bounded nullary export invocation | Loader/validation/instantiation errors, guest traps, fuel exhaustion, and unsupported signatures are OK. Panics, aborts, or result-stack shape mismatches are bugs. |
 | `fuzz-aot` | AOT compile, AOT loader, and instantiate path | Compile/instantiate errors are OK. The harness deliberately sets `invoke_start = false` and does not execute attacker-supplied start functions. |
-| `fuzz-diff` | Interpreter load plus AOT compile/instantiate scaffold | Pipeline errors are OK. Result comparison for supported exports is tracked as follow-up work. |
+| `fuzz-diff` | Interpreter vs AOT result oracle for a statically safe straight-line scalar subset | Loader/instantiate errors, interpreter traps, fuel exhaustion, unsupported signatures, and exports whose bytecode is outside the safe subset are OK. A result-shape, tag, or value mismatch is saved as `diff-mismatch-<hash>.wasm` and is a bug. |
 
 ## Local use
 
@@ -69,9 +69,18 @@ The harnesses replay every `.wasm` file under `--corpus` until the duration
 expires. They are not coverage-guided mutators by themselves; use them as stable
 entry points for CI and future mutation/generation infrastructure.
 
-`fuzz-interp` uses `--fuel <instructions>` as a per-export interpreter instruction
-budget. Fuel exhaustion is an expected outcome and is reported separately from a
-guest `unreachable` trap.
+`fuzz-interp` and `fuzz-diff` accept `--fuel <instructions>` as a per-export
+interpreter instruction budget. Fuel exhaustion is an expected outcome and is
+reported separately from a guest `unreachable` trap.
+
+For `fuzz-diff` smoke with the same minimal seed:
+
+```sh
+rm -rf /tmp/wamr-diff-corpus /tmp/wamr-fuzz-crashes
+mkdir -p /tmp/wamr-diff-corpus /tmp/wamr-fuzz-crashes
+printf '\000asm\001\000\000\000\001\005\001\140\000\001\177\003\002\001\000\007\007\001\003run\000\000\012\006\001\004\000\101\052\013' > /tmp/wamr-diff-corpus/minimal-interp-run.wasm
+./zig-out/bin/fuzz-diff --corpus /tmp/wamr-diff-corpus --crashes /tmp/wamr-fuzz-crashes --duration 5 --fuel 100000
+```
 
 ## Crash artifacts and reproduction
 
@@ -97,14 +106,14 @@ touch runtime/compiler/component/fuzz code. The workflow:
 - builds all harnesses with `zig build fuzz -Doptimize=ReleaseSafe`;
 - seeds per-target corpora from `tests/malformed/fuzz` and `tests/spec-json`;
 - adds a generated minimal component seed for `fuzz-component-loader`;
-- adds a generated nullary scalar export seed for `fuzz-interp`;
+- adds a generated nullary scalar export seed for `fuzz-interp` and `fuzz-diff`;
 - uploads `.fuzz-crashes` artifacts with 30-day retention;
 - uploads per-target corpus artifacts with 7-day retention;
 - fails the job when any crash artifact remains.
 
 Manual runs can choose `all`, `loader`, `component-loader`, `interp`, `aot`, or
-`diff`, set a per-target duration, and set the per-export `fuzz-interp` fuel
-budget.
+`diff`, set a per-target duration, and set the per-export interpreter fuel
+budget shared by `fuzz-interp` and `fuzz-diff`.
 
 ## Current limitations and follow-ups
 
@@ -117,9 +126,13 @@ host-protection mechanism.
   `() -> i32`, `() -> i64`, `() -> f32`, or `() -> f64`. Parameterized,
   reference-typed, `v128`, imported-function, and multi-result exports remain
   out of scope until a deterministic input and host-import policy is designed.
-- `fuzz-diff` does not yet compare typed interpreter and AOT results (#246). A future
-  oracle should select supported nullary or bounded-argument scalar exports and
-  handle platform-specific AOT traps outside the test runner.
+- `fuzz-diff` only compares results for nullary scalar exports whose bytecode
+  passes a conservative straight-line filter that rejects calls, branches,
+  loops, memory/table/atomic/exception/SIMD/ref ops, integer div/rem,
+  truncation conversions, and `unreachable`. Broader AOT execution (arbitrary
+  exports, parameterized exports, native trap differential) needs subprocess
+  isolation because the AOT runtime only converts traps to typed errors on
+  Windows x86_64; on Linux/AArch64 a native AOT trap can terminate the host.
 - Direct WASI and component-adapter fuzzing needs a deterministic byte-command
   model for resource tables, paths, descriptors, sockets, HTTP streams, and
   guest-memory pointer/length pairs (#247).


### PR DESCRIPTION
Closes #246

Turns `fuzz-diff` into a real interp-vs-AOT result oracle for a conservative
straight-line scalar export subset, while keeping the existing scaffold's
loader/compile/instantiate coverage.

## What changed

- New `src/tests/fuzz/invoke.zig` shared helper:
  - module policy (skip imports / start funcs);
  - export selection with the existing `max_exports_per_input` cap;
  - supported nullary scalar signatures: `() -> ()`, `() -> i32/i64/f32/f64`;
  - fuel-bounded interpreter invocation;
  - scalar result capture into a small union;
  - AOT-safe straight-line bytecode filter (rejects calls/branches/loops,
    memory/table/atomic/exception/SIMD/ref ops, integer div/rem, truncation
    conversions, and `unreachable`).
- `fuzz-interp` now uses the shared helper; #245 behavior preserved.
- `fuzz-diff` now: loads once, runs interpreter under fuel, AOT
  compile/instantiates with `invoke_start=false`, calls each safe export's
  scalar AOT entry, compares result counts/tags/values (NaN-aware for floats),
  and saves `diff-mismatch-<hash>.wasm` crashers on divergence.
- Workflow seeds the generated minimal `run: () -> i32` module for the `diff`
  target and passes `--fuel`.
- `common` help text and `tests/fuzz/README.md` updated.

## Why conservative

The AOT runtime only converts traps to typed errors on Windows x86_64; on
Linux/AArch64 a native AOT trap can terminate the host. The straight-line
filter ensures we only execute exports that should not trap or loop in
generated code. Broader differential coverage needs subprocess isolation and
is intentionally out of scope here.

## Validation

- `zig build test`
- `zig build fuzz -Doptimize=ReleaseSafe`
- Local smoke: `fuzz-diff`, `fuzz-interp`, `fuzz-loader` over malformed
  corpus + minimal valid seed for 1s each. No crashers produced.
- `git diff --check` clean.