### PR TITLE
perf(aarch64): lower i8x16.popcnt

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -2076,6 +2076,7 @@ fn emitI32x4UnOp(
     switch (un.op) {
         .abs => try code.abs4s(dest_reg, vector_reg),
         .neg => try code.neg4s(dest_reg, vector_reg),
+        .popcnt => unreachable,
     }
 }
 
@@ -2124,6 +2125,7 @@ fn emitI8x16UnOp(
     switch (un.op) {
         .abs => try code.abs16b(dest_reg, vector_reg),
         .neg => try code.neg16b(dest_reg, vector_reg),
+        .popcnt => try code.cnt16b(dest_reg, vector_reg),
     }
 }
 
@@ -2140,6 +2142,7 @@ fn emitI16x8UnOp(
     switch (un.op) {
         .abs => try code.abs8h(dest_reg, vector_reg),
         .neg => try code.neg8h(dest_reg, vector_reg),
+        .popcnt => unreachable,
     }
 }
 
@@ -2437,6 +2440,7 @@ fn emitI64x2UnOp(
     switch (un.op) {
         .abs => try code.abs2d(dest_reg, vector_reg),
         .neg => try code.neg2d(dest_reg, vector_reg),
+        .popcnt => unreachable,
     }
 }
 
@@ -7067,7 +7071,7 @@ test "compile: SIMD int-to-float conversions emit NEON instructions" {
     try std.testing.expect(found_ucvtf2d);
 }
 
-test "compile: integer SIMD abs and neg ops emit NEON instructions" {
+test "compile: integer SIMD unary ops emit NEON instructions" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -7087,7 +7091,10 @@ test "compile: integer SIMD abs and neg ops emit NEON instructions" {
     try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x8000_0000_0000_0000_8000_0000_807F_0180 }, .dest = source, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i8x16_unop = .{ .op = .abs, .vector = source } }, .dest = i8_abs, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i8x16_unop = .{ .op = .neg, .vector = i8_abs } }, .dest = i8_neg, .type = .v128 });
