### PR TITLE
perf(aarch64): add i32x4 SIMD minmax

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -2006,6 +2006,10 @@ fn emitI32x4BinOp(
         .add => try code.i32x4Op(.add, dest_reg, lhs_reg, rhs_reg),
         .sub => try code.i32x4Op(.sub, dest_reg, lhs_reg, rhs_reg),
         .mul => try code.i32x4Op(.mul, dest_reg, lhs_reg, rhs_reg),
+        .min_s => try code.i32x4Op(.smin, dest_reg, lhs_reg, rhs_reg),
+        .min_u => try code.i32x4Op(.umin, dest_reg, lhs_reg, rhs_reg),
+        .max_s => try code.i32x4Op(.smax, dest_reg, lhs_reg, rhs_reg),
+        .max_u => try code.i32x4Op(.umax, dest_reg, lhs_reg, rhs_reg),
         .eq => try code.i32x4Op(.cmeq, dest_reg, lhs_reg, rhs_reg),
         .ne => {
             try code.i32x4Op(.cmeq, dest_reg, lhs_reg, rhs_reg);
@@ -5810,7 +5814,7 @@ test "compile: i64x2 lane ops emit NEON instructions" {
     try std.testing.expect(found_umov);
 }
 
-test "compile: i32x4 cmp and mul ops emit NEON instructions" {
+test "compile: i32x4 cmp and arithmetic ops emit NEON instructions" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -5819,6 +5823,10 @@ test "compile: i32x4 cmp and mul ops emit NEON instructions" {
     const a = func.newVReg();
     const b = func.newVReg();
     const mul = func.newVReg();
+    const min_s = func.newVReg();
+    const min_u = func.newVReg();
+    const max_s = func.newVReg();
+    const max_u = func.newVReg();
     const ne = func.newVReg();
     const lt_s = func.newVReg();
     const gt_s = func.newVReg();
@@ -5833,6 +5841,10 @@ test "compile: i32x4 cmp and mul ops emit NEON instructions" {
     try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0000_0004_8000_0000_FFFF_FFFF_0000_0002 }, .dest = a, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x0000_0003_8000_0000_0000_0001_0000_0003 }, .dest = b, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .mul, .lhs = a, .rhs = b } }, .dest = mul, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .min_s, .lhs = a, .rhs = b } }, .dest = min_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .min_u, .lhs = a, .rhs = b } }, .dest = min_u, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .max_s, .lhs = a, .rhs = b } }, .dest = max_s, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .max_u, .lhs = a, .rhs = b } }, .dest = max_u, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .ne, .lhs = a, .rhs = b } }, .dest = ne, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .lt_s, .lhs = a, .rhs = b } }, .dest = lt_s, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i32x4_binop = .{ .op = .gt_s, .lhs = a, .rhs = b } }, .dest = gt_s, .type = .v128 });
