### PR TITLE
aarch64 aot: SIMD f64x2 arithmetic

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -587,6 +587,7 @@ fn isSupportedV128Def(inst: ir.Inst) bool {
         .i64x2_shift,
         .i64x2_splat,
         .i64x2_replace_lane,
+        .f64x2_binop,
         => inst.type == .v128,
         else => false,
     };
@@ -638,6 +639,7 @@ fn functionHasUnsupportedV128(func: *const ir.IrFunction, allocator: std.mem.All
                 .i64x2_shift,
                 .i64x2_splat,
                 .i64x2_replace_lane,
+                .f64x2_binop,
                 => {
                     if (!isSupportedV128Def(inst)) return true;
                 },
@@ -1446,6 +1448,7 @@ fn isV128Inst(inst: ir.Inst) bool {
         .i64x2_splat,
         .i64x2_extract_lane,
         .i64x2_replace_lane,
+        .f64x2_binop,
         => true,
         else => false,
     };
@@ -1628,6 +1631,7 @@ fn compileInst(
         .i64x2_splat => |src| try emitI64x2Splat(code, inst, src, reg_map, v128_map, v128_cache),
         .i64x2_extract_lane => |lane| try emitI64x2ExtractLane(code, inst, lane, reg_map, v128_map, v128_cache),
         .i64x2_replace_lane => |lane| try emitI64x2ReplaceLane(code, inst, lane, reg_map, v128_map, v128_cache, fctx),
+        .f64x2_binop => |bin| try emitF64x2BinOp(code, inst, bin, v128_map, v128_cache, fctx),
 
         .add => |bin| if (inst.type == .f32 or inst.type == .f64)
             try emitFBinOp(code, inst, bin, reg_map, .add)
@@ -2853,6 +2857,38 @@ fn emitI64x2BinOp(
         .ge_s => try code.i64x2Op(.cmge, dest_reg, lhs_reg, rhs_reg),
         .lt_s => try code.i64x2Op(.cmgt, dest_reg, rhs_reg, lhs_reg),
         .le_s => try code.i64x2Op(.cmge, dest_reg, rhs_reg, lhs_reg),
+    }
+}
+
+fn emitF64x2BinOp(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    bin: ir.Inst.F64x2BinOp,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+    fctx: *const FuncCompileCtx,
+) !void {
+    const lhs_reg = try v128_cache.ensure(code, v128_map, bin.lhs, null);
+    const rhs_reg = if (bin.rhs == bin.lhs)
+        lhs_reg
+    else
+        try v128_cache.ensure(code, v128_map, bin.rhs, lhs_reg);
+    const dest_reg = try prepareV128BinaryDest(
+        code,
+        inst,
+        bin.lhs,
+        lhs_reg,
+        bin.rhs,
+        rhs_reg,
+        v128_map,
+        v128_cache,
+        fctx,
+    );
+    switch (bin.op) {
+        .add => try code.f64x2Op(.add, dest_reg, lhs_reg, rhs_reg),
+        .sub => try code.f64x2Op(.sub, dest_reg, lhs_reg, rhs_reg),
+        .mul => try code.f64x2Op(.mul, dest_reg, lhs_reg, rhs_reg),
+        .div => try code.f64x2Op(.div, dest_reg, lhs_reg, rhs_reg),
     }
 }
 
@@ -6753,6 +6789,57 @@ test "compile: i64x2 cmp and arithmetic ops emit NEON instructions" {
     try std.testing.expect(found_mvn);
     try std.testing.expect(found_cmgt);
     try std.testing.expect(found_cmge);
+}
+
+test "compile: f64x2 arithmetic ops emit NEON instructions" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+
+    const a = func.newVReg();
+    const b = func.newVReg();
+    const add = func.newVReg();
+    const sub = func.newVReg();
+    const mul = func.newVReg();
+    const div = func.newVReg();
+    const lane = func.newVReg();
+    const wrapped = func.newVReg();
+
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x4008_0000_0000_0000_3ff0_0000_0000_0000 }, .dest = a, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x4010_0000_0000_0000_4000_0000_0000_0000 }, .dest = b, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .add, .lhs = a, .rhs = b } }, .dest = add, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .sub, .lhs = add, .rhs = b } }, .dest = sub, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .mul, .lhs = sub, .rhs = b } }, .dest = mul, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .div, .lhs = mul, .rhs = b } }, .dest = div, .type = .v128 });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i64x2_extract_lane = .{ .vector = div, .lane = 0 } },
+        .dest = lane,
+        .type = .i64,
+    });
+    try func.getBlock(bid).append(.{ .op = .{ .wrap_i64 = lane }, .dest = wrapped, .type = .i32 });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = wrapped } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    var found_fadd = false;
+    var found_fsub = false;
+    var found_fmul = false;
+    var found_fdiv = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFE0FC00) == 0x4E60D400) found_fadd = true;
+        if ((w & 0xFFE0FC00) == 0x4EE0D400) found_fsub = true;
+        if ((w & 0xFFE0FC00) == 0x6E60DC00) found_fmul = true;
+        if ((w & 0xFFE0FC00) == 0x6E60FC00) found_fdiv = true;
+    }
+
+    try std.testing.expect(found_fadd);
+    try std.testing.expect(found_fsub);
+    try std.testing.expect(found_fmul);
+    try std.testing.expect(found_fdiv);
 }
 
 test "compile: integer SIMD abs and neg ops emit NEON instructions" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -874,6 +874,21 @@ pub const CodeBuffer = struct {
             vd);
     }
 
