### PR TITLE
perf(aarch64): lower v128.loadN_splat

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -553,6 +553,7 @@ fn isSupportedV128Def(inst: ir.Inst) bool {
     return switch (inst.op) {
         .v128_const,
         .v128_load,
+        .v128_load_splat,
         .v128_not,
         .v128_bitwise,
         .v128_bitselect,
@@ -608,6 +609,7 @@ fn functionHasUnsupportedV128(func: *const ir.IrFunction, allocator: std.mem.All
             switch (inst.op) {
                 .v128_const,
                 .v128_load,
+                .v128_load_splat,
                 .v128_not,
                 .v128_bitwise,
                 .v128_bitselect,
@@ -1415,6 +1417,7 @@ fn isV128Inst(inst: ir.Inst) bool {
     return switch (inst.op) {
         .v128_const,
         .v128_load,
+        .v128_load_splat,
         .v128_store,
         .v128_not,
         .v128_bitwise,
@@ -1604,6 +1607,7 @@ fn compileInst(
         },
         .v128_const => |val| try emitV128Const(code, inst, val, v128_map, v128_cache),
         .v128_load => |ld| try emitV128Load(code, inst, ld, reg_map, v128_map, v128_cache),
+        .v128_load_splat => |ld| try emitV128LoadSplat(code, inst, ld, reg_map, v128_map, v128_cache),
         .v128_store => |st| try emitV128Store(code, st, reg_map, v128_map, v128_cache),
         .v128_not => |src| try emitV128Not(code, inst, src, v128_map, v128_cache, fctx),
         .v128_bitwise => |bin| try emitV128Bitwise(code, inst, bin, v128_map, v128_cache, fctx),
@@ -2008,6 +2012,30 @@ fn emitV128Load(
         try emitMemAddr(code, reg_map, ld.base, ld.offset, end_offset);
     }
     try code.ldrQ(dest_reg, RegMap.tmp0);
+}
+
+fn emitV128LoadSplat(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    ld: ir.Inst.V128LoadSplat,
+    reg_map: *RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+) !void {
+    const dest = inst.dest orelse return;
+    const dest_reg = try v128_cache.defineFresh(code, v128_map, dest, null);
+    const end_offset: u64 = if (ld.checked_end > 0) ld.checked_end else @as(u64, ld.offset) + ld.accessSize();
+    if (ld.bounds_known) {
+        try emitMemAddrSkipBounds(code, reg_map, ld.base, ld.offset);
+    } else {
+        try emitMemAddr(code, reg_map, ld.base, ld.offset, end_offset);
+    }
+    switch (ld.width) {
+        .i8x16 => try code.ld1r16b(dest_reg, RegMap.tmp0),
+        .i16x8 => try code.ld1r8h(dest_reg, RegMap.tmp0),
+        .i32x4 => try code.ld1r4s(dest_reg, RegMap.tmp0),
+        .i64x2 => try code.ld1r2d(dest_reg, RegMap.tmp0),
+    }
 }
 
 fn emitV128Store(
@@ -8099,6 +8127,73 @@ test "load: bounds check emits B.LS + trap BLR + BRK" {
         if ((w & 0xFFFFFC1F) == 0xD63F0000) found_blr = true;
         if ((w & 0xFFE0001F) == 0xD4200000) found_brk = true;
     }
+    try std.testing.expect(found_bls);
+    try std.testing.expect(found_blr);
+    try std.testing.expect(found_brk);
+}
+
+test "compile: v128.load_splat emits LD1R forms with bounds trap" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+    const addr = func.newVReg();
+    try func.getBlock(bid).append(.{ .op = .{ .iconst_32 = 0 }, .dest = addr, .type = .i32 });
+
+    const cases = [_]struct {
+        width: ir.Inst.V128LoadSplatWidth,
+        offset: u32,
+        alignment: u32,
+    }{
+        .{ .width = .i8x16, .offset = 0, .alignment = 0 },
+        .{ .width = .i16x8, .offset = 2, .alignment = 1 },
+        .{ .width = .i32x4, .offset = 4, .alignment = 2 },
+        .{ .width = .i64x2, .offset = 8, .alignment = 3 },
+    };
+    for (cases) |case| {
+        const vec = func.newVReg();
+        try func.getBlock(bid).append(.{
+            .op = .{ .v128_load_splat = .{
+                .width = case.width,
+                .base = addr,
+                .offset = case.offset,
+                .alignment = case.alignment,
+            } },
+            .dest = vec,
+            .type = .v128,
+        });
+    }
+
+    const ret = func.newVReg();
+    try func.getBlock(bid).append(.{ .op = .{ .iconst_32 = 0 }, .dest = ret, .type = .i32 });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = ret } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    var found_ld1r_16b = false;
+    var found_ld1r_8h = false;
+    var found_ld1r_4s = false;
+    var found_ld1r_2d = false;
+    var found_bls = false;
+    var found_blr = false;
+    var found_brk = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFFFFC00) == 0x4D40C000) found_ld1r_16b = true;
+        if ((w & 0xFFFFFC00) == 0x4D40C400) found_ld1r_8h = true;
+        if ((w & 0xFFFFFC00) == 0x4D40C800) found_ld1r_4s = true;
+        if ((w & 0xFFFFFC00) == 0x4D40CC00) found_ld1r_2d = true;
+        if ((w & 0xFF000010) == 0x54000000 and (w & 0xF) == 0x9) found_bls = true;
+        if ((w & 0xFFFFFC1F) == 0xD63F0000) found_blr = true;
+        if ((w & 0xFFE0001F) == 0xD4200000) found_brk = true;
+    }
+
+    try std.testing.expect(found_ld1r_16b);
+    try std.testing.expect(found_ld1r_8h);
+    try std.testing.expect(found_ld1r_4s);
+    try std.testing.expect(found_ld1r_2d);
     try std.testing.expect(found_bls);
     try std.testing.expect(found_blr);
     try std.testing.expect(found_brk);

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -755,6 +755,33 @@ pub const CodeBuffer = struct {
         try self.emit32(0x3DC00000 | (@as(u32, rn.encoding()) << 5) | vt);
     }
 
+    fn ld1r(self: *CodeBuffer, vt: u5, rn: Reg, size: u2) !void {
+        try self.emit32(0x4D40C000 |
+            (@as(u32, size) << 10) |
+            (@as(u32, rn.encoding()) << 5) |
+            vt);
+    }
+
+    /// LD1R { Vt.16B }, [Xn] — load one byte and broadcast to all lanes.
+    pub fn ld1r16b(self: *CodeBuffer, vt: u5, rn: Reg) !void {
+        try self.ld1r(vt, rn, 0);
+    }
+
+    /// LD1R { Vt.8H }, [Xn] — load one halfword and broadcast to all lanes.
+    pub fn ld1r8h(self: *CodeBuffer, vt: u5, rn: Reg) !void {
+        try self.ld1r(vt, rn, 1);
+    }
+
+    /// LD1R { Vt.4S }, [Xn] — load one word and broadcast to all lanes.
+    pub fn ld1r4s(self: *CodeBuffer, vt: u5, rn: Reg) !void {
+        try self.ld1r(vt, rn, 2);
+    }
+
+    /// LD1R { Vt.2D }, [Xn] — load one doubleword and broadcast to all lanes.
+    pub fn ld1r2d(self: *CodeBuffer, vt: u5, rn: Reg) !void {
+        try self.ld1r(vt, rn, 3);
+    }
+
     /// STR Qt, [Xn] — full-width 128-bit vector store.
     pub fn strQ(self: *CodeBuffer, vt: u5, rn: Reg) !void {
         try self.emit32(0x3D800000 | (@as(u32, rn.encoding()) << 5) | vt);
@@ -2362,6 +2389,33 @@ test "emit: LDR q0, [x1]" {
     defer code.deinit();
     try code.ldrQ(0, .x1);
     try expectWord(0x3DC00020, &code);
+}
+
+test "emit: LD1R vector broadcast load forms" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.ld1r16b(0, .x9);
+        try expectWord(0x4D40C120, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.ld1r8h(1, .x10);
+        try expectWord(0x4D40C541, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.ld1r4s(2, .x11);
+        try expectWord(0x4D40C962, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.ld1r2d(3, .x12);
+        try expectWord(0x4D40CD83, &code);
+    }
 }
 
 test "emit: STR q0, [x1]" {

--- a/src/compiler/codegen/aarch64/schedule.zig
+++ b/src/compiler/codegen/aarch64/schedule.zig
@@ -245,7 +245,7 @@ fn opClass(inst: ir.Inst) Class {
     return switch (inst.op) {
         .iconst_32, .iconst_64 => if (def != null) .constant else .barrier,
         .v128_const => if (def != null) .constant else .barrier,
-        .v128_load => if (def != null) .load else .barrier,
+        .v128_load, .v128_load_splat => if (def != null) .load else .barrier,
         .store, .v128_store => .store,
         .v128_not,
         .v128_any_true,
@@ -371,7 +371,7 @@ fn isOrderedMemory(inst: ir.Inst) bool {
 
 fn isOrderedMemoryOp(op: ir.Inst.Op) bool {
     return switch (op) {
-        .load, .store, .v128_load, .v128_store => true,
+        .load, .store, .v128_load, .v128_load_splat, .v128_store => true,
         else => false,
     };
 }
@@ -537,6 +537,7 @@ pub fn forEachUse(
         .v128_not => |v| try visit(context, v),
         .v128_any_true => |v| try visit(context, v),
         .v128_load => |ld| try visit(context, ld.base),
+        .v128_load_splat => |ld| try visit(context, ld.base),
         .v128_store => |st| {
             try visit(context, st.base);
             try visit(context, st.val);

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1251,6 +1251,7 @@ fn compileInst(
         },
         .v128_const,
         .v128_load,
+        .v128_load_splat,
         .v128_store,
         .v128_not,
         .v128_bitwise,
@@ -1549,6 +1550,7 @@ fn functionUsesV128(func: *const ir.IrFunction) bool {
             switch (inst.op) {
                 .v128_const,
                 .v128_load,
+                .v128_load_splat,
                 .v128_store,
                 .v128_not,
                 .v128_bitwise,

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -1793,6 +1793,34 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         });
                         try vreg_stack.append(allocator, dest);
                     },
+                    .v128_load8_splat,
+                    .v128_load16_splat,
+                    .v128_load32_splat,
+                    .v128_load64_splat,
+                    => {
+                        const alignment = readU32(code, &ip);
+                        const offset = readU32(code, &ip);
+                        const base = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        const width: ir.Inst.V128LoadSplatWidth = switch (simd_op) {
+                            .v128_load8_splat => .i8x16,
+                            .v128_load16_splat => .i16x8,
+                            .v128_load32_splat => .i32x4,
+                            .v128_load64_splat => .i64x2,
+                            else => unreachable,
+                        };
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .v128_load_splat = .{
+                                .width = width,
+                                .base = base,
+                                .offset = offset,
+                                .alignment = alignment,
+                            } },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
                     .v128_store => {
                         const alignment = readU32(code, &ip);
                         const offset = readU32(code, &ip);
@@ -3759,6 +3787,80 @@ test "lower integer SIMD bitmask opcodes produce i32" {
         try std.testing.expectEqual(ir.IrType.i32, inst.type);
     }
     try std.testing.expect(insts[11].op.ret != null);
+}
+
+test "lower v128.loadN_splat opcodes preserve memarg offsets" {
+    const allocator = std.testing.allocator;
+
+    const appendULEB = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, value: u32) !void {
+            var v = value;
+            while (true) {
+                var byte: u8 = @intCast(v & 0x7F);
+                v >>= 7;
+                if (v != 0) byte |= 0x80;
+                try buf.append(alloc, byte);
+                if (v == 0) break;
+            }
+        }
+    }.call;
+    const appendSimdMem = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, opcode: u32, alignment: u32, offset: u32) !void {
+            try buf.append(alloc, 0xFD);
+            try appendULEB(buf, alloc, opcode);
+            try appendULEB(buf, alloc, alignment);
+            try appendULEB(buf, alloc, offset);
+        }
+    }.call;
+
+    const cases = [_]struct {
+        opcode: u32,
+        width: ir.Inst.V128LoadSplatWidth,
+        alignment: u32,
+        offset: u32,
+    }{
+        .{ .opcode = 0x07, .width = .i8x16, .alignment = 0, .offset = 17 },
+        .{ .opcode = 0x08, .width = .i16x8, .alignment = 1, .offset = 130 },
+        .{ .opcode = 0x09, .width = .i32x4, .alignment = 2, .offset = 1024 },
+        .{ .opcode = 0x0A, .width = .i64x2, .alignment = 3, .offset = 4096 },
+    };
+
+    for (cases) |case| {
+        var code: std.ArrayList(u8) = .empty;
+        defer code.deinit(allocator);
+        try code.appendSlice(allocator, &[_]u8{ 0x41, 0x00 }); // i32.const 0
+        try appendSimdMem(&code, allocator, case.opcode, case.alignment, case.offset);
+        try code.append(allocator, 0x0B);
+
+        const func_type = types.FuncType{
+            .params = &.{},
+            .results = &.{.v128},
+        };
+        const func = types.WasmFunction{
+            .type_idx = 0,
+            .func_type = func_type,
+            .local_count = 0,
+            .locals = &.{},
+            .code = code.items,
+        };
+        const wasm_module = types.WasmModule{
+            .types = &[_]types.FuncType{func_type},
+            .functions = &[_]types.WasmFunction{func},
+        };
+
+        var ir_module = try lowerModule(&wasm_module, allocator);
+        defer ir_module.deinit();
+
+        const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+        try std.testing.expectEqual(@as(usize, 3), insts.len);
+        try std.testing.expectEqual(.v128_load_splat, std.meta.activeTag(insts[1].op));
+        try std.testing.expectEqual(case.width, insts[1].op.v128_load_splat.width);
+        try std.testing.expectEqual(insts[0].dest.?, insts[1].op.v128_load_splat.base);
+        try std.testing.expectEqual(case.alignment, insts[1].op.v128_load_splat.alignment);
+        try std.testing.expectEqual(case.offset, insts[1].op.v128_load_splat.offset);
+        try std.testing.expectEqual(ir.IrType.v128, insts[1].type);
+        try std.testing.expect(insts[2].op.ret != null);
+    }
 }
 
 test "lower i8x16.shuffle parses lane immediates and operands" {

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -329,6 +329,7 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
         .global_set => |gs| live.put(gs.val, {}) catch {},
         .load => |ld| live.put(ld.base, {}) catch {},
         .v128_load => |ld| live.put(ld.base, {}) catch {},
+        .v128_load_splat => |ld| live.put(ld.base, {}) catch {},
         .store => |st| {
             live.put(st.base, {}) catch {};
             live.put(st.val, {}) catch {};
@@ -746,6 +747,7 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
         .global_set => |gs| last_use.put(gs.val, pos) catch {},
         .load => |ld| last_use.put(ld.base, pos) catch {},
         .v128_load => |ld| last_use.put(ld.base, pos) catch {},
+        .v128_load_splat => |ld| last_use.put(ld.base, pos) catch {},
         .store => |st| {
             last_use.put(st.base, pos) catch {};
             last_use.put(st.val, pos) catch {};

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -67,6 +67,7 @@ pub const Inst = struct {
         // wasm SIMD coverage or exported v128 ABI support.
         v128_const: u128,
         v128_load: V128Mem,
+        v128_load_splat: V128LoadSplat,
         v128_store: V128Store,
         v128_not: VReg,
         v128_bitwise: V128Bitwise,
@@ -420,6 +421,35 @@ pub const Inst = struct {
         alignment: u32,
         bounds_known: bool = false,
         checked_end: u64 = 0,
+    };
+
+    pub const V128LoadSplatWidth = enum {
+        i8x16,
+        i16x8,
+        i32x4,
+        i64x2,
+
+        pub fn accessSize(self: V128LoadSplatWidth) u8 {
+            return switch (self) {
+                .i8x16 => 1,
+                .i16x8 => 2,
+                .i32x4 => 4,
+                .i64x2 => 8,
+            };
+        }
+    };
+
+    pub const V128LoadSplat = struct {
+        width: V128LoadSplatWidth,
+        base: VReg,
+        offset: u32,
+        alignment: u32,
+        bounds_known: bool = false,
+        checked_end: u64 = 0,
+
+        pub fn accessSize(self: V128LoadSplat) u8 {
+            return self.width.accessSize();
+        }
     };
 
     pub const V128Store = struct {
@@ -795,6 +825,22 @@ test "Inst: first v128 op family preserves operand shape" {
     };
     try std.testing.expectEqual(Inst.SimdBitmaskWidth.i16x8, bitmask.op.simd_bitmask.width);
     try std.testing.expectEqual(@as(VReg, 7), bitmask.op.simd_bitmask.vector);
+
+    const load_splat = Inst{
+        .op = .{ .v128_load_splat = .{
+            .width = .i32x4,
+            .base = 6,
+            .offset = 12,
+            .alignment = 2,
+        } },
+        .dest = 8,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(Inst.V128LoadSplatWidth.i32x4, load_splat.op.v128_load_splat.width);
+    try std.testing.expectEqual(@as(VReg, 6), load_splat.op.v128_load_splat.base);
+    try std.testing.expectEqual(@as(u32, 12), load_splat.op.v128_load_splat.offset);
+    try std.testing.expectEqual(@as(u32, 2), load_splat.op.v128_load_splat.alignment);
+    try std.testing.expectEqual(@as(u8, 4), load_splat.op.v128_load_splat.accessSize());
 
     const c = Inst{ .op = .{ .v128_const = 0x0011_2233_4455_6677_8899_AABB_CCDD_EEFF }, .dest = 1, .type = .v128 };
     try std.testing.expectEqual(IrType.v128, c.type);

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -289,6 +289,7 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
         .global_set => |gs| list.append(gs.val),
         .load => |ld| list.append(ld.base),
         .v128_load => |ld| list.append(ld.base),
+        .v128_load_splat => |ld| list.append(ld.base),
         .store => |st| {
             list.append(st.base);
             list.append(st.val);
@@ -667,6 +668,9 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
             ld.base = new;
         },
         .v128_load => |*ld| if (ld.base == old) {
+            ld.base = new;
+        },
+        .v128_load_splat => |*ld| if (ld.base == old) {
             ld.base = new;
         },
         .store => |*st| {
@@ -1640,6 +1644,7 @@ fn hasSideEffect(inst: ir.Inst) bool {
         // Trapping ops: must not be removed even if result is unused.
         .load,
         .v128_load,
+        .v128_load_splat,
         .table_get,
         .div_u,
         .rem_u,
@@ -3680,6 +3685,7 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
         .global_set => |*gs| gs.val += offset,
         .load => |*ld| ld.base += offset,
         .v128_load => |*ld| ld.base += offset,
+        .v128_load_splat => |*ld| ld.base += offset,
         .store => |*st| {
             st.base += offset;
             st.val += offset;

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -929,6 +929,35 @@ test "differential SIMD: v128.load/store round trip extracts lane 0" {
     try expectSimdDiffI32(wasm, "f", @bitCast(@as(u32, 0x1122_3344)));
 }
 
+test "differential SIMD: v128.loadN_splat lane0 values" {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+
+    try appendI32Const(&body, testing.allocator, 0);
+    try appendLoadSplatLane0I32(&body, testing.allocator, 0x07, 0, 3);
+    try appendI32Const(&body, testing.allocator, 0);
+    try appendLoadSplatLane0I32(&body, testing.allocator, 0x08, 1, 4);
+    try body.append(testing.allocator, 0x6A);
+    try appendI32Const(&body, testing.allocator, 0);
+    try appendLoadSplatLane0I32(&body, testing.allocator, 0x09, 2, 8);
+    try body.append(testing.allocator, 0x6A);
+    try appendI32Const(&body, testing.allocator, 0);
+    try appendLoadSplatLane0I32(&body, testing.allocator, 0x0A, 3, 16);
+    try body.append(testing.allocator, 0x6A);
+    try body.append(testing.allocator, 0x0B);
+
+    var data = [_]u8{0} ** 24;
+    data[3] = 7;
+    std.mem.writeInt(u16, data[4..][0..2], 17, .little);
+    std.mem.writeInt(u32, data[8..][0..4], 291, .little);
+    std.mem.writeInt(u64, data[16..][0..8], 17_767, .little);
+
+    const wasm = try buildCustomMemoryModule(testing.allocator, body.items, data[0..]);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", 18_082);
+}
+
 test "differential SIMD: v128.load out-of-bounds traps" {
     var body: std.ArrayList(u8) = .empty;
     defer body.deinit(testing.allocator);
@@ -942,6 +971,32 @@ test "differential SIMD: v128.load out-of-bounds traps" {
     const wasm = try buildCustomMemoryModule(testing.allocator, body.items, &.{});
     defer testing.allocator.free(wasm);
     try expectSimdMemoryTrap(wasm, "f");
+}
+
+test "differential SIMD: v128.loadN_splat out-of-bounds traps" {
+    const cases = [_]struct {
+        opcode: u32,
+        alignment: u32,
+        access_size: u32,
+    }{
+        .{ .opcode = 0x07, .alignment = 0, .access_size = 1 },
+        .{ .opcode = 0x08, .alignment = 1, .access_size = 2 },
+        .{ .opcode = 0x09, .alignment = 2, .access_size = 4 },
+        .{ .opcode = 0x0A, .alignment = 3, .access_size = 8 },
+    };
+
+    for (cases) |case| {
+        var body: std.ArrayList(u8) = .empty;
+        defer body.deinit(testing.allocator);
+        try body.append(testing.allocator, 0x00);
+        try appendI32Const(&body, testing.allocator, 65_536 - case.access_size + 1);
+        try appendLoadSplatLane0I32(&body, testing.allocator, case.opcode, case.alignment, 0);
+        try body.append(testing.allocator, 0x0B);
+
+        const wasm = try buildCustomMemoryModule(testing.allocator, body.items, &.{});
+        defer testing.allocator.free(wasm);
+        try expectSimdMemoryTrap(wasm, "f");
+    }
 }
 
 /// Build a wasm module with a custom bytecode body for a `() -> i32` function.
@@ -1092,8 +1147,18 @@ fn appendI32x4Splat(buf: *std.ArrayList(u8), allocator: std.mem.Allocator) !void
     try appendSimdOpcode(buf, allocator, 0x11);
 }
 
+fn appendI32Const(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, value: i64) !void {
+    try buf.append(allocator, 0x41);
+    try encodeSLEB128(buf, allocator, value);
+}
+
 fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x1B);
+    try buf.append(allocator, lane);
+}
+
+fn appendI16x8ExtractLaneU(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x19);
     try buf.append(allocator, lane);
 }
 
@@ -1130,6 +1195,26 @@ fn appendSimdMemOpcode(
     try appendSimdOpcode(buf, allocator, opcode);
     try encodeULEB128(buf, allocator, alignment);
     try encodeULEB128(buf, allocator, offset);
+}
+
+fn appendLoadSplatLane0I32(
+    buf: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    opcode: u32,
+    alignment: u32,
+    offset: u32,
+) !void {
+    try appendSimdMemOpcode(buf, allocator, opcode, alignment, offset);
+    switch (opcode) {
+        0x07 => try appendI8x16ExtractLaneU(buf, allocator, 0),
+        0x08 => try appendI16x8ExtractLaneU(buf, allocator, 0),
+        0x09 => try appendI32x4ExtractLane(buf, allocator, 0),
+        0x0A => {
+            try appendI64x2ExtractLane(buf, allocator, 0);
+            try appendI32WrapI64(buf, allocator);
+        },
+        else => unreachable,
+    }
 }
 
 fn writeI32Lane(dst: []u8, value: u32) void {

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -644,6 +644,26 @@ const cases = [_]BenchCase{
         .build = buildSimdLoadStoreLane0Module,
     },
     .{
+        .name = "simd_v128_load8_splat_lane0",
+        .simd = true,
+        .build = buildSimdV128Load8SplatLane0Module,
+    },
+    .{
+        .name = "simd_v128_load16_splat_lane0",
+        .simd = true,
+        .build = buildSimdV128Load16SplatLane0Module,
+    },
+    .{
+        .name = "simd_v128_load32_splat_lane0",
+        .simd = true,
+        .build = buildSimdV128Load32SplatLane0Module,
+    },
+    .{
+        .name = "simd_v128_load64_splat_lane0",
+        .simd = true,
+        .build = buildSimdV128Load64SplatLane0Module,
+    },
+    .{
         .name = "scalar_i32_mem_add_4k_loop",
         .simd = false,
         .build = buildScalarI32MemoryAdd4kLoopModule,
@@ -2376,6 +2396,46 @@ fn buildSimdLoadStoreLane0Module(allocator: Allocator) ![]u8 {
     writeI32Lane(data[4..8], 0x5566_7788);
     writeI32Lane(data[8..12], @bitCast(@as(i32, -7)));
     writeI32Lane(data[12..16], 0x0102_0304);
+
+    return buildRunI32Module(allocator, instr.items, .{
+        .memory_min = 1,
+        .data = data[0..],
+    });
+}
+
+fn buildSimdV128Load8SplatLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdV128LoadSplatLane0Module(allocator, 0x07, 0, 3);
+}
+
+fn buildSimdV128Load16SplatLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdV128LoadSplatLane0Module(allocator, 0x08, 1, 4);
+}
+
+fn buildSimdV128Load32SplatLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdV128LoadSplatLane0Module(allocator, 0x09, 2, 8);
+}
+
+fn buildSimdV128Load64SplatLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdV128LoadSplatLane0Module(allocator, 0x0A, 3, 16);
+}
+
+fn buildSimdV128LoadSplatLane0Module(
+    allocator: Allocator,
+    opcode: u32,
+    alignment: u32,
+    offset: u32,
+) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendI32Const(&instr, allocator, 0);
+    try appendLoadSplatLane0I32(&instr, allocator, opcode, alignment, offset);
+
+    var data = [_]u8{0} ** 24;
+    data[3] = 7;
+    writeI16Lane(data[4..][0..2], 17);
+    writeI32Lane(data[8..][0..4], 291);
+    writeI64Lane(data[16..][0..8], 17_767);
 
     return buildRunI32Module(allocator, instr.items, .{
         .memory_min = 1,
@@ -4155,6 +4215,26 @@ fn appendSimdMemOpcode(
     try appendSimdOpcode(buf, allocator, opcode);
     try encodeULEB128(buf, allocator, alignment);
     try encodeULEB128(buf, allocator, offset);
+}
+
+fn appendLoadSplatLane0I32(
+    buf: *std.ArrayList(u8),
+    allocator: Allocator,
+    opcode: u32,
+    alignment: u32,
+    offset: u32,
+) !void {
+    try appendSimdMemOpcode(buf, allocator, opcode, alignment, offset);
+    switch (opcode) {
+        0x07 => try appendI8x16ExtractLaneU(buf, allocator, 0),
+        0x08 => try appendI16x8ExtractLaneU(buf, allocator, 0),
+        0x09 => try appendI32x4ExtractLane(buf, allocator, 0),
+        0x0A => {
+            try appendI64x2ExtractLane(buf, allocator, 0);
+            try appendI32WrapI64(buf, allocator);
+        },
+        else => unreachable,
+    }
 }
 
 fn appendSimdOpcode(buf: *std.ArrayList(u8), allocator: Allocator, opcode: u32) !void {


### PR DESCRIPTION
Closes #277.

## Summary
- add width-carrying `v128_load_splat` IR/frontend lowering for load8/load16/load32/load64 splat
- reuse existing AArch64 memory address and bounds-check path before emitting `LD1R` broadcast loads
- add emitter, frontend, differential, OOB trap, and SIMD bench coverage

## Validation
- `zig build test`
- `zig build`
- `zig build simd-bench -- --iterations 1`