-    try func.getBlock(bid).append(.{ .op = .{ .i16x8_unop = .{ .op = .abs, .vector = i8_neg } }, .dest = i16_abs, .type = .v128 });
+    const i8_popcnt = func.newVReg();
+    try func.getBlock(bid).append(.{ .op = .{ .i8x16_unop = .{ .op = .popcnt, .vector = source } }, .dest = i8_popcnt, .type = .v128 });
+
+    try func.getBlock(bid).append(.{ .op = .{ .i16x8_unop = .{ .op = .abs, .vector = i8_popcnt } }, .dest = i16_abs, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i16x8_unop = .{ .op = .neg, .vector = i16_abs } }, .dest = i16_neg, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i32x4_unop = .{ .op = .abs, .vector = i16_neg } }, .dest = i32_abs, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .i32x4_unop = .{ .op = .neg, .vector = i32_abs } }, .dest = i32_neg, .type = .v128 });
@@ -7111,6 +7118,7 @@ test "compile: integer SIMD abs and neg ops emit NEON instructions" {
     var found_neg4s = false;
     var found_abs2d = false;
     var found_neg2d = false;
+    var found_cnt16b = false;
     var i: usize = 0;
     while (i + 4 <= code.len) : (i += 4) {
         const w = std.mem.readInt(u32, code[i..][0..4], .little);
@@ -7122,6 +7130,7 @@ test "compile: integer SIMD abs and neg ops emit NEON instructions" {
         if ((w & 0xFFFFFC00) == 0x6EA0B800) found_neg4s = true;
         if ((w & 0xFFFFFC00) == 0x4EE0B800) found_abs2d = true;
         if ((w & 0xFFFFFC00) == 0x6EE0B800) found_neg2d = true;
+        if ((w & 0xFFFFFC00) == 0x4E205800) found_cnt16b = true;
     }
 
     try std.testing.expect(found_abs16b);
@@ -7132,6 +7141,7 @@ test "compile: integer SIMD abs and neg ops emit NEON instructions" {
     try std.testing.expect(found_neg4s);
     try std.testing.expect(found_abs2d);
     try std.testing.expect(found_neg2d);
+    try std.testing.expect(found_cnt16b);
 }
 
 test "compile: integer SIMD pairwise extended add ops emit NEON instructions" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -674,6 +674,13 @@ pub const CodeBuffer = struct {
         try self.emit32(0x0E205800 | (@as(u32, vn) << 5) | vd);
     }
 
+    /// CNT Vd.16B, Vn.16B — population count per byte in a 128-bit vector.
+    /// Each destination byte holds popcount(0..=8) of the corresponding source byte.
+    pub fn cnt16b(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        // 0 Q 1 01110 size 10000 00101 10 Rn Rd, Q=1 (16B), size=00
+        try self.emit32(0x4E205800 | (@as(u32, vn) << 5) | vd);
+    }
+
     /// ADDV Bd, Vn.8B — sum all 8 bytes of Vn into the low byte of Vd.
     pub fn addvB8b(self: *CodeBuffer, vd: u5, vn: u5) !void {
         // 0 Q 0 01110 size 11000 11011 10 Rn Rd, Q=0, size=00
@@ -2192,6 +2199,13 @@ test "emit: CNT v0.8b, v1.8b" {
     defer code.deinit();
     try code.cnt8b(0, 1);
     try expectWord(0x0E205820, &code);
+}
+
+test "emit: CNT v0.16b, v1.16b" {
+    var code = CodeBuffer.init(std.testing.allocator);
+    defer code.deinit();
+    try code.cnt16b(0, 1);
+    try expectWord(0x4E205820, &code);
 }
 
 test "emit: ADDV b0, v1.8b" {

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -1814,6 +1814,7 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     },
                     .i8x16_abs,
                     .i8x16_neg,
+                    .i8x16_popcnt,
                     .i16x8_abs,
                     .i16x8_neg,
                     .i32x4_abs,
@@ -1835,12 +1836,13 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                                 .i32x4_neg,
                                 .i64x2_neg,
                                 => .neg,
+                                .i8x16_popcnt => .popcnt,
                                 else => unreachable,
                             },
                             .vector = vector,
                         };
                         const inst_op: ir.Inst.Op = switch (simd_op) {
-                            .i8x16_abs, .i8x16_neg => .{ .i8x16_unop = unary },
+                            .i8x16_abs, .i8x16_neg, .i8x16_popcnt => .{ .i8x16_unop = unary },
                             .i16x8_abs, .i16x8_neg => .{ .i16x8_unop = unary },
                             .i32x4_abs, .i32x4_neg => .{ .i32x4_unop = unary },
                             .i64x2_abs, .i64x2_neg => .{ .i64x2_unop = unary },
@@ -4086,7 +4088,7 @@ test "lower i64x2 scalar-count shift opcodes" {
     try std.testing.expect(insts[9].op.ret != null);
 }
 
-test "lower integer SIMD abs and neg opcodes" {
+test "lower integer SIMD unary opcodes" {
     const allocator = std.testing.allocator;
 
     const func_type = types.FuncType{
@@ -4103,6 +4105,7 @@ test "lower integer SIMD abs and neg opcodes" {
     const cases = [_]Case{
         .{ .opcode = 0x60, .family = .i8x16, .expected = .abs },
         .{ .opcode = 0x61, .family = .i8x16, .expected = .neg },
+        .{ .opcode = 0x62, .family = .i8x16, .expected = .popcnt },
         .{ .opcode = 0x80, .family = .i16x8, .expected = .abs },
         .{ .opcode = 0x81, .family = .i16x8, .expected = .neg },
         .{ .opcode = 0xA0, .family = .i32x4, .expected = .abs },

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -282,7 +282,7 @@ pub const Inst = struct {
     pub const AtomicRmwOp = enum { add, sub, @"and", @"or", xor, xchg };
 
     pub const V128BitwiseOp = enum { @"and", andnot, @"or", xor };
-    pub const SimdUnaryOp = enum { abs, neg };
+    pub const SimdUnaryOp = enum { abs, neg, popcnt };
     pub const SimdExtAddPairwiseSign = enum { signed, unsigned };
     pub const SimdExtendSign = enum { signed, unsigned };
     pub const SimdExtendHalfSelect = enum { low, high };


### PR DESCRIPTION
Fixes #282.

Adds the SIMD unary frontend/IR path for `i8x16.popcnt` and lowers it to AArch64 NEON `CNT` on 16-byte vectors.

Validation:
- `zig build test`
- `zig build`