### PR TITLE
perf(aarch64): lower f32x4 pmin pmax

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -3274,6 +3274,16 @@ fn emitF32x4BinOp(
         try emitF32x4MinMax(code, inst, bin, lhs_reg, rhs_reg, v128_map, v128_cache, fctx);
         return;
     }
+    if (bin.op == .pmin or bin.op == .pmax) {
+        const dest = inst.dest orelse return;
+        const cmp_lhs = if (bin.op == .pmin) lhs_reg else rhs_reg;
+        const cmp_rhs = if (bin.op == .pmin) rhs_reg else lhs_reg;
+        try code.fcmgt4s(v128_tmp0, cmp_lhs, cmp_rhs);
+        try code.bsl16b(v128_tmp0, rhs_reg, lhs_reg);
+        const dest_reg = try v128_cache.defineFresh(code, v128_map, dest, null);
+        try code.bitwise16b(.orr, dest_reg, v128_tmp0, v128_tmp0);
+        return;
+    }
     const dest_reg = try prepareV128BinaryDest(
         code,
         inst,
@@ -3291,6 +3301,7 @@ fn emitF32x4BinOp(
         .mul => try code.f32x4Op(.mul, dest_reg, lhs_reg, rhs_reg),
         .div => try code.f32x4Op(.div, dest_reg, lhs_reg, rhs_reg),
         .min, .max => unreachable,
+        .pmin, .pmax => unreachable,
     }
 }
 
@@ -7604,7 +7615,7 @@ test "compile: f64x2 arithmetic and comparison ops emit NEON instructions" {
     try std.testing.expect(bsl_count >= 2);
 }
 
-test "compile: f32x4 arithmetic/minmax ops emit NEON instructions" {
+test "compile: f32x4 arithmetic/minmax and pseudo-minmax ops emit NEON instructions" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -7618,6 +7629,8 @@ test "compile: f32x4 arithmetic/minmax ops emit NEON instructions" {
     const div = func.newVReg();
     const min = func.newVReg();
     const max = func.newVReg();
+    const pmin = func.newVReg();
+    const pmax = func.newVReg();
     const lane = func.newVReg();
 
     try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x4080_0000_4040_0000_4000_0000_3f80_0000 }, .dest = a, .type = .v128 });
@@ -7628,8 +7641,10 @@ test "compile: f32x4 arithmetic/minmax ops emit NEON instructions" {
     try func.getBlock(bid).append(.{ .op = .{ .f32x4_binop = .{ .op = .div, .lhs = mul, .rhs = b } }, .dest = div, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f32x4_binop = .{ .op = .min, .lhs = div, .rhs = b } }, .dest = min, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f32x4_binop = .{ .op = .max, .lhs = min, .rhs = a } }, .dest = max, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f32x4_binop = .{ .op = .pmin, .lhs = max, .rhs = b } }, .dest = pmin, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f32x4_binop = .{ .op = .pmax, .lhs = pmin, .rhs = a } }, .dest = pmax, .type = .v128 });
     try func.getBlock(bid).append(.{
-        .op = .{ .i32x4_extract_lane = .{ .vector = max, .lane = 0 } },
+        .op = .{ .i32x4_extract_lane = .{ .vector = pmax, .lane = 0 } },
         .dest = lane,
         .type = .i32,
     });
