### PR TITLE
Add fuzz crasher reducer and regression-seed convention

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -83,6 +83,9 @@ jobs:
           if [ -d tests/spec-json ]; then
             find tests/spec-json -maxdepth 1 -name '*.wasm' -exec cp -n {} .fuzz-corpus/${{ matrix.target }}/ \; || true
           fi
+          if [ -d tests/fuzz/regression/${{ matrix.target }} ]; then
+            cp -n tests/fuzz/regression/${{ matrix.target }}/*.wasm .fuzz-corpus/${{ matrix.target }}/ 2>/dev/null || true
+          fi
           if [ "${{ matrix.target }}" = "component-loader" ]; then
             # Minimal component: "\0asm" plus version/layer 0x0001000d.
             printf '\000asm\015\000\001\000' > .fuzz-corpus/${{ matrix.target }}/minimal-component.wasm

--- a/SECURITY_PROCESS.md
+++ b/SECURITY_PROCESS.md
@@ -141,7 +141,8 @@ Reviewer guidance:
 - For loader/runtime/component/compiler/fuzz harness changes, consider
   `zig build fuzz` or the GitHub fuzz workflow when the change affects input
   parsing or execution boundaries. See [tests/fuzz/README.md](tests/fuzz/README.md)
-  for harness-specific oracles and
+  for harness-specific oracles, `scripts/fuzz_reduce.py` for crash
+  minimization, and
   [tests/fuzz/OSS_FUZZ.md](tests/fuzz/OSS_FUZZ.md) for the OSS-Fuzz integration
   decision and prerequisites.
 - For documentation-only changes, a full Zig build is usually unnecessary; check

--- a/scripts/fuzz_reduce.py
+++ b/scripts/fuzz_reduce.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Reduce a fuzz crasher by repeatedly running the matching ``fuzz-<target>``
+harness against shrunken candidates.
+
+The script treats a candidate as "still reproducing" if running the harness
+for a short duration over a single-element corpus either exits non-zero or
+leaves a named crasher (e.g. ``diff-mismatch-*.wasm``) in the crashes
+directory.
+
+Two reduction strategies are attempted in order:
+
+1. ``wasm-tools shrink`` if the binary is on ``PATH``. The predicate is a
+   tiny shell wrapper that re-invokes this script in ``--predicate-mode``.
+2. A built-in byte-level shrinker that deletes contiguous ranges of bytes
+   and accepts the shorter candidate when it still reproduces.
+
+The smallest reproducer is written next to the original input as
+``<original>.reduced.wasm`` unless ``--out`` is given.
+
+Usage::
+
+    scripts/fuzz_reduce.py <target> <crasher.wasm> [options]
+
+See ``tests/fuzz/README.md`` for the regression vs. private-security policy
+that decides whether a reduced reproducer should land as a regression seed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_HARNESS_DIR = REPO_ROOT / "zig-out" / "bin"
+NAMED_CRASHER_GLOBS = ("diff-mismatch-*.wasm",)
+
+
+def harness_path(target: str, harness_dir: Path) -> Path:
+    candidate = harness_dir / f"fuzz-{target}"
+    if not candidate.exists():
+        sys.exit(
+            f"fuzz-{target} not found at {candidate}. Run "
+            "'zig build fuzz -Doptimize=ReleaseSafe' first."
+        )
+    return candidate
+
+
+def reproduces(
+    harness: Path,
+    candidate_bytes: bytes,
+    duration: int,
+    extra_args: list[str],
+) -> bool:
+    """Return True if running the harness against ``candidate_bytes`` either
+    aborts non-zero or leaves a named crasher artifact behind.
+    """
+    with tempfile.TemporaryDirectory(prefix="fuzz-reduce-") as tmp:
+        tmp_path = Path(tmp)
+        corpus = tmp_path / "corpus"
+        crashes = tmp_path / "crashes"
+        corpus.mkdir()
+        crashes.mkdir()
+        (corpus / "candidate.wasm").write_bytes(candidate_bytes)
+
+        argv: list[str] = [
+            str(harness),
+            "--corpus",
+            str(corpus),
+            "--crashes",
+            str(crashes),
+            "--duration",
+            str(duration),
+            *extra_args,
+        ]
+        proc = subprocess.run(
+            argv,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return True
+        for pattern in NAMED_CRASHER_GLOBS:
+            if any(crashes.glob(pattern)):
+                return True
+        return False
+
+
+def byte_level_shrink(
+    harness: Path,
+    initial: bytes,
+    duration: int,
+    extra_args: list[str],
+    max_passes: int,
+) -> bytes:
+    """Greedy delta-debug-style byte shrinker.
+
+    Repeatedly halves the deletion window and tries to delete every aligned
+    chunk. Accepts the shorter candidate when the harness still reproduces.
+    """
+    best = initial
+    pass_idx = 0
+    while pass_idx < max_passes:
+        improved = False
+        n = len(best)
+        chunk = max(1, n // 2)
+        while chunk > 0:
+            offset = 0
+            while offset < len(best):
+                end = min(offset + chunk, len(best))
+                candidate = best[:offset] + best[end:]
+                if candidate and reproduces(harness, candidate, duration, extra_args):
+                    print(
+                        f"  shrink chunk={chunk} offset={offset}: "
+                        f"{len(best)} -> {len(candidate)} bytes",
+                        file=sys.stderr,
+                    )
+                    best = candidate
+                    improved = True
+                else:
+                    offset += chunk
+            chunk //= 2
+        if not improved:
+            break
+        pass_idx += 1
+    return best
+
+
+def try_wasm_tools_shrink(
+    target: str,
+    harness: Path,
+    input_path: Path,
+    out_path: Path,
+    duration: int,
+    extra_args: list[str],
+) -> bool:
+    """Use ``wasm-tools shrink`` when available.
+
+    Returns True if it ran. The predicate script re-invokes this module in
+    predicate mode so a single Python file is enough.
+    """
+    if shutil.which("wasm-tools") is None:
+        return False
+    with tempfile.TemporaryDirectory(prefix="fuzz-reduce-wt-") as tmp:
+        tmp_path = Path(tmp)
+        predicate = tmp_path / "predicate.sh"
+        predicate.write_text(
+            "#!/usr/bin/env bash\n"
+            "exec '{python}' '{script}' --predicate-mode "
+            "--harness '{harness}' --duration {duration} "
+            "{extra} -- \"$1\"\n".format(
+                python=sys.executable,
+                script=str(Path(__file__).resolve()),
+                harness=str(harness),
+                duration=duration,
+                extra=" ".join(f"--extra {a}" for a in extra_args),
+            )
+        )
+        predicate.chmod(0o755)
+        try:
+            subprocess.run(
+                [
+                    "wasm-tools",
+                    "shrink",
+                    str(predicate),
+                    str(input_path),
+                    "--output",
+                    str(out_path),
+                ],
+                check=False,
+            )
+            return out_path.exists()
+        except Exception as e:  # noqa: BLE001
+            print(f"wasm-tools shrink failed: {e}", file=sys.stderr)
+            return False
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("target", nargs="?", help="fuzz target name (loader, component-loader, interp, aot, diff, canon)")
+    parser.add_argument("input", nargs="?", type=Path, help="path to crasher .wasm")
+    parser.add_argument("--out", type=Path, default=None, help="output path for reduced reproducer")
+    parser.add_argument("--duration", type=int, default=2, help="seconds per predicate run")
+    parser.add_argument(
+        "--harness-dir",
+        type=Path,
+        default=DEFAULT_HARNESS_DIR,
+        help="directory containing fuzz-<target> binaries",
+    )
+    parser.add_argument(
+        "--extra",
+        action="append",
+        default=[],
+        help="extra argv pass-through to the harness (e.g. --extra --fuel --extra 100000)",
+    )
+    parser.add_argument(
+        "--max-passes",
+        type=int,
+        default=4,
+        help="maximum number of byte-level shrink passes",
+    )
+    parser.add_argument(
+        "--no-wasm-tools",
+        action="store_true",
+        help="skip wasm-tools shrink even if installed",
+    )
+    parser.add_argument(
+        "--predicate-mode",
+        action="store_true",
+        help="internal: run as a wasm-tools shrink predicate",
+    )
+    parser.add_argument(
+        "--harness",
+        type=Path,
+        help="internal: path to fuzz-<target> binary (used by --predicate-mode)",
+    )
+    parser.add_argument(
+        "predicate_input",
+        nargs="?",
+        type=Path,
+        help="internal: candidate wasm passed by wasm-tools shrink",
+    )
+    args = parser.parse_args(argv)
+
+    if args.predicate_mode:
+        if not args.harness or not args.predicate_input:
+            sys.exit("--predicate-mode requires --harness and a candidate path")
+        bytes_ = args.predicate_input.read_bytes()
+        ok = reproduces(args.harness, bytes_, args.duration, args.extra)
+        return 0 if ok else 1
+
+    if not args.target or not args.input:
+        parser.error("target and input are required outside --predicate-mode")
+    if not args.input.exists():
+        sys.exit(f"input not found: {args.input}")
+
+    harness = harness_path(args.target, args.harness_dir)
+    initial = args.input.read_bytes()
+    print(f"verifying initial reproduction ({len(initial)} bytes)...", file=sys.stderr)
+    if not reproduces(harness, initial, args.duration, args.extra):
+        sys.exit("initial input does not reproduce; check target/duration/extra args")
+
+    out = args.out or args.input.with_suffix(".reduced.wasm")
+    best = initial
+
+    if not args.no_wasm_tools and shutil.which("wasm-tools") is not None:
+        print("attempting wasm-tools shrink...", file=sys.stderr)
+        wt_out = out.with_suffix(".wt.wasm")
+        if try_wasm_tools_shrink(args.target, harness, args.input, wt_out, args.duration, args.extra):
+            wt_bytes = wt_out.read_bytes()
+            if reproduces(harness, wt_bytes, args.duration, args.extra) and len(wt_bytes) < len(best):
+                print(
+                    f"  wasm-tools: {len(initial)} -> {len(wt_bytes)} bytes",
+                    file=sys.stderr,
+                )
+                best = wt_bytes
+            wt_out.unlink(missing_ok=True)
+
+    print("running byte-level shrinker...", file=sys.stderr)
+    best = byte_level_shrink(harness, best, args.duration, args.extra, args.max_passes)
+
+    out.write_bytes(best)
+    print(
+        f"done: {len(initial)} -> {len(best)} bytes ({len(best) * 100 // max(1, len(initial))}% of original)",
+        file=sys.stderr,
+    )
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -116,13 +116,57 @@ To reproduce a crash:
    an unfixed security issue. Use the private reporting flow in `SECURITY.md`
    and `SECURITY_PROCESS.md` for sensitive payloads.
 
+## Reducing a crasher
+
+Use `scripts/fuzz_reduce.py` to shrink a reproducer to a small deterministic
+form before triage:
+
+```sh
+zig build fuzz -Doptimize=ReleaseSafe
+scripts/fuzz_reduce.py <target> <crasher.wasm> [--duration 2] [--extra --fuel --extra 100000]
+```
+
+The script verifies the input still reproduces, optionally invokes
+`wasm-tools shrink` if it is on `PATH`, then runs a built-in byte-level
+delta-debug pass. The smallest reproducer is written next to the input as
+`<crasher>.reduced.wasm` (override with `--out`).
+
+A candidate "still reproduces" when the harness exits non-zero (process
+abort) or leaves a named crasher file like `diff-mismatch-*.wasm`. Pass
+target-specific flags through with `--extra`, e.g.
+`--extra --fuel --extra 100000` for `fuzz-interp`/`fuzz-diff`.
+
+Loader and validator crashers usually reduce to under 100 bytes; runtime
+or codegen crashers may stay larger. Reduce on the same architecture you
+intend to share the seed for; AArch64 vs x86_64 AOT codegen differences
+can change reproduction.
+
+## Regression seeds vs private reports
+
+A reduced crasher can take one of two paths:
+
+- **Public regression seed** (`tests/fuzz/regression/<target>/`): only for
+  bugs that have already been **fixed** in this repository. The committed
+  seed locks in coverage so the same path can never silently regress.
+  Each file must be deterministic, ≤ 4 KB, and free of PII/proprietary
+  content. See `tests/fuzz/regression/README.md` for the full policy.
+- **Private security attachment**: any reproducer that still exposes a
+  panic, safety-checked UB, abort, oversize allocation, or potentially
+  exploitable behaviour goes through the private reporting flow in
+  `SECURITY.md` and `SECURITY_PROCESS.md`. Do not open a public PR or
+  issue with the bytes attached.
+
+If you are unsure, treat the reproducer as private until a maintainer
+confirms otherwise.
+
 ## CI workflow
 
 `.github/workflows/fuzz.yml` runs on a daily schedule, on demand, and on PRs that
 touch runtime/compiler/component/fuzz code. The workflow:
 
 - builds all harnesses with `zig build fuzz -Doptimize=ReleaseSafe`;
-- seeds per-target corpora from `tests/malformed/fuzz` and `tests/spec-json`;
+- seeds per-target corpora from `tests/malformed/fuzz`, `tests/spec-json`,
+  and any committed regression seeds in `tests/fuzz/regression/<target>/`;
 - adds a generated minimal component seed for `fuzz-component-loader`;
 - adds a generated nullary scalar export seed for `fuzz-interp` and `fuzz-diff`;
 - uploads `.fuzz-crashes` artifacts with 30-day retention;
@@ -166,6 +210,7 @@ host-protection mechanism.
   model for resource tables, paths, descriptors, sockets, HTTP streams, and
   guest-memory pointer/length pairs (#247).
 - Corpus minimization should preserve a small checked-in seed set while storing
-  larger evolving corpora as workflow artifacts (#248).
+  larger evolving corpora as workflow artifacts (#248). See `scripts/fuzz_reduce.py`
+  and `tests/fuzz/regression/README.md`.
 - OSS-Fuzz integration was evaluated in [`OSS_FUZZ.md`](OSS_FUZZ.md); the
   decision is to defer until a documented prerequisite list is met (#249).

--- a/tests/fuzz/regression/README.md
+++ b/tests/fuzz/regression/README.md
@@ -1,0 +1,22 @@
+# Regression seeds
+
+Each subdirectory `<target>/` holds minimized fuzz inputs that previously
+exposed a real bug, were reduced with `scripts/fuzz_reduce.py`, fixed in
+the relevant code path, and locked in here as a permanent regression seed
+for `fuzz-<target>`.
+
+## Rules
+
+- Seeds must be deterministic: same bytes, same outcome on every run.
+- Each file must be ≤ 4 KB. Larger reproducers belong in workflow
+  artifacts, not in the repo.
+- Add a one-line filename hint that matches the original issue or PR
+  number where the fix landed (e.g., `259-canon-utf16-overrun.wasm`).
+- Only add a seed for a **fixed** bug. Inputs that still expose an
+  unfixed panic, UB, abort, or potential security bug must be reported
+  privately per `SECURITY.md` and `SECURITY_PROCESS.md`, not committed.
+- Never include reproducers containing PII, proprietary content, or
+  other sensitive bytes the original reporter did not consent to share.
+
+The fuzz workflow seeds these alongside `tests/malformed/fuzz` and
+`tests/spec-json` so every PR run replays the regression coverage.


### PR DESCRIPTION
Closes #248.

## What changed

- **`scripts/fuzz_reduce.py`** — deterministic reducer that wraps
  `wasm-tools shrink` when available and falls back to a built-in
  byte-level delta-debug pass. The predicate considers a candidate
  "still reproduces" when the matching `fuzz-<target>` harness exits
  non-zero (process abort) or leaves a named crasher artifact such as
  `diff-mismatch-*.wasm`.
- **`tests/fuzz/regression/<target>/`** — new convention for committed
  minimized seeds. Each subdirectory holds reduced inputs that
  previously exposed a fixed bug; a README enforces deterministic
  bytes, a 4 KB per-file cap, naming hints, and a "fixed-bug only"
  rule.
- **`.github/workflows/fuzz.yml`** — seeds per-target corpora from
  `tests/fuzz/regression/<target>/` alongside the existing
  `tests/malformed/fuzz` and `tests/spec-json` sources.
- **`tests/fuzz/README.md`** — adds a "Reducing a crasher" section and
  an explicit "Regression seeds vs private reports" policy that points
  unfixed crashers to `SECURITY.md` / `SECURITY_PROCESS.md`.
- **`SECURITY_PROCESS.md`** — cross-links the new reducer next to the
  existing fuzz docs.

## Why

Without a documented reducer, triaging a crasher pulled from a CI
artifact has been ad hoc. The script + regression directory + policy
text together close that gap with no new heavyweight dependencies; the
script needs only Python, with `wasm-tools` as an optional accelerator.

## Validation

- `zig build test`
- `zig build fuzz -Doptimize=ReleaseSafe`
- `git diff --check` clean.
- YAML syntax check on `.github/workflows/fuzz.yml`.
- End-to-end smoke against a synthetic harness that exits non-zero
  when input contains "BOOM": 204 bytes reduced to 4 bytes (the
  literal `BOOM`), confirming the byte-level shrinker converges.

## What's intentionally not in scope

- No coverage-guided fuzzer. That decision is captured separately in
  `tests/fuzz/OSS_FUZZ.md` (#249) and tracked for re-evaluation in #262.
- No real reproducers committed yet; `tests/fuzz/regression/<target>/`
  starts empty. Future PRs may add seeds when fixing fuzzer-reported
  bugs.