### PR TITLE
Add AArch64 f64x2 SIMD comparisons

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -2893,6 +2893,15 @@ fn emitF64x2BinOp(
         .sub => try code.f64x2Op(.sub, dest_reg, lhs_reg, rhs_reg),
         .mul => try code.f64x2Op(.mul, dest_reg, lhs_reg, rhs_reg),
         .div => try code.f64x2Op(.div, dest_reg, lhs_reg, rhs_reg),
+        .eq => try code.fcmeq2d(dest_reg, lhs_reg, rhs_reg),
+        .ne => {
+            try code.fcmeq2d(dest_reg, lhs_reg, rhs_reg);
+            try code.mvn16b(dest_reg, dest_reg);
+        },
+        .gt => try code.fcmgt2d(dest_reg, lhs_reg, rhs_reg),
+        .ge => try code.fcmge2d(dest_reg, lhs_reg, rhs_reg),
+        .lt => try code.fcmgt2d(dest_reg, rhs_reg, lhs_reg),
+        .le => try code.fcmge2d(dest_reg, rhs_reg, lhs_reg),
         .min, .max => unreachable,
     }
 }
@@ -6836,7 +6845,7 @@ test "compile: i64x2 cmp and arithmetic ops emit NEON instructions" {
     try std.testing.expect(found_cmge);
 }
 
-test "compile: f64x2 arithmetic ops emit NEON instructions" {
+test "compile: f64x2 arithmetic and comparison ops emit NEON instructions" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -6850,6 +6859,12 @@ test "compile: f64x2 arithmetic ops emit NEON instructions" {
     const div = func.newVReg();
     const min = func.newVReg();
     const max = func.newVReg();
+    const eq = func.newVReg();
+    const ne = func.newVReg();
+    const lt = func.newVReg();
+    const gt = func.newVReg();
+    const le = func.newVReg();
+    const ge = func.newVReg();
     const lane = func.newVReg();
     const wrapped = func.newVReg();
 
@@ -6861,8 +6876,14 @@ test "compile: f64x2 arithmetic ops emit NEON instructions" {
     try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .div, .lhs = mul, .rhs = b } }, .dest = div, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .min, .lhs = div, .rhs = b } }, .dest = min, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .max, .lhs = min, .rhs = b } }, .dest = max, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .eq, .lhs = a, .rhs = b } }, .dest = eq, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .ne, .lhs = eq, .rhs = b } }, .dest = ne, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .lt, .lhs = a, .rhs = b } }, .dest = lt, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .gt, .lhs = b, .rhs = a } }, .dest = gt, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .le, .lhs = a, .rhs = b } }, .dest = le, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_binop = .{ .op = .ge, .lhs = b, .rhs = a } }, .dest = ge, .type = .v128 });
     try func.getBlock(bid).append(.{
-        .op = .{ .i64x2_extract_lane = .{ .vector = max, .lane = 0 } },
+        .op = .{ .i64x2_extract_lane = .{ .vector = ge, .lane = 0 } },
         .dest = lane,
         .type = .i64,
     });