+    pub const F64x2Op = enum(u32) {
+        add = 0x4E60D400,
+        sub = 0x4EE0D400,
+        mul = 0x6E60DC00,
+        div = 0x6E60FC00,
+    };
+
+    /// Floating-point 2D binary vector op: FADD/FSUB/FMUL/FDIV.
+    pub fn f64x2Op(self: *CodeBuffer, op: F64x2Op, vd: u5, vn: u5, vm: u5) !void {
+        try self.emit32(@intFromEnum(op) |
+            (@as(u32, vm) << 16) |
+            (@as(u32, vn) << 5) |
+            vd);
+    }
+
     /// SSHL Vd.2D, Vn.2D, Vm.2D — signed variable shift.
     pub fn sshl2d(self: *CodeBuffer, vd: u5, vn: u5, vm: u5) !void {
         try self.emit32(0x4EE04400 |
@@ -2511,6 +2526,33 @@ test "emit: i64x2 vector ops" {
         defer code.deinit();
         try code.i64x2Op(.cmge, 16, 17, 30);
         try expectWord(0x4EFE3E30, &code);
+    }
+}
+
+test "emit: f64x2 vector arithmetic ops" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.f64x2Op(.add, 16, 17, 30);
+        try expectWord(0x4E7ED630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.f64x2Op(.sub, 16, 17, 30);
+        try expectWord(0x4EFED630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.f64x2Op(.mul, 16, 17, 30);
+        try expectWord(0x6E7EDE30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.f64x2Op(.div, 16, 17, 30);
+        try expectWord(0x6E7EFE30, &code);
     }
 }
 

--- a/src/compiler/codegen/aarch64/schedule.zig
+++ b/src/compiler/codegen/aarch64/schedule.zig
@@ -285,6 +285,7 @@ fn opClass(inst: ir.Inst) Class {
         .i64x2_splat,
         .i64x2_extract_lane,
         .i64x2_replace_lane,
+        .f64x2_binop,
         => if (def != null) .alu else .barrier,
 
         .mul => if (def != null and isIntegerType(inst.type)) .mul else .barrier,
@@ -585,6 +586,10 @@ pub fn forEachUse(
             try visit(context, op.rhs);
         },
         .i64x2_binop => |bin| {
+            try visit(context, bin.lhs);
+            try visit(context, bin.rhs);
+        },
+        .f64x2_binop => |bin| {
             try visit(context, bin.lhs);
             try visit(context, bin.rhs);
         },

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1290,6 +1290,7 @@ fn compileInst(
         .i64x2_splat,
         .i64x2_extract_lane,
         .i64x2_replace_lane,
+        .f64x2_binop,
         => return error.UnsupportedV128,
         // Phi must be lowered before codegen.
         .phi => unreachable,
@@ -1581,6 +1582,7 @@ fn functionUsesV128(func: *const ir.IrFunction) bool {
                 .i64x2_splat,
                 .i64x2_extract_lane,
                 .i64x2_replace_lane,
+                .f64x2_binop,
                 => return true,
                 else => {},
             }

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -2292,6 +2292,32 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         });
                         try vreg_stack.append(allocator, dest);
                     },
+                    .f64x2_add,
+                    .f64x2_sub,
+                    .f64x2_mul,
+                    .f64x2_div,
+                    => {
+                        const rhs = safePop(&vreg_stack);
+                        const lhs = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        const lane_op: ir.Inst.F64x2Op = switch (simd_op) {
+                            .f64x2_add => .add,
+                            .f64x2_sub => .sub,
+                            .f64x2_mul => .mul,
+                            .f64x2_div => .div,
+                            else => unreachable,
+                        };
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .f64x2_binop = .{
+                                .op = lane_op,
+                                .lhs = lhs,
+                                .rhs = rhs,
+                            } },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
                     .i32x4_shl,
                     .i32x4_shr_s,
                     .i32x4_shr_u,
@@ -4885,6 +4911,98 @@ test "lower i64x2 cmp and arithmetic opcodes" {
     var inst_idx: usize = 2;
     for (cases, 0..) |case, idx| {
         try std.testing.expectEqual(case.expected, insts[inst_idx].op.i64x2_binop.op);
+        inst_idx += 1;
+        if (idx + 1 < cases.len) {
+            try std.testing.expectEqual(ir.IrType.v128, insts[inst_idx].type);
+            inst_idx += 1;
+        }
+    }
+    try std.testing.expectEqual(@as(u1, 0), insts[inst_idx].op.i64x2_extract_lane.lane);
+    try std.testing.expectEqual(ir.IrType.i64, insts[inst_idx].type);
+    try std.testing.expectEqual(insts[inst_idx].dest.?, insts[inst_idx + 1].op.wrap_i64);
+    try std.testing.expect(insts[inst_idx + 2].op.ret != null);
+}
+
+test "lower f64x2 arithmetic opcodes" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i32},
+    };
+
+    const Case = struct {
+        opcode: u32,
+        expected: ir.Inst.F64x2Op,
+    };
+    const cases = [_]Case{
+        .{ .opcode = 0xF0, .expected = .add },
+        .{ .opcode = 0xF1, .expected = .sub },
+        .{ .opcode = 0xF2, .expected = .mul },
+        .{ .opcode = 0xF3, .expected = .div },
+    };
+
+    const appendULEB = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, value: u32) !void {
+            var v = value;
+            while (true) {
+                var byte: u8 = @intCast(v & 0x7F);
+                v >>= 7;
+                if (v != 0) byte |= 0x80;
+                try buf.append(alloc, byte);
+                if (v == 0) break;
+            }
+        }
+    }.call;
+    const appendSimd = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, opcode: u32) !void {
+            try buf.append(alloc, 0xFD);
+            try appendULEB(buf, alloc, opcode);
+        }
+    }.call;
+    const appendConst = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, lanes: [2]u64) !void {
+            try appendSimd(buf, alloc, 0x0C);
+            for (lanes) |lane| {
+                var le = std.mem.nativeToLittle(u64, lane);
+                try buf.appendSlice(alloc, std.mem.asBytes(&le));
+            }
+        }
+    }.call;
+
+    var code: std.ArrayList(u8) = .empty;
+    defer code.deinit(allocator);
+    try appendConst(&code, allocator, .{ 0x3ff0_0000_0000_0000, 0x4000_0000_0000_0000 });
+    try appendConst(&code, allocator, .{ 0x4008_0000_0000_0000, 0x4010_0000_0000_0000 });
+    for (cases, 0..) |case, idx| {
+        if (idx != 0) try appendConst(&code, allocator, .{ 0x3ff0_0000_0000_0000, 0x3ff0_0000_0000_0000 });
+        try appendSimd(&code, allocator, case.opcode);
+    }
+    try appendSimd(&code, allocator, 0x1D); // i64x2.extract_lane
+    try code.append(allocator, 0);
+    try code.append(allocator, 0xA7); // i32.wrap_i64
+    try code.append(allocator, 0x0B);
+
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = code.items,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+    try std.testing.expectEqual(@as(usize, 2 + cases.len * 2 + 2), insts.len);
+    var inst_idx: usize = 2;
+    for (cases, 0..) |case, idx| {
+        try std.testing.expectEqual(case.expected, insts[inst_idx].op.f64x2_binop.op);
         inst_idx += 1;
         if (idx + 1 < cases.len) {
             try std.testing.expectEqual(ir.IrType.v128, insts[inst_idx].type);

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -231,6 +231,10 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
             live.put(bin.lhs, {}) catch {};
             live.put(bin.rhs, {}) catch {};
         },
+        .f64x2_binop => |bin| {
+            live.put(bin.lhs, {}) catch {};
+            live.put(bin.rhs, {}) catch {};
+        },
         .i64x2_unop => |un| live.put(un.vector, {}) catch {},
         .i64x2_extend_i32x4 => |op| live.put(op.vector, {}) catch {},
         .i64x2_extmul_i32x4 => |op| {
@@ -631,6 +635,10 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
             last_use.put(op.rhs, pos) catch {};
         },
         .i64x2_binop => |bin| {
+            last_use.put(bin.lhs, pos) catch {};
+            last_use.put(bin.rhs, pos) catch {};
+        },
+        .f64x2_binop => |bin| {
             last_use.put(bin.lhs, pos) catch {};
             last_use.put(bin.rhs, pos) catch {};
         },

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -106,6 +106,7 @@ pub const Inst = struct {
         i64x2_splat: VReg,
         i64x2_extract_lane: I64x2ExtractLane,
         i64x2_replace_lane: I64x2ReplaceLane,
+        f64x2_binop: F64x2BinOp,
 
         // Binary arithmetic (dest = lhs op rhs)
         add: BinOp,
@@ -389,6 +390,13 @@ pub const Inst = struct {
         shr_u,
     };
 
+    pub const F64x2Op = enum {
+        add,
+        sub,
+        mul,
+        div,
+    };
+
     pub const V128Mem = struct {
         base: VReg,
         offset: u32,
@@ -474,6 +482,12 @@ pub const Inst = struct {
 
     pub const I64x2BinOp = struct {
         op: I64x2Op,
+        lhs: VReg,
+        rhs: VReg,
+    };
+
+    pub const F64x2BinOp = struct {
+        op: F64x2Op,
         lhs: VReg,
         rhs: VReg,
     };
@@ -973,6 +987,14 @@ test "Inst: first v128 op family preserves operand shape" {
     };
     try std.testing.expectEqual(Inst.I64x2Op.gt_s, i64_bin.op.i64x2_binop.op);
     try std.testing.expectEqual(@as(VReg, 23), i64_bin.op.i64x2_binop.lhs);
+
+    const f64_bin = Inst{
+        .op = .{ .f64x2_binop = .{ .op = .div, .lhs = 24, .rhs = 25 } },
+        .dest = 26,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(Inst.F64x2Op.div, f64_bin.op.f64x2_binop.op);
+    try std.testing.expectEqual(@as(VReg, 24), f64_bin.op.f64x2_binop.lhs);
 
     const i64_splat = Inst{
         .op = .{ .i64x2_splat = 26 },

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -195,6 +195,10 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
             list.append(bin.lhs);
             list.append(bin.rhs);
         },
+        .f64x2_binop => |bin| {
+            list.append(bin.lhs);
+            list.append(bin.rhs);
+        },
         .i64x2_unop => |un| list.append(un.vector),
         .i64x2_shift => |shift| {
             list.append(shift.vector);
@@ -524,6 +528,10 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
             if (op.rhs == old) op.rhs = new;
         },
         .i64x2_binop => |*bin| {
+            if (bin.lhs == old) bin.lhs = new;
+            if (bin.rhs == old) bin.rhs = new;
+        },
+        .f64x2_binop => |*bin| {
             if (bin.lhs == old) bin.lhs = new;
             if (bin.rhs == old) bin.rhs = new;
         },
@@ -1834,6 +1842,7 @@ fn isPure(inst: ir.Inst) bool {
         .i16x8_extract_lane,
         .i16x8_replace_lane,
         .i64x2_binop,
+        .f64x2_binop,
         .i64x2_unop,
         .i64x2_extend_i32x4,
         .i64x2_extmul_i32x4,
@@ -1959,6 +1968,7 @@ fn sameOp(a: ir.Inst, b: ir.Inst) bool {
         .i16x8_extract_lane => |lane| lane.vector == b.op.i16x8_extract_lane.vector and lane.lane == b.op.i16x8_extract_lane.lane and lane.sign == b.op.i16x8_extract_lane.sign,
         .i16x8_replace_lane => |lane| lane.vector == b.op.i16x8_replace_lane.vector and lane.val == b.op.i16x8_replace_lane.val and lane.lane == b.op.i16x8_replace_lane.lane,
         .i64x2_binop => |bin| bin.op == b.op.i64x2_binop.op and bin.lhs == b.op.i64x2_binop.lhs and bin.rhs == b.op.i64x2_binop.rhs,
+        .f64x2_binop => |bin| bin.op == b.op.f64x2_binop.op and bin.lhs == b.op.f64x2_binop.lhs and bin.rhs == b.op.f64x2_binop.rhs,
         .i64x2_unop => |un| un.op == b.op.i64x2_unop.op and un.vector == b.op.i64x2_unop.vector,
         .i64x2_extend_i32x4 => |op| op.sign == b.op.i64x2_extend_i32x4.sign and op.half == b.op.i64x2_extend_i32x4.half and op.vector == b.op.i64x2_extend_i32x4.vector,
         .i64x2_extmul_i32x4 => |op| op.sign == b.op.i64x2_extmul_i32x4.sign and op.half == b.op.i64x2_extmul_i32x4.half and op.lhs == b.op.i64x2_extmul_i32x4.lhs and op.rhs == b.op.i64x2_extmul_i32x4.rhs,
@@ -3529,6 +3539,10 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
             op.rhs += offset;
         },
         .i64x2_binop => |*bin| {
+            bin.lhs += offset;
+            bin.rhs += offset;
+        },
+        .f64x2_binop => |*bin| {
             bin.lhs += offset;
             bin.rhs += offset;
         },

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -392,6 +392,60 @@ test "differential SIMD: i32x4.splat feeds i32x4.add" {
     try expectSimdDiffI32(wasm, "f", 9);
 }
 
+fn expectF64x2ArithmeticLane0High(opcode: u32, lhs: [2]u64, rhs: [2]u64, expected: i32) !void {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendV128ConstI64x2(&body, testing.allocator, lhs);
+    try appendV128ConstI64x2(&body, testing.allocator, rhs);
+    try appendSimdOpcode(&body, testing.allocator, opcode);
+    try appendI64x2ExtractLane(&body, testing.allocator, 0);
+    try appendI64Const(&body, testing.allocator, 32);
+    try appendI64ShrU(&body, testing.allocator);
+    try appendI32WrapI64(&body, testing.allocator);
+    try body.append(testing.allocator, 0x0B);
+
+    const wasm = try buildCustomModule(testing.allocator, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", expected);
+}
+
+test "differential SIMD: f64x2.add lane 0 matches interpreter" {
+    try expectF64x2ArithmeticLane0High(
+        0xF0,
+        .{ 0x3ff4_0000_0000_0000, 0x4008_0000_0000_0000 },
+        .{ 0x4004_0000_0000_0000, 0x4010_0000_0000_0000 },
+        0x400e_0000,
+    );
+}
+
+test "differential SIMD: f64x2.sub lane 0 matches interpreter" {
+    try expectF64x2ArithmeticLane0High(
+        0xF1,
+        .{ 0x4023_0000_0000_0000, 0x4010_0000_0000_0000 },
+        .{ 0x4002_0000_0000_0000, 0x4000_0000_0000_0000 },
+        0x401d_0000,
+    );
+}
+
+test "differential SIMD: f64x2.mul lane 0 matches interpreter" {
+    try expectF64x2ArithmeticLane0High(
+        0xF2,
+        .{ 0x4008_0000_0000_0000, 0x3ff0_0000_0000_0000 },
+        .{ 0xc004_0000_0000_0000, 0x4000_0000_0000_0000 },
+        @bitCast(@as(u32, 0xc01e_0000)),
+    );
+}
+
+test "differential SIMD: f64x2.div lane 0 matches interpreter" {
+    try expectF64x2ArithmeticLane0High(
+        0xF3,
+        .{ 0x4022_0000_0000_0000, 0x4010_0000_0000_0000 },
+        .{ 0x4000_0000_0000_0000, 0x4000_0000_0000_0000 },
+        0x4012_0000,
+    );
+}
+
 test "differential SIMD: i8x16.shuffle selects bytes from both inputs" {
     var body: std.ArrayList(u8) = .empty;
     defer body.deinit(testing.allocator);
@@ -654,6 +708,14 @@ fn appendV128ConstI32x4(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, l
     }
 }
 
+fn appendV128ConstI64x2(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lanes: [2]u64) !void {
+    try appendSimdOpcode(buf, allocator, 0x0C);
+    for (lanes) |lane| {
+        var le = std.mem.nativeToLittle(u64, lane);
+        try buf.appendSlice(allocator, std.mem.asBytes(&le));
+    }
+}
+
 fn appendV128ConstI8x16(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lanes: [16]u8) !void {
     try appendSimdOpcode(buf, allocator, 0x0C);
     try buf.appendSlice(allocator, &lanes);
@@ -682,9 +744,27 @@ fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator,
     try buf.append(allocator, lane);
 }
 
+fn appendI64x2ExtractLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x1D);
+    try buf.append(allocator, lane);
+}
+
 fn appendI32x4ReplaceLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x1C);
     try buf.append(allocator, lane);
+}
+
+fn appendI64Const(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, value: i64) !void {
+    try buf.append(allocator, 0x42);
+    try encodeSLEB128(buf, allocator, value);
+}
+
+fn appendI64ShrU(buf: *std.ArrayList(u8), allocator: std.mem.Allocator) !void {
+    try buf.append(allocator, 0x88);
+}
+
+fn appendI32WrapI64(buf: *std.ArrayList(u8), allocator: std.mem.Allocator) !void {
+    try buf.append(allocator, 0xA7);
 }
 
 fn appendSimdMemOpcode(


### PR DESCRIPTION
## Summary
- add IR/frontend lowering for f64x2.add/sub/mul/div
- emit AArch64 NEON FADD/FSUB/FMUL/FDIV for V.2D vectors
- add frontend, emitter, compile, and interpreter-vs-AOT differential coverage

## Validation
- zig build test --summary all
- zig build simd-bench -- --iterations 1

Closes #297