### PR TITLE
perf(aarch64): add i16x8 SIMD arithmetic extras

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -2249,6 +2249,11 @@ fn emitI16x8BinOp(
         .add => try code.i16x8Op(.add, dest_reg, lhs_reg, rhs_reg),
         .sub => try code.i16x8Op(.sub, dest_reg, lhs_reg, rhs_reg),
         .mul => try code.i16x8Op(.mul, dest_reg, lhs_reg, rhs_reg),
+        .q15mulr_sat_s => try code.i16x8Op(.sqrdmulh, dest_reg, lhs_reg, rhs_reg),
+        .add_sat_s => try code.i16x8Op(.sqadd, dest_reg, lhs_reg, rhs_reg),
+        .add_sat_u => try code.i16x8Op(.uqadd, dest_reg, lhs_reg, rhs_reg),
+        .sub_sat_s => try code.i16x8Op(.sqsub, dest_reg, lhs_reg, rhs_reg),
+        .sub_sat_u => try code.i16x8Op(.uqsub, dest_reg, lhs_reg, rhs_reg),
         .eq => try code.i16x8Op(.cmeq, dest_reg, lhs_reg, rhs_reg),
         .ne => {
             try code.i16x8Op(.cmeq, dest_reg, lhs_reg, rhs_reg);
@@ -2262,6 +2267,11 @@ fn emitI16x8BinOp(
         .ge_u => try code.i16x8Op(.cmhs, dest_reg, lhs_reg, rhs_reg),
         .lt_u => try code.i16x8Op(.cmhi, dest_reg, rhs_reg, lhs_reg),
         .le_u => try code.i16x8Op(.cmhs, dest_reg, rhs_reg, lhs_reg),
+        .min_s => try code.i16x8Op(.smin, dest_reg, lhs_reg, rhs_reg),
+        .min_u => try code.i16x8Op(.umin, dest_reg, lhs_reg, rhs_reg),
+        .max_s => try code.i16x8Op(.smax, dest_reg, lhs_reg, rhs_reg),
+        .max_u => try code.i16x8Op(.umax, dest_reg, lhs_reg, rhs_reg),
+        .avgr_u => try code.i16x8Op(.urhadd, dest_reg, lhs_reg, rhs_reg),
     }
 }
 
@@ -5990,7 +6000,7 @@ test "compile: i8x16 cmp and arithmetic ops emit NEON instructions" {
     try std.testing.expect(found_urhadd);
 }
 
-test "compile: i16x8 cmp and mul ops emit NEON instructions" {
+test "compile: i16x8 cmp and arithmetic ops emit NEON instructions" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -5998,6 +6008,11 @@ test "compile: i16x8 cmp and mul ops emit NEON instructions" {
 
     const a = func.newVReg();
     const b = func.newVReg();
+    const q15mulr_sat_s = func.newVReg();
+    const add_sat_s = func.newVReg();
+    const add_sat_u = func.newVReg();
+    const sub_sat_s = func.newVReg();
+    const sub_sat_u = func.newVReg();
     const mul = func.newVReg();
     const ne = func.newVReg();
     const lt_s = func.newVReg();
@@ -6008,10 +6023,20 @@ test "compile: i16x8 cmp and mul ops emit NEON instructions" {
     const gt_u = func.newVReg();
     const le_u = func.newVReg();
     const ge_u = func.newVReg();
+    const min_s = func.newVReg();
+    const min_u = func.newVReg();
+    const max_s = func.newVReg();
+    const max_u = func.newVReg();
+    const avgr_u = func.newVReg();
     const lane = func.newVReg();
 
     try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0008_0007_0006_0005_8000_FFFF_0002_0001 }, .dest = a, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0007_0008_0005_0006_8000_0001_0003_0001 }, .dest = b, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .q15mulr_sat_s, .lhs = a, .rhs = b } }, .dest = q15mulr_sat_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .add_sat_s, .lhs = a, .rhs = b } }, .dest = add_sat_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .add_sat_u, .lhs = a, .rhs = b } }, .dest = add_sat_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .sub_sat_s, .lhs = a, .rhs = b } }, .dest = sub_sat_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .sub_sat_u, .lhs = a, .rhs = b } }, .dest = sub_sat_u, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .mul, .lhs = a, .rhs = b } }, .dest = mul, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .ne, .lhs = a, .rhs = b } }, .dest = ne, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .lt_s, .lhs = a, .rhs = b } }, .dest = lt_s, .type = .v128 });
