### PR TITLE
Optimize small fixed bulk memory ops

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,18 +5,17 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     // Whether the selected target CPU can execute AOT code natively.
-    // Test/bench binaries that exercise AOT execution (codegen-bench,
-    // spec-test-runner, coremark-aot-runner) are only installed on these
-    // arches so cross-compiled release builds for e.g. riscv64 don't try
-    // to compile x86-only inline asm or the AOT execution path.
+    // Test/bench binaries tied to native AOT support are only installed on
+    // these arches so cross-compiled release builds for e.g. riscv64 don't
+    // try to compile or run the AOT execution path.
     const target_arch = target.result.cpu.arch;
     const aot_executable_target = switch (target_arch) {
         .x86_64, .aarch64 => true,
         else => false,
     };
-    // codegen-bench uses x86-specific `rdtsc` inline asm and only
-    // exercises the x86-64 codegen path.
-    const bench_target = target_arch == .x86_64;
+    // codegen-bench emits x86-64 machine code but does not execute it. It can
+    // run on the native AOT arches with a portable timer fallback.
+    const bench_target = aot_executable_target;
 
     // ── Build flags ────────────────────────────────────────────────────
     const strip = b.option(bool, "strip", "Strip debug info from binaries") orelse false;

--- a/src/compiler/bench_codegen.zig
+++ b/src/compiler/bench_codegen.zig
@@ -6,30 +6,52 @@
 //! Run with: zig build bench
 
 const std = @import("std");
+const builtin = @import("builtin");
 const ir = @import("ir/ir.zig");
 const passes = @import("ir/passes.zig");
 const compile = @import("codegen/x86_64/compile.zig");
 
