### PR TITLE
perf(aarch64): add i8x16 SIMD arithmetic extras

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -2121,6 +2121,10 @@ fn emitI8x16BinOp(
     switch (bin.op) {
         .add => try code.i8x16Op(.add, dest_reg, lhs_reg, rhs_reg),
         .sub => try code.i8x16Op(.sub, dest_reg, lhs_reg, rhs_reg),
+        .add_sat_s => try code.i8x16Op(.sqadd, dest_reg, lhs_reg, rhs_reg),
+        .add_sat_u => try code.i8x16Op(.uqadd, dest_reg, lhs_reg, rhs_reg),
+        .sub_sat_s => try code.i8x16Op(.sqsub, dest_reg, lhs_reg, rhs_reg),
+        .sub_sat_u => try code.i8x16Op(.uqsub, dest_reg, lhs_reg, rhs_reg),
         .eq => try code.i8x16Op(.cmeq, dest_reg, lhs_reg, rhs_reg),
         .ne => {
             try code.i8x16Op(.cmeq, dest_reg, lhs_reg, rhs_reg);
@@ -2134,6 +2138,11 @@ fn emitI8x16BinOp(
         .ge_u => try code.i8x16Op(.cmhs, dest_reg, lhs_reg, rhs_reg),
         .lt_u => try code.i8x16Op(.cmhi, dest_reg, rhs_reg, lhs_reg),
         .le_u => try code.i8x16Op(.cmhs, dest_reg, rhs_reg, lhs_reg),
+        .min_s => try code.i8x16Op(.smin, dest_reg, lhs_reg, rhs_reg),
+        .min_u => try code.i8x16Op(.umin, dest_reg, lhs_reg, rhs_reg),
+        .max_s => try code.i8x16Op(.smax, dest_reg, lhs_reg, rhs_reg),
+        .max_u => try code.i8x16Op(.umax, dest_reg, lhs_reg, rhs_reg),
+        .avgr_u => try code.i8x16Op(.urhadd, dest_reg, lhs_reg, rhs_reg),
     }
 }
 
@@ -5871,6 +5880,10 @@ test "compile: i8x16 cmp and arithmetic ops emit NEON instructions" {
     const b = func.newVReg();
     const add = func.newVReg();
     const sub = func.newVReg();
+    const add_sat_s = func.newVReg();
+    const add_sat_u = func.newVReg();
+    const sub_sat_s = func.newVReg();
+    const sub_sat_u = func.newVReg();
     const ne = func.newVReg();
     const lt_s = func.newVReg();
     const gt_s = func.newVReg();
@@ -5880,12 +5893,21 @@ test "compile: i8x16 cmp and arithmetic ops emit NEON instructions" {
     const gt_u = func.newVReg();
     const le_u = func.newVReg();
     const ge_u = func.newVReg();
+    const min_s = func.newVReg();
+    const min_u = func.newVReg();
+    const max_s = func.newVReg();
+    const max_u = func.newVReg();
+    const avgr_u = func.newVReg();
     const lane = func.newVReg();
 
     try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0E0D_0C0B_0A09_0807_0605_0403_8001_FF00 }, .dest = a, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0F0E_0D0C_0B0A_0908_0706_0504_7F02_0100 }, .dest = b, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .add, .lhs = a, .rhs = b } }, .dest = add, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .sub, .lhs = a, .rhs = b } }, .dest = sub, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .add_sat_s, .lhs = a, .rhs = b } }, .dest = add_sat_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .add_sat_u, .lhs = a, .rhs = b } }, .dest = add_sat_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .sub_sat_s, .lhs = a, .rhs = b } }, .dest = sub_sat_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .sub_sat_u, .lhs = a, .rhs = b } }, .dest = sub_sat_u, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .ne, .lhs = a, .rhs = b } }, .dest = ne, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .lt_s, .lhs = a, .rhs = b } }, .dest = lt_s, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .gt_s, .lhs = a, .rhs = b } }, .dest = gt_s, .type = .v128 });
