### PR TITLE
Add fuzz-canon for canonical-ABI pointer/length handling

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,7 +19,7 @@ on:
         required: false
         default: "100000"
       target:
-        description: "Fuzz target (all, loader, component-loader, interp, aot, diff)"
+        description: "Fuzz target (all, loader, component-loader, interp, aot, diff, canon)"
         required: false
         default: "all"
   pull_request:
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [loader, component-loader, interp, aot, diff]
+        target: [loader, component-loader, interp, aot, diff, canon]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -90,6 +90,12 @@ jobs:
           if [ "${{ matrix.target }}" = "interp" ] || [ "${{ matrix.target }}" = "diff" ]; then
             # Minimal core module exporting `run: () -> i32`.
             printf '\000asm\001\000\000\000\001\005\001\140\000\001\177\003\002\001\000\007\007\001\003run\000\000\012\006\001\004\000\101\052\013' > .fuzz-corpus/${{ matrix.target }}/minimal-interp-run.wasm
+          fi
+          if [ "${{ matrix.target }}" = "canon" ]; then
+            # Header: mode=load_primitive, prim=string, ptr=0, len=8 + 16B "Hello, world!\0\0\0".
+            printf '\x00\x0e\x00\x00\x00\x00\x08\x00\x00\x00Hello, world!\x00\x00\x00' > .fuzz-corpus/${{ matrix.target }}/seed-load-string.wasm
+            # mode=validate_utf8, ptr=0, len=11, body "hello world".
+            printf '\x01\x00\x00\x00\x00\x00\x0b\x00\x00\x00hello world' > .fuzz-corpus/${{ matrix.target }}/seed-validate-utf8.wasm
           fi
           ls .fuzz-corpus/${{ matrix.target }} | wc -l
 

--- a/build.zig
+++ b/build.zig
@@ -360,13 +360,14 @@ pub fn build(b: *std.Build) void {
         simd_bench_step.dependOn(&run_simd_bench.step);
     }
 