-/// Read the CPU timestamp counter (RDTSC) for cycle-accurate timing.
-inline fn rdtsc() u64 {
-    var lo: u32 = undefined;
-    var hi: u32 = undefined;
-    asm volatile ("rdtsc"
-        : [lo] "={eax}" (lo),
-          [hi] "={edx}" (hi),
-    );
-    return (@as(u64, hi) << 32) | lo;
+fn usesCycleCounter() bool {
+    return switch (builtin.cpu.arch) {
+        .x86, .x86_64 => true,
+        else => false,
+    };
+}
+
+fn sampleUnit() []const u8 {
+    return if (comptime usesCycleCounter()) "cycles/op" else "ns/op";
+}
+
+/// Read the fastest available monotonic-ish sample source for benchmark timing.
+inline fn sampleTicks() u64 {
+    if (comptime usesCycleCounter()) {
+        var lo: u32 = undefined;
+        var hi: u32 = undefined;
+        asm volatile ("rdtsc"
+            : [lo] "={eax}" (lo),
+              [hi] "={edx}" (hi),
+        );
+        return (@as(u64, hi) << 32) | lo;
+    }
+    if (comptime builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        var ts: linux.timespec = undefined;
+        const rc = linux.clock_gettime(.MONOTONIC, &ts);
+        if (rc != 0) @panic("clock_gettime(CLOCK_MONOTONIC) failed");
+        return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+    }
+    @compileError("codegen benchmark needs a portable timer for this non-x86 target");
 }
 
 const BenchResult = struct {
     name: []const u8,
     iterations: u64,
-    total_cycles: u64,
+    total_ticks: u64,
     code_size: usize,
 
-    fn cyclesPerOp(self: BenchResult) u64 {
+    fn ticksPerOp(self: BenchResult) u64 {
         if (self.iterations == 0) return 0;
-        return self.total_cycles / self.iterations;
+        return self.total_ticks / self.iterations;
     }
 };
 
@@ -68,7 +90,7 @@ fn runBench(
 
     // Timed iterations (fixed count for consistency)
     const iterations: u64 = 10_000;
-    const start = rdtsc();
+    const start = sampleTicks();
 
     for (0..iterations) |_| {
         const r = try compile.compileFunctionRA(&func, 0, allocator);
@@ -76,12 +98,12 @@ fn runBench(
         allocator.free(r.call_patches);
     }
 
-    const end = rdtsc();
+    const end = sampleTicks();
 
     return .{
         .name = name,
         .iterations = iterations,
-        .total_cycles = end - start,
+        .total_ticks = end - start,
         .code_size = code_size,
     };
 }
@@ -420,6 +442,60 @@ fn bodyLoadStoreMulti(func: *ir.IrFunction, block: *ir.BasicBlock) void {
     block.append(.{ .op = .{ .ret = sum3 } }) catch unreachable;
 }
 
+fn bodyMemoryCopyFixed(func: *ir.IrFunction, block: *ir.BasicBlock, comptime len_value: i32) void {
+    const dst = func.newVReg();
+    const src = func.newVReg();
+    const len = func.newVReg();
+    block.append(.{ .op = .{ .iconst_32 = 0x1000 }, .dest = dst, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .iconst_32 = 0x1100 }, .dest = src, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .iconst_32 = len_value }, .dest = len, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .memory_copy = .{ .dst = dst, .src = src, .len = len } } }) catch unreachable;
+    block.append(.{ .op = .{ .ret = null } }) catch unreachable;
+}
+
+fn bodyMemoryCopy8(func: *ir.IrFunction, block: *ir.BasicBlock) void {
+    bodyMemoryCopyFixed(func, block, 8);
+}
+
+fn bodyMemoryCopy16(func: *ir.IrFunction, block: *ir.BasicBlock) void {
+    bodyMemoryCopyFixed(func, block, 16);
+}
+
+fn bodyMemoryCopy32(func: *ir.IrFunction, block: *ir.BasicBlock) void {
+    bodyMemoryCopyFixed(func, block, 32);
+}
+
+fn bodyMemoryCopy64(func: *ir.IrFunction, block: *ir.BasicBlock) void {
+    bodyMemoryCopyFixed(func, block, 64);
+}
+
+fn bodyMemoryFillFixed(func: *ir.IrFunction, block: *ir.BasicBlock, comptime len_value: i32) void {
+    const dst = func.newVReg();
+    const val = func.newVReg();
+    const len = func.newVReg();
+    block.append(.{ .op = .{ .iconst_32 = 0x1000 }, .dest = dst, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .iconst_32 = 0x5a }, .dest = val, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .iconst_32 = len_value }, .dest = len, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .memory_fill = .{ .dst = dst, .val = val, .len = len } } }) catch unreachable;
+    block.append(.{ .op = .{ .ret = null } }) catch unreachable;
+}
+
+fn bodyMemoryFill8(func: *ir.IrFunction, block: *ir.BasicBlock) void {
+    bodyMemoryFillFixed(func, block, 8);
+}
+
+fn bodyMemoryFill16(func: *ir.IrFunction, block: *ir.BasicBlock) void {
+    bodyMemoryFillFixed(func, block, 16);
+}
+
+fn bodyMemoryFill32(func: *ir.IrFunction, block: *ir.BasicBlock) void {
+    bodyMemoryFillFixed(func, block, 32);
+}
+
+fn bodyMemoryFill64(func: *ir.IrFunction, block: *ir.BasicBlock) void {
+    bodyMemoryFillFixed(func, block, 64);
+}
+
 // ── Call benchmark bodies ────────────────────────────────────────────
 
 /// call + ret — exercises call ABI, caller-saved save/restore.
@@ -502,7 +578,7 @@ fn runBenchWithPasses(
 
     // Timed iterations
     const iterations: u64 = 10_000;
-    const start = rdtsc();
+    const start = sampleTicks();
 
     for (0..iterations) |_| {
         const r = try compile.compileFunctionRA(&module.functions.items[0], 0, allocator);
@@ -510,18 +586,19 @@ fn runBenchWithPasses(
         allocator.free(r.call_patches);
     }
 
-    const end = rdtsc();
+    const end = sampleTicks();
 
     return .{
         .name = name,
         .iterations = iterations,
-        .total_cycles = end - start,
+        .total_ticks = end - start,
         .code_size = code_size,
     };
 }
 
 pub fn main() !void {
     const allocator = std.heap.page_allocator;
+    const metric_label = sampleUnit();
 
     std.debug.print("\n", .{});
     std.debug.print("  x86-64 Codegen Benchmark (10,000 iterations each)\n", .{});
@@ -529,7 +606,7 @@ pub fn main() !void {
 
     // ── Atomic operations (raw codegen, no passes) ──────────────────
     std.debug.print("  Atomic operations\n", .{});
-    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", "cycles/op", "code bytes" });
+    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", metric_label, "code bytes" });
     std.debug.print("  {s:-<34} {s:->12} {s:->10}\n", .{ "", "", "" });
 
     const atomic_benchmarks = [_]struct { name: []const u8, body: BuildBodyFn }{
@@ -546,12 +623,12 @@ pub fn main() !void {
     };
     for (atomic_benchmarks) |b| {
         const result = try runBench(allocator, b.name, b.body);
-        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.cyclesPerOp(), result.code_size });
+        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.ticksPerOp(), result.code_size });
     }
 
     // ── Arithmetic (raw codegen) ────────────────────────────────────
     std.debug.print("\n  Arithmetic\n", .{});