@@ -6022,6 +6047,11 @@ test "compile: i16x8 cmp and mul ops emit NEON instructions" {
     try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .gt_u, .lhs = a, .rhs = b } }, .dest = gt_u, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .le_u, .lhs = a, .rhs = b } }, .dest = le_u, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .ge_u, .lhs = a, .rhs = b } }, .dest = ge_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .min_s, .lhs = a, .rhs = b } }, .dest = min_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .min_u, .lhs = a, .rhs = b } }, .dest = min_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .max_s, .lhs = a, .rhs = b } }, .dest = max_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .max_u, .lhs = a, .rhs = b } }, .dest = max_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_binop = .{ .op = .avgr_u, .lhs = a, .rhs = b } }, .dest = avgr_u, .type = .v128 });
     try func.getBlock(bid).append(.{
         .op = .{ .i16x8_extract_lane = .{ .vector = ge_u, .lane = 0, .sign = .unsigned } },
         .dest = lane,
@@ -6032,6 +6062,11 @@ test "compile: i16x8 cmp and mul ops emit NEON instructions" {
     const code = try compileFunction(&func, allocator);
     defer allocator.free(code);
 
+    var found_sqrdmulh = false;
+    var found_sqadd = false;
+    var found_uqadd = false;
+    var found_sqsub = false;
+    var found_uqsub = false;
     var found_mul = false;
     var found_cmeq = false;
     var found_mvn = false;
@@ -6039,9 +6074,19 @@ test "compile: i16x8 cmp and mul ops emit NEON instructions" {
     var found_cmge = false;
     var found_cmhi = false;
     var found_cmhs = false;
+    var found_smin = false;
+    var found_umin = false;
+    var found_smax = false;
+    var found_umax = false;
+    var found_urhadd = false;
     var i: usize = 0;
     while (i + 4 <= code.len) : (i += 4) {
         const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFE0FC00) == 0x6E60B400) found_sqrdmulh = true;
+        if ((w & 0xFFE0FC00) == 0x4E600C00) found_sqadd = true;
+        if ((w & 0xFFE0FC00) == 0x6E600C00) found_uqadd = true;
+        if ((w & 0xFFE0FC00) == 0x4E602C00) found_sqsub = true;
+        if ((w & 0xFFE0FC00) == 0x6E602C00) found_uqsub = true;
         if ((w & 0xFFE0FC00) == 0x4E609C00) found_mul = true;
         if ((w & 0xFFE0FC00) == 0x6E608C00) found_cmeq = true;
         if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
@@ -6049,8 +6094,18 @@ test "compile: i16x8 cmp and mul ops emit NEON instructions" {
         if ((w & 0xFFE0FC00) == 0x4E603C00) found_cmge = true;
         if ((w & 0xFFE0FC00) == 0x6E603400) found_cmhi = true;
         if ((w & 0xFFE0FC00) == 0x6E603C00) found_cmhs = true;
+        if ((w & 0xFFE0FC00) == 0x4E606C00) found_smin = true;
+        if ((w & 0xFFE0FC00) == 0x6E606C00) found_umin = true;
+        if ((w & 0xFFE0FC00) == 0x4E606400) found_smax = true;
+        if ((w & 0xFFE0FC00) == 0x6E606400) found_umax = true;
+        if ((w & 0xFFE0FC00) == 0x6E601400) found_urhadd = true;
     }
 
+    try std.testing.expect(found_sqrdmulh);
+    try std.testing.expect(found_sqadd);
+    try std.testing.expect(found_uqadd);
+    try std.testing.expect(found_sqsub);
+    try std.testing.expect(found_uqsub);
     try std.testing.expect(found_mul);
     try std.testing.expect(found_cmeq);
     try std.testing.expect(found_mvn);
@@ -6058,6 +6113,11 @@ test "compile: i16x8 cmp and mul ops emit NEON instructions" {
     try std.testing.expect(found_cmge);
     try std.testing.expect(found_cmhi);
     try std.testing.expect(found_cmhs);
+    try std.testing.expect(found_smin);
+    try std.testing.expect(found_umin);
+    try std.testing.expect(found_smax);
+    try std.testing.expect(found_umax);
+    try std.testing.expect(found_urhadd);
 }
 
 test "compile: i64x2 cmp and arithmetic ops emit NEON instructions" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -813,14 +813,24 @@ pub const CodeBuffer = struct {
         add = 0x4E608400,
         sub = 0x6E608400,
         mul = 0x4E609C00,
+        sqrdmulh = 0x6E60B400,
+        sqadd = 0x4E600C00,
+        uqadd = 0x6E600C00,
+        sqsub = 0x4E602C00,
+        uqsub = 0x6E602C00,
         cmeq = 0x6E608C00,
         cmgt = 0x4E603400,
         cmge = 0x4E603C00,
         cmhi = 0x6E603400,
         cmhs = 0x6E603C00,
+        smin = 0x4E606C00,
+        umin = 0x6E606C00,
+        smax = 0x4E606400,
+        umax = 0x6E606400,
+        urhadd = 0x6E601400,
     };
 
-    /// Integer 8H binary vector op: ADD/SUB/MUL/CMEQ/CMGT/CMGE/CMHI/CMHS.
+    /// Integer 8H binary vector op.
     pub fn i16x8Op(self: *CodeBuffer, op: I16x8Op, vd: u5, vn: u5, vm: u5) !void {
         try self.emit32(@intFromEnum(op) |
             (@as(u32, vm) << 16) |
@@ -2043,6 +2053,36 @@ test "emit: i16x8 vector ops" {
     {
         var code = CodeBuffer.init(std.testing.allocator);
         defer code.deinit();
+        try code.i16x8Op(.sqrdmulh, 16, 17, 30);
+        try expectWord(0x6E7EB630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.sqadd, 16, 17, 30);
+        try expectWord(0x4E7E0E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.uqadd, 16, 17, 30);
+        try expectWord(0x6E7E0E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.sqsub, 16, 17, 30);
+        try expectWord(0x4E7E2E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.uqsub, 16, 17, 30);
+        try expectWord(0x6E7E2E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
         try code.i16x8Op(.cmeq, 9, 10, 11);
         try expectWord(0x6E6B8D49, &code);
     }
@@ -2069,6 +2109,36 @@ test "emit: i16x8 vector ops" {
         defer code.deinit();
         try code.i16x8Op(.cmhs, 21, 22, 23);
         try expectWord(0x6E773ED5, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.smin, 16, 17, 30);
+        try expectWord(0x4E7E6E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.umin, 16, 17, 30);
+        try expectWord(0x6E7E6E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.smax, 16, 17, 30);
+        try expectWord(0x4E7E6630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.umax, 16, 17, 30);
+        try expectWord(0x6E7E6630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i16x8Op(.urhadd, 16, 17, 30);
+        try expectWord(0x6E7E1630, &code);
     }
 }
 

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -1885,6 +1885,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     },
                     .i16x8_add,
                     .i16x8_sub,
+                    .i16x8_add_sat_s,
+                    .i16x8_add_sat_u,
+                    .i16x8_sub_sat_s,
+                    .i16x8_sub_sat_u,
                     .i16x8_eq,
                     .i16x8_ne,
                     .i16x8_lt_s,
@@ -1896,6 +1900,12 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .i16x8_ge_s,
                     .i16x8_ge_u,
                     .i16x8_mul,
+                    .i16x8_q15mulr_sat_s,
+                    .i16x8_min_s,
+                    .i16x8_min_u,
+                    .i16x8_max_s,
+                    .i16x8_max_u,
+                    .i16x8_avgr_u,
                     => {
                         const rhs = safePop(&vreg_stack);
                         const lhs = safePop(&vreg_stack);
@@ -1903,6 +1913,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         const lane_op: ir.Inst.I16x8Op = switch (simd_op) {
                             .i16x8_add => .add,
                             .i16x8_sub => .sub,
+                            .i16x8_add_sat_s => .add_sat_s,
+                            .i16x8_add_sat_u => .add_sat_u,
+                            .i16x8_sub_sat_s => .sub_sat_s,
+                            .i16x8_sub_sat_u => .sub_sat_u,
                             .i16x8_eq => .eq,
                             .i16x8_ne => .ne,
                             .i16x8_lt_s => .lt_s,
@@ -1914,6 +1928,12 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                             .i16x8_ge_s => .ge_s,
                             .i16x8_ge_u => .ge_u,
                             .i16x8_mul => .mul,
+                            .i16x8_q15mulr_sat_s => .q15mulr_sat_s,
+                            .i16x8_min_s => .min_s,
+                            .i16x8_min_u => .min_u,
+                            .i16x8_max_s => .max_s,
+                            .i16x8_max_u => .max_u,
+                            .i16x8_avgr_u => .avgr_u,
                             else => unreachable,
                         };
                         try ir_func.getBlock(current_block).append(.{
@@ -3778,9 +3798,19 @@ test "lower i16x8 cmp and arithmetic opcodes" {
         .{ .opcode = 0x34, .expected = .le_u },
         .{ .opcode = 0x35, .expected = .ge_s },
         .{ .opcode = 0x36, .expected = .ge_u },
+        .{ .opcode = 0x82, .expected = .q15mulr_sat_s },
         .{ .opcode = 0x8E, .expected = .add },
+        .{ .opcode = 0x8F, .expected = .add_sat_s },
+        .{ .opcode = 0x90, .expected = .add_sat_u },
         .{ .opcode = 0x91, .expected = .sub },
+        .{ .opcode = 0x92, .expected = .sub_sat_s },
+        .{ .opcode = 0x93, .expected = .sub_sat_u },
         .{ .opcode = 0x95, .expected = .mul },
+        .{ .opcode = 0x96, .expected = .min_s },
+        .{ .opcode = 0x97, .expected = .min_u },
+        .{ .opcode = 0x98, .expected = .max_s },
+        .{ .opcode = 0x99, .expected = .max_u },
+        .{ .opcode = 0x9B, .expected = .avgr_u },
     };
 
     const appendULEB = struct {

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -307,6 +307,10 @@ pub const Inst = struct {
     pub const I16x8Op = enum {
         add,
         sub,
+        add_sat_s,
+        add_sat_u,
+        sub_sat_s,
+        sub_sat_u,
         eq,
         ne,
         lt_s,
@@ -318,6 +322,12 @@ pub const Inst = struct {
         ge_s,
         ge_u,
         mul,
+        q15mulr_sat_s,
+        min_s,
+        min_u,
+        max_s,
+        max_u,
+        avgr_u,
     };
 
     pub const I64x2Op = enum {

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -114,6 +114,56 @@ const cases = [_]BenchCase{
         .build = buildSimdI16x8MulLane0Module,
     },
     .{
+        .name = "simd_i16x8_q15mulr_sat_s_lane0",
+        .simd = true,
+        .build = buildSimdI16x8Q15MulrSatSLane0Module,
+    },
+    .{
+        .name = "simd_i16x8_add_sat_s_lane0",
+        .simd = true,
+        .build = buildSimdI16x8AddSatSLane0Module,
+    },
+    .{
+        .name = "simd_i16x8_add_sat_u_lane0",
+        .simd = true,
+        .build = buildSimdI16x8AddSatULane0Module,
+    },
+    .{
+        .name = "simd_i16x8_sub_sat_s_lane0",
+        .simd = true,
+        .build = buildSimdI16x8SubSatSLane0Module,
+    },
+    .{
+        .name = "simd_i16x8_sub_sat_u_lane0",
+        .simd = true,
+        .build = buildSimdI16x8SubSatULane0Module,
+    },
+    .{
+        .name = "simd_i16x8_min_s_lane0",
+        .simd = true,
+        .build = buildSimdI16x8MinSLane0Module,
+    },
+    .{
+        .name = "simd_i16x8_min_u_lane0",
+        .simd = true,
+        .build = buildSimdI16x8MinULane0Module,
+    },
+    .{
+        .name = "simd_i16x8_max_s_lane0",
+        .simd = true,
+        .build = buildSimdI16x8MaxSLane0Module,
+    },
+    .{
+        .name = "simd_i16x8_max_u_lane0",
+        .simd = true,
+        .build = buildSimdI16x8MaxULane0Module,
+    },
+    .{
+        .name = "simd_i16x8_avgr_u_lane0",
+        .simd = true,
+        .build = buildSimdI16x8AvgrULane0Module,
+    },
+    .{
         .name = "simd_i16x8_gt_s_lane0",
         .simd = true,
         .build = buildSimdI16x8GtSLane0Module,
@@ -322,6 +372,11 @@ const cases = [_]BenchCase{
         .name = "simd_i16x8_shift_mix_4k_loop",
         .simd = true,
         .build = buildSimdI16x8ShiftMix4kLoopModule,
+    },
+    .{
+        .name = "simd_i16x8_arith_extra_4k_loop",
+        .simd = true,
+        .build = buildSimdI16x8ArithExtra4kLoopModule,
     },
     .{
         .name = "simd_i8x16_mem_add_4k_loop",
@@ -776,6 +831,127 @@ fn buildSimdI16x8MulLane0Module(allocator: Allocator) ![]u8 {
     try appendV128ConstI16x8(&instr, allocator, .{ 300, 6, 7, 8, 9, 10, 11, 12 });
     try appendSimdOpcode(&instr, allocator, 0x95); // i16x8.mul
     try appendI16x8ExtractLaneU(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI16x8Q15MulrSatSLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI16x8BinaryLane0Module(
+        allocator,
+        0x82,
+        .{ 0x8000, 0x4000, 0x7FFF, 0xC000, 1, 2, 3, 4 },
+        .{ 0x8000, 0x4000, 0x7FFF, 0xC000, 5, 6, 7, 8 },
+        .signed,
+    );
+}
+
+fn buildSimdI16x8AddSatSLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI16x8BinaryLane0Module(
+        allocator,
+        0x8F,
+        .{ 0x7FFF, 0x8000, 30000, 0x9000, 1, 2, 3, 4 },
+        .{ 1, 0xFFFF, 10000, 0x9000, 5, 6, 7, 8 },
+        .signed,
+    );
+}
+
+fn buildSimdI16x8AddSatULane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI16x8BinaryLane0Module(
+        allocator,
+        0x90,
+        .{ 65530, 0, 32768, 65535, 1, 2, 3, 4 },
+        .{ 20, 1, 32768, 1, 5, 6, 7, 8 },
+        .unsigned,
+    );
+}
+
+fn buildSimdI16x8SubSatSLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI16x8BinaryLane0Module(
+        allocator,
+        0x92,
+        .{ 0x8000, 0x7FFF, 0x9000, 30000, 1, 2, 3, 4 },
+        .{ 1, 0xFFFF, 30000, 0x9000, 5, 6, 7, 8 },
+        .signed,
+    );
+}
+
+fn buildSimdI16x8SubSatULane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI16x8BinaryLane0Module(
+        allocator,
+        0x93,
+        .{ 3, 0, 32768, 65535, 1, 2, 3, 4 },
+        .{ 7, 1, 32769, 1, 5, 6, 7, 8 },
+        .unsigned,
+    );
+}
+
+fn buildSimdI16x8MinSLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI16x8BinaryLane0Module(
+        allocator,
+        0x96,
+        .{ 0x8000, 0x7FFF, 0xFFFF, 1, 2, 3, 4, 5 },
+        .{ 0x7FFF, 0x8000, 1, 0xFFFF, 6, 7, 8, 9 },
+        .signed,
+    );
+}
+
+fn buildSimdI16x8MinULane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI16x8BinaryLane0Module(
+        allocator,
+        0x97,
+        .{ 0x8000, 0x7FFF, 0xFFFF, 1, 2, 3, 4, 5 },
+        .{ 0x7FFF, 0x8000, 1, 0xFFFF, 6, 7, 8, 9 },
+        .unsigned,
+    );
+}
+
+fn buildSimdI16x8MaxSLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI16x8BinaryLane0Module(
+        allocator,
+        0x98,
+        .{ 0x8000, 0x7FFF, 0xFFFF, 1, 2, 3, 4, 5 },
+        .{ 0x7FFF, 0x8000, 1, 0xFFFF, 6, 7, 8, 9 },
+        .signed,
+    );
+}
+
+fn buildSimdI16x8MaxULane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI16x8BinaryLane0Module(
+        allocator,
+        0x99,
+        .{ 0x8000, 0x7FFF, 0xFFFF, 1, 2, 3, 4, 5 },
+        .{ 0x7FFF, 0x8000, 1, 0xFFFF, 6, 7, 8, 9 },
+        .unsigned,
+    );
+}
+
+fn buildSimdI16x8AvgrULane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdI16x8BinaryLane0Module(
+        allocator,
+        0x9B,
+        .{ 5, 65534, 0, 1, 2, 3, 4, 5 },
+        .{ 6, 65535, 1, 2, 6, 7, 8, 9 },
+        .unsigned,
+    );
+}
+
+fn buildSimdI16x8BinaryLane0Module(
+    allocator: Allocator,
+    opcode: u32,
+    lhs: [8]u16,
+    rhs: [8]u16,
+    extract_sign: I16x8ExtractSign,
+) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI16x8(&instr, allocator, lhs);
+    try appendV128ConstI16x8(&instr, allocator, rhs);
+    try appendSimdOpcode(&instr, allocator, opcode);
+    switch (extract_sign) {
+        .signed => try appendI16x8ExtractLaneS(&instr, allocator, 0),
+        .unsigned => try appendI16x8ExtractLaneU(&instr, allocator, 0),
+    }
 
     return buildRunI32Module(allocator, instr.items, .{});
 }
@@ -1578,6 +1754,114 @@ fn buildSimdI16x8ShiftMix4kLoopModule(allocator: Allocator) ![]u8 {
     });
 }
 
+fn buildSimdI16x8ArithExtra4kLoopModule(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendI32Const(&instr, allocator, 0);
+    try appendLocalSet(&instr, allocator, 0);
+    try appendBlock(&instr, allocator);
+    try appendLoop(&instr, allocator);
+
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Const(&instr, allocator, memory_loop_bytes);
+    try appendI32GeU(&instr, allocator);
+    try appendBrIf(&instr, allocator, 1);
+
+    try appendI32Const(&instr, allocator, memory_loop_dst_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendSimdOpcode(&instr, allocator, 0x82); // i16x8.q15mulr_sat_s
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x8F); // i16x8.add_sat_s
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x90); // i16x8.add_sat_u
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x92); // i16x8.sub_sat_s
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x93); // i16x8.sub_sat_u
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x9B); // i16x8.avgr_u
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x96); // i16x8.min_s
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x97); // i16x8.min_u
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x98); // i16x8.max_s
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0x99); // i16x8.max_u
+
+    try appendSimdMemOpcode(&instr, allocator, 0x0B, 4, 0); // v128.store
+
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Const(&instr, allocator, 16);
+    try appendI32Add(&instr, allocator);
+    try appendLocalSet(&instr, allocator, 0);
+    try appendBr(&instr, allocator, 0);
+
+    try appendEnd(&instr, allocator);
+    try appendEnd(&instr, allocator);
+
+    try appendI32Const(&instr, allocator, memory_loop_dst_base + memory_loop_bytes - 16);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendI16x8ExtractLaneU(&instr, allocator, 7);
+
+    const data = try buildMemoryLoopDataI16ArithExtra(allocator);
+    defer allocator.free(data);
+    return buildRunI32Module(allocator, instr.items, .{
+        .memory_min = 1,
+        .data = data,
+        .local_i32_count = 1,
+    });
+}
+
 fn buildSimdI8x16MemoryAdd4kLoopModule(allocator: Allocator) ![]u8 {
     var instr: std.ArrayList(u8) = .empty;
     defer instr.deinit(allocator);
@@ -1953,6 +2237,23 @@ fn buildMemoryLoopDataI16(allocator: Allocator) ![]u8 {
         const b_pos: usize = @intCast(memory_loop_b_base + lane_offset);
         writeI16Lane(data[a_pos..][0..2], @intCast((lane * 3 + 5) & 0xFFFF));
         writeI16Lane(data[b_pos..][0..2], @intCast((lane * 7 + 11) & 0xFFFF));
+    }
+
+    return data;
+}
+
+fn buildMemoryLoopDataI16ArithExtra(allocator: Allocator) ![]u8 {
+    const data_len = memory_loop_b_base + memory_loop_bytes;
+    const data = try allocator.alloc(u8, data_len);
+    @memset(data, 0);
+
+    var lane: u32 = 0;
+    while (lane < memory_loop_bytes / @sizeOf(u16)) : (lane += 1) {
+        const lane_offset = lane * @sizeOf(u16);
+        const a_pos: usize = @intCast(memory_loop_a_base + lane_offset);
+        const b_pos: usize = @intCast(memory_loop_b_base + lane_offset);
+        writeI16Lane(data[a_pos..][0..2], @intCast((lane * 1103 + 0x8000) & 0xFFFF));
+        writeI16Lane(data[b_pos..][0..2], @intCast((lane * 1741 + 0x7FFF) & 0xFFFF));
     }
 
     return data;

--- a/tests/benchmarks/simd/README.md
+++ b/tests/benchmarks/simd/README.md
@@ -29,6 +29,8 @@ The `simd_i16x8_mem_add_4k_loop` row is the 16-bit lane counterpart to the i32x4
 
 The `simd_i16x8_shift_mix_4k_loop` row is the 16-bit dynamic-shift counterpart to the i32x4 shift probe. Each loop iteration derives scalar counts from the loop index, exercises `i16x8.shl`, `i16x8.shr_u`, and `i16x8.shr_s`, stores a vector result, and returns one unsigned 16-bit checksum lane.
 
+The `simd_i16x8_arith_extra_4k_loop` row extends the halfword-lane memory probe with Q15 saturating rounded multiply, saturated add/subtract, signed/unsigned min/max, and unsigned rounding average operations. It uses high-bit halfword data so signed and unsigned arithmetic paths produce distinct checksums.
+
 The `simd_i8x16_mem_add_4k_loop` row is the byte-lane memory-add probe. It walks the same 4 KiB input shape as the wider-lane rows using packed unsigned bytes, `v128.load`, wrapping `i8x16.add`, and `v128.store`, then returns the final byte lane as an unsigned scalar checksum.
 
 The `simd_i8x16_shift_mix_4k_loop` row is the byte-lane dynamic-shift counterpart to the i16/i32 shift probes. Each loop iteration derives scalar counts from the vector index, exercises `i8x16.shl`, `i8x16.shr_u`, and `i8x16.shr_s`, stores a vector result, and returns one unsigned byte checksum lane. The derived counts intentionally exceed 8 so AOT modulo-8 count masking is covered.


### PR DESCRIPTION
## Summary
- add IR/frontend lowering for i16x8 q15mulr_sat_s, saturated add/sub, signed/unsigned min/max, and unsigned rounding average
- add AArch64 NEON emit/lowering for SQRDMULH, SQADD/UQADD, SQSUB/UQSUB, SMIN/UMIN, SMAX/UMAX, and URHADD
- add SIMD status rows and a 4 KiB i16x8 arithmetic-extra throughput probe

## Validation
- zig build test
- zig build simd-bench -- --iterations 10000
- zig build simd-bench -- --iterations 100 --wasmtime --wasmtime-iterations 3
- scripts/bench_simd.py --baseline origin/main --target HEAD --runs 3 --iterations 10000

## Benchmark notes
- new i16x8 arithmetic-extra AOT rows are unsupported on origin/main and ok on HEAD
- simd_i16x8_arith_extra_4k_loop AOT: ok, result 62385, run ~25.233 ms, compile ~6.913 ms, code size 9382 bytes
- scalar lane checks matched interpreter/AOT/Wasmtime for q15mulr_sat_s, saturation, signed/unsigned min/max, and avgr_u