-    const fuzz_step = b.step("fuzz", "Build fuzz harnesses (loader, component-loader, interp, aot, diff)");
+    const fuzz_step = b.step("fuzz", "Build fuzz harnesses (loader, component-loader, interp, aot, diff, canon)");
     inline for (.{
         .{ .name = "loader", .file = "loader.zig", .needs_aot = false },
         .{ .name = "component-loader", .file = "component_loader.zig", .needs_aot = false },
         .{ .name = "interp", .file = "interp.zig", .needs_aot = false },
         .{ .name = "aot", .file = "aot.zig", .needs_aot = true },
         .{ .name = "diff", .file = "diff.zig", .needs_aot = true },
+        .{ .name = "canon", .file = "canon.zig", .needs_aot = false },
     }) |tgt| {
         const fuzz_mod = b.createModule(.{
             .root_source_file = b.path("src/tests/fuzz/" ++ tgt.file),

--- a/src/tests/fuzz/canon.zig
+++ b/src/tests/fuzz/canon.zig
@@ -1,0 +1,169 @@
+//! fuzz-canon — Canonical ABI lift/lower and string codecs over
+//! attacker-controlled guest memory.
+//!
+//! The host must tolerate any (ptr, len, type) triple from a malicious
+//! guest. This harness drives `loadVal`, the UTF-8 validator, and the
+//! UTF-8/UTF-16/Latin-1 codecs against arbitrary memory bytes and
+//! arbitrary ptr/len values. Typed errors and silent zero-fill on
+//! out-of-bounds reads are expected; panics, safety-checked UB,
+//! over-allocation crashes, or process aborts are bugs.
+
+const std = @import("std");
+const wamr = @import("wamr");
+const ctypes = wamr.component_types;
+const canon = wamr.canonical_abi;
+const common = @import("common.zig");
+
+/// Hard cap on memory size after we mirror the input bytes. Keeps each
+/// iteration bounded and avoids allocator pressure on tiny seeds.
+const max_memory_bytes: usize = 64 * 1024;
+/// Hard cap on the destination buffer for write-back codecs.
+const max_out_bytes: usize = 16 * 1024;
+
+const PrimitiveKind = enum(u8) {
+    bool_,
+    s8,
+    u8_,
+    s16,
+    u16_,
+    s32,
+    u32_,
+    s64,
+    u64_,
+    f32_,
+    f64_,
+    char,
+    own_,
+    borrow_,
+    string,
+    list,
+};
+
+fn primitiveValType(kind: PrimitiveKind) ctypes.ValType {
+    return switch (kind) {
+        .bool_ => .bool,
+        .s8 => .s8,
+        .u8_ => .u8,
+        .s16 => .s16,
+        .u16_ => .u16,
+        .s32 => .s32,
+        .u32_ => .u32,
+        .s64 => .s64,
+        .u64_ => .u64,
+        .f32_ => .f32,
+        .f64_ => .f64,
+        .char => .char,
+        .own_ => .{ .own = 0 },
+        .borrow_ => .{ .borrow = 0 },
+        .string => .string,
+        .list => .{ .list = 0 },
+    };
+}
+
+const Mode = enum(u8) {
+    load_primitive,
+    validate_utf8,
+    utf8_to_utf16,
+    utf16_to_utf8,
+    decode_latin1_utf16,
+    encode_utf16_to_mem,
+};
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
+    const argv = try init.minimal.args.toSlice(init.arena.allocator());
+
+    const args = try common.Args.parse(argv);
+    var corpus = try common.Corpus.load(allocator, io, args.corpus_dir);
+    defer corpus.deinit();
+
+    if (corpus.count() == 0) {
+        std.log.err("empty corpus at {s}", .{args.corpus_dir});
+        return error.EmptyCorpus;
+    }
+
+    const deadline = common.Deadline.init(io, args.duration_ms);
+    var iter: u64 = 0;
+    var idx: usize = 0;
+    while (!deadline.expired(io)) : (iter += 1) {
+        const input = corpus.get(idx);
+        idx +%= 1;
+
+        try common.markInFlight(io, args.crashes_dir, input);
+        try runOnce(allocator, input);
+        common.clearInFlight(io, args.crashes_dir);
+    }
+
+    std.log.info("fuzz-canon: {d} iterations over {d} inputs", .{ iter, corpus.count() });
+}
+
+const Header = struct {
+    mode: Mode,
+    ptr: u32,
+    len: u32,
+    primitive: PrimitiveKind,
+    body: []const u8,
+};
+
+fn parseHeader(input: []const u8) ?Header {
+    if (input.len < 11) return null;
+    const mode_byte = input[0];
+    const prim_byte = input[1];
+    const ptr = std.mem.readInt(u32, input[2..6], .little);
+    const len = std.mem.readInt(u32, input[6..10], .little);
+    const mode = std.enums.fromInt(Mode, mode_byte) orelse return null;
+    const prim = std.enums.fromInt(PrimitiveKind, prim_byte % @as(u8, @intCast(@typeInfo(PrimitiveKind).@"enum".fields.len))) orelse return null;
+    return .{ .mode = mode, .ptr = ptr, .len = len, .primitive = prim, .body = input[10..] };
+}
+
+fn runOnce(allocator: std.mem.Allocator, input: []const u8) !void {
+    const header = parseHeader(input) orelse return;
+
+    const mem_len = @min(header.body.len, max_memory_bytes);
+    const memory = try allocator.alloc(u8, mem_len);
+    defer allocator.free(memory);
+    @memcpy(memory, header.body[0..mem_len]);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    switch (header.mode) {
+        .load_primitive => {
+            // `loadVal` accepts only primitive ValTypes (no registry).
+            const t = primitiveValType(header.primitive);
+            _ = canon.loadVal(memory, header.ptr, t) catch {};
+        },
+        .validate_utf8 => {
+            _ = canon.validateUtf8(memory, header.ptr, header.len);
+        },
+        .utf8_to_utf16 => {
+            const src_len = @min(header.len, @as(u32, @intCast(memory.len)));
+            const src_start = @min(header.ptr, @as(u32, @intCast(memory.len)));
+            const src = memory[src_start .. src_start + @min(src_len, @as(u32, @intCast(memory.len - src_start)))];
+            // Allow worst-case 1:1 expansion plus surrogate pairs.
+            const out_units: usize = @min(src.len * 2 + 1, max_out_bytes / 2);
+            const out = try arena.allocator().alloc(u16, out_units);
+            _ = canon.utf8ToUtf16(src, out) catch {};
+        },
+        .utf16_to_utf8 => {
+            // utf16ToUtf8 reads 2*code_units bytes from memory[ptr..]. Cap.
+            const code_units = @min(header.len, @as(u32, @intCast(max_out_bytes / 2)));
+            const out = canon.utf16ToUtf8(memory, header.ptr, code_units, arena.allocator()) catch return;
+            _ = out;
+        },
+        .decode_latin1_utf16 => {
+            const tagged_len = @min(header.len, @as(u32, @intCast(max_out_bytes / 2))) | (header.len & canon.LATIN1_UTF16_TAG);
+            const out = canon.decodeLatin1Utf16(memory, header.ptr, tagged_len, arena.allocator()) catch return;
+            _ = out;
+        },
+        .encode_utf16_to_mem => {
+            const dst_len = @min(memory.len, max_out_bytes);
+            const dst = try arena.allocator().alloc(u8, dst_len);
+            const src_start = @min(header.ptr, @as(u32, @intCast(header.body.len)));
+            const src_end = @min(header.body.len, src_start + header.len);
+            const src = header.body[src_start..src_end];
+            _ = canon.encodeUtf16ToMem(dst, 0, src) catch {};
+        },
+    }
+}

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -29,6 +29,7 @@ abort, or small-input OOM is a bug.
 | `fuzz-interp` | Interpreter load, instantiate, and bounded nullary export invocation | Loader/validation/instantiation errors, guest traps, fuel exhaustion, and unsupported signatures are OK. Panics, aborts, or result-stack shape mismatches are bugs. |
 | `fuzz-aot` | AOT compile, AOT loader, and instantiate path | Compile/instantiate errors are OK. The harness deliberately sets `invoke_start = false` and does not execute attacker-supplied start functions. |
 | `fuzz-diff` | Interpreter vs AOT result oracle for a statically safe straight-line scalar subset | Loader/instantiate errors, interpreter traps, fuel exhaustion, unsupported signatures, and exports whose bytecode is outside the safe subset are OK. A result-shape, tag, or value mismatch is saved as `diff-mismatch-<hash>.wasm` and is a bug. |
+| `fuzz-canon` | Canonical ABI lift and string codecs over attacker-controlled guest memory | Typed errors and silent zero-fill on out-of-bounds reads are OK. Panics, safety-checked UB, oversize allocations, or process aborts are bugs. |
 
 ## Local use
 
@@ -64,6 +65,23 @@ mkdir -p /tmp/wamr-interp-corpus /tmp/wamr-fuzz-crashes
 printf '\000asm\001\000\000\000\001\005\001\140\000\001\177\003\002\001\000\007\007\001\003run\000\000\012\006\001\004\000\101\052\013' > /tmp/wamr-interp-corpus/minimal-interp-run.wasm
 ./zig-out/bin/fuzz-interp --corpus /tmp/wamr-interp-corpus --crashes /tmp/wamr-fuzz-crashes --duration 5 --fuel 100000
 ```
+
+For `fuzz-canon` smoke (pointer/length and string-codec exercise):
+
+```sh
+rm -rf /tmp/wamr-canon-corpus /tmp/wamr-fuzz-crashes
+mkdir -p /tmp/wamr-canon-corpus /tmp/wamr-fuzz-crashes
+# mode=load_primitive, prim=string, ptr=0, len=8, body 16B.
+printf '\x00\x0e\x00\x00\x00\x00\x08\x00\x00\x00Hello, world!\x00\x00\x00' > /tmp/wamr-canon-corpus/seed-load-string.wasm
+# mode=validate_utf8, ptr=0, len=11, body "hello world".
+printf '\x01\x00\x00\x00\x00\x00\x0b\x00\x00\x00hello world' > /tmp/wamr-canon-corpus/seed-validate-utf8.wasm
+./zig-out/bin/fuzz-canon --corpus /tmp/wamr-canon-corpus --crashes /tmp/wamr-fuzz-crashes --duration 5
+```
+
+`fuzz-canon` reads a small fixed header from each input (`mode`, primitive
+selector, `ptr`, `len`) and treats the rest as guest memory. It exercises
+`canonical_abi.loadVal` for primitive types and the UTF-8/UTF-16/Latin-1
+string codecs against attacker-controlled bytes.
 
 The harnesses replay every `.wasm` file under `--corpus` until the duration
 expires. They are not coverage-guided mutators by themselves; use them as stable
@@ -111,9 +129,9 @@ touch runtime/compiler/component/fuzz code. The workflow:
 - uploads per-target corpus artifacts with 7-day retention;
 - fails the job when any crash artifact remains.
 
-Manual runs can choose `all`, `loader`, `component-loader`, `interp`, `aot`, or
-`diff`, set a per-target duration, and set the per-export interpreter fuel
-budget shared by `fuzz-interp` and `fuzz-diff`.
+Manual runs can choose `all`, `loader`, `component-loader`, `interp`, `aot`,
+`diff`, or `canon`, set a per-target duration, and set the per-export
+interpreter fuel budget shared by `fuzz-interp` and `fuzz-diff`.
 
 ## Current limitations and follow-ups
 
@@ -133,6 +151,17 @@ host-protection mechanism.
   exports, parameterized exports, native trap differential) needs subprocess
   isolation because the AOT runtime only converts traps to typed errors on
   Windows x86_64; on Linux/AArch64 a native AOT trap can terminate the host.
+- `fuzz-canon` exercises only primitive `loadVal` and the string codecs
+  (`validateUtf8`, `utf8ToUtf16`, `utf16ToUtf8`, `decodeLatin1Utf16`,
+  `encodeUtf16ToMem`). Compound types (record, variant, list, tuple, flags,
+  enum, option, result) and the storeVal round-trip are intentionally out of
+  scope here; covering them needs a controlled `TypeRegistry` builder driven
+  from the same input bytes.
+- WASI/component resource-table command-model fuzzing — descriptor lifecycle,
+  preopen escape checks, stream drops, socket option get/set on disconnected
+  sockets, and HTTP stream lifetimes — is a follow-up that needs a thin
+  test wrapper around `WasiCliAdapter` so the fuzzer can drive the host
+  surface without a guest module.
 - Direct WASI and component-adapter fuzzing needs a deterministic byte-command
   model for resource tables, paths, descriptors, sockets, HTTP streams, and
   guest-memory pointer/length pairs (#247).


### PR DESCRIPTION
Partial coverage for #247 (guest pointer/length handling). Closes #247 with the
canonical-ABI slice; adapter/resource-table command-model fuzzing is split out
to #258.

## What changed

- New `src/tests/fuzz/canon.zig` fuzz target.
- `build.zig` registers `fuzz-canon`.
- `.github/workflows/fuzz.yml` adds the `canon` matrix target with two seed
  inputs (load-string and validate-utf8 byte streams).
- `tests/fuzz/README.md` documents the new target, its current scope, and
  the remaining adapter command-model work that lives in #258.

## Oracle

`fuzz-canon` decodes a small fixed header from each input — `mode`,
primitive selector, `ptr`, `len` — and treats the rest as guest memory.
For each input it exercises one of:

- `canonical_abi.loadVal` for a primitive ValType (`bool`, signed/unsigned
  ints, floats, char, own/borrow handles, string, list);
- `canonical_abi.validateUtf8`;
- `canonical_abi.utf8ToUtf16`;
- `canonical_abi.utf16ToUtf8`;
- `canonical_abi.decodeLatin1Utf16`;
- `canonical_abi.encodeUtf16ToMem`.

Typed errors and silent zero-fill on out-of-bounds reads are expected. A panic,
safety-checked UB, oversize allocation, or process abort is a bug.

## Why partial coverage

The remaining bullets in #247 (descriptor/path validation, preopen escape,
resource drop, socket options, HTTP stream lifetimes) need a thin test
wrapper around `WasiCliAdapter` that synthesizes a fake guest frame so the
host bindings can be driven without a real wasm guest. That work is tracked
separately as #258 to keep this PR focused.

## Validation

- `zig build test`
- `zig build fuzz -Doptimize=ReleaseSafe`
- 1s smoke run of every target (`loader`, `component-loader`, `interp`,
  `aot`, `diff`, `canon`) — no crashers produced. `fuzz-canon` reached
  ~31k iterations/sec over 14 seeds.
- `git diff --check` clean.