### PR TITLE
perf(aarch64): lower f32x4 comparisons

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -3333,6 +3333,15 @@ fn emitF32x4BinOp(
         .sub => try code.f32x4Op(.sub, dest_reg, lhs_reg, rhs_reg),
         .mul => try code.f32x4Op(.mul, dest_reg, lhs_reg, rhs_reg),
         .div => try code.f32x4Op(.div, dest_reg, lhs_reg, rhs_reg),
+        .eq => try code.fcmeq4s(dest_reg, lhs_reg, rhs_reg),
+        .ne => {
+            try code.fcmeq4s(dest_reg, lhs_reg, rhs_reg);
+            try code.mvn16b(dest_reg, dest_reg);
+        },
+        .gt => try code.fcmgt4s(dest_reg, lhs_reg, rhs_reg),
+        .ge => try code.fcmge4s(dest_reg, lhs_reg, rhs_reg),
+        .lt => try code.fcmgt4s(dest_reg, rhs_reg, lhs_reg),
+        .le => try code.fcmge4s(dest_reg, rhs_reg, lhs_reg),
         .min, .max => unreachable,
         .pmin, .pmax => unreachable,
     }
@@ -7697,6 +7706,60 @@ test "compile: f32x4 unary ops emit NEON instructions" {
     try std.testing.expect(found_fcmeq);
     try std.testing.expect(found_mvn);
     try std.testing.expect(found_bsl);
+}
+
+test "compile: f32x4 comparisons emit ordered NEON comparisons" {
+    const allocator = std.testing.allocator;
+
+    const Case = struct {
+        op: ir.Inst.F32x4Op,
+        expected_cmp: u32,
+        expect_mvn: bool = false,
+    };
+    const cases = [_]Case{
+        .{ .op = .eq, .expected_cmp = 0x4E31E610 },
+        .{ .op = .ne, .expected_cmp = 0x4E31E610, .expect_mvn = true },
+        .{ .op = .gt, .expected_cmp = 0x6EB1E610 },
+        .{ .op = .ge, .expected_cmp = 0x6E31E610 },
+        .{ .op = .lt, .expected_cmp = 0x6EB0E630 },
+        .{ .op = .le, .expected_cmp = 0x6E30E630 },
+    };
+
+    for (cases) |case| {
+        var func = ir.IrFunction.init(allocator, 0, 1, 0);
+        defer func.deinit();
+        const bid = try func.newBlock();
+
+        const a = func.newVReg();
+        const b = func.newVReg();
+        const cmp = func.newVReg();
+        const lane = func.newVReg();
+
+        try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x4080_0000_4040_0000_4000_0000_3f80_0000 }, .dest = a, .type = .v128 });
+        try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x4100_0000_40e0_0000_40c0_0000_40a0_0000 }, .dest = b, .type = .v128 });
+        try func.getBlock(bid).append(.{ .op = .{ .f32x4_binop = .{ .op = case.op, .lhs = a, .rhs = b } }, .dest = cmp, .type = .v128 });
+        try func.getBlock(bid).append(.{
+            .op = .{ .i32x4_extract_lane = .{ .vector = cmp, .lane = 0 } },
+            .dest = lane,
+            .type = .i32,
+        });
+        try func.getBlock(bid).append(.{ .op = .{ .ret = lane } });
+
+        const code = try compileFunction(&func, allocator);
+        defer allocator.free(code);
+
+        var found_cmp = false;
+        var found_mvn = false;
+        var i: usize = 0;
+        while (i + 4 <= code.len) : (i += 4) {
+            const w = std.mem.readInt(u32, code[i..][0..4], .little);
+            if (w == case.expected_cmp) found_cmp = true;
+            if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
+        }
+
+        try std.testing.expect(found_cmp);
+        try std.testing.expectEqual(case.expect_mvn, found_mvn);
+    }
 }
 
 test "compile: f32x4 arithmetic/minmax and pseudo-minmax ops emit NEON instructions" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -1144,6 +1144,14 @@ pub const CodeBuffer = struct {
             vd);
     }
 