-    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", "cycles/op", "code bytes" });
+    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", metric_label, "code bytes" });
     std.debug.print("  {s:-<34} {s:->12} {s:->10}\n", .{ "", "", "" });
 
     const arith_benchmarks = [_]struct { name: []const u8, body: BuildBodyFn }{
@@ -562,12 +639,12 @@ pub fn main() !void {
     };
     for (arith_benchmarks) |b| {
         const result = try runBench(allocator, b.name, b.body);
-        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.cyclesPerOp(), result.code_size });
+        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.ticksPerOp(), result.code_size });
     }
 
     // ── Branches + control flow (raw codegen) ──────────────────────
     std.debug.print("\n  Branches + control flow\n", .{});
-    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", "cycles/op", "code bytes" });
+    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", metric_label, "code bytes" });
     std.debug.print("  {s:-<34} {s:->12} {s:->10}\n", .{ "", "", "" });
 
     const branch_benchmarks = [_]struct { name: []const u8, body: BuildBodyFn }{
@@ -577,26 +654,34 @@ pub fn main() !void {
     };
     for (branch_benchmarks) |b| {
         const result = try runBench(allocator, b.name, b.body);
-        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.cyclesPerOp(), result.code_size });
+        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.ticksPerOp(), result.code_size });
     }
 
     // ── Memory (raw codegen) ───────────────────────────────────────
     std.debug.print("\n  Memory\n", .{});
-    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", "cycles/op", "code bytes" });
+    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", metric_label, "code bytes" });
     std.debug.print("  {s:-<34} {s:->12} {s:->10}\n", .{ "", "", "" });
 
     const memory_benchmarks = [_]struct { name: []const u8, body: BuildBodyFn }{
         .{ .name = "load + add + store", .body = &bodyLoadStore },
         .{ .name = "4× load + sum + store", .body = &bodyLoadStoreMulti },
+        .{ .name = "memory.copy fixed 8", .body = &bodyMemoryCopy8 },
+        .{ .name = "memory.copy fixed 16", .body = &bodyMemoryCopy16 },
+        .{ .name = "memory.copy fixed 32", .body = &bodyMemoryCopy32 },
+        .{ .name = "memory.copy fixed 64", .body = &bodyMemoryCopy64 },
+        .{ .name = "memory.fill fixed 8", .body = &bodyMemoryFill8 },
+        .{ .name = "memory.fill fixed 16", .body = &bodyMemoryFill16 },
+        .{ .name = "memory.fill fixed 32", .body = &bodyMemoryFill32 },
+        .{ .name = "memory.fill fixed 64", .body = &bodyMemoryFill64 },
     };
     for (memory_benchmarks) |b| {
         const result = try runBench(allocator, b.name, b.body);
-        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.cyclesPerOp(), result.code_size });
+        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.ticksPerOp(), result.code_size });
     }
 
     // ── Calls (raw codegen) ────────────────────────────────────────
     std.debug.print("\n  Calls\n", .{});
-    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", "cycles/op", "code bytes" });
+    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", metric_label, "code bytes" });
     std.debug.print("  {s:-<34} {s:->12} {s:->10}\n", .{ "", "", "" });
 
     const call_benchmarks = [_]struct { name: []const u8, body: BuildBodyFn }{
@@ -604,12 +689,12 @@ pub fn main() !void {
     };
     for (call_benchmarks) |b| {
         const result = try runBench(allocator, b.name, b.body);
-        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.cyclesPerOp(), result.code_size });
+        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.ticksPerOp(), result.code_size });
     }
 
     // ── Float (raw codegen) ────────────────────────────────────────
     std.debug.print("\n  Float\n", .{});