@@ -5895,6 +5917,11 @@ test "compile: i8x16 cmp and arithmetic ops emit NEON instructions" {
     try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .gt_u, .lhs = a, .rhs = b } }, .dest = gt_u, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .le_u, .lhs = a, .rhs = b } }, .dest = le_u, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .ge_u, .lhs = a, .rhs = b } }, .dest = ge_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .min_s, .lhs = a, .rhs = b } }, .dest = min_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .min_u, .lhs = a, .rhs = b } }, .dest = min_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .max_s, .lhs = a, .rhs = b } }, .dest = max_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .max_u, .lhs = a, .rhs = b } }, .dest = max_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i8x16_binop = .{ .op = .avgr_u, .lhs = a, .rhs = b } }, .dest = avgr_u, .type = .v128 });
     try func.getBlock(bid).append(.{
         .op = .{ .i8x16_extract_lane = .{ .vector = ge_u, .lane = 0, .sign = .unsigned } },
         .dest = lane,
@@ -5907,33 +5934,60 @@ test "compile: i8x16 cmp and arithmetic ops emit NEON instructions" {
 
     var found_add = false;
     var found_sub = false;
+    var found_sqadd = false;
+    var found_uqadd = false;
+    var found_sqsub = false;
+    var found_uqsub = false;
     var found_cmeq = false;
     var found_mvn = false;
     var found_cmgt = false;
     var found_cmge = false;
     var found_cmhi = false;
     var found_cmhs = false;
+    var found_smin = false;
+    var found_umin = false;
+    var found_smax = false;
+    var found_umax = false;
+    var found_urhadd = false;
     var i: usize = 0;
     while (i + 4 <= code.len) : (i += 4) {
         const w = std.mem.readInt(u32, code[i..][0..4], .little);
         if ((w & 0xFFE0FC00) == 0x4E208400) found_add = true;
         if ((w & 0xFFE0FC00) == 0x6E208400) found_sub = true;
+        if ((w & 0xFFE0FC00) == 0x4E200C00) found_sqadd = true;
+        if ((w & 0xFFE0FC00) == 0x6E200C00) found_uqadd = true;
+        if ((w & 0xFFE0FC00) == 0x4E202C00) found_sqsub = true;
+        if ((w & 0xFFE0FC00) == 0x6E202C00) found_uqsub = true;
         if ((w & 0xFFE0FC00) == 0x6E208C00) found_cmeq = true;
         if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
         if ((w & 0xFFE0FC00) == 0x4E203400) found_cmgt = true;
         if ((w & 0xFFE0FC00) == 0x4E203C00) found_cmge = true;
         if ((w & 0xFFE0FC00) == 0x6E203400) found_cmhi = true;
         if ((w & 0xFFE0FC00) == 0x6E203C00) found_cmhs = true;
+        if ((w & 0xFFE0FC00) == 0x4E206C00) found_smin = true;
+        if ((w & 0xFFE0FC00) == 0x6E206C00) found_umin = true;
+        if ((w & 0xFFE0FC00) == 0x4E206400) found_smax = true;
+        if ((w & 0xFFE0FC00) == 0x6E206400) found_umax = true;
+        if ((w & 0xFFE0FC00) == 0x6E201400) found_urhadd = true;
     }
 
     try std.testing.expect(found_add);
     try std.testing.expect(found_sub);
+    try std.testing.expect(found_sqadd);
+    try std.testing.expect(found_uqadd);
+    try std.testing.expect(found_sqsub);
+    try std.testing.expect(found_uqsub);
     try std.testing.expect(found_cmeq);
     try std.testing.expect(found_mvn);
     try std.testing.expect(found_cmgt);
     try std.testing.expect(found_cmge);
     try std.testing.expect(found_cmhi);
     try std.testing.expect(found_cmhs);
+    try std.testing.expect(found_smin);
+    try std.testing.expect(found_umin);
+    try std.testing.expect(found_smax);
+    try std.testing.expect(found_umax);
+    try std.testing.expect(found_urhadd);
 }
 
 test "compile: i16x8 cmp and mul ops emit NEON instructions" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -785,14 +785,23 @@ pub const CodeBuffer = struct {
     pub const I8x16Op = enum(u32) {
         add = 0x4E208400,
         sub = 0x6E208400,
+        sqadd = 0x4E200C00,
+        uqadd = 0x6E200C00,
+        sqsub = 0x4E202C00,
+        uqsub = 0x6E202C00,
         cmeq = 0x6E208C00,
         cmgt = 0x4E203400,
         cmge = 0x4E203C00,
         cmhi = 0x6E203400,
         cmhs = 0x6E203C00,
+        smin = 0x4E206C00,
+        umin = 0x6E206C00,
+        smax = 0x4E206400,
+        umax = 0x6E206400,
+        urhadd = 0x6E201400,
     };
 
-    /// Integer 16B binary vector op: ADD/SUB/CMEQ/CMGT/CMGE/CMHI/CMHS.
+    /// Integer 16B binary vector op.
     pub fn i8x16Op(self: *CodeBuffer, op: I8x16Op, vd: u5, vn: u5, vm: u5) !void {
         try self.emit32(@intFromEnum(op) |
             (@as(u32, vm) << 16) |
@@ -1929,6 +1938,30 @@ test "emit: i8x16 vector ops" {
     {
         var code = CodeBuffer.init(std.testing.allocator);
         defer code.deinit();
+        try code.i8x16Op(.sqadd, 16, 17, 30);
+        try expectWord(0x4E3E0E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i8x16Op(.uqadd, 16, 17, 30);
+        try expectWord(0x6E3E0E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i8x16Op(.sqsub, 16, 17, 30);
+        try expectWord(0x4E3E2E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i8x16Op(.uqsub, 16, 17, 30);
+        try expectWord(0x6E3E2E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
         try code.i8x16Op(.cmeq, 16, 17, 30);
         try expectWord(0x6E3E8E30, &code);
     }
@@ -1955,6 +1988,36 @@ test "emit: i8x16 vector ops" {
         defer code.deinit();
         try code.i8x16Op(.cmhs, 16, 17, 30);
         try expectWord(0x6E3E3E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i8x16Op(.smin, 16, 17, 30);
+        try expectWord(0x4E3E6E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i8x16Op(.umin, 16, 17, 30);
+        try expectWord(0x6E3E6E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i8x16Op(.smax, 16, 17, 30);
+        try expectWord(0x4E3E6630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i8x16Op(.umax, 16, 17, 30);
+        try expectWord(0x6E3E6630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i8x16Op(.urhadd, 16, 17, 30);
+        try expectWord(0x6E3E1630, &code);
     }
 }
 

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -1825,6 +1825,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     },
                     .i8x16_add,
                     .i8x16_sub,
+                    .i8x16_add_sat_s,
+                    .i8x16_add_sat_u,
+                    .i8x16_sub_sat_s,
+                    .i8x16_sub_sat_u,
                     .i8x16_eq,
                     .i8x16_ne,
                     .i8x16_lt_s,
@@ -1835,6 +1839,11 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .i8x16_le_u,
                     .i8x16_ge_s,
                     .i8x16_ge_u,
+                    .i8x16_min_s,
+                    .i8x16_min_u,
+                    .i8x16_max_s,
+                    .i8x16_max_u,
+                    .i8x16_avgr_u,
                     => {
                         const rhs = safePop(&vreg_stack);
                         const lhs = safePop(&vreg_stack);
@@ -1842,6 +1851,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         const lane_op: ir.Inst.I8x16Op = switch (simd_op) {
                             .i8x16_add => .add,
                             .i8x16_sub => .sub,
+                            .i8x16_add_sat_s => .add_sat_s,
+                            .i8x16_add_sat_u => .add_sat_u,
+                            .i8x16_sub_sat_s => .sub_sat_s,
+                            .i8x16_sub_sat_u => .sub_sat_u,
                             .i8x16_eq => .eq,
                             .i8x16_ne => .ne,
                             .i8x16_lt_s => .lt_s,
@@ -1852,6 +1865,11 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                             .i8x16_le_u => .le_u,
                             .i8x16_ge_s => .ge_s,
                             .i8x16_ge_u => .ge_u,
+                            .i8x16_min_s => .min_s,
+                            .i8x16_min_u => .min_u,
+                            .i8x16_max_s => .max_s,
+                            .i8x16_max_u => .max_u,
+                            .i8x16_avgr_u => .avgr_u,
                             else => unreachable,
                         };
                         try ir_func.getBlock(current_block).append(.{
@@ -3657,7 +3675,16 @@ test "lower i8x16 cmp and arithmetic opcodes" {
         .{ .opcode = 0x2B, .expected = .ge_s },
         .{ .opcode = 0x2C, .expected = .ge_u },
         .{ .opcode = 0x6E, .expected = .add },
+        .{ .opcode = 0x6F, .expected = .add_sat_s },
+        .{ .opcode = 0x70, .expected = .add_sat_u },
         .{ .opcode = 0x71, .expected = .sub },
+        .{ .opcode = 0x72, .expected = .sub_sat_s },
+        .{ .opcode = 0x73, .expected = .sub_sat_u },
+        .{ .opcode = 0x76, .expected = .min_s },
+        .{ .opcode = 0x77, .expected = .min_u },
+        .{ .opcode = 0x78, .expected = .max_s },
+        .{ .opcode = 0x79, .expected = .max_u },
+        .{ .opcode = 0x7B, .expected = .avgr_u },
     };
 
     const appendULEB = struct {

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -283,6 +283,10 @@ pub const Inst = struct {
     pub const I8x16Op = enum {
         add,
         sub,
+        add_sat_s,
+        add_sat_u,
+        sub_sat_s,
+        sub_sat_u,
         eq,
         ne,
         lt_s,
@@ -293,6 +297,11 @@ pub const Inst = struct {
         le_u,
         ge_s,
         ge_u,
+        min_s,
+        min_u,
+        max_s,
+        max_u,
+        avgr_u,
     };
 
     pub const I16x8Op = enum {

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -159,6 +159,51 @@ const cases = [_]BenchCase{
         .build = buildSimdI8x16SubLane0Module,
     },
     .{
+        .name = "simd_i8x16_add_sat_s_lane0",
+        .simd = true,
+        .build = buildSimdI8x16AddSatSLane0Module,
+    },
+    .{
+        .name = "simd_i8x16_add_sat_u_lane0",
+        .simd = true,
+        .build = buildSimdI8x16AddSatULane0Module,
+    },
+    .{
+        .name = "simd_i8x16_sub_sat_s_lane0",
+        .simd = true,
+        .build = buildSimdI8x16SubSatSLane0Module,
+    },
+    .{
+        .name = "simd_i8x16_sub_sat_u_lane0",
+        .simd = true,
+        .build = buildSimdI8x16SubSatULane0Module,
+    },
+    .{
+        .name = "simd_i8x16_min_s_lane0",
+        .simd = true,
+        .build = buildSimdI8x16MinSLane0Module,
+    },
+    .{
+        .name = "simd_i8x16_min_u_lane0",
+        .simd = true,
+        .build = buildSimdI8x16MinULane0Module,
+    },
+    .{
+        .name = "simd_i8x16_max_s_lane0",
+        .simd = true,
+        .build = buildSimdI8x16MaxSLane0Module,
+    },
+    .{
+        .name = "simd_i8x16_max_u_lane0",
+        .simd = true,
+        .build = buildSimdI8x16MaxULane0Module,
+    },
+    .{
+        .name = "simd_i8x16_avgr_u_lane0",
+        .simd = true,
+        .build = buildSimdI8x16AvgrULane0Module,
+    },
+    .{
         .name = "simd_i8x16_eq_lane0",
         .simd = true,
         .build = buildSimdI8x16EqLane0Module,
@@ -287,6 +332,11 @@ const cases = [_]BenchCase{
         .name = "simd_i8x16_shift_mix_4k_loop",
         .simd = true,
         .build = buildSimdI8x16ShiftMix4kLoopModule,
+    },
+    .{
+        .name = "simd_i8x16_arith_extra_4k_loop",
+        .simd = true,
+        .build = buildSimdI8x16ArithExtra4kLoopModule,
     },
     .{
         .name = "simd_i64x2_mem_add_4k_loop",
@@ -835,6 +885,117 @@ fn buildSimdI8x16SubLane0Module(allocator: Allocator) ![]u8 {
     try appendV128ConstI8x16(&instr, allocator, .{ 7, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 });
     try appendSimdOpcode(&instr, allocator, 0x71); // i8x16.sub
     try appendI8x16ExtractLaneU(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI8x16AddSatSLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI8x16BinaryLane0Module(
+        allocator,
+        0x6F,
+        .{ 0x7F, 0x80, 100, 0x90, 1, 2, 3, 4, 0x7F, 0x80, 5, 6, 7, 8, 9, 10 },
+        .{ 1, 0xFF, 50, 0x90, 11, 12, 13, 14, 1, 0xFF, 15, 16, 17, 18, 19, 20 },
+        .signed,
+    );
+}
+
+fn buildSimdI8x16AddSatULane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI8x16BinaryLane0Module(
+        allocator,
+        0x70,
+        .{ 250, 0, 128, 255, 1, 2, 3, 4, 250, 0, 5, 6, 7, 8, 9, 10 },
+        .{ 20, 1, 128, 1, 11, 12, 13, 14, 20, 1, 15, 16, 17, 18, 19, 20 },
+        .unsigned,
+    );
+}
+
+fn buildSimdI8x16SubSatSLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI8x16BinaryLane0Module(
+        allocator,
+        0x72,
+        .{ 0x80, 0x7F, 0x90, 100, 1, 2, 3, 4, 0x80, 0x7F, 5, 6, 7, 8, 9, 10 },
+        .{ 1, 0xFF, 100, 0x90, 11, 12, 13, 14, 1, 0xFF, 15, 16, 17, 18, 19, 20 },
+        .signed,
+    );
+}
+
+fn buildSimdI8x16SubSatULane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI8x16BinaryLane0Module(
+        allocator,
+        0x73,
+        .{ 3, 0, 128, 255, 1, 2, 3, 4, 3, 0, 5, 6, 7, 8, 9, 10 },
+        .{ 7, 1, 129, 1, 11, 12, 13, 14, 7, 1, 15, 16, 17, 18, 19, 20 },
+        .unsigned,
+    );
+}
+
+fn buildSimdI8x16MinSLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI8x16BinaryLane0Module(
+        allocator,
+        0x76,
+        .{ 0x80, 0x7F, 0xFF, 1, 2, 3, 4, 5, 0x80, 0x7F, 6, 7, 8, 9, 10, 11 },
+        .{ 0x7F, 0x80, 1, 0xFF, 12, 13, 14, 15, 0x7F, 0x80, 16, 17, 18, 19, 20, 21 },
+        .signed,
+    );
+}
+
+fn buildSimdI8x16MinULane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI8x16BinaryLane0Module(
+        allocator,
+        0x77,
+        .{ 0x80, 0x7F, 0xFF, 1, 2, 3, 4, 5, 0x80, 0x7F, 6, 7, 8, 9, 10, 11 },
+        .{ 0x7F, 0x80, 1, 0xFF, 12, 13, 14, 15, 0x7F, 0x80, 16, 17, 18, 19, 20, 21 },
+        .unsigned,
+    );
+}
+
+fn buildSimdI8x16MaxSLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI8x16BinaryLane0Module(
+        allocator,
+        0x78,
+        .{ 0x80, 0x7F, 0xFF, 1, 2, 3, 4, 5, 0x80, 0x7F, 6, 7, 8, 9, 10, 11 },
+        .{ 0x7F, 0x80, 1, 0xFF, 12, 13, 14, 15, 0x7F, 0x80, 16, 17, 18, 19, 20, 21 },
+        .signed,
+    );
+}
+
+fn buildSimdI8x16MaxULane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI8x16BinaryLane0Module(
+        allocator,
+        0x79,
+        .{ 0x80, 0x7F, 0xFF, 1, 2, 3, 4, 5, 0x80, 0x7F, 6, 7, 8, 9, 10, 11 },
+        .{ 0x7F, 0x80, 1, 0xFF, 12, 13, 14, 15, 0x7F, 0x80, 16, 17, 18, 19, 20, 21 },
+        .unsigned,
+    );
+}
+
+fn buildSimdI8x16AvgrULane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI8x16BinaryLane0Module(
+        allocator,
+        0x7B,
+        .{ 5, 254, 0, 1, 2, 3, 4, 5, 5, 254, 6, 7, 8, 9, 10, 11 },
+        .{ 6, 255, 1, 2, 12, 13, 14, 15, 6, 255, 16, 17, 18, 19, 20, 21 },
+        .unsigned,
+    );
+}
+
+fn buildSimdI8x16BinaryLane0Module(
+    allocator: Allocator,
+    opcode: u32,
+    lhs: [16]u8,
+    rhs: [16]u8,
+    extract_sign: I8x16ExtractSign,
+) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI8x16(&instr, allocator, lhs);
+    try appendV128ConstI8x16(&instr, allocator, rhs);
+    try appendSimdOpcode(&instr, allocator, opcode);
+    switch (extract_sign) {
+        .signed => try appendI8x16ExtractLaneS(&instr, allocator, 0),
+        .unsigned => try appendI8x16ExtractLaneU(&instr, allocator, 0),
+    }
 
     return buildRunI32Module(allocator, instr.items, .{});
 }
@@ -1534,6 +1695,96 @@ fn buildSimdI8x16ShiftMix4kLoopModule(allocator: Allocator) ![]u8 {
     try appendI32Const(&instr, allocator, memory_loop_dst_base + memory_loop_bytes - 16);
     try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
     try appendI8x16ExtractLaneU(&instr, allocator, 14);
+
+    const data = try buildMemoryLoopDataI8(allocator);
+    defer allocator.free(data);
+    return buildRunI32Module(allocator, instr.items, .{
+        .memory_min = 1,
+        .data = data,
+        .local_i32_count = 1,
+    });
+}
+
+fn buildSimdI8x16ArithExtra4kLoopModule(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendI32Const(&instr, allocator, 0);
+    try appendLocalSet(&instr, allocator, 0);
+    try appendBlock(&instr, allocator);
+    try appendLoop(&instr, allocator);
+
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Const(&instr, allocator, memory_loop_bytes);
+    try appendI32GeU(&instr, allocator);
+    try appendBrIf(&instr, allocator, 1);
+
+    try appendI32Const(&instr, allocator, memory_loop_dst_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendSimdOpcode(&instr, allocator, 0x70); // i8x16.add_sat_u
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x73); // i8x16.sub_sat_u
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x7B); // i8x16.avgr_u
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x6F); // i8x16.add_sat_s
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x72); // i8x16.sub_sat_s
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x79); // i8x16.max_u
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x76); // i8x16.min_s
+
+    try appendSimdMemOpcode(&instr, allocator, 0x0B, 4, 0); // v128.store
+
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Const(&instr, allocator, 16);
+    try appendI32Add(&instr, allocator);
+    try appendLocalSet(&instr, allocator, 0);
+    try appendBr(&instr, allocator, 0);
+
+    try appendEnd(&instr, allocator);
+    try appendEnd(&instr, allocator);
+
+    try appendI32Const(&instr, allocator, memory_loop_dst_base + memory_loop_bytes - 16);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendI8x16ExtractLaneU(&instr, allocator, 15);
 
     const data = try buildMemoryLoopDataI8(allocator);
     defer allocator.free(data);

--- a/tests/benchmarks/simd/README.md
+++ b/tests/benchmarks/simd/README.md
@@ -33,6 +33,8 @@ The `simd_i8x16_mem_add_4k_loop` row is the byte-lane memory-add probe. It walks
 
 The `simd_i8x16_shift_mix_4k_loop` row is the byte-lane dynamic-shift counterpart to the i16/i32 shift probes. Each loop iteration derives scalar counts from the vector index, exercises `i8x16.shl`, `i8x16.shr_u`, and `i8x16.shr_s`, stores a vector result, and returns one unsigned byte checksum lane. The derived counts intentionally exceed 8 so AOT modulo-8 count masking is covered.
 
+The `simd_i8x16_arith_extra_4k_loop` row extends the byte-lane memory probe with saturated add/subtract, signed/unsigned min/max, and unsigned rounding average operations. It uses high-bit byte data so signed and unsigned arithmetic paths produce distinct checksums.
+
 The `simd_i64x2_mem_add_4k_loop` row is the 64-bit lane counterpart to the integer memory-add probes. It walks the same 4 KiB input shape as packed 64-bit lanes with `v128.load`, wrapping `i64x2.add`, and `v128.store`, then extracts an `i64` checksum lane and returns it via `i32.wrap_i64`.
 
 The `simd_i64x2_shift_mix_4k_loop` row is the 64-bit dynamic-shift counterpart to the narrower shift probes. Each loop iteration derives scalar counts from the vector index, exercises `i64x2.shl`, `i64x2.shr_u`, and `i64x2.shr_s`, stores a vector result, then extracts and wraps an `i64` checksum lane. The derived counts intentionally exceed 64 so AOT modulo-64 count masking is covered.


### PR DESCRIPTION
## Summary
- add IR/frontend lowering for i8x16 saturated add/sub, signed/unsigned min/max, and unsigned rounding average
- add AArch64 NEON emit/lowering for SQADD/UQADD/SQSUB/UQSUB/SMIN/UMIN/SMAX/UMAX/URHADD
- add SIMD status rows and a 4 KiB i8x16 arithmetic-extra throughput probe

## Validation
- zig build test
- zig build simd-bench -- --iterations 10000
- zig build simd-bench -- --iterations 100 --wasmtime --wasmtime-iterations 3
- scripts/bench_simd.py --baseline origin/main --target HEAD --runs 3 --iterations 10000

## Benchmark notes
- new i8x16 arithmetic-extra AOT rows are unsupported on origin/main and ok on HEAD
- simd_i8x16_arith_extra_4k_loop AOT: ok, result 2, run ~20.848 ms, compile ~7.048 ms, code size 9202 bytes
- scalar lane checks matched interpreter/AOT/Wasmtime for saturation, signed/unsigned min/max, and avgr_u