+    /// FCMGE Vd.4S, Vn.4S, Vm.4S — floating-point compare greater-or-equal per lane.
+    pub fn fcmge4s(self: *CodeBuffer, vd: u5, vn: u5, vm: u5) !void {
+        try self.emit32(0x6E20E400 |
+            (@as(u32, vm) << 16) |
+            (@as(u32, vn) << 5) |
+            vd);
+    }
+
     pub const F64x2Op = enum(u32) {
         add = 0x4E60D400,
         sub = 0x4EE0D400,
@@ -3145,6 +3153,12 @@ test "emit: f32x4 vector arithmetic/minmax ops" {
         defer code.deinit();
         try code.fcmgt4s(16, 17, 30);
         try expectWord(0x6EBEE630, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.fcmge4s(16, 17, 30);
+        try expectWord(0x6E3EE630, &code);
     }
 }
 

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -2593,6 +2593,12 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .f32x4_max,
                     .f32x4_pmin,
                     .f32x4_pmax,
+                    .f32x4_eq,
+                    .f32x4_ne,
+                    .f32x4_lt,
+                    .f32x4_gt,
+                    .f32x4_le,
+                    .f32x4_ge,
                     => {
                         const rhs = safePop(&vreg_stack);
                         const lhs = safePop(&vreg_stack);
@@ -2606,6 +2612,12 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                             .f32x4_max => .max,
                             .f32x4_pmin => .pmin,
                             .f32x4_pmax => .pmax,
+                            .f32x4_eq => .eq,
+                            .f32x4_ne => .ne,
+                            .f32x4_lt => .lt,
+                            .f32x4_gt => .gt,
+                            .f32x4_le => .le,
+                            .f32x4_ge => .ge,
                             else => unreachable,
                         };
                         try ir_func.getBlock(current_block).append(.{
@@ -6329,7 +6341,7 @@ test "lower f64x2 arithmetic and comparison opcodes" {
     try std.testing.expect(insts[inst_idx + 2].op.ret != null);
 }
 
-test "lower f32x4 arithmetic/minmax and pseudo-minmax opcodes" {
+test "lower f32x4 arithmetic/minmax, pseudo-minmax, and comparison opcodes" {
     const allocator = std.testing.allocator;
 
     const func_type = types.FuncType{
@@ -6342,6 +6354,12 @@ test "lower f32x4 arithmetic/minmax and pseudo-minmax opcodes" {
         expected: ir.Inst.F32x4Op,
     };
     const cases = [_]Case{
+        .{ .opcode = 0x41, .expected = .eq },
+        .{ .opcode = 0x42, .expected = .ne },
+        .{ .opcode = 0x43, .expected = .lt },
+        .{ .opcode = 0x44, .expected = .gt },
+        .{ .opcode = 0x45, .expected = .le },
+        .{ .opcode = 0x46, .expected = .ge },
         .{ .opcode = 0xE4, .expected = .add },
         .{ .opcode = 0xE5, .expected = .sub },
         .{ .opcode = 0xE6, .expected = .mul },

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -431,6 +431,12 @@ pub const Inst = struct {
         max,
         pmin,
         pmax,
+        eq,
+        ne,
+        lt,
+        gt,
+        le,
+        ge,
     };
 
     pub const F32x4UnaryOp = enum {

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -832,6 +832,138 @@ test "differential SIMD: f32x4.pmin/pmax NaN comparisons select lhs" {
     );
 }
 
+test "differential SIMD: f32x4 comparisons normal zero and infinity lanes match interpreter" {
+    try expectF32x4BinLaneBits(
+        0x41,
+        .{ 0x3f80_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x3f80_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+    try expectF32x4BinLaneBits(
+        0x42,
+        .{ 0x3f80_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x4000_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+    try expectF32x4BinLaneBits(
+        0x43,
+        .{ 0xbf80_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x4000_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+    try expectF32x4BinLaneBits(
+        0x44,
+        .{ 0x4040_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x4000_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+    try expectF32x4BinLaneBits(
+        0x45,
+        .{ 0x4000_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x4000_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+    try expectF32x4BinLaneBits(
+        0x46,
+        .{ 0x4000_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x4000_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+    try expectF32x4BinLaneBits(
+        0x41,
+        .{ 0x8000_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x0000_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+    try expectF32x4BinLaneBits(
+        0x42,
+        .{ 0x8000_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x0000_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0,
+    );
+    try expectF32x4BinLaneBits(
+        0x43,
+        .{ 0xff80_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x7f80_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+    try expectF32x4BinLaneBits(
+        0x44,
+        .{ 0x7f80_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0xff80_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+}
+
+test "differential SIMD: f32x4 comparisons NaN lanes match interpreter" {
+    try expectF32x4BinLaneBits(
+        0x41,
+        .{ 0x7fc0_0001, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x7fc0_0001, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0,
+    );
+    try expectF32x4BinLaneBits(
+        0x42,
+        .{ 0x7fc0_0001, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x7fc0_0001, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+    try expectF32x4BinLaneBits(
+        0x41,
+        .{ 0x7fc0_0001, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x3f80_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0,
+    );
+    try expectF32x4BinLaneBits(
+        0x42,
+        .{ 0x7fc0_0001, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x3f80_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0xffff_ffff,
+    );
+    try expectF32x4BinLaneBits(
+        0x43,
+        .{ 0x7fc0_0001, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x3f80_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0,
+    );
+    try expectF32x4BinLaneBits(
+        0x44,
+        .{ 0x3f80_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x7fc0_0001, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0,
+    );
+    try expectF32x4BinLaneBits(
+        0x45,
+        .{ 0x7fc0_0001, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x3f80_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0,
+    );
+    try expectF32x4BinLaneBits(
+        0x46,
+        .{ 0x3f80_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 },
+        .{ 0x7fc0_0001, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 },
+        0,
+        0,
+    );
+}
+
 test "differential SIMD: f64x2.convert_low_i32x4_s lane 0 matches interpreter" {
     try expectF64x2ConvertLowLane0High(
         0xFE,

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -329,6 +329,36 @@ const cases = [_]BenchCase{
         .build = buildSimdF32x4SqrtLane0Module,
     },
     .{
+        .name = "simd_f32x4_eq_lane0",
+        .simd = true,
+        .build = buildSimdF32x4EqLane0Module,
+    },
+    .{
+        .name = "simd_f32x4_ne_lane0",
+        .simd = true,
+        .build = buildSimdF32x4NeLane0Module,
+    },
+    .{
+        .name = "simd_f32x4_lt_lane0",
+        .simd = true,
+        .build = buildSimdF32x4LtLane0Module,
+    },
+    .{
+        .name = "simd_f32x4_gt_lane0",
+        .simd = true,
+        .build = buildSimdF32x4GtLane0Module,
+    },
+    .{
+        .name = "simd_f32x4_le_lane0",
+        .simd = true,
+        .build = buildSimdF32x4LeLane0Module,
+    },
+    .{
+        .name = "simd_f32x4_ge_lane0",
+        .simd = true,
+        .build = buildSimdF32x4GeLane0Module,
+    },
+    .{
         .name = "simd_f32x4_add_lane0",
         .simd = true,
         .build = buildSimdF32x4AddLane0Module,
@@ -1766,6 +1796,42 @@ fn buildSimdF32x4ConvertI32x4SLane0Module(allocator: Allocator) ![]u8 {
 
 fn buildSimdF32x4ConvertI32x4ULane0Module(allocator: Allocator) ![]u8 {
     return buildSimdF32x4ConvertI32x4Lane0Module(allocator, 0xFB);
+}
+
+fn buildSimdF32x4CmpLane0Module(allocator: Allocator, simd_opcode: u32, lhs0: u32, rhs0: u32) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstF32x4Bits(&instr, allocator, .{ lhs0, 0x4000_0000, 0x4040_0000, 0x4080_0000 });
+    try appendV128ConstF32x4Bits(&instr, allocator, .{ rhs0, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 });
+    try appendSimdOpcode(&instr, allocator, simd_opcode);
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdF32x4EqLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4CmpLane0Module(allocator, 0x41, 0x8000_0000, 0x0000_0000);
+}
+
+fn buildSimdF32x4NeLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4CmpLane0Module(allocator, 0x42, 0x3f80_0000, 0x4000_0000);
+}
+
+fn buildSimdF32x4LtLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4CmpLane0Module(allocator, 0x43, 0x3f80_0000, 0x4000_0000);
+}
+
+fn buildSimdF32x4GtLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4CmpLane0Module(allocator, 0x44, 0x4000_0000, 0x3f80_0000);
+}
+
+fn buildSimdF32x4LeLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4CmpLane0Module(allocator, 0x45, 0x3f80_0000, 0x3f80_0000);
+}
+
+fn buildSimdF32x4GeLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4CmpLane0Module(allocator, 0x46, 0x3f80_0000, 0x3f80_0000);
 }
 
 const f32x4_arith_lhs_bits: [4]u32 = .{ 0x4140_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 };


### PR DESCRIPTION
Closes #294.

## Summary
- extend `f32x4` lowering for eq/ne/lt/gt/le/ge comparison opcodes
- emit AArch64 `FCMEQ`/`FCMGT`/`FCMGE Vd.4S,Vn.4S,Vm.4S`, with `MVN` for `ne` and swapped operands for `lt`/`le`
- add frontend, emitter/codegen, differential, and SIMD bench coverage, including NaN and signed-zero cases

## Validation
- `zig build test`
- `zig build`
- `zig build simd-bench -- --iterations 1`