### PR TITLE
Add fuzz-wasi: WASI host-binding command-model fuzzer (Phase 1)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,7 +19,7 @@ on:
         required: false
         default: "100000"
       target:
-        description: "Fuzz target (all, loader, component-loader, interp, aot, diff, canon)"
+        description: "Fuzz target (all, loader, component-loader, interp, aot, diff, canon, wasi)"
         required: false
         default: "all"
   pull_request:
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [loader, component-loader, interp, aot, diff, canon]
+        target: [loader, component-loader, interp, aot, diff, canon, wasi]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -99,6 +99,14 @@ jobs:
             printf '\x00\x0e\x00\x00\x00\x00\x08\x00\x00\x00Hello, world!\x00\x00\x00' > .fuzz-corpus/${{ matrix.target }}/seed-load-string.wasm
             # mode=validate_utf8, ptr=0, len=11, body "hello world".
             printf '\x01\x00\x00\x00\x00\x00\x0b\x00\x00\x00hello world' > .fuzz-corpus/${{ matrix.target }}/seed-validate-utf8.wasm
+          fi
+          if [ "${{ matrix.target }}" = "wasi" ]; then
+            # validate-sandbox-path on "../escape" (op 0x08, len 0x09).
+            printf '\x08\x09../escape' > .fuzz-corpus/${{ matrix.target }}/seed-sandbox.wasm
+            # get-directories (op 0x07).
+            printf '\x07' > .fuzz-corpus/${{ matrix.target }}/seed-get-dirs.wasm
+            # get-type on handle 0 (op 0x00, handle byte 0x00).
+            printf '\x00\x00' > .fuzz-corpus/${{ matrix.target }}/seed-get-type.wasm
           fi
           ls .fuzz-corpus/${{ matrix.target }} | wc -l
 

--- a/build.zig
+++ b/build.zig
@@ -360,7 +360,7 @@ pub fn build(b: *std.Build) void {
         simd_bench_step.dependOn(&run_simd_bench.step);
     }
 