@@ -6879,6 +6900,9 @@ test "compile: f64x2 arithmetic ops emit NEON instructions" {
     var found_fmin = false;
     var found_fmax = false;
     var found_fcmeq = false;
+    var found_fcmgt = false;
+    var found_fcmge = false;
+    var found_mvn = false;
     var i: usize = 0;
     while (i + 4 <= code.len) : (i += 4) {
         const w = std.mem.readInt(u32, code[i..][0..4], .little);
@@ -6889,6 +6913,9 @@ test "compile: f64x2 arithmetic ops emit NEON instructions" {
         if ((w & 0xFFE0FC00) == 0x4EE0F400) found_fmin = true;
         if ((w & 0xFFE0FC00) == 0x4E60F400) found_fmax = true;
         if ((w & 0xFFE0FC00) == 0x4E60E400) found_fcmeq = true;
+        if ((w & 0xFFE0FC00) == 0x6EE0E400) found_fcmgt = true;
+        if ((w & 0xFFE0FC00) == 0x6E60E400) found_fcmge = true;
+        if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
     }
 
     try std.testing.expect(found_fadd);
@@ -6898,6 +6925,9 @@ test "compile: f64x2 arithmetic ops emit NEON instructions" {
     try std.testing.expect(found_fmin);
     try std.testing.expect(found_fmax);
     try std.testing.expect(found_fcmeq);
+    try std.testing.expect(found_fcmgt);
+    try std.testing.expect(found_fcmge);
+    try std.testing.expect(found_mvn);
 }
 
 test "compile: integer SIMD abs and neg ops emit NEON instructions" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -899,6 +899,22 @@ pub const CodeBuffer = struct {
             vd);
     }
 
+    /// FCMGT Vd.2D, Vn.2D, Vm.2D — floating-point compare greater-than per lane.
+    pub fn fcmgt2d(self: *CodeBuffer, vd: u5, vn: u5, vm: u5) !void {
+        try self.emit32(0x6EE0E400 |
+            (@as(u32, vm) << 16) |
+            (@as(u32, vn) << 5) |
+            vd);
+    }
+
+    /// FCMGE Vd.2D, Vn.2D, Vm.2D — floating-point compare greater-or-equal per lane.
+    pub fn fcmge2d(self: *CodeBuffer, vd: u5, vn: u5, vm: u5) !void {
+        try self.emit32(0x6E60E400 |
+            (@as(u32, vm) << 16) |
+            (@as(u32, vn) << 5) |
+            vd);
+    }
+
     /// SSHL Vd.2D, Vn.2D, Vm.2D — signed variable shift.
     pub fn sshl2d(self: *CodeBuffer, vd: u5, vn: u5, vm: u5) !void {
         try self.emit32(0x4EE04400 |
@@ -2581,6 +2597,18 @@ test "emit: f64x2 vector arithmetic ops" {
         defer code.deinit();
         try code.fcmeq2d(16, 17, 30);
         try expectWord(0x4E7EE630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.fcmgt2d(16, 17, 30);
+        try expectWord(0x6EFEE630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.fcmge2d(16, 17, 30);
+        try expectWord(0x6E7EE630, &code);
     }
 }
 

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -2298,6 +2298,12 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .f64x2_div,
                     .f64x2_min,
                     .f64x2_max,
+                    .f64x2_eq,
+                    .f64x2_ne,
+                    .f64x2_lt,
+                    .f64x2_gt,
+                    .f64x2_le,
+                    .f64x2_ge,
                     => {
                         const rhs = safePop(&vreg_stack);
                         const lhs = safePop(&vreg_stack);
@@ -2309,6 +2315,12 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                             .f64x2_div => .div,
                             .f64x2_min => .min,
                             .f64x2_max => .max,
+                            .f64x2_eq => .eq,
+                            .f64x2_ne => .ne,
+                            .f64x2_lt => .lt,
+                            .f64x2_gt => .gt,
+                            .f64x2_le => .le,
+                            .f64x2_ge => .ge,
                             else => unreachable,
                         };
                         try ir_func.getBlock(current_block).append(.{
@@ -4927,7 +4939,7 @@ test "lower i64x2 cmp and arithmetic opcodes" {
     try std.testing.expect(insts[inst_idx + 2].op.ret != null);
 }
 
-test "lower f64x2 arithmetic opcodes" {
+test "lower f64x2 arithmetic and comparison opcodes" {
     const allocator = std.testing.allocator;
 
     const func_type = types.FuncType{
@@ -4940,6 +4952,12 @@ test "lower f64x2 arithmetic opcodes" {
         expected: ir.Inst.F64x2Op,
     };
     const cases = [_]Case{
+        .{ .opcode = 0x47, .expected = .eq },
+        .{ .opcode = 0x48, .expected = .ne },
+        .{ .opcode = 0x49, .expected = .lt },
+        .{ .opcode = 0x4A, .expected = .gt },
+        .{ .opcode = 0x4B, .expected = .le },
+        .{ .opcode = 0x4C, .expected = .ge },
         .{ .opcode = 0xF0, .expected = .add },
         .{ .opcode = 0xF1, .expected = .sub },
         .{ .opcode = 0xF2, .expected = .mul },

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -397,6 +397,12 @@ pub const Inst = struct {
         div,
         min,
         max,
+        eq,
+        ne,
+        lt,
+        gt,
+        le,
+        ge,
     };
 
     pub const V128Mem = struct {

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -424,6 +424,64 @@ fn expectF64x2ArithmeticLane0High(opcode: u32, lhs: [2]u64, rhs: [2]u64, expecte
     try expectF64x2Lane0High(opcode, lhs, rhs, expected);
 }
 
+fn expectF64x2ComparisonLane0(opcode: u32, lhs: [2]u64, rhs: [2]u64, expected: i32) !void {
+    try expectF64x2Lane0Low(opcode, lhs, rhs, expected);
+}
+
+test "differential SIMD: f64x2.eq lane 0 matches interpreter" {
+    try expectF64x2ComparisonLane0(
+        0x47,
+        .{ 0x3ff0_0000_0000_0000, 0x4000_0000_0000_0000 },
+        .{ 0x3ff0_0000_0000_0000, 0x4008_0000_0000_0000 },
+        -1,
+    );
+}
+
+test "differential SIMD: f64x2.ne lane 0 matches interpreter for NaN" {
+    try expectF64x2ComparisonLane0(
+        0x48,
+        .{ 0x7ff8_0000_0000_0001, 0x4000_0000_0000_0000 },
+        .{ 0x3ff0_0000_0000_0000, 0x4008_0000_0000_0000 },
+        -1,
+    );
+}
+
+test "differential SIMD: f64x2.lt lane 0 matches interpreter" {
+    try expectF64x2ComparisonLane0(
+        0x49,
+        .{ 0x3ff0_0000_0000_0000, 0x4000_0000_0000_0000 },
+        .{ 0x4000_0000_0000_0000, 0x4008_0000_0000_0000 },
+        -1,
+    );
+}
+
+test "differential SIMD: f64x2.gt lane 0 matches interpreter" {
+    try expectF64x2ComparisonLane0(
+        0x4A,
+        .{ 0x4008_0000_0000_0000, 0x4000_0000_0000_0000 },
+        .{ 0x4000_0000_0000_0000, 0x4008_0000_0000_0000 },
+        -1,
+    );
+}
+
+test "differential SIMD: f64x2.le lane 0 matches interpreter" {
+    try expectF64x2ComparisonLane0(
+        0x4B,
+        .{ 0x4000_0000_0000_0000, 0x4000_0000_0000_0000 },
+        .{ 0x4000_0000_0000_0000, 0x4008_0000_0000_0000 },
+        -1,
+    );
+}
+
+test "differential SIMD: f64x2.ge lane 0 matches interpreter for NaN false" {
+    try expectF64x2ComparisonLane0(
+        0x4C,
+        .{ 0x7ff8_0000_0000_0001, 0x4000_0000_0000_0000 },
+        .{ 0x4000_0000_0000_0000, 0x4008_0000_0000_0000 },
+        0,
+    );
+}
+
 test "differential SIMD: f64x2.add lane 0 matches interpreter" {
     try expectF64x2ArithmeticLane0High(
         0xF0,


### PR DESCRIPTION
Closes #301.

- Lower f64x2 comparison opcodes into AOT IR
- Emit FCMEQ/FCMGT/FCMGE with NEON swap/invert patterns
- Add interpreter-vs-AOT differential coverage for all six opcodes

Validation:
- zig build test
- zig build