-    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", "cycles/op", "code bytes" });
+    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", metric_label, "code bytes" });
     std.debug.print("  {s:-<34} {s:->12} {s:->10}\n", .{ "", "", "" });
 
     const float_benchmarks = [_]struct { name: []const u8, body: BuildBodyFn }{
@@ -618,12 +703,12 @@ pub fn main() !void {
     };
     for (float_benchmarks) |b| {
         const result = try runBench(allocator, b.name, b.body);
-        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.cyclesPerOp(), result.code_size });
+        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.ticksPerOp(), result.code_size });
     }
 
     // ── Optimization passes (codegen after default_passes) ─────────
     std.debug.print("\n  Optimization passes (codegen after default_passes)\n", .{});
-    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", "cycles/op", "code bytes" });
+    std.debug.print("  {s:<34} {s:>12} {s:>10}\n", .{ "operation", metric_label, "code bytes" });
     std.debug.print("  {s:-<34} {s:->12} {s:->10}\n", .{ "", "", "" });
 
     const pass_benchmarks = [_]struct { name: []const u8, body: BuildBodyFn }{
@@ -637,7 +722,7 @@ pub fn main() !void {
     };
     for (pass_benchmarks) |b| {
         const result = try runBenchWithPasses(allocator, b.name, b.body);
-        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.cyclesPerOp(), result.code_size });
+        std.debug.print("  {s:<34} {d:>12} {d:>10}\n", .{ result.name, result.ticksPerOp(), result.code_size });
     }
 
     std.debug.print("\n", .{});

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -35,6 +35,8 @@ const callee_saved_alloc = if (builtin.os.tag == .windows)
 else
     [_]emit.Reg{ .rbx, .r12, .r13, .r14, .r15 };
 
+const small_bulk_mem_max_len = 64;
+
 /// Fixed frame offset for the VMContext pointer.
 /// Stored at [rbp - 8] by compileFunctionRA at function entry.
 /// Points to a VmCtx struct with memory_base at +0, globals_base at +16.
@@ -1309,16 +1311,27 @@ fn dumpFuncIRAlloc(func: *const ir.IrFunction, fi: u32, import_count: u32, alloc
     p("=== IR DUMP func[{d}] param_count={d} local_count={d} blocks={d} ===\n", .{ fi, func.param_count, func.local_count, func.blocks.items.len });
 
     // Rebuild clobber points (same logic as compileFunctionRA) so allocation matches.
+    var const_vals = try buildConstVals(func, allocator);
+    defer const_vals.deinit();
     var clobbers: std.ArrayList(regalloc.ClobberPoint) = .empty;
     defer clobbers.deinit(allocator);
     var cp_pos: u32 = 0;
     for (func.blocks.items) |block| {
         for (block.instructions.items) |ci| {
             switch (ci.op) {
-                .call, .call_indirect, .call_ref, .memory_grow, .memory_copy, .table_grow, .table_set => {
+                .call, .call_indirect, .call_ref, .memory_grow, .table_grow, .table_set => {
                     try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = x86_64_call_clobber_mask });
                 },
-                .memory_fill => try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = @as(u64, 1) << 3 }),
+                .memory_copy => |mc| {
+                    if (smallFixedBulkMemLen(&const_vals, mc.len) == null) {
+                        try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = x86_64_call_clobber_mask });
+                    }
+                },
+                .memory_fill => |mf| {
+                    if (smallFixedBulkMemLen(&const_vals, mf.len) == null) {
+                        try clobbers.append(allocator, .{ .pos = cp_pos, .regs_clobbered = @as(u64, 1) << 3 });
+                    }
+                },
                 else => {},
             }
             cp_pos += 1;
@@ -1494,6 +1507,29 @@ fn x86_64_reg_set(local_count: u32) regalloc.RegSet {
     };
 }
 