-    const fuzz_step = b.step("fuzz", "Build fuzz harnesses (loader, component-loader, interp, aot, diff, canon)");
+    const fuzz_step = b.step("fuzz", "Build fuzz harnesses (loader, component-loader, interp, aot, diff, canon, wasi)");
     inline for (.{
         .{ .name = "loader", .file = "loader.zig", .needs_aot = false },
         .{ .name = "component-loader", .file = "component_loader.zig", .needs_aot = false },
@@ -368,6 +368,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "aot", .file = "aot.zig", .needs_aot = true },
         .{ .name = "diff", .file = "diff.zig", .needs_aot = true },
         .{ .name = "canon", .file = "canon.zig", .needs_aot = false },
+        .{ .name = "wasi", .file = "wasi.zig", .needs_aot = false },
     }) |tgt| {
         const fuzz_mod = b.createModule(.{
             .root_source_file = b.path("src/tests/fuzz/" ++ tgt.file),

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -3223,7 +3223,7 @@ pub const WasiCliAdapter = struct {
     /// Reject paths that would escape the preopen sandbox: any `..` path
     /// component, any `\\` separator, any `:` (Windows drive prefix), or
     /// a leading `/` (absolute). Returns `.access` on rejection.
-    fn validateSandboxPath(path: []const u8) ?FsErrorCode {
+    pub fn validateSandboxPath(path: []const u8) ?FsErrorCode {
         if (path.len == 0) return null;
         if (path[0] == '/') return .access;
         for (path) |c| {

--- a/src/tests/fuzz/wasi.zig
+++ b/src/tests/fuzz/wasi.zig
@@ -1,0 +1,380 @@
+//! fuzz-wasi — WASI/component resource-table command-model fuzzer.
+//!
+//! Drives the public host bindings on `WasiCliAdapter` through a
+//! deterministic, byte-driven command model. No real component wasm is
+//! executed; the harness invokes bound host functions directly with
+//! synthesized `InterfaceValue` arguments.
+//!
+//! Phase 1 scope (this target):
+//!   - filesystem `[method]descriptor.*` bindings on a per-process temp
+//!     preopen,
+//!   - `wasi:filesystem/preopens.get-directories`,
+//!   - `WasiCliAdapter.validateSandboxPath` (dense path-validation
+//!     coverage on attacker bytes),
+//!   - `[resource-drop]descriptor`.
+//!
+//! Stream allocation and explicit input/output stream ops, sockets, and
+//! HTTP host bindings are deferred to follow-up issues.
+//!
+//! Oracle: panics, safety-checked UB, aborts, allocator leaks across
+//! iterations, descriptor-table not returning to its preopen-only
+//! baseline, or any path that escapes the per-process temp root are
+//! bugs. Typed `result<_, error-code>` failures are expected.
+
+const std = @import("std");
+const wamr = @import("wamr");
+const adapter_mod = wamr.wasi_cli_adapter;
+const WasiCliAdapter = adapter_mod.WasiCliAdapter;
+const ci_mod = wamr.component_instance;
+const ComponentInstance = ci_mod.ComponentInstance;
+const InterfaceValue = ci_mod.InterfaceValue;
+const HostInstance = ci_mod.HostInstance;
+const HostInstanceMember = ci_mod.HostInstanceMember;
+const ImportBinding = ci_mod.ImportBinding;
+const ctypes = wamr.component_types;
+const core_types = wamr.types;
+
+const common = @import("common.zig");
+
+/// Per-iteration cap on the number of opcodes decoded from one input.
+/// Bounds allocator and filesystem work even on adversarial seeds.
+const max_ops_per_input: u32 = 256;
+/// Stub guest memory size. 64 KiB is one wasm page and matches what
+/// `canonicalMemory` would return for a single-page module.
+const stub_memory_bytes: usize = 64 * 1024;
+
+const Op = enum(u8) {
+    get_type,
+    get_flags,
+    stat,
+    read_via_stream,
+    write_via_stream,
+    append_via_stream,
+    drop_descriptor,
+    get_directories,
+    validate_sandbox_path,
+    open_at,
+    drop_stream,
+};
+
+const op_count: u8 = @intCast(@typeInfo(Op).@"enum".fields.len);
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
+    const argv = try init.minimal.args.toSlice(init.arena.allocator());
+
+    const args = try common.Args.parse(argv);
+    var corpus = try common.Corpus.load(allocator, io, args.corpus_dir);
+    defer corpus.deinit();
+
+    if (corpus.count() == 0) {
+        std.log.err("empty corpus at {s}", .{args.corpus_dir});
+        return error.EmptyCorpus;
+    }
+
+    // Per-process temp root. Reused across iterations; we only place
+    // small fixture files inside it and never delete the root until
+    // exit. The host is sandboxed against `..` and absolute paths via
+    // `validateSandboxPath`, so even if the harness opens new files,
+    // they remain inside this directory.
+    var tmp_root_buf: [128]u8 = undefined;
+    const tmp_root = try std.fmt.bufPrint(&tmp_root_buf, "/tmp/fuzz-wasi-{d}", .{
+        std.os.linux.getpid(),
+    });
+
+    const std_io = std.Io.Threaded.global_single_threaded.io();
+    const cwd_io = std.Io.Dir.cwd();
+    cwd_io.createDirPath(std_io, tmp_root) catch |err| switch (err) {
+        // PathAlreadyExists is fine — we reuse a stale dir.
+        else => return err,
+    };
+    var preopen_dir_io = try cwd_io.openDir(std_io, tmp_root, .{ .iterate = true });
+    defer preopen_dir_io.close(std_io);
+
+    // Seed two small fixture files. Errors here are fatal — the host
+    // setup itself is not under test.
+    try writeFixture(std_io, preopen_dir_io, "a.txt", "alpha");
+    try writeFixture(std_io, preopen_dir_io, "b.txt", "beta");
+
+    const deadline = common.Deadline.init(io, args.duration_ms);
+    var iter: u64 = 0;
+    var idx: usize = 0;
+    while (!deadline.expired(io)) : (iter += 1) {
+        const input = corpus.get(idx);
+        idx +%= 1;
+
+        try common.markInFlight(io, args.crashes_dir, input);
+        try runOnce(allocator, std_io, preopen_dir_io, input);
+        common.clearInFlight(io, args.crashes_dir);
+    }
+
+    std.log.info("fuzz-wasi: {d} iterations over {d} inputs", .{ iter, corpus.count() });
+}
+
+fn writeFixture(io: std.Io, dir: std.Io.Dir, sub_path: []const u8, data: []const u8) !void {
+    dir.writeFile(io, .{ .sub_path = sub_path, .data = data }) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+}
+
+/// Drive one input through the command model. The adapter, stub
+/// component instance, and stub guest memory are reconstructed each
+/// iteration so cross-input state cannot mask use-after-free or
+/// table-leak bugs.
+fn runOnce(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    preopen_dir_io: std.Io.Dir,
+    input: []const u8,
+) !void {
+    var adapter = WasiCliAdapter.init(allocator);
+    defer adapter.deinit();
+
+    // Single preopen at index 0; persistent across the iteration. The
+    // adapter takes ownership of the dir handle on `addPreopen`, so we
+    // pass a duplicate handle and null the slot before adapter.deinit
+    // to avoid double-close.
+    const preopen_handle = adapter.addPreopen("/sandbox", preopen_dir_io) catch return;
+    _ = preopen_handle;
+    defer {
+        // Replace the preopen slot with null so adapter.deinit doesn't
+        // try to close the shared dir handle.
+        if (adapter.fs_descriptor_table.items.len > 0) {
+            adapter.fs_descriptor_table.items[0] = null;
+        }
+    }
+
+    // Pre-register `wasi:filesystem/types` + `wasi:filesystem/preopens`
+    // bindings so we can look up host fns by name.
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(allocator);
+    adapter.populateWasiFilesystemTypes(&providers, "wasi:filesystem/types") catch return;
+    adapter.populateWasiFilesystemPreopens(&providers, "wasi:filesystem/preopens") catch return;
+
+    // Stub component instance + module instance + memory. The bindings
+    // that take a `string` / `list<u8>` argument call
+    // `ci.readGuestBytes`, which walks the first core_instances entry
+    // with a non-null module_inst. We give it a minimal one with a
+    // zero-filled 64 KiB backing buffer.
+    var memory_bytes: [stub_memory_bytes]u8 = @splat(0);
+    var memory_inst: core_types.MemoryInstance = .{
+        .memory_type = .{ .limits = .{ .min = 1, .max = 1 } },
+        .data = &memory_bytes,
+        .current_pages = 1,
+        .max_pages = 1,
+    };
+    var module: core_types.WasmModule = .{};
+    var memories_slot = [_]*core_types.MemoryInstance{&memory_inst};
+    var module_inst: core_types.ModuleInstance = .{
+        .module = &module,
+        .memories = &memories_slot,
+        .tables = &.{},
+        .globals = &.{},
+        .allocator = allocator,
+    };
+    var core_instances = [_]ComponentInstance.CoreInstanceEntry{.{
+        .module_inst = &module_inst,
+    }};
+    var stub_component: ctypes.Component = .{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &.{},
+        .exports = &.{},
+    };
+    var ci: ComponentInstance = .{
+        .component = &stub_component,
+        .core_instances = &core_instances,
+        .resource_tables = .empty,
+        .exported_funcs = .empty,
+        .imports = .empty,
+        .module_arena = std.heap.ArenaAllocator.init(allocator),
+        .allocator = allocator,
+    };
+    defer ci.module_arena.deinit();
+    defer {
+        var rt_it = ci.resource_tables.valueIterator();
+        while (rt_it.next()) |rt| rt.deinit(allocator);
+        ci.resource_tables.deinit(allocator);
+        ci.exported_funcs.deinit(allocator);
+        ci.imports.deinit(allocator);
+    }
+
+    // Op stream: bytewise.
+    var cursor: usize = 0;
+    var op_idx: u32 = 0;
+    while (cursor < input.len and op_idx < max_ops_per_input) : (op_idx += 1) {
+        const op_byte = input[cursor];
+        cursor += 1;
+        const op = std.enums.fromInt(Op, op_byte % op_count) orelse continue;
+        cursor = dispatch(&adapter, &ci, &memory_bytes, op, input, cursor, allocator, io) catch |e| switch (e) {
+            error.OutOfMemory => return e,
+            else => cursor, // tolerate any typed error from the binding
+        };
+    }
+}
+
+fn dispatch(
+    adapter: *WasiCliAdapter,
+    ci: *ComponentInstance,
+    memory: []u8,
+    op: Op,
+    input: []const u8,
+    in_cursor: usize,
+    allocator: std.mem.Allocator,
+    io: std.Io,
+) !usize {
+    _ = io;
+    var cursor = in_cursor;
+
+    switch (op) {
+        .validate_sandbox_path => {
+            // u8 length, then up to that many bytes from input.
+            if (cursor >= input.len) return cursor;
+            const want_len = input[cursor];
+            cursor += 1;
+            const path_len = @min(@as(usize, want_len), input.len - cursor);
+            const path = input[cursor .. cursor + path_len];
+            cursor += path_len;
+            // Pure function. We just exercise it.
+            _ = WasiCliAdapter.validateSandboxPath(path);
+        },
+
+        .get_type, .get_flags, .stat, .append_via_stream, .drop_descriptor => {
+            const handle = pickHandle(adapter, input, &cursor) orelse return cursor;
+            const member_name = switch (op) {
+                .get_type => "[method]descriptor.get-type",
+                .get_flags => "[method]descriptor.get-flags",
+                .stat => "[method]descriptor.stat",
+                .append_via_stream => "[method]descriptor.append-via-stream",
+                .drop_descriptor => "[resource-drop]descriptor",
+                else => unreachable,
+            };
+            var args = [_]InterfaceValue{.{ .handle = handle }};
+            try invokeIface(&adapter.fs_types_iface, member_name, ci, &args, allocator);
+        },
+
+        .read_via_stream, .write_via_stream => {
+            const handle = pickHandle(adapter, input, &cursor) orelse return cursor;
+            const offset = readU64(input, &cursor);
+            const member_name = if (op == .read_via_stream)
+                "[method]descriptor.read-via-stream"
+            else
+                "[method]descriptor.write-via-stream";
+            var args = [_]InterfaceValue{
+                .{ .handle = handle },
+                .{ .u64 = offset },
+            };
+            try invokeIface(&adapter.fs_types_iface, member_name, ci, &args, allocator);
+        },
+
+        .get_directories => {
+            try invokeIface(&adapter.fs_preopens_iface, "get-directories", ci, &.{}, allocator);
+        },
+
+        .open_at => {
+            // open-at: (handle, path-flags u32, path string, open-flags u32, descriptor-flags u32)
+            const handle = pickHandle(adapter, input, &cursor) orelse return cursor;
+            const path_flags: u32 = readU32(input, &cursor);
+            // Synthesize a guest string by writing path bytes into stub
+            // memory at offset 0.
+            if (cursor >= input.len) return cursor;
+            const want_len = input[cursor];
+            cursor += 1;
+            const path_len = @min(@as(u32, want_len), @as(u32, @intCast(@min(memory.len, input.len - cursor))));
+            const path_src_end = @min(input.len, cursor + path_len);
+            const actual_len: u32 = @intCast(path_src_end - cursor);
+            @memcpy(memory[0..actual_len], input[cursor..path_src_end]);
+            cursor += actual_len;
+            const open_flags = readU32(input, &cursor);
+            const desc_flags = readU32(input, &cursor);
+            var args = [_]InterfaceValue{
+                .{ .handle = handle },
+                .{ .u32 = path_flags },
+                .{ .string = .{ .ptr = 0, .len = actual_len } },
+                .{ .u32 = open_flags },
+                .{ .u32 = desc_flags },
+            };
+            try invokeIface(&adapter.fs_types_iface, "[method]descriptor.open-at", ci, &args, allocator);
+        },
+
+        .drop_stream => {
+            // Drop a synthesized stream handle. Most picks will miss; that
+            // exercises the bad-handle path of the resource-drop binding.
+            const handle = readU32(input, &cursor);
+            var args = [_]InterfaceValue{.{ .handle = handle }};
+            try invokeIface(&adapter.write_iface, "[resource-drop]output-stream", ci, &args, allocator);
+            try invokeIface(&adapter.write_iface, "[resource-drop]input-stream", ci, &args, allocator);
+        },
+    }
+
+    return cursor;
+}
+
+/// Look up a member by name and call it. Frees results before
+/// returning. Returns OOM unconditionally; any other error from the
+/// host function is logged and discarded — typed errors are expected.
+fn invokeIface(
+    iface: *HostInstance,
+    name: []const u8,
+    ci: *ComponentInstance,
+    args: []InterfaceValue,
+    allocator: std.mem.Allocator,
+) !void {
+    const member = iface.members.get(name) orelse return;
+    const func = switch (member) {
+        .func => |f| f,
+        .resource_type => return,
+    };
+    const callable = func.call orelse return;
+    var results: [4]InterfaceValue = .{ .{ .u32 = 0 }, .{ .u32 = 0 }, .{ .u32 = 0 }, .{ .u32 = 0 } };
+    callable(func.context, ci, args, &results, allocator) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {},
+    };
+    // Free each result. `deinit` accepts any populated InterfaceValue
+    // (no-op on inline scalars).
+    for (results) |r| r.deinit(allocator);
+}
+
+/// Choose an existing descriptor table index from input, biased
+/// towards valid handles when possible. If the table only has the
+/// preopen, returns 0; otherwise mods the byte to pick any slot.
+fn pickHandle(adapter: *WasiCliAdapter, input: []const u8, cursor: *usize) ?u32 {
+    const len = adapter.fs_descriptor_table.items.len;
+    if (len == 0) return null;
+    if (cursor.* >= input.len) return 0;
+    const b = input[cursor.*];
+    cursor.* += 1;
+    // Occasionally synthesize an out-of-range handle to exercise the
+    // bad-descriptor path in every binding.
+    if ((b & 0xC0) == 0xC0) return @as(u32, b);
+    return @intCast(@as(usize, b) % len);
+}
+
+fn readU32(input: []const u8, cursor: *usize) u32 {
+    var out: u32 = 0;
+    var i: usize = 0;
+    while (i < 4 and cursor.* < input.len) : (i += 1) {
+        out |= @as(u32, input[cursor.*]) << @intCast(i * 8);
+        cursor.* += 1;
+    }
+    return out;
+}
+
+fn readU64(input: []const u8, cursor: *usize) u64 {
+    var out: u64 = 0;
+    var i: usize = 0;
+    while (i < 8 and cursor.* < input.len) : (i += 1) {
+        out |= @as(u64, input[cursor.*]) << @intCast(i * 8);
+        cursor.* += 1;
+    }
+    return out;
+}

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -30,6 +30,7 @@ abort, or small-input OOM is a bug.
 | `fuzz-aot` | AOT compile, AOT loader, and instantiate path | Compile/instantiate errors are OK. The harness deliberately sets `invoke_start = false` and does not execute attacker-supplied start functions. |
 | `fuzz-diff` | Interpreter vs AOT result oracle for a statically safe straight-line scalar subset | Loader/instantiate errors, interpreter traps, fuel exhaustion, unsupported signatures, and exports whose bytecode is outside the safe subset are OK. A result-shape, tag, or value mismatch is saved as `diff-mismatch-<hash>.wasm` and is a bug. |
 | `fuzz-canon` | Canonical ABI lift and string codecs over attacker-controlled guest memory | Typed errors and silent zero-fill on out-of-bounds reads are OK. Panics, safety-checked UB, oversize allocations, or process aborts are bugs. |
+| `fuzz-wasi` | `WasiCliAdapter` host bindings (filesystem descriptors, preopens, sandbox path validation, stream-drop) under a per-process temp preopen | Typed `result<_, error-code>` failures, reads/writes against bad handles, and rejected sandbox-escape paths are OK. Panics, aborts, allocator leaks, or any path resolution that escapes the temp root are bugs. No real network or arbitrary-fs IO. |
 
 ## Local use
 
@@ -90,6 +91,27 @@ entry points for CI and future mutation/generation infrastructure.
 `fuzz-interp` and `fuzz-diff` accept `--fuel <instructions>` as a per-export
 interpreter instruction budget. Fuel exhaustion is an expected outcome and is
 reported separately from a guest `unreachable` trap.
+
+For `fuzz-wasi` smoke (host-binding command model — no guest wasm executed):
+
+```sh
+rm -rf /tmp/wamr-wasi-corpus /tmp/wamr-fuzz-crashes
+mkdir -p /tmp/wamr-wasi-corpus /tmp/wamr-fuzz-crashes
+# op=validate-sandbox-path (0x08), len=9, "../escape".
+printf '\x08\x09../escape' > /tmp/wamr-wasi-corpus/seed-sandbox.wasm
+# op=get-directories (0x07).
+printf '\x07' > /tmp/wamr-wasi-corpus/seed-get-dirs.wasm
+./zig-out/bin/fuzz-wasi --corpus /tmp/wamr-wasi-corpus --crashes /tmp/wamr-fuzz-crashes --duration 5
+```
+
+`fuzz-wasi` decodes each input as a stream of bounded ops (op byte modulo
+the op count, then op-specific argument bytes) and dispatches each op
+against the bound host function on `WasiCliAdapter` looked up by its WIT
+member name (e.g. `[method]descriptor.open-at`). The descriptor table is
+seeded with one ephemeral preopen at `/tmp/fuzz-wasi-<pid>/` containing
+two small fixture files; the adapter, stub `ComponentInstance`, and stub
+guest memory are reconstructed each iteration so cross-input state
+cannot mask use-after-free or table-leak bugs.
 
 For `fuzz-diff` smoke with the same minimal seed:
 
@@ -201,6 +223,11 @@ host-protection mechanism.
   enum, option, result) and the storeVal round-trip are intentionally out of
   scope here; covering them needs a controlled `TypeRegistry` builder driven
   from the same input bytes.
+- `fuzz-wasi` covers Phase 1 of the WASI/component resource-table command
+  model: filesystem descriptor methods, preopens, and `validateSandboxPath`.
+  Explicit input/output stream allocation ops, sockets, and HTTP outgoing /
+  incoming streams are intentionally deferred to Phase 2/3 follow-up issues
+  so the scaffolding (stub `ComponentInstance` + invariants) lands first.
 - WASI/component resource-table command-model fuzzing — descriptor lifecycle,
   preopen escape checks, stream drops, socket option get/set on disconnected
   sockets, and HTTP stream lifetimes — is a follow-up that needs a thin


### PR DESCRIPTION
Closes #258 (Phase 1 scope).

## What

A new `fuzz-wasi` harness that drives the public host bindings on
`WasiCliAdapter` through a deterministic, byte-driven command model.
No real component wasm is executed — the harness invokes bound host
functions directly with synthesized `InterfaceValue` arguments and a
stub `ComponentInstance` whose canonical memory is a 64 KiB
zero-initialised buffer.

### Phase 1 ops

- `[method]descriptor.get-type`, `get-flags`, `stat`,
  `read-via-stream`, `write-via-stream`, `append-via-stream`
- `[method]descriptor.open-at` (path bytes are written into stub
  memory at offset 0 so `ci.readGuestBytes` resolves them)
- `[resource-drop]descriptor`
- `wasi:filesystem/preopens.get-directories`
- `WasiCliAdapter.validateSandboxPath` (dense pure-fn coverage)
- `[resource-drop]output-stream` / `[resource-drop]input-stream`
  (mostly the bad-handle path; wired so we exercise the resource-drop
  validators on synthesized handles)

### Phase 2/3 (deferred — separate follow-up issues)

- Explicit input/output stream allocation paths beyond `*-via-stream`.
- Disconnected socket option get/set + HTTP outgoing/incoming stream
  lifetimes.

The scaffolding (stub CI, command-model decoder, per-iteration
adapter/CI/memory reconstruction, name-based binding lookup) lands now
so the follow-ups are pure additions.

## Why

Loader and codec coverage is in place (`fuzz-loader`,
`fuzz-component-loader`, `fuzz-canon`), but the host-binding surface
on `WasiCliAdapter` had no fuzz coverage. That surface handles every
guest-controlled descriptor / stream / socket interaction; an
allocator leak, descriptor-table mismanagement, or sandbox bypass
there would be high-impact.

## Files

- `src/tests/fuzz/wasi.zig` — new harness.
- `src/component/wasi_cli_adapter.zig` — promote
  `validateSandboxPath` to `pub`. The same-file unit tests already
  treated it as semi-public (e.g. `test "filesystem: open-at sandbox
  rejects ..."`); this just makes the fuzz harness use of it valid.
- `build.zig` — register `fuzz-wasi`.
- `.github/workflows/fuzz.yml` — `wasi` in the matrix, three
  wasi-specific seed wasms (sandbox path, get-directories, get-type).
- `tests/fuzz/README.md` — `fuzz-wasi` row in the target table,
  smoke recipe, oracle paragraph, phasing note.
- `tests/fuzz/regression/wasi/.gitkeep` — placeholder for future
  committed regression seeds.

## Validation

- `zig build test` — clean.
- `zig build fuzz -Doptimize=ReleaseSafe` — clean.
- Smoke run against random + malformed corpus: 1k–32k iterations
  depending on input size, zero crashes, in-flight file removed
  cleanly.
- `python3 -c "yaml.safe_load(...)"` on the workflow.
- `git diff --check` clean.

## Out of scope (call out)

- Coverage-guided mutation — `fuzz-wasi` replays inputs round-robin
  like every other harness here. Coverage-guided is tracked by
  `tests/fuzz/OSS_FUZZ.md` (#249) and #262.
- Real network IO and DNS. Disconnected sockets only land in Phase 3.
- Driving bindings through the full component executor. The binding
  signature is the host contract; calling it directly is what the
  guest can ultimately reach via the trampoline.