### PR TITLE
aarch64 aot: SIMD f64x2 min/max

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -2873,6 +2873,10 @@ fn emitF64x2BinOp(
         lhs_reg
     else
         try v128_cache.ensure(code, v128_map, bin.rhs, lhs_reg);
+    if (bin.op == .min or bin.op == .max) {
+        try emitF64x2MinMax(code, inst, bin, lhs_reg, rhs_reg, v128_map, v128_cache, fctx);
+        return;
+    }
     const dest_reg = try prepareV128BinaryDest(
         code,
         inst,
@@ -2889,7 +2893,48 @@ fn emitF64x2BinOp(
         .sub => try code.f64x2Op(.sub, dest_reg, lhs_reg, rhs_reg),
         .mul => try code.f64x2Op(.mul, dest_reg, lhs_reg, rhs_reg),
         .div => try code.f64x2Op(.div, dest_reg, lhs_reg, rhs_reg),
+        .min, .max => unreachable,
     }
+}
+
+fn emitF64x2MinMax(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    bin: ir.Inst.F64x2BinOp,
+    lhs_reg: u5,
+    rhs_reg: u5,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+    fctx: *const FuncCompileCtx,
+) !void {
+    try code.fcmeq2d(v128_tmp0, lhs_reg, lhs_reg);
+    try code.fcmeq2d(v128_tmp1, rhs_reg, rhs_reg);
+    try code.bitwise16b(.@"and", v128_tmp0, v128_tmp0, v128_tmp1);
+    try code.mvn16b(v128_tmp0, v128_tmp0);
+
+    const dest_reg = try prepareV128BinaryDest(
+        code,
+        inst,
+        bin.lhs,
+        lhs_reg,
+        bin.rhs,
+        rhs_reg,
+        v128_map,
+        v128_cache,
+        fctx,
+    );
+
+    switch (bin.op) {
+        .min => try code.f64x2Op(.min, dest_reg, lhs_reg, rhs_reg),
+        .max => try code.f64x2Op(.max, dest_reg, lhs_reg, rhs_reg),
+        else => unreachable,
+    }
+
+    try code.movImm64(RegMap.tmp0, 0x7ff8_0000_0000_0000);
+    try code.dup2dFromGp64(v128_tmp1, RegMap.tmp0);
+    try code.bitwise16b(.bic, dest_reg, dest_reg, v128_tmp0);
+    try code.bitwise16b(.@"and", v128_tmp1, v128_tmp1, v128_tmp0);
+    try code.bitwise16b(.orr, dest_reg, dest_reg, v128_tmp1);
 }
 
 fn emitI64x2Shift(
@@ -6803,6 +6848,8 @@ test "compile: f64x2 arithmetic ops emit NEON instructions" {
     const sub = func.newVReg();
     const mul = func.newVReg();
     const div = func.newVReg();
+    const min = func.newVReg();
+    const max = func.newVReg();
     const lane = func.newVReg();
     const wrapped = func.newVReg();
 
@@ -6812,8 +6859,10 @@ test "compile: f64x2 arithmetic ops emit NEON instructions" {
     try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .sub, .lhs = add, .rhs = b } }, .dest = sub, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .mul, .lhs = sub, .rhs = b } }, .dest = mul, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .div, .lhs = mul, .rhs = b } }, .dest = div, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .min, .lhs = div, .rhs = b } }, .dest = min, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .max, .lhs = min, .rhs = b } }, .dest = max, .type = .v128 });
     try func.getBlock(bid).append(.{
-        .op = .{ .i64x2_extract_lane = .{ .vector = div, .lane = 0 } },
+        .op = .{ .i64x2_extract_lane = .{ .vector = max, .lane = 0 } },
         .dest = lane,
         .type = .i64,
     });