+fn buildConstVals(func: *const ir.IrFunction, allocator: std.mem.Allocator) !std.AutoHashMap(ir.VReg, i64) {
+    var const_vals = std.AutoHashMap(ir.VReg, i64).init(allocator);
+    errdefer const_vals.deinit();
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |inst| {
+            if (inst.dest) |dest| {
+                switch (inst.op) {
+                    .iconst_32 => |v| try const_vals.put(dest, v),
+                    .iconst_64 => |v| try const_vals.put(dest, v),
+                    else => {},
+                }
+            }
+        }
+    }
+    return const_vals;
+}
+
+fn smallFixedBulkMemLen(const_vals: *const std.AutoHashMap(ir.VReg, i64), len: ir.VReg) ?u8 {
+    const val = const_vals.get(len) orelse return null;
+    if (val < 0 or val > small_bulk_mem_max_len) return null;
+    return @intCast(val);
+}
+
 fn functionUsesV128(func: *const ir.IrFunction) bool {
     if (func.local_types) |local_types| {
         for (local_types) |ty| if (ty == .v128) return true;
@@ -1561,6 +1597,9 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
     const block_order = try passes.reorderBlocks(func, allocator);
     defer allocator.free(block_order);
 
+    var const_vals = try buildConstVals(func, allocator);
+    defer const_vals.deinit();
+
     // Collect clobber points: instructions that destroy specific registers.
     // Uses block_order so numbering matches live-range computation.
     var clobber_points: std.ArrayList(regalloc.ClobberPoint) = .empty;
@@ -1570,18 +1609,26 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
         for (block_order) |block_id| {
             for (func.blocks.items[block_id].instructions.items) |ci| {
                 switch (ci.op) {
-                    .call, .call_indirect, .call_ref, .memory_grow, .memory_copy, .table_grow, .table_set => {
+                    .call, .call_indirect, .call_ref, .memory_grow, .table_grow, .table_set => {
                         // Calls clobber caller-saved allocatable regs.
-                        // memory.grow / memory.copy are compiled as host calls (same ABI),
-                        // so they clobber the same set of caller-saved registers.
+                        // memory.grow and table helpers are compiled as host calls
+                        // (same ABI), so they clobber caller-saved registers.
                         try clobber_points.append(allocator, .{ .pos = pos, .regs_clobbered = x86_64_call_clobber_mask });
                     },
-                    .memory_fill => {
-                        // REP STOSB clobbers rdi (index 3 in alloc_regs).
-                        try clobber_points.append(allocator, .{
-                            .pos = pos,
-                            .regs_clobbered = @as(u64, 1) << 3,
-                        });
+                    .memory_copy => |mc| {
+                        if (smallFixedBulkMemLen(&const_vals, mc.len) == null) {
+                            // Variable/large memory.copy is compiled as a host call.
+                            try clobber_points.append(allocator, .{ .pos = pos, .regs_clobbered = x86_64_call_clobber_mask });
+                        }
+                    },
+                    .memory_fill => |mf| {
+                        if (smallFixedBulkMemLen(&const_vals, mf.len) == null) {
+                            // REP STOSB clobbers rdi (index 3 in alloc_regs).
+                            try clobber_points.append(allocator, .{
+                                .pos = pos,
+                                .regs_clobbered = @as(u64, 1) << 3,
+                            });
+                        }
                     },
                     else => {},
                 }
@@ -1624,9 +1671,11 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
         for (func.blocks.items) |block| {
             for (block.instructions.items) |blk_inst| {
                 switch (blk_inst.op) {
-                    .memory_fill => {
-                        for (callee_saved_alloc, 0..) |cs_reg, i| {
-                            if (cs_reg == .rdi) used_callee_saved[i] = true;
+                    .memory_fill => |mf| {
+                        if (smallFixedBulkMemLen(&const_vals, mf.len) == null) {
+                            for (callee_saved_alloc, 0..) |cs_reg, i| {
+                                if (cs_reg == .rdi) used_callee_saved[i] = true;
+                            }
                         }
                     },
                     else => {},
@@ -1717,21 +1766,6 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
         if (used_callee_saved[i]) try code.pushReg(reg);
     }
 
-    // Build constant value table for immediate folding
-    var const_vals = std.AutoHashMap(ir.VReg, i64).init(allocator);
-    defer const_vals.deinit();
-    for (func.blocks.items) |block| {
-        for (block.instructions.items) |inst| {
-            if (inst.dest) |dest| {
-                switch (inst.op) {
-                    .iconst_32 => |v| try const_vals.put(dest, v),
-                    .iconst_64 => |v| try const_vals.put(dest, v),
-                    else => {},
-                }
-            }
-        }
-    }
-
     var block_offsets = std.AutoHashMap(ir.BlockId, usize).init(allocator);
     defer block_offsets.deinit();
     var branch_patches: std.ArrayList(BranchPatch) = .empty;
@@ -1812,6 +1846,133 @@ fn useVReg(
             return scratch;
         },
     }
+}
+
+fn loadWasmU32Addr(
+    code: *emit.CodeBuffer,
+    alloc_result: *const regalloc.AllocResult,
+    vreg: ir.VReg,
+    dst: emit.Reg,
+) !void {
+    const src_reg = try useVReg(code, alloc_result, vreg, dst);
+    if (src_reg != dst) try code.movRegReg(dst, src_reg);
+    try code.zeroExtend32(dst);
+}
+
+fn emitStaticBulkMemBoundsCheck(
+    code: *emit.CodeBuffer,
+    alloc_result: *const regalloc.AllocResult,
+    addr: ir.VReg,
+    len: u8,
+) !void {
+    try code.movRegMem(.r10, .rbp, vmctx_offset);
+    try loadWasmU32Addr(code, alloc_result, addr, .rax);
+    try emitMemBoundsCheck(code, len);
+}
+
+const CopyDirection = enum { forward, backward };
+
+fn copyChunkSize(remaining: u8) u8 {
+    if (remaining >= 8) return 8;
+    if (remaining >= 4) return 4;
+    if (remaining >= 2) return 2;
+    return 1;
+}
+
+fn emitUnrolledCopy(
+    code: *emit.CodeBuffer,
+    dst: emit.Reg,
+    src: emit.Reg,
+    len: u8,
+    direction: CopyDirection,
+) !void {
+    var remaining = len;
+    var forward_offset: u8 = 0;
+    while (remaining > 0) {
+        const chunk = copyChunkSize(remaining);
+        const offset: u8 = switch (direction) {
+            .forward => forward_offset,
+            .backward => remaining - chunk,
+        };
+        const disp: i32 = @intCast(offset);
+        try code.movRegMemSized(.r11, src, disp, chunk);
+        try code.movMemRegSized(dst, disp, .r11, chunk);
+        switch (direction) {
+            .forward => forward_offset += chunk,
+            .backward => {},
+        }
+        remaining -= chunk;
+    }
+}
+
+fn emitUnrolledFill(code: *emit.CodeBuffer, dst: emit.Reg, len: u8) !void {
+    var remaining = len;
+    var offset: u8 = 0;
+    while (remaining > 0) {
+        const chunk = copyChunkSize(remaining);
+        try code.movMemRegSized(dst, @intCast(offset), .r11, chunk);
+        offset += chunk;
+        remaining -= chunk;
+    }
+}
+
+fn patchRel32ToHere(code: *emit.CodeBuffer, imm_offset: usize) void {
+    const rel: i32 = @intCast(@as(i64, @intCast(code.len())) - @as(i64, @intCast(imm_offset + 4)));
+    code.patchI32(imm_offset, rel);
+}
+
+fn emitSmallMemoryCopy(
+    code: *emit.CodeBuffer,
+    alloc_result: *const regalloc.AllocResult,
+    dst: ir.VReg,
+    src: ir.VReg,
+    len: u8,
+) !void {
+    try emitStaticBulkMemBoundsCheck(code, alloc_result, dst, len);
+    try emitStaticBulkMemBoundsCheck(code, alloc_result, src, len);
+    if (len == 0) return;
+
+    try code.movRegMem(.r10, .rbp, vmctx_offset);
+    try loadWasmU32Addr(code, alloc_result, dst, .rax);
+    try code.movRegMem(.r10, .r10, vmctx_membase_field);
+    try code.addRegReg(.rax, .r10);
+    try loadWasmU32Addr(code, alloc_result, src, .rcx);
+    try code.addRegReg(.rcx, .r10);
+
+    try code.cmpRegReg(.rax, .rcx);
+    const forward_jcc = code.len();
+    try code.jbe(0);
+    try emitUnrolledCopy(code, .rax, .rcx, len, .backward);
+    const end_jmp = code.len();
+    try code.jmpRel32(0);
+    patchRel32ToHere(code, forward_jcc + 2);
+    try emitUnrolledCopy(code, .rax, .rcx, len, .forward);
+    patchRel32ToHere(code, end_jmp + 1);
+}
+
+fn emitSmallMemoryFill(
+    code: *emit.CodeBuffer,
+    alloc_result: *const regalloc.AllocResult,
+    dst: ir.VReg,
+    val: ir.VReg,
+    len: u8,
+) !void {
+    try emitStaticBulkMemBoundsCheck(code, alloc_result, dst, len);
+    if (len == 0) return;
+
+    try code.movRegMem(.r10, .rbp, vmctx_offset);
+    try loadWasmU32Addr(code, alloc_result, dst, .rax);
+    try code.movRegMem(.r10, .r10, vmctx_membase_field);
+    try code.addRegReg(.rax, .r10);
+
+    const val_reg = try useVReg(code, alloc_result, val, .r11);
+    if (val_reg != .r11) try code.movRegReg(.r11, val_reg);
+    try code.andRegImm32(.r11, 0xFF);
+    if (len > 1) {
+        try code.movRegImm64(.rcx, 0x0101010101010101);
+        try code.imulRegReg(.r11, .rcx);
+    }
+    try emitUnrolledFill(code, .rax, len);
 }
 
 /// Emit parallel move of wasm call args into Win64/SysV param_regs[1..].
@@ -2779,6 +2940,10 @@ fn compileInstRA(
             try code.movMemRegSized(.rax, st_disp, .rcx, st.size);
         },
         .memory_copy => |mc| {
+            if (smallFixedBulkMemLen(const_vals, mc.len)) |len| {
+                try emitSmallMemoryCopy(code, alloc_result, mc.dst, mc.src, len);
+                return;
+            }
             // Call the host helper via vmctx.mem_copy_fn(vmctx, dst, src, len).
             // The helper handles bounds-check + overlapping memmove semantics.
             // ABI-portable via param_regs.
@@ -2800,6 +2965,10 @@ fn compileInstRA(
             if (stack_adjust > 0) try code.addRegImm32(.rsp, @intCast(stack_adjust));
         },
         .memory_fill => |mf| {
+            if (smallFixedBulkMemLen(const_vals, mf.len)) |len| {
+                try emitSmallMemoryFill(code, alloc_result, mf.dst, mf.val, len);
+                return;
+            }
             // REP STOSB: rdi=dst, al=val, rcx=len
             //
             // Bounds check semantics (wasm spec): trap if dst + len > mem_size.
@@ -4675,7 +4844,7 @@ test "compileFunctionRA: extend_i32_s emits MOVSXD" {
     try std.testing.expect(containsBytes(code, &.{0x63}));
 }
 
-test "compileFunctionRA: memory_copy emits call via mem_copy_fn" {
+test "compileFunctionRA: small fixed memory_copy emits inline directional copy" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -4687,7 +4856,7 @@ test "compileFunctionRA: memory_copy emits call via mem_copy_fn" {
     const len = func.newVReg();
     try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = dst });
     try block.append(.{ .op = .{ .iconst_32 = 100 }, .dest = src });
-    try block.append(.{ .op = .{ .iconst_32 = 50 }, .dest = len });
+    try block.append(.{ .op = .{ .iconst_32 = 16 }, .dest = len });
     try block.append(.{ .op = .{ .memory_copy = .{ .dst = dst, .src = src, .len = len } } });
     try block.append(.{ .op = .{ .ret = null } });
 
@@ -4696,15 +4865,44 @@ test "compileFunctionRA: memory_copy emits call via mem_copy_fn" {
     defer allocator.free(compile_result.call_patches);
     defer allocator.free(code);
 
-    // Must NOT contain REP MOVSB (F3 A4): the inline path was buggy on overlap,
-    // we now dispatch through the vmctx.mem_copy_fn host helper which implements
-    // memmove semantics.
+    const mem_copy_field: [4]u8 = @bitCast(vmctx_mem_copy_fn_field);
+
+    // Must not use REP MOVSB: overlap-safe inline copy chooses direction first.
     try std.testing.expect(!containsBytes(code, &.{ 0xF3, 0xA4 }));
-    // Must contain CALL reg (FF /2): dispatch to the helper via rax.
+    try std.testing.expect(!containsBytes(code, &mem_copy_field));
+    // JBE rel32 selects the forward path when dst <= src.
+    try std.testing.expect(containsBytes(code, &.{ 0x0F, 0x86 }));
+}
+
+test "compileFunctionRA: large memory_copy emits call via mem_copy_fn" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const dst = func.newVReg();
+    const src = func.newVReg();
+    const len = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = dst });
+    try block.append(.{ .op = .{ .iconst_32 = 100 }, .dest = src });
+    try block.append(.{ .op = .{ .iconst_32 = 100 }, .dest = len });
+    try block.append(.{ .op = .{ .memory_copy = .{ .dst = dst, .src = src, .len = len } } });
+    try block.append(.{ .op = .{ .ret = null } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    const mem_copy_field: [4]u8 = @bitCast(vmctx_mem_copy_fn_field);
+
+    // Variable/large copies still dispatch to the helper for memmove semantics.
+    try std.testing.expect(containsBytes(code, &mem_copy_field));
     try std.testing.expect(containsBytes(code, &.{ 0xFF, 0xD0 }));
 }
 
-test "compileFunctionRA: memory_fill emits REP STOSB" {
+test "compileFunctionRA: large memory_fill emits REP STOSB" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -4727,6 +4925,32 @@ test "compileFunctionRA: memory_fill emits REP STOSB" {
 
     // Should contain REP STOSB (F3 AA)
     try std.testing.expect(containsBytes(code, &.{ 0xF3, 0xAA }));
+}
+
+test "compileFunctionRA: small fixed memory_fill emits unrolled stores" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const dst = func.newVReg();
+    const val = func.newVReg();
+    const len = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = dst });
+    try block.append(.{ .op = .{ .iconst_32 = 0xFF }, .dest = val });
+    try block.append(.{ .op = .{ .iconst_32 = 16 }, .dest = len });
+    try block.append(.{ .op = .{ .memory_fill = .{ .dst = dst, .val = val, .len = len } } });
+    try block.append(.{ .op = .{ .ret = null } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    try std.testing.expect(!containsBytes(code, &.{ 0xF3, 0xAA }));
+    // MOV rcx, 0x0101010101010101 builds the repeated fill byte pattern.
+    try std.testing.expect(containsBytes(code, &.{ 0x48, 0xB9, 0x01, 0x01, 0x01, 0x01 }));
 }
 
 test "compileFunctionRA: division uses rax/rdx" {

--- a/src/compiler/codegen/x86_64/emit.zig
+++ b/src/compiler/codegen/x86_64/emit.zig
@@ -288,6 +288,13 @@ pub const CodeBuffer = struct {
         try self.emitI32(rel);
     }
 
+    /// JBE rel32 (unsigned below or equal).
+    pub fn jbe(self: *CodeBuffer, rel: i32) !void {
+        try self.emitByte(0x0F);
+        try self.emitByte(0x86);
+        try self.emitI32(rel);
+    }
+
     // ── Memory access ─────────────────────────────────────────────────
 
     /// MOV reg, [base + disp32] (64-bit load from memory).


### PR DESCRIPTION
## Summary

- inline x86-64 AOT `memory.copy` for fixed lengths `0...64` with static bounds checks and direction-aware unrolled copies
- inline fixed-size `memory.fill` with unrolled stores while keeping variable/large fills on `REP STOSB`
- keep variable/large `memory.copy` on `mem_copy_fn` for overlap-safe helper semantics
- make `zig build bench` portable on aarch64 hosts and add fixed-size bulk-memory benchmark rows

Closes #231

## Validation

- `zig build test`
- `zig build bench`

## Baseline caveat

`zig build spec-tests-aot` still fails with the same pre-existing `linking.* FileNotFound` / `wasm trap: unreachable` baseline failure observed before these changes.