@@ -7645,6 +7660,8 @@ test "compile: f32x4 arithmetic/minmax ops emit NEON instructions" {
     var found_fmin = false;
     var found_fmax = false;
     var found_fcmeq = false;
+    var found_fcmgt = false;
+    var bsl_count: u32 = 0;
     var i: usize = 0;
     while (i + 4 <= code.len) : (i += 4) {
         const w = std.mem.readInt(u32, code[i..][0..4], .little);
@@ -7655,6 +7672,8 @@ test "compile: f32x4 arithmetic/minmax ops emit NEON instructions" {
         if ((w & 0xFFE0FC00) == 0x4EA0F400) found_fmin = true;
         if ((w & 0xFFE0FC00) == 0x4E20F400) found_fmax = true;
         if ((w & 0xFFE0FC00) == 0x4E20E400) found_fcmeq = true;
+        if ((w & 0xFFE0FC00) == 0x6EA0E400) found_fcmgt = true;
+        if ((w & 0xFFE0FC00) == 0x6E601C00) bsl_count += 1;
     }
 
     try std.testing.expect(found_fadd);
@@ -7664,6 +7683,60 @@ test "compile: f32x4 arithmetic/minmax ops emit NEON instructions" {
     try std.testing.expect(found_fmin);
     try std.testing.expect(found_fmax);
     try std.testing.expect(found_fcmeq);
+    try std.testing.expect(found_fcmgt);
+    try std.testing.expect(bsl_count >= 2);
+}
+
+test "compile: f32x4 pseudo-minmax uses compare and select operand order" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+
+    const a = func.newVReg();
+    const b = func.newVReg();
+    const pmin = func.newVReg();
+    const pmax = func.newVReg();
+    const mix = func.newVReg();
+    const lane = func.newVReg();
+
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x4080_0000_4040_0000_4000_0000_3f80_0000 }, .dest = a, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x4100_0000_40e0_0000_40c0_0000_40a0_0000 }, .dest = b, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f32x4_binop = .{ .op = .pmin, .lhs = a, .rhs = b } }, .dest = pmin, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f32x4_binop = .{ .op = .pmax, .lhs = a, .rhs = b } }, .dest = pmax, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .v128_bitwise = .{ .op = .xor, .lhs = pmin, .rhs = pmax } }, .dest = mix, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .i32x4_extract_lane = .{ .vector = mix, .lane = 0 } }, .dest = lane, .type = .i32 });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = lane } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    const pmin_cmp = @as(u32, 0x6EA0E400) | (@as(u32, 17) << 16) | (@as(u32, 16) << 5);
+    const pmax_cmp = @as(u32, 0x6EA0E400) | (@as(u32, 16) << 16) | (@as(u32, 17) << 5);
+    const select_rhs_else_lhs = @as(u32, 0x6E601C00) | (@as(u32, 16) << 16) | (@as(u32, 17) << 5);
+
+    var found_pmin_cmp = false;
+    var found_pmax_cmp = false;
+    var ordered_selects: u32 = 0;
+    var after_expected_cmp = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if (w == pmin_cmp) {
+            found_pmin_cmp = true;
+            after_expected_cmp = true;
+        } else if (w == pmax_cmp) {
+            found_pmax_cmp = true;
+            after_expected_cmp = true;
+        } else if (w == select_rhs_else_lhs and after_expected_cmp) {
+            ordered_selects += 1;
+            after_expected_cmp = false;
+        }
+    }
+
+    try std.testing.expect(found_pmin_cmp);
+    try std.testing.expect(found_pmax_cmp);
+    try std.testing.expectEqual(@as(u32, 2), ordered_selects);
 }
 
 test "compile: SIMD int-to-float conversions emit NEON instructions" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -1108,6 +1108,14 @@ pub const CodeBuffer = struct {
             vd);
     }
 