@@ -6827,6 +6876,9 @@ test "compile: f64x2 arithmetic ops emit NEON instructions" {
     var found_fsub = false;
     var found_fmul = false;
     var found_fdiv = false;
+    var found_fmin = false;
+    var found_fmax = false;
+    var found_fcmeq = false;
     var i: usize = 0;
     while (i + 4 <= code.len) : (i += 4) {
         const w = std.mem.readInt(u32, code[i..][0..4], .little);
@@ -6834,12 +6886,18 @@ test "compile: f64x2 arithmetic ops emit NEON instructions" {
         if ((w & 0xFFE0FC00) == 0x4EE0D400) found_fsub = true;
         if ((w & 0xFFE0FC00) == 0x6E60DC00) found_fmul = true;
         if ((w & 0xFFE0FC00) == 0x6E60FC00) found_fdiv = true;
+        if ((w & 0xFFE0FC00) == 0x4EE0F400) found_fmin = true;
+        if ((w & 0xFFE0FC00) == 0x4E60F400) found_fmax = true;
+        if ((w & 0xFFE0FC00) == 0x4E60E400) found_fcmeq = true;
     }
 
     try std.testing.expect(found_fadd);
     try std.testing.expect(found_fsub);
     try std.testing.expect(found_fmul);
     try std.testing.expect(found_fdiv);
+    try std.testing.expect(found_fmin);
+    try std.testing.expect(found_fmax);
+    try std.testing.expect(found_fcmeq);
 }
 
 test "compile: integer SIMD abs and neg ops emit NEON instructions" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -879,11 +879,21 @@ pub const CodeBuffer = struct {
         sub = 0x4EE0D400,
         mul = 0x6E60DC00,
         div = 0x6E60FC00,
+        max = 0x4E60F400,
+        min = 0x4EE0F400,
     };
 
-    /// Floating-point 2D binary vector op: FADD/FSUB/FMUL/FDIV.
+    /// Floating-point 2D binary vector op: FADD/FSUB/FMUL/FDIV/FMAX/FMIN.
     pub fn f64x2Op(self: *CodeBuffer, op: F64x2Op, vd: u5, vn: u5, vm: u5) !void {
         try self.emit32(@intFromEnum(op) |
+            (@as(u32, vm) << 16) |
+            (@as(u32, vn) << 5) |
+            vd);
+    }
+
+    /// FCMEQ Vd.2D, Vn.2D, Vm.2D — floating-point compare equal per lane.
+    pub fn fcmeq2d(self: *CodeBuffer, vd: u5, vn: u5, vm: u5) !void {
+        try self.emit32(0x4E60E400 |
             (@as(u32, vm) << 16) |
             (@as(u32, vn) << 5) |
             vd);
@@ -2553,6 +2563,24 @@ test "emit: f64x2 vector arithmetic ops" {
         defer code.deinit();
         try code.f64x2Op(.div, 16, 17, 30);
         try expectWord(0x6E7EFE30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.f64x2Op(.min, 16, 17, 30);
+        try expectWord(0x4EFEF630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.f64x2Op(.max, 16, 17, 30);
+        try expectWord(0x4E7EF630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.fcmeq2d(16, 17, 30);
+        try expectWord(0x4E7EE630, &code);
     }
 }
 

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -2296,6 +2296,8 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .f64x2_sub,
                     .f64x2_mul,
                     .f64x2_div,
+                    .f64x2_min,
+                    .f64x2_max,
                     => {
                         const rhs = safePop(&vreg_stack);
                         const lhs = safePop(&vreg_stack);
@@ -2305,6 +2307,8 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                             .f64x2_sub => .sub,
                             .f64x2_mul => .mul,
                             .f64x2_div => .div,
+                            .f64x2_min => .min,
+                            .f64x2_max => .max,
                             else => unreachable,
                         };
                         try ir_func.getBlock(current_block).append(.{
@@ -4940,6 +4944,8 @@ test "lower f64x2 arithmetic opcodes" {
         .{ .opcode = 0xF1, .expected = .sub },
         .{ .opcode = 0xF2, .expected = .mul },
         .{ .opcode = 0xF3, .expected = .div },
+        .{ .opcode = 0xF4, .expected = .min },
+        .{ .opcode = 0xF5, .expected = .max },
     };
 
     const appendULEB = struct {

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -395,6 +395,8 @@ pub const Inst = struct {
         sub,
         mul,
         div,
+        min,
+        max,
     };
 
     pub const V128Mem = struct {

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -392,7 +392,7 @@ test "differential SIMD: i32x4.splat feeds i32x4.add" {
     try expectSimdDiffI32(wasm, "f", 9);
 }
 
-fn expectF64x2ArithmeticLane0High(opcode: u32, lhs: [2]u64, rhs: [2]u64, expected: i32) !void {
+fn expectF64x2Lane0Part(opcode: u32, lhs: [2]u64, rhs: [2]u64, shift: u6, expected: i32) !void {
     var body: std.ArrayList(u8) = .empty;
     defer body.deinit(testing.allocator);
     try body.append(testing.allocator, 0x00);
@@ -400,14 +400,28 @@ fn expectF64x2ArithmeticLane0High(opcode: u32, lhs: [2]u64, rhs: [2]u64, expecte
     try appendV128ConstI64x2(&body, testing.allocator, rhs);
     try appendSimdOpcode(&body, testing.allocator, opcode);
     try appendI64x2ExtractLane(&body, testing.allocator, 0);
-    try appendI64Const(&body, testing.allocator, 32);
-    try appendI64ShrU(&body, testing.allocator);
+    if (shift != 0) {
+        try appendI64Const(&body, testing.allocator, shift);
+        try appendI64ShrU(&body, testing.allocator);
+    }
     try appendI32WrapI64(&body, testing.allocator);
     try body.append(testing.allocator, 0x0B);
 
     const wasm = try buildCustomModule(testing.allocator, body.items);
     defer testing.allocator.free(wasm);
     try expectSimdDiffI32(wasm, "f", expected);
+}
+
+fn expectF64x2Lane0Low(opcode: u32, lhs: [2]u64, rhs: [2]u64, expected: i32) !void {
+    try expectF64x2Lane0Part(opcode, lhs, rhs, 0, expected);
+}
+
+fn expectF64x2Lane0High(opcode: u32, lhs: [2]u64, rhs: [2]u64, expected: i32) !void {
+    try expectF64x2Lane0Part(opcode, lhs, rhs, 32, expected);
+}
+
+fn expectF64x2ArithmeticLane0High(opcode: u32, lhs: [2]u64, rhs: [2]u64, expected: i32) !void {
+    try expectF64x2Lane0High(opcode, lhs, rhs, expected);
 }
 
 test "differential SIMD: f64x2.add lane 0 matches interpreter" {
@@ -444,6 +458,56 @@ test "differential SIMD: f64x2.div lane 0 matches interpreter" {
         .{ 0x4000_0000_0000_0000, 0x4000_0000_0000_0000 },
         0x4012_0000,
     );
+}
+
+test "differential SIMD: f64x2.min lane 0 matches interpreter" {
+    try expectF64x2Lane0High(
+        0xF4,
+        .{ 0x400c_0000_0000_0000, 0x3ff0_0000_0000_0000 },
+        .{ 0xc000_0000_0000_0000, 0x4000_0000_0000_0000 },
+        @bitCast(@as(u32, 0xc000_0000)),
+    );
+}
+
+test "differential SIMD: f64x2.max lane 0 matches interpreter" {
+    try expectF64x2Lane0High(
+        0xF5,
+        .{ 0x400c_0000_0000_0000, 0x3ff0_0000_0000_0000 },
+        .{ 0xc000_0000_0000_0000, 0x4000_0000_0000_0000 },
+        0x400c_0000,
+    );
+}
+
+test "differential SIMD: f64x2.min preserves negative zero" {
+    try expectF64x2Lane0High(
+        0xF4,
+        .{ 0x0000_0000_0000_0000, 0x3ff0_0000_0000_0000 },
+        .{ 0x8000_0000_0000_0000, 0x4000_0000_0000_0000 },
+        @bitCast(@as(u32, 0x8000_0000)),
+    );
+}
+
+test "differential SIMD: f64x2.max preserves positive zero" {
+    try expectF64x2Lane0High(
+        0xF5,
+        .{ 0x8000_0000_0000_0000, 0x3ff0_0000_0000_0000 },
+        .{ 0x0000_0000_0000_0000, 0x4000_0000_0000_0000 },
+        0,
+    );
+}
+
+test "differential SIMD: f64x2.min canonicalizes lhs NaN" {
+    const lhs = [2]u64{ 0x7ff8_0000_0000_0001, 0x3ff0_0000_0000_0000 };
+    const rhs = [2]u64{ 0x3ff0_0000_0000_0000, 0x4000_0000_0000_0000 };
+    try expectF64x2Lane0High(0xF4, lhs, rhs, 0x7ff8_0000);
+    try expectF64x2Lane0Low(0xF4, lhs, rhs, 0);
+}
+
+test "differential SIMD: f64x2.max canonicalizes rhs NaN" {
+    const lhs = [2]u64{ 0x3ff0_0000_0000_0000, 0x3ff0_0000_0000_0000 };
+    const rhs = [2]u64{ 0x7ff8_0000_0000_0001, 0x4000_0000_0000_0000 };
+    try expectF64x2Lane0High(0xF5, lhs, rhs, 0x7ff8_0000);
+    try expectF64x2Lane0Low(0xF5, lhs, rhs, 0);
 }
 
 test "differential SIMD: i8x16.shuffle selects bytes from both inputs" {


### PR DESCRIPTION
Closes #298.

Implements f64x2.min and f64x2.max AArch64 AOT lowering with canonical NaN fixup to match interpreter behavior, plus differential tests for normal, signed-zero, and NaN cases.