### PR TITLE
perf(aarch64): lower f32x4 rounding

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -2438,6 +2438,22 @@ fn emitF32x4UnOp(
             try code.fsqrt4s(dest_reg, vector_reg);
             try canonicalizeF32x4NaNs(code, dest_reg);
         },
+        .ceil => {
+            try code.frint4s(.ceil, dest_reg, vector_reg);
+            try canonicalizeF32x4NaNs(code, dest_reg);
+        },
+        .floor => {
+            try code.frint4s(.floor, dest_reg, vector_reg);
+            try canonicalizeF32x4NaNs(code, dest_reg);
+        },
+        .trunc => {
+            try code.frint4s(.trunc, dest_reg, vector_reg);
+            try canonicalizeF32x4NaNs(code, dest_reg);
+        },
+        .nearest => {
+            try code.frint4s(.nearest, dest_reg, vector_reg);
+            try canonicalizeF32x4NaNs(code, dest_reg);
+        },
     }
 }
 
@@ -7768,14 +7784,22 @@ test "compile: f32x4 unary ops emit NEON instructions" {
     const abs = func.newVReg();
     const neg = func.newVReg();
     const sqrt = func.newVReg();
+    const ceil = func.newVReg();
+    const floor = func.newVReg();
+    const trunc = func.newVReg();
+    const nearest = func.newVReg();
     const lane = func.newVReg();
 
     try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x4110_0000_4080_0000_8000_0000_c060_0000 }, .dest = a, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f32x4_unop = .{ .op = .abs, .vector = a } }, .dest = abs, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f32x4_unop = .{ .op = .neg, .vector = abs } }, .dest = neg, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f32x4_unop = .{ .op = .sqrt, .vector = neg } }, .dest = sqrt, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f32x4_unop = .{ .op = .ceil, .vector = sqrt } }, .dest = ceil, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f32x4_unop = .{ .op = .floor, .vector = ceil } }, .dest = floor, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f32x4_unop = .{ .op = .trunc, .vector = floor } }, .dest = trunc, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f32x4_unop = .{ .op = .nearest, .vector = trunc } }, .dest = nearest, .type = .v128 });
     try func.getBlock(bid).append(.{
-        .op = .{ .i32x4_extract_lane = .{ .vector = sqrt, .lane = 0 } },
+        .op = .{ .i32x4_extract_lane = .{ .vector = nearest, .lane = 0 } },
         .dest = lane,
         .type = .i32,
     });