@@ -5853,6 +5865,10 @@ test "compile: i32x4 cmp and mul ops emit NEON instructions" {
     defer allocator.free(code);
 
     var found_mul = false;
+    var found_smin = false;
+    var found_umin = false;
+    var found_smax = false;
+    var found_umax = false;
     var found_cmeq = false;
     var found_mvn = false;
     var found_cmgt = false;
@@ -5863,6 +5879,10 @@ test "compile: i32x4 cmp and mul ops emit NEON instructions" {
     while (i + 4 <= code.len) : (i += 4) {
         const w = std.mem.readInt(u32, code[i..][0..4], .little);
         if ((w & 0xFFE0FC00) == 0x4EA09C00) found_mul = true;
+        if ((w & 0xFFE0FC00) == 0x4EA06C00) found_smin = true;
+        if ((w & 0xFFE0FC00) == 0x6EA06C00) found_umin = true;
+        if ((w & 0xFFE0FC00) == 0x4EA06400) found_smax = true;
+        if ((w & 0xFFE0FC00) == 0x6EA06400) found_umax = true;
         if ((w & 0xFFE0FC00) == 0x6EA08C00) found_cmeq = true;
         if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
         if ((w & 0xFFE0FC00) == 0x4EA03400) found_cmgt = true;
@@ -5872,6 +5892,10 @@ test "compile: i32x4 cmp and mul ops emit NEON instructions" {
     }
 
     try std.testing.expect(found_mul);
+    try std.testing.expect(found_smin);
+    try std.testing.expect(found_umin);
+    try std.testing.expect(found_smax);
+    try std.testing.expect(found_umax);
     try std.testing.expect(found_cmeq);
     try std.testing.expect(found_mvn);
     try std.testing.expect(found_cmgt);

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -767,6 +767,10 @@ pub const CodeBuffer = struct {
         add = 0x4EA08400,
         sub = 0x6EA08400,
         mul = 0x4EA09C00,
+        smin = 0x4EA06C00,
+        umin = 0x6EA06C00,
+        smax = 0x4EA06400,
+        umax = 0x6EA06400,
         cmeq = 0x6EA08C00,
         cmgt = 0x4EA03400,
         cmge = 0x4EA03C00,
@@ -774,7 +778,7 @@ pub const CodeBuffer = struct {
         cmhs = 0x6EA03C00,
     };
 
-    /// Integer 4S binary vector op: ADD/SUB/MUL/CMEQ/CMGT/CMGE/CMHI/CMHS.
+    /// Integer 4S binary vector op: ADD/SUB/MUL/SMIN/UMIN/SMAX/UMAX/CMEQ/CMGT/CMGE/CMHI/CMHS.
     pub fn i32x4Op(self: *CodeBuffer, op: I32x4Op, vd: u5, vn: u5, vm: u5) !void {
         try self.emit32(@intFromEnum(op) |
             (@as(u32, vm) << 16) |
@@ -1930,6 +1934,33 @@ test "emit: MUL v0.4s, v1.4s, v2.4s" {
     defer code.deinit();
     try code.i32x4Op(.mul, 0, 1, 2);
     try expectWord(0x4EA29C20, &code);
+}
+
+test "emit: i32x4 min/max vector ops" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i32x4Op(.smin, 16, 17, 30);
+        try expectWord(0x4EBE6E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i32x4Op(.umin, 16, 17, 30);
+        try expectWord(0x6EBE6E30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i32x4Op(.smax, 16, 17, 30);
+        try expectWord(0x4EBE6630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.i32x4Op(.umax, 16, 17, 30);
+        try expectWord(0x6EBE6630, &code);
+    }
 }
 
 test "emit: i8x16 vector ops" {

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -1792,6 +1792,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .i32x4_ge_s,
                     .i32x4_ge_u,
                     .i32x4_mul,
+                    .i32x4_min_s,
+                    .i32x4_min_u,
+                    .i32x4_max_s,
+                    .i32x4_max_u,
                     => {
                         const rhs = safePop(&vreg_stack);
                         const lhs = safePop(&vreg_stack);
@@ -1810,6 +1814,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                             .i32x4_ge_s => .ge_s,
                             .i32x4_ge_u => .ge_u,
                             .i32x4_mul => .mul,
+                            .i32x4_min_s => .min_s,
+                            .i32x4_min_u => .min_u,
+                            .i32x4_max_s => .max_s,
+                            .i32x4_max_u => .max_u,
                             else => unreachable,
                         };
                         try ir_func.getBlock(current_block).append(.{
@@ -3599,6 +3607,10 @@ test "lower i32x4 cmp and mul opcodes" {
         .{ .opcode = 0x3F, .expected = .ge_s },
         .{ .opcode = 0x40, .expected = .ge_u },
         .{ .opcode = 0xB5, .expected = .mul },
+        .{ .opcode = 0xB6, .expected = .min_s },
+        .{ .opcode = 0xB7, .expected = .min_u },
+        .{ .opcode = 0xB8, .expected = .max_s },
+        .{ .opcode = 0xB9, .expected = .max_u },
     };
 
     const appendULEB = struct {

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -278,6 +278,10 @@ pub const Inst = struct {
         ge_s,
         ge_u,
         mul,
+        min_s,
+        min_u,
+        max_s,
+        max_u,
     };
 
     pub const I8x16Op = enum {

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -64,6 +64,26 @@ const cases = [_]BenchCase{
         .build = buildSimdI32x4MulLane0Module,
     },
     .{
+        .name = "simd_i32x4_min_s_lane0",
+        .simd = true,
+        .build = buildSimdI32x4MinSLane0Module,
+    },
+    .{
+        .name = "simd_i32x4_min_u_lane0",
+        .simd = true,
+        .build = buildSimdI32x4MinULane0Module,
+    },
+    .{
+        .name = "simd_i32x4_max_s_lane0",
+        .simd = true,
+        .build = buildSimdI32x4MaxSLane0Module,
+    },
+    .{
+        .name = "simd_i32x4_max_u_lane0",
+        .simd = true,
+        .build = buildSimdI32x4MaxULane0Module,
+    },
+    .{
         .name = "simd_i32x4_ne_lane0",
         .simd = true,
         .build = buildSimdI32x4NeLane0Module,
@@ -362,6 +382,11 @@ const cases = [_]BenchCase{
         .name = "simd_i32x4_shift_mix_4k_loop",
         .simd = true,
         .build = buildSimdI32x4ShiftMix4kLoopModule,
+    },
+    .{
+        .name = "simd_i32x4_minmax_4k_loop",
+        .simd = true,
+        .build = buildSimdI32x4MinMax4kLoopModule,
     },
     .{
         .name = "simd_i16x8_mem_add_4k_loop",
@@ -717,6 +742,54 @@ fn buildSimdI32x4MulLane0Module(allocator: Allocator) ![]u8 {
     try appendV128ConstI32x4(&instr, allocator, .{ 50_000, -7, 3, 4 });
     try appendV128ConstI32x4(&instr, allocator, .{ 50_000, 6, 7, 8 });
     try appendSimdOpcode(&instr, allocator, 0xB5); // i32x4.mul
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4MinSLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ std.math.minInt(i32), -7, 500, -1 });
+    try appendV128ConstI32x4(&instr, allocator, .{ std.math.maxInt(i32), 6, -500, 1 });
+    try appendSimdOpcode(&instr, allocator, 0xB6); // i32x4.min_s
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4MinULane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ std.math.minInt(i32), -7, 500, -1 });
+    try appendV128ConstI32x4(&instr, allocator, .{ std.math.maxInt(i32), 6, -500, 1 });
+    try appendSimdOpcode(&instr, allocator, 0xB7); // i32x4.min_u
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4MaxSLane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ std.math.minInt(i32), -7, 500, -1 });
+    try appendV128ConstI32x4(&instr, allocator, .{ std.math.maxInt(i32), 6, -500, 1 });
+    try appendSimdOpcode(&instr, allocator, 0xB8); // i32x4.max_s
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdI32x4MaxULane0Module(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI32x4(&instr, allocator, .{ std.math.minInt(i32), -7, 500, -1 });
+    try appendV128ConstI32x4(&instr, allocator, .{ std.math.maxInt(i32), 6, -500, 1 });
+    try appendSimdOpcode(&instr, allocator, 0xB9); // i32x4.max_u
     try appendI32x4ExtractLane(&instr, allocator, 0);
 
     return buildRunI32Module(allocator, instr.items, .{});
@@ -1633,6 +1706,82 @@ fn buildSimdI32x4ShiftMix4kLoopModule(allocator: Allocator) ![]u8 {
     });
 }
 
+fn buildSimdI32x4MinMax4kLoopModule(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendI32Const(&instr, allocator, 0);
+    try appendLocalSet(&instr, allocator, 0);
+    try appendBlock(&instr, allocator);
+    try appendLoop(&instr, allocator);
+
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Const(&instr, allocator, memory_loop_bytes);
+    try appendI32GeU(&instr, allocator);
+    try appendBrIf(&instr, allocator, 1);
+
+    try appendI32Const(&instr, allocator, memory_loop_dst_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0xB6); // i32x4.min_s
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0xB9); // i32x4.max_u
+    try appendSimdOpcode(&instr, allocator, 0xB8); // i32x4.max_s
+
+    try appendI32Const(&instr, allocator, memory_loop_a_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+
+    try appendI32Const(&instr, allocator, memory_loop_b_base);
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Add(&instr, allocator);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendSimdOpcode(&instr, allocator, 0xB7); // i32x4.min_u
+    try appendSimdOpcode(&instr, allocator, 0xB9); // i32x4.max_u
+    try appendSimdMemOpcode(&instr, allocator, 0x0B, 4, 0); // v128.store
+
+    try appendLocalGet(&instr, allocator, 0);
+    try appendI32Const(&instr, allocator, 16);
+    try appendI32Add(&instr, allocator);
+    try appendLocalSet(&instr, allocator, 0);
+    try appendBr(&instr, allocator, 0);
+
+    try appendEnd(&instr, allocator);
+    try appendEnd(&instr, allocator);
+
+    try appendI32Const(&instr, allocator, memory_loop_dst_base + memory_loop_bytes - 16);
+    try appendSimdMemOpcode(&instr, allocator, 0x00, 4, 0); // v128.load
+    try appendI32x4ExtractLane(&instr, allocator, 3);
+
+    const data = try buildMemoryLoopDataI32MinMax(allocator);
+    defer allocator.free(data);
+    return buildRunI32Module(allocator, instr.items, .{
+        .memory_min = 1,
+        .data = data,
+        .local_i32_count = 1,
+    });
+}
+
 fn buildSimdI16x8MemoryAdd4kLoopModule(allocator: Allocator) ![]u8 {
     var instr: std.ArrayList(u8) = .empty;
     defer instr.deinit(allocator);
@@ -2220,6 +2369,27 @@ fn buildMemoryLoopData(allocator: Allocator) ![]u8 {
         const b_pos: usize = @intCast(memory_loop_b_base + lane_offset);
         writeI32Lane(data[a_pos..][0..4], lane * 3 + 5);
         writeI32Lane(data[b_pos..][0..4], lane * 7 + 11);
+    }
+
+    return data;
+}
+
+fn buildMemoryLoopDataI32MinMax(allocator: Allocator) ![]u8 {
+    const data_len = memory_loop_b_base + memory_loop_bytes;
+    const data = try allocator.alloc(u8, data_len);
+    @memset(data, 0);
+
+    var lane: u32 = 0;
+    while (lane < memory_loop_lanes) : (lane += 1) {
+        const lane_offset = lane * @sizeOf(u32);
+        const a_pos: usize = @intCast(memory_loop_a_base + lane_offset);
+        const b_pos: usize = @intCast(memory_loop_b_base + lane_offset);
+        const a_mag = lane * 3 + 5;
+        const b_mag = lane * 7 + 11;
+        const a_value = if ((lane & 1) == 0) 0x8000_0000 | a_mag else a_mag;
+        const b_value = if ((lane & 1) == 0) b_mag else 0x8000_0000 | b_mag;
+        writeI32Lane(data[a_pos..][0..4], a_value);
+        writeI32Lane(data[b_pos..][0..4], b_value);
     }
 
     return data;

--- a/tests/benchmarks/simd/README.md
+++ b/tests/benchmarks/simd/README.md
@@ -25,6 +25,8 @@ The `simd_i32x4_mem_sum8_4k_loop` row is a v128 register-pressure probe. Each lo
 
 The `simd_i32x4_shift_mix_4k_loop` row is a dynamic-shift throughput probe. Each loop iteration derives the scalar shift count from the loop index, exercises `i32x4.shl`, `i32x4.shr_u`, and `i32x4.shr_s`, stores a vector result, and returns one scalar checksum lane. This keeps shift counts data-dependent and above the lane width so modulo masking is covered in the AOT path.
 
+The `simd_i32x4_minmax_4k_loop` row extends the 32-bit lane memory probe with signed and unsigned min/max operations. It uses alternating high-bit lane data so signed and unsigned `i32x4.min_*`/`max_*` paths produce distinct intermediate values while still returning a stable scalar checksum.
+
 The `simd_i16x8_mem_add_4k_loop` row is the 16-bit lane counterpart to the i32x4 memory-add loop. It walks two 4 KiB arrays as packed 16-bit lanes with `v128.load`, `i16x8.add`, and `v128.store`, then returns the final unsigned 16-bit lane as a scalar checksum.
 
 The `simd_i16x8_shift_mix_4k_loop` row is the 16-bit dynamic-shift counterpart to the i32x4 shift probe. Each loop iteration derives scalar counts from the loop index, exercises `i16x8.shl`, `i16x8.shr_u`, and `i16x8.shr_s`, stores a vector result, and returns one unsigned 16-bit checksum lane.


### PR DESCRIPTION
## Summary
- add IR/frontend lowering for `i32x4.min_s`, `i32x4.min_u`, `i32x4.max_s`, and `i32x4.max_u`
- emit direct AArch64 NEON `SMIN`/`UMIN`/`SMAX`/`UMAX` instructions for the new i32x4 ops
- add scalar status rows plus `simd_i32x4_minmax_4k_loop` to the SIMD benchmark harness

## Validation
- `zig build test`
- `zig build simd-bench -- --iterations 10000`
- `zig build simd-bench -- --iterations 100 --wasmtime --wasmtime-iterations 3`
- `scripts/bench_simd.py --baseline origin/main --target HEAD --runs 3 --iterations 10000`

## SIMD comparison highlights
| row | engine | origin/main | HEAD |
| --- | --- | --- | --- |
| `simd_i32x4_min_s_lane0` | AOT | unsupported | ok, result `-2147483648`, run `3.234 ms` |
| `simd_i32x4_min_u_lane0` | AOT | unsupported | ok, result `2147483647`, run `3.259 ms` |
| `simd_i32x4_max_s_lane0` | AOT | unsupported | ok, result `2147483647`, run `3.246 ms` |
| `simd_i32x4_max_u_lane0` | AOT | unsupported | ok, result `-2147483648`, run `3.231 ms` |
| `simd_i32x4_minmax_4k_loop` | AOT | unsupported | ok, result `-2147476476`, run `17.006 ms` |