+    /// FCMGT Vd.4S, Vn.4S, Vm.4S — floating-point compare greater-than per lane.
+    pub fn fcmgt4s(self: *CodeBuffer, vd: u5, vn: u5, vm: u5) !void {
+        try self.emit32(0x6EA0E400 |
+            (@as(u32, vm) << 16) |
+            (@as(u32, vn) << 5) |
+            vd);
+    }
+
     pub const F64x2Op = enum(u32) {
         add = 0x4E60D400,
         sub = 0x4EE0D400,
@@ -3103,6 +3111,12 @@ test "emit: f32x4 vector arithmetic/minmax ops" {
         defer code.deinit();
         try code.fcmeq4s(16, 17, 30);
         try expectWord(0x4E3EE630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.fcmgt4s(16, 17, 30);
+        try expectWord(0x6EBEE630, &code);
     }
 }
 

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -2569,6 +2569,8 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .f32x4_div,
                     .f32x4_min,
                     .f32x4_max,
+                    .f32x4_pmin,
+                    .f32x4_pmax,
                     => {
                         const rhs = safePop(&vreg_stack);
                         const lhs = safePop(&vreg_stack);
@@ -2580,6 +2582,8 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                             .f32x4_div => .div,
                             .f32x4_min => .min,
                             .f32x4_max => .max,
+                            .f32x4_pmin => .pmin,
+                            .f32x4_pmax => .pmax,
                             else => unreachable,
                         };
                         try ir_func.getBlock(current_block).append(.{
@@ -6220,7 +6224,7 @@ test "lower f64x2 arithmetic and comparison opcodes" {
     try std.testing.expect(insts[inst_idx + 2].op.ret != null);
 }
 
-test "lower f32x4 arithmetic/minmax opcodes" {
+test "lower f32x4 arithmetic/minmax and pseudo-minmax opcodes" {
     const allocator = std.testing.allocator;
 
     const func_type = types.FuncType{
@@ -6239,6 +6243,8 @@ test "lower f32x4 arithmetic/minmax opcodes" {
         .{ .opcode = 0xE7, .expected = .div },
         .{ .opcode = 0xE8, .expected = .min },
         .{ .opcode = 0xE9, .expected = .max },
+        .{ .opcode = 0xEA, .expected = .pmin },
+        .{ .opcode = 0xEB, .expected = .pmax },
     };
 
     const appendULEB = struct {

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -428,6 +428,8 @@ pub const Inst = struct {
         div,
         min,
         max,
+        pmin,
+        pmax,
     };
 
     pub const V128Mem = struct {
@@ -1211,11 +1213,11 @@ test "Inst: first v128 op family preserves operand shape" {
     try std.testing.expectEqual(@as(VReg, 26), f32_convert.op.f32x4_convert_i32x4.vector);
 
     const f32_bin = Inst{
-        .op = .{ .f32x4_binop = .{ .op = .max, .lhs = 27, .rhs = 28 } },
+        .op = .{ .f32x4_binop = .{ .op = .pmax, .lhs = 27, .rhs = 28 } },
         .dest = 29,
         .type = .v128,
     };
-    try std.testing.expectEqual(Inst.F32x4Op.max, f32_bin.op.f32x4_binop.op);
+    try std.testing.expectEqual(Inst.F32x4Op.pmax, f32_bin.op.f32x4_binop.op);
     try std.testing.expectEqual(@as(VReg, 27), f32_bin.op.f32x4_binop.lhs);
     try std.testing.expectEqual(@as(VReg, 28), f32_bin.op.f32x4_binop.rhs);
 

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -674,6 +674,57 @@ test "differential SIMD: f32x4 minmax NaN zero and infinity edges match interpre
     );
 }
 
+test "differential SIMD: f32x4.pmin/pmax normal and infinity lanes match interpreter" {
+    try expectF32x4BinLaneBits(
+        0xEA,
+        .{ 0x4040_0000, 0x3f80_0000, 0x7f80_0000, 0x4080_0000 },
+        .{ 0xc000_0000, 0x4000_0000, 0xff80_0000, 0x4100_0000 },
+        0,
+        0xc000_0000,
+    );
+    try expectF32x4BinLaneBits(
+        0xEB,
+        .{ 0xc040_0000, 0x3f80_0000, 0xff80_0000, 0x4080_0000 },
+        .{ 0x4000_0000, 0x4000_0000, 0x7f80_0000, 0x4100_0000 },
+        2,
+        0x7f80_0000,
+    );
+}
+
+test "differential SIMD: f32x4.pmin/pmax keep lhs signed zero on ties" {
+    try expectF32x4BinLaneBits(
+        0xEA,
+        .{ 0x8000_0000, 0x3f80_0000, 0x4000_0000, 0x4040_0000 },
+        .{ 0x0000_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        0,
+        0x8000_0000,
+    );
+    try expectF32x4BinLaneBits(
+        0xEB,
+        .{ 0x8000_0000, 0x3f80_0000, 0x4000_0000, 0x4040_0000 },
+        .{ 0x0000_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        0,
+        0x8000_0000,
+    );
+}
+
+test "differential SIMD: f32x4.pmin/pmax NaN comparisons select lhs" {
+    try expectF32x4BinLaneBits(
+        0xEA,
+        .{ 0x3f80_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x7fc0_1234, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        0,
+        0x3f80_0000,
+    );
+    try expectF32x4BinLaneBits(
+        0xEB,
+        .{ 0x7fc0_1234, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x4000_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        0,
+        0x7fc0_1234,
+    );
+}
+
 test "differential SIMD: f64x2.convert_low_i32x4_s lane 0 matches interpreter" {
     try expectF64x2ConvertLowLane0High(
         0xFE,

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -344,6 +344,16 @@ const cases = [_]BenchCase{
         .build = buildSimdF32x4MaxLane0Module,
     },
     .{
+        .name = "simd_f32x4_pmin_lane0",
+        .simd = true,
+        .build = buildSimdF32x4PminLane0Module,
+    },
+    .{
+        .name = "simd_f32x4_pmax_lane0",
+        .simd = true,
+        .build = buildSimdF32x4PmaxLane0Module,
+    },
+    .{
         .name = "simd_f64x2_convert_low_i32x4_s_lane0_high",
         .simd = true,
         .build = buildSimdF64x2ConvertLowI32x4SLane0HighModule,
@@ -1780,6 +1790,14 @@ fn buildSimdF32x4MinLane0Module(allocator: Allocator) ![]u8 {
 
 fn buildSimdF32x4MaxLane0Module(allocator: Allocator) ![]u8 {
     return buildSimdF32x4BinLane0Module(allocator, 0xE9);
+}
+
+fn buildSimdF32x4PminLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4BinLane0Module(allocator, 0xEA);
+}
+
+fn buildSimdF32x4PmaxLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4BinLane0Module(allocator, 0xEB);
 }
 
 fn buildSimdF64x2ConvertLowI32x4Lane0HighModule(allocator: Allocator, simd_opcode: u32) ![]u8 {


### PR DESCRIPTION
Implements cataggar/wamr#292.\n\nSummary:\n- Lowers f32x4.pmin/pmax (0xEA/0xEB) through frontend IR and AArch64 codegen.\n- Emits FCMGT .4S masks plus BSL to select rhs on true, lhs otherwise.\n- Adds frontend/codegen/differential NaN/zero/inf tests and simd-bench rows.\n\nValidation:\n- zig build test\n- zig build\n- zig build simd-bench -- --iterations 1