@@ -7787,6 +7811,10 @@ test "compile: f32x4 unary ops emit NEON instructions" {
     var found_fabs = false;
     var found_fneg = false;
     var found_fsqrt = false;
+    var found_frintp = false;
+    var found_frintm = false;
+    var found_frintz = false;
+    var found_frintn = false;
     var found_fcmeq = false;
     var found_mvn = false;
     var found_bsl = false;
@@ -7796,6 +7824,10 @@ test "compile: f32x4 unary ops emit NEON instructions" {
         if ((w & 0xFFFFFC00) == 0x4EA0F800) found_fabs = true;
         if ((w & 0xFFFFFC00) == 0x6EA0F800) found_fneg = true;
         if ((w & 0xFFFFFC00) == 0x6EA1F800) found_fsqrt = true;
+        if ((w & 0xFFFFFC00) == 0x4EA18800) found_frintp = true;
+        if ((w & 0xFFFFFC00) == 0x4E219800) found_frintm = true;
+        if ((w & 0xFFFFFC00) == 0x4EA19800) found_frintz = true;
+        if ((w & 0xFFFFFC00) == 0x4E218800) found_frintn = true;
         if ((w & 0xFFE0FC00) == 0x4E20E400) found_fcmeq = true;
         if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
         if ((w & 0xFFE0FC00) == 0x6E601C00) found_bsl = true;
@@ -7804,6 +7836,10 @@ test "compile: f32x4 unary ops emit NEON instructions" {
     try std.testing.expect(found_fabs);
     try std.testing.expect(found_fneg);
     try std.testing.expect(found_fsqrt);
+    try std.testing.expect(found_frintp);
+    try std.testing.expect(found_frintm);
+    try std.testing.expect(found_frintz);
+    try std.testing.expect(found_frintn);
     try std.testing.expect(found_fcmeq);
     try std.testing.expect(found_mvn);
     try std.testing.expect(found_bsl);

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -1104,9 +1104,13 @@ pub const CodeBuffer = struct {
         abs = 0x4EA0F800,
         neg = 0x6EA0F800,
         sqrt = 0x6EA1F800,
+        frintn = 0x4E218800,
+        frintp = 0x4EA18800,
+        frintm = 0x4E219800,
+        frintz = 0x4EA19800,
     };
 
-    /// Floating-point 4S unary vector op: FABS/FNEG/FSQRT.
+    /// Floating-point 4S unary vector op: FABS/FNEG/FSQRT/FRINT*.
     pub fn f32x4UnOp(self: *CodeBuffer, op: F32x4UnaryOp, vd: u5, vn: u5) !void {
         try self.emit32(@intFromEnum(op) |
             (@as(u32, vn) << 5) |
@@ -1126,6 +1130,37 @@ pub const CodeBuffer = struct {
     /// FSQRT Vd.4S, Vn.4S.
     pub fn fsqrt4s(self: *CodeBuffer, vd: u5, vn: u5) !void {
         return self.f32x4UnOp(.sqrt, vd, vn);
+    }
+
+    /// FRINTN/P/M/Z Vd.4S, Vn.4S — round each f32 lane to integral.
+    pub fn frint4s(self: *CodeBuffer, mode: FRoundMode, vd: u5, vn: u5) !void {
+        const op: F32x4UnaryOp = switch (mode) {
+            .nearest => .frintn,
+            .ceil => .frintp,
+            .floor => .frintm,
+            .trunc => .frintz,
+        };
+        return self.f32x4UnOp(op, vd, vn);
+    }
+
+    /// FRINTP Vd.4S, Vn.4S.
+    pub fn frintp4s(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.frint4s(.ceil, vd, vn);
+    }
+
+    /// FRINTM Vd.4S, Vn.4S.
+    pub fn frintm4s(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.frint4s(.floor, vd, vn);
+    }
+
+    /// FRINTZ Vd.4S, Vn.4S.
+    pub fn frintz4s(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.frint4s(.trunc, vd, vn);
+    }
+
+    /// FRINTN Vd.4S, Vn.4S.
+    pub fn frintn4s(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.frint4s(.nearest, vd, vn);
     }
 
     /// FCMEQ Vd.4S, Vn.4S, Vm.4S — floating-point compare equal per lane.
@@ -3180,6 +3215,30 @@ test "emit: f32x4 vector unary ops" {
         defer code.deinit();
         try code.fsqrt4s(16, 17);
         try expectWord(0x6EA1FA30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.frintp4s(16, 17);
+        try expectWord(0x4EA18A30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.frintm4s(16, 17);
+        try expectWord(0x4E219A30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.frintz4s(16, 17);
+        try expectWord(0x4EA19A30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.frintn4s(16, 17);
+        try expectWord(0x4E218A30, &code);
     }
 }
 

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -2078,6 +2078,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .f32x4_abs,
                     .f32x4_neg,
                     .f32x4_sqrt,
+                    .f32x4_ceil,
+                    .f32x4_floor,
+                    .f32x4_trunc,
+                    .f32x4_nearest,
                     => {
                         const vector = safePop(&vreg_stack);
                         const dest = ir_func.newVReg();
@@ -2086,6 +2090,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                                 .f32x4_abs => .abs,
                                 .f32x4_neg => .neg,
                                 .f32x4_sqrt => .sqrt,
+                                .f32x4_ceil => .ceil,
+                                .f32x4_floor => .floor,
+                                .f32x4_trunc => .trunc,
+                                .f32x4_nearest => .nearest,
                                 else => unreachable,
                             },
                             .vector = vector,
@@ -5362,6 +5370,10 @@ test "lower f32x4 unary opcodes" {
         expected: ir.Inst.F32x4UnaryOp,
     };
     const cases = [_]Case{
+        .{ .opcode = 0x67, .expected = .ceil },
+        .{ .opcode = 0x68, .expected = .floor },
+        .{ .opcode = 0x69, .expected = .trunc },
+        .{ .opcode = 0x6A, .expected = .nearest },
         .{ .opcode = 0xE0, .expected = .abs },
         .{ .opcode = 0xE1, .expected = .neg },
         .{ .opcode = 0xE3, .expected = .sqrt },

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -446,6 +446,10 @@ pub const Inst = struct {
         abs,
         neg,
         sqrt,
+        ceil,
+        floor,
+        trunc,
+        nearest,
     };
 
     pub const V128Mem = struct {

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -685,6 +685,112 @@ test "differential SIMD: f32x4 unary NaN behavior matches interpreter" {
     );
 }
 
+test "differential SIMD: f32x4 rounding fractions match interpreter" {
+    try expectF32x4UnLaneBits(
+        0x67,
+        .{ 0x3fa0_0000, 0xbfa0_0000, 0x3fe0_0000, 0xbfe0_0000 },
+        0,
+        0x4000_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x67,
+        .{ 0x3fa0_0000, 0xbfa0_0000, 0x3fe0_0000, 0xbfe0_0000 },
+        1,
+        0xbf80_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x68,
+        .{ 0x3fa0_0000, 0xbfa0_0000, 0x3fe0_0000, 0xbfe0_0000 },
+        0,
+        0x3f80_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x68,
+        .{ 0x3fa0_0000, 0xbfa0_0000, 0x3fe0_0000, 0xbfe0_0000 },
+        1,
+        0xc000_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x69,
+        .{ 0x3fe0_0000, 0xbfe0_0000, 0x3fa0_0000, 0xbfa0_0000 },
+        0,
+        0x3f80_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x69,
+        .{ 0x3fe0_0000, 0xbfe0_0000, 0x3fa0_0000, 0xbfa0_0000 },
+        1,
+        0xbf80_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x6A,
+        .{ 0x3fe0_0000, 0xbfe0_0000, 0x3fa0_0000, 0xbfa0_0000 },
+        0,
+        0x4000_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x6A,
+        .{ 0x3fe0_0000, 0xbfe0_0000, 0x3fa0_0000, 0xbfa0_0000 },
+        1,
+        0xc000_0000,
+    );
+}
+
+test "differential SIMD: f32x4 nearest ties to even matches interpreter" {
+    const ties = [_]u32{ 0x4020_0000, 0x4060_0000, 0xc020_0000, 0xc060_0000 };
+    try expectF32x4UnLaneBits(0x6A, ties, 0, 0x4000_0000);
+    try expectF32x4UnLaneBits(0x6A, ties, 1, 0x4080_0000);
+    try expectF32x4UnLaneBits(0x6A, ties, 2, 0xc000_0000);
+    try expectF32x4UnLaneBits(0x6A, ties, 3, 0xc080_0000);
+}
+
+test "differential SIMD: f32x4 rounding signed zeros and infinities match interpreter" {
+    try expectF32x4UnLaneBits(
+        0x67,
+        .{ 0xbe80_0000, 0x3e80_0000, 0x7f80_0000, 0xff80_0000 },
+        0,
+        0x8000_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x68,
+        .{ 0xbe80_0000, 0x3e80_0000, 0x7f80_0000, 0xff80_0000 },
+        1,
+        0x0000_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x69,
+        .{ 0xbe80_0000, 0x3e80_0000, 0x7f80_0000, 0xff80_0000 },
+        0,
+        0x8000_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x6A,
+        .{ 0xbe80_0000, 0x3e80_0000, 0x7f80_0000, 0xff80_0000 },
+        0,
+        0x8000_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x67,
+        .{ 0x7f80_0000, 0xff80_0000, 0x0000_0001, 0x8000_0001 },
+        0,
+        0x7f80_0000,
+    );
+    try expectF32x4UnLaneBits(
+        0x68,
+        .{ 0x7f80_0000, 0xff80_0000, 0x0000_0001, 0x8000_0001 },
+        1,
+        0xff80_0000,
+    );
+}
+
+test "differential SIMD: f32x4 rounding NaN behavior matches interpreter" {
+    const lanes = [_]u32{ 0x7fc1_2345, 0xffc1_2345, 0x3f80_0000, 0x4000_0000 };
+    try expectF32x4UnLaneBits(0x67, lanes, 0, 0x7fc0_0000);
+    try expectF32x4UnLaneBits(0x68, lanes, 1, 0x7fc0_0000);
+    try expectF32x4UnLaneBits(0x69, lanes, 0, 0x7fc0_0000);
+    try expectF32x4UnLaneBits(0x6A, lanes, 1, 0x7fc0_0000);
+}
+
 test "differential SIMD: f32x4 arithmetic normal lanes match interpreter" {
     try expectF32x4BinLaneBits(
         0xE4,

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -344,6 +344,26 @@ const cases = [_]BenchCase{
         .build = buildSimdF32x4SqrtLane0Module,
     },
     .{
+        .name = "simd_f32x4_ceil_lane0",
+        .simd = true,
+        .build = buildSimdF32x4CeilLane0Module,
+    },
+    .{
+        .name = "simd_f32x4_floor_lane0",
+        .simd = true,
+        .build = buildSimdF32x4FloorLane0Module,
+    },
+    .{
+        .name = "simd_f32x4_trunc_lane0",
+        .simd = true,
+        .build = buildSimdF32x4TruncLane0Module,
+    },
+    .{
+        .name = "simd_f32x4_nearest_lane0",
+        .simd = true,
+        .build = buildSimdF32x4NearestLane0Module,
+    },
+    .{
         .name = "simd_f32x4_eq_lane0",
         .simd = true,
         .build = buildSimdF32x4EqLane0Module,
@@ -1888,6 +1908,7 @@ fn buildSimdF32x4ReplaceLane2Module(allocator: Allocator) ![]u8 {
 const f32x4_arith_lhs_bits: [4]u32 = .{ 0x4140_0000, 0x4000_0000, 0x4040_0000, 0x4080_0000 };
 const f32x4_arith_rhs_bits: [4]u32 = .{ 0x4080_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 };
 const f32x4_unary_bits: [4]u32 = .{ 0x4110_0000, 0x4000_0000, 0x4080_0000, 0x40c0_0000 };
+const f32x4_rounding_bits: [4]u32 = .{ 0x3fe0_0000, 0xbfa0_0000, 0x4020_0000, 0xc060_0000 };
 
 fn buildSimdF32x4UnLane0Module(allocator: Allocator, simd_opcode: u32) ![]u8 {
     var instr: std.ArrayList(u8) = .empty;
@@ -1910,6 +1931,33 @@ fn buildSimdF32x4NegLane0Module(allocator: Allocator) ![]u8 {
 
 fn buildSimdF32x4SqrtLane0Module(allocator: Allocator) ![]u8 {
     return buildSimdF32x4UnLane0Module(allocator, 0xE3);
+}
+
+fn buildSimdF32x4RoundLane0Module(allocator: Allocator, simd_opcode: u32) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstF32x4Bits(&instr, allocator, f32x4_rounding_bits);
+    try appendSimdOpcode(&instr, allocator, simd_opcode);
+    try appendI32x4ExtractLane(&instr, allocator, 0);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdF32x4CeilLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4RoundLane0Module(allocator, 0x67);
+}
+
+fn buildSimdF32x4FloorLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4RoundLane0Module(allocator, 0x68);
+}
+
+fn buildSimdF32x4TruncLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4RoundLane0Module(allocator, 0x69);
+}
+
+fn buildSimdF32x4NearestLane0Module(allocator: Allocator) ![]u8 {
+    return buildSimdF32x4RoundLane0Module(allocator, 0x6A);
 }
 
 fn buildSimdF32x4BinLane0Module(allocator: Allocator, simd_opcode: u32) ![]u8 {


### PR DESCRIPTION
Implements #296.

Summary:
- Lower f32x4.ceil/floor/trunc/nearest to AArch64 FRINTP/FRINTM/FRINTZ/FRINTN Vd.4S,Vn.4S.
- Canonicalize NaN lanes to match interpreter semantics.
- Add frontend, emitter/codegen, differential, and SIMD bench coverage.

Validation:
- zig build test
- zig build
- zig build simd-bench -- --iterations 1

Closes #296.