### PR TITLE
perf(aarch64): lower f64x2 unary

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -602,6 +602,7 @@ fn isSupportedV128Def(inst: ir.Inst) bool {
         .i64x2_shift,
         .i64x2_splat,
         .i64x2_replace_lane,
+        .f64x2_unop,
         .f64x2_binop,
         => inst.type == .v128,
         else => false,
@@ -669,6 +670,7 @@ fn functionHasUnsupportedV128(func: *const ir.IrFunction, allocator: std.mem.All
                 .i64x2_shift,
                 .i64x2_splat,
                 .i64x2_replace_lane,
+                .f64x2_unop,
                 .f64x2_binop,
                 => {
                     if (!isSupportedV128Def(inst)) return true;
@@ -1500,6 +1502,7 @@ fn isV128Inst(inst: ir.Inst) bool {
         .i64x2_splat,
         .i64x2_extract_lane,
         .i64x2_replace_lane,
+        .f64x2_unop,
         .f64x2_binop,
         => true,
         else => false,
@@ -1703,6 +1706,7 @@ fn compileInst(
         .i64x2_splat => |src| try emitI64x2Splat(code, inst, src, reg_map, v128_map, v128_cache),
         .i64x2_extract_lane => |lane| try emitI64x2ExtractLane(code, inst, lane, reg_map, v128_map, v128_cache),
         .i64x2_replace_lane => |lane| try emitI64x2ReplaceLane(code, inst, lane, reg_map, v128_map, v128_cache, fctx),
+        .f64x2_unop => |un| try emitF64x2UnOp(code, inst, un, v128_map, v128_cache, fctx),
         .f64x2_binop => |bin| try emitF64x2BinOp(code, inst, bin, v128_map, v128_cache, fctx),
 
         .add => |bin| if (inst.type == .f32 or inst.type == .f64)
@@ -2474,6 +2478,35 @@ fn canonicalizeF32x4NaNs(code: *emit.CodeBuffer, dest_reg: u5) !void {
     try code.mvn16b(v128_tmp0, v128_tmp0);
     try code.movImm32(RegMap.tmp0, @bitCast(@as(u32, 0x7fc0_0000)));
     try code.dup4sFromGp32(v128_tmp1, RegMap.tmp0);
+    try code.bsl16b(v128_tmp0, v128_tmp1, dest_reg);
+    try code.bitwise16b(.orr, dest_reg, v128_tmp0, v128_tmp0);
+}
+
+fn emitF64x2UnOp(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    un: ir.Inst.F64x2UnOp,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+    fctx: *const FuncCompileCtx,
+) !void {
+    const vector_reg = try v128_cache.ensure(code, v128_map, un.vector, null);
+    const dest_reg = try prepareV128UnaryDest(code, inst, un.vector, vector_reg, v128_map, v128_cache, fctx);
+    switch (un.op) {
+        .abs => try code.fabs2d(dest_reg, vector_reg),
+        .neg => try code.fneg2d(dest_reg, vector_reg),
+        .sqrt => {
+            try code.fsqrt2d(dest_reg, vector_reg);
+            try canonicalizeF64x2NaNs(code, dest_reg);
+        },
+    }
+}
+
+fn canonicalizeF64x2NaNs(code: *emit.CodeBuffer, dest_reg: u5) !void {
+    try code.fcmeq2d(v128_tmp0, dest_reg, dest_reg);
+    try code.mvn16b(v128_tmp0, v128_tmp0);
+    try code.movImm64(RegMap.tmp0, 0x7ff8_0000_0000_0000);
+    try code.dup2dFromGp64(v128_tmp1, RegMap.tmp0);
     try code.bsl16b(v128_tmp0, v128_tmp1, dest_reg);
     try code.bitwise16b(.orr, dest_reg, v128_tmp0, v128_tmp0);
 }
@@ -7849,6 +7882,59 @@ test "compile: f64x2 arithmetic and comparison ops emit NEON instructions" {
     try std.testing.expect(found_fcmge);
     try std.testing.expect(found_mvn);
     try std.testing.expect(bsl_count >= 2);
+}
+
+test "compile: f64x2 unary ops emit NEON instructions" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+
+    const a = func.newVReg();
+    const abs = func.newVReg();
+    const neg = func.newVReg();
+    const sqrt = func.newVReg();
+    const lane = func.newVReg();
+    const wrapped = func.newVReg();
+
+    try func.getBlock(bid).append(.{ .op = .{ .v128_const = 0x4010_0000_0000_0000_c010_0000_0000_0000 }, .dest = a, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_unop = .{ .op = .abs, .vector = a } }, .dest = abs, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_unop = .{ .op = .neg, .vector = abs } }, .dest = neg, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_unop = .{ .op = .sqrt, .vector = neg } }, .dest = sqrt, .type = .v128 });
+    try func.getBlock(bid).append(.{
+        .op = .{ .i64x2_extract_lane = .{ .vector = sqrt, .lane = 0 } },
+        .dest = lane,
+        .type = .i64,
+    });
+    try func.getBlock(bid).append(.{ .op = .{ .wrap_i64 = lane }, .dest = wrapped, .type = .i32 });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = wrapped } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    var found_fabs = false;
+    var found_fneg = false;
+    var found_fsqrt = false;
+    var found_fcmeq = false;
+    var found_mvn = false;
+    var found_bsl = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFFFFC00) == 0x4EE0F800) found_fabs = true;
+        if ((w & 0xFFFFFC00) == 0x6EE0F800) found_fneg = true;
+        if ((w & 0xFFFFFC00) == 0x6EE1F800) found_fsqrt = true;
+        if ((w & 0xFFE0FC00) == 0x4E60E400) found_fcmeq = true;
+        if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
+        if ((w & 0xFFE0FC00) == 0x6E601C00) found_bsl = true;
+    }
+
+    try std.testing.expect(found_fabs);
+    try std.testing.expect(found_fneg);
+    try std.testing.expect(found_fsqrt);
+    try std.testing.expect(found_fcmeq);
+    try std.testing.expect(found_mvn);
+    try std.testing.expect(found_bsl);
 }
 
 test "compile: f32x4 unary ops emit NEON instructions" {

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -1196,6 +1196,34 @@ pub const CodeBuffer = struct {
         min = 0x4EE0F400,
     };
 
+    pub const F64x2UnaryOp = enum(u32) {
+        abs = 0x4EE0F800,
+        neg = 0x6EE0F800,
+        sqrt = 0x6EE1F800,
+    };
+
+    /// Floating-point 2D unary vector op: FABS/FNEG/FSQRT.
+    pub fn f64x2UnOp(self: *CodeBuffer, op: F64x2UnaryOp, vd: u5, vn: u5) !void {
+        try self.emit32(@intFromEnum(op) |
+            (@as(u32, vn) << 5) |
+            vd);
+    }
+
+    /// FABS Vd.2D, Vn.2D.
+    pub fn fabs2d(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.f64x2UnOp(.abs, vd, vn);
+    }
+
+    /// FNEG Vd.2D, Vn.2D.
+    pub fn fneg2d(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.f64x2UnOp(.neg, vd, vn);
+    }
+
+    /// FSQRT Vd.2D, Vn.2D.
+    pub fn fsqrt2d(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.f64x2UnOp(.sqrt, vd, vn);
+    }
+
     /// Floating-point 2D binary vector op: FADD/FSUB/FMUL/FDIV/FMAX/FMIN.
     pub fn f64x2Op(self: *CodeBuffer, op: F64x2Op, vd: u5, vn: u5, vm: u5) !void {
         try self.emit32(@intFromEnum(op) |
@@ -3357,6 +3385,27 @@ test "emit: f64x2 vector arithmetic ops" {
         defer code.deinit();
         try code.fcmge2d(16, 17, 30);
         try expectWord(0x6E7EE630, &code);
+    }
+}
+
+test "emit: f64x2 vector unary ops" {
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.fabs2d(16, 17);
+        try expectWord(0x4EE0FA30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.fneg2d(16, 17);
+        try expectWord(0x6EE0FA30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.fsqrt2d(16, 17);
+        try expectWord(0x6EE1FA30, &code);
     }
 }
 

--- a/src/compiler/codegen/aarch64/schedule.zig
+++ b/src/compiler/codegen/aarch64/schedule.zig
@@ -298,6 +298,7 @@ fn opClass(inst: ir.Inst) Class {
         .i64x2_splat,
         .i64x2_extract_lane,
         .i64x2_replace_lane,
+        .f64x2_unop,
         .f64x2_binop,
         .f64x2_convert_low_i32x4,
         .f64x2_promote_low_f32x4,
@@ -645,6 +646,7 @@ pub fn forEachUse(
             try visit(context, bin.lhs);
             try visit(context, bin.rhs);
         },
+        .f64x2_unop => |un| try visit(context, un.vector),
         .f64x2_convert_low_i32x4 => |op| try visit(context, op.vector),
         .f64x2_promote_low_f32x4 => |op| try visit(context, op.vector),
         .i64x2_unop => |un| try visit(context, un.vector),

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1310,6 +1310,7 @@ fn compileInst(
         .i64x2_splat,
         .i64x2_extract_lane,
         .i64x2_replace_lane,
+        .f64x2_unop,
         .f64x2_binop,
         => return error.UnsupportedV128,
         // Phi must be lowered before codegen.
@@ -1622,6 +1623,7 @@ fn functionUsesV128(func: *const ir.IrFunction) bool {
                 .i64x2_splat,
                 .i64x2_extract_lane,
                 .i64x2_replace_lane,
+                .f64x2_unop,
                 .f64x2_binop,
                 => return true,
                 else => {},

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -2105,6 +2105,28 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         });
                         try vreg_stack.append(allocator, dest);
                     },
+                    .f64x2_abs,
+                    .f64x2_neg,
+                    .f64x2_sqrt,
+                    => {
+                        const vector = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        const unary = ir.Inst.F64x2UnOp{
+                            .op = switch (simd_op) {
+                                .f64x2_abs => .abs,
+                                .f64x2_neg => .neg,
+                                .f64x2_sqrt => .sqrt,
+                                else => unreachable,
+                            },
+                            .vector = vector,
+                        };
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .f64x2_unop = unary },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
                     .i16x8_extadd_pairwise_i8x16_s,
                     .i16x8_extadd_pairwise_i8x16_u,
                     .i32x4_extadd_pairwise_i16x8_s,
@@ -5495,6 +5517,92 @@ test "lower f32x4 unary opcodes" {
     const extract_idx = 1 + cases.len;
     try std.testing.expectEqual(@as(u2, 0), insts[extract_idx].op.i32x4_extract_lane.lane);
     try std.testing.expect(insts[extract_idx + 1].op.ret != null);
+}
+
+test "lower f64x2 unary opcodes" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i32},
+    };
+
+    const Case = struct {
+        opcode: u32,
+        expected: ir.Inst.F64x2UnaryOp,
+    };
+    const cases = [_]Case{
+        .{ .opcode = 0xEC, .expected = .abs },
+        .{ .opcode = 0xED, .expected = .neg },
+        .{ .opcode = 0xEF, .expected = .sqrt },
+    };
+
+    const appendULEB = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, value: u32) !void {
+            var v = value;
+            while (true) {
+                var byte: u8 = @intCast(v & 0x7F);
+                v >>= 7;
+                if (v != 0) byte |= 0x80;
+                try buf.append(alloc, byte);
+                if (v == 0) break;
+            }
+        }
+    }.call;
+    const appendSimd = struct {
+        fn call(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, opcode: u32) !void {
+            try buf.append(alloc, 0xFD);
+            try appendULEB(buf, alloc, opcode);
+        }
+    }.call;
+
+    var code: std.ArrayList(u8) = .empty;
+    defer code.deinit(allocator);
+    try appendSimd(&code, allocator, 0x0C); // v128.const
+    const lanes = [_]u64{ 0xc010_0000_0000_0000, 0x7ff8_0000_0000_1234 };
+    for (lanes) |lane| {
+        var le = std.mem.nativeToLittle(u64, lane);
+        try code.appendSlice(allocator, std.mem.asBytes(&le));
+    }
+    for (cases) |case| {
+        try appendSimd(&code, allocator, case.opcode);
+    }
+    try appendSimd(&code, allocator, 0x1D); // i64x2.extract_lane
+    try code.append(allocator, 0);
+    try code.append(allocator, 0xA7); // i32.wrap_i64
+    try code.append(allocator, 0x0B);
+
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = code.items,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+    try std.testing.expectEqual(@as(usize, 1 + cases.len + 3), insts.len);
+    var prev_dest = insts[0].dest.?;
+    for (cases, 0..) |case, idx| {
+        const inst = insts[1 + idx];
+        const un = inst.op.f64x2_unop;
+        try std.testing.expectEqual(case.expected, un.op);
+        try std.testing.expectEqual(prev_dest, un.vector);
+        try std.testing.expectEqual(ir.IrType.v128, inst.type);
+        prev_dest = inst.dest.?;
+    }
+    const extract_idx = 1 + cases.len;
+    try std.testing.expectEqual(@as(u1, 0), insts[extract_idx].op.i64x2_extract_lane.lane);
+    try std.testing.expectEqual(ir.IrType.i64, insts[extract_idx].type);
+    try std.testing.expectEqual(insts[extract_idx].dest.?, insts[extract_idx + 1].op.wrap_i64);
+    try std.testing.expect(insts[extract_idx + 2].op.ret != null);
 }
 
 test "lower integer SIMD pairwise extended add opcodes" {

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -252,6 +252,7 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
             live.put(bin.lhs, {}) catch {};
             live.put(bin.rhs, {}) catch {};
         },
+        .f64x2_unop => |un| live.put(un.vector, {}) catch {},
         .f64x2_convert_low_i32x4 => |op| live.put(op.vector, {}) catch {},
         .f64x2_promote_low_f32x4 => |op| live.put(op.vector, {}) catch {},
         .i64x2_unop => |un| live.put(un.vector, {}) catch {},
@@ -698,6 +699,7 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
             last_use.put(bin.lhs, pos) catch {};
             last_use.put(bin.rhs, pos) catch {};
         },
+        .f64x2_unop => |un| last_use.put(un.vector, pos) catch {},
         .f64x2_convert_low_i32x4 => |op| last_use.put(op.vector, pos) catch {},
         .f64x2_promote_low_f32x4 => |op| last_use.put(op.vector, pos) catch {},
         .i64x2_unop => |un| last_use.put(un.vector, pos) catch {},

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -124,6 +124,7 @@ pub const Inst = struct {
         i64x2_splat: VReg,
         i64x2_extract_lane: I64x2ExtractLane,
         i64x2_replace_lane: I64x2ReplaceLane,
+        f64x2_unop: F64x2UnOp,
         f64x2_binop: F64x2BinOp,
         f64x2_convert_low_i32x4: SimdIntToFloatConvert,
         f64x2_promote_low_f32x4: SimdFloatPrecisionConvert,
@@ -460,6 +461,12 @@ pub const Inst = struct {
         nearest,
     };
 
+    pub const F64x2UnaryOp = enum {
+        abs,
+        neg,
+        sqrt,
+    };
+
     pub const V128Mem = struct {
         base: VReg,
         offset: u32,
@@ -721,6 +728,11 @@ pub const Inst = struct {
 
     pub const F32x4UnOp = struct {
         op: F32x4UnaryOp,
+        vector: VReg,
+    };
+
+    pub const F64x2UnOp = struct {
+        op: F64x2UnaryOp,
         vector: VReg,
     };
 
@@ -1402,6 +1414,14 @@ test "Inst: first v128 op family preserves operand shape" {
     };
     try std.testing.expectEqual(Inst.I64x2Op.gt_s, i64_bin.op.i64x2_binop.op);
     try std.testing.expectEqual(@as(VReg, 23), i64_bin.op.i64x2_binop.lhs);
+
+    const f64_un = Inst{
+        .op = .{ .f64x2_unop = .{ .op = .sqrt, .vector = 24 } },
+        .dest = 26,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(Inst.F64x2UnaryOp.sqrt, f64_un.op.f64x2_unop.op);
+    try std.testing.expectEqual(@as(VReg, 24), f64_un.op.f64x2_unop.vector);
 
     const f64_bin = Inst{
         .op = .{ .f64x2_binop = .{ .op = .div, .lhs = 24, .rhs = 25 } },

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -216,6 +216,7 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
             list.append(bin.lhs);
             list.append(bin.rhs);
         },
+        .f64x2_unop => |un| list.append(un.vector),
         .f64x2_convert_low_i32x4 => |op| list.append(op.vector),
         .f64x2_promote_low_f32x4 => |op| list.append(op.vector),
         .i64x2_unop => |un| list.append(un.vector),
@@ -598,6 +599,9 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
         .f64x2_binop => |*bin| {
             if (bin.lhs == old) bin.lhs = new;
             if (bin.rhs == old) bin.rhs = new;
+        },
+        .f64x2_unop => |*un| if (un.vector == old) {
+            un.vector = new;
         },
         .f64x2_convert_low_i32x4 => |*op| if (op.vector == old) {
             op.vector = new;
@@ -1963,6 +1967,7 @@ fn isPure(inst: ir.Inst) bool {
         .i16x8_replace_lane,
         .i64x2_binop,
         .f64x2_binop,
+        .f64x2_unop,
         .f64x2_convert_low_i32x4,
         .f64x2_promote_low_f32x4,
         .i64x2_unop,
@@ -2104,6 +2109,7 @@ fn sameOp(a: ir.Inst, b: ir.Inst) bool {
         .f32x4_unop => |un| un.op == b.op.f32x4_unop.op and un.vector == b.op.f32x4_unop.vector,
         .f32x4_binop => |bin| bin.op == b.op.f32x4_binop.op and bin.lhs == b.op.f32x4_binop.lhs and bin.rhs == b.op.f32x4_binop.rhs,
         .f64x2_binop => |bin| bin.op == b.op.f64x2_binop.op and bin.lhs == b.op.f64x2_binop.lhs and bin.rhs == b.op.f64x2_binop.rhs,
+        .f64x2_unop => |un| un.op == b.op.f64x2_unop.op and un.vector == b.op.f64x2_unop.vector,
         .f64x2_convert_low_i32x4 => |op| op.sign == b.op.f64x2_convert_low_i32x4.sign and op.vector == b.op.f64x2_convert_low_i32x4.vector,
         .f64x2_promote_low_f32x4 => |op| op.vector == b.op.f64x2_promote_low_f32x4.vector,
         .i64x2_unop => |un| un.op == b.op.i64x2_unop.op and un.vector == b.op.i64x2_unop.vector,
@@ -3763,6 +3769,7 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
             bin.lhs += offset;
             bin.rhs += offset;
         },
+        .f64x2_unop => |*un| un.vector += offset,
         .f64x2_convert_low_i32x4 => |*op| op.vector += offset,
         .f64x2_promote_low_f32x4 => |*op| op.vector += offset,
         .i64x2_unop => |*un| un.vector += offset,

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -554,6 +554,33 @@ fn expectF64x2ConvertLowLane0High(opcode: u32, lanes: [4]i32, expected_high_bits
     try expectSimdDiffI32(wasm, "f", expected_high_bits);
 }
 
+fn expectF64x2UnLanePart(opcode: u32, lanes: [2]u64, lane: u8, shift: u6, expected: i32) !void {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendV128ConstI64x2(&body, testing.allocator, lanes);
+    try appendSimdOpcode(&body, testing.allocator, opcode);
+    try appendI64x2ExtractLane(&body, testing.allocator, lane);
+    if (shift != 0) {
+        try appendI64Const(&body, testing.allocator, shift);
+        try appendI64ShrU(&body, testing.allocator);
+    }
+    try appendI32WrapI64(&body, testing.allocator);
+    try body.append(testing.allocator, 0x0B);
+
+    const wasm = try buildCustomModule(testing.allocator, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", expected);
+}
+
+fn expectF64x2UnLaneLow(opcode: u32, lanes: [2]u64, lane: u8, expected: i32) !void {
+    try expectF64x2UnLanePart(opcode, lanes, lane, 0, expected);
+}
+
+fn expectF64x2UnLaneHigh(opcode: u32, lanes: [2]u64, lane: u8, expected: i32) !void {
+    try expectF64x2UnLanePart(opcode, lanes, lane, 32, expected);
+}
+
 test "differential SIMD: f32x4.convert_i32x4_s lane 0 matches interpreter" {
     try expectF32x4ConvertLane0(
         0xFA,
@@ -1466,6 +1493,147 @@ test "differential SIMD: f64x2.promote_low_f32x4 inf NaN and subnormal" {
     );
     try expectF64x2PromoteLaneHighMatchesInterp(
         .{ 0x7fc0_0001, 0x3f80_0000, 0xff80_0000, 0x0000_0001 },
+        0,
+    );
+}
+
+test "differential SIMD: f64x2 unary normal lanes match interpreter" {
+    try expectF64x2UnLaneHigh(
+        0xEC,
+        .{ 0xc00c_0000_0000_0000, 0x4000_0000_0000_0000 },
+        0,
+        0x400c_0000,
+    );
+    try expectF64x2UnLaneHigh(
+        0xED,
+        .{ 0x3ff0_0000_0000_0000, 0x4000_0000_0000_0000 },
+        1,
+        @bitCast(@as(u32, 0xc000_0000)),
+    );
+    try expectF64x2UnLaneHigh(
+        0xEF,
+        .{ 0x4010_0000_0000_0000, 0x3ff0_0000_0000_0000 },
+        0,
+        0x4000_0000,
+    );
+}
+
+test "differential SIMD: f64x2 unary signed zero infinity and subnormal edges match interpreter" {
+    try expectF64x2UnLaneHigh(
+        0xEC,
+        .{ 0x8000_0000_0000_0000, 0xfff0_0000_0000_0000 },
+        0,
+        0,
+    );
+    try expectF64x2UnLaneHigh(
+        0xEC,
+        .{ 0x8000_0000_0000_0000, 0xfff0_0000_0000_0000 },
+        1,
+        0x7ff0_0000,
+    );
+    try expectF64x2UnLaneLow(
+        0xEC,
+        .{ 0x8000_0000_0000_0001, 0x3ff0_0000_0000_0000 },
+        0,
+        1,
+    );
+    try expectF64x2UnLaneHigh(
+        0xED,
+        .{ 0x0000_0000_0000_0000, 0x7ff0_0000_0000_0000 },
+        0,
+        @bitCast(@as(u32, 0x8000_0000)),
+    );
+    try expectF64x2UnLaneHigh(
+        0xED,
+        .{ 0x0000_0000_0000_0000, 0x7ff0_0000_0000_0000 },
+        1,
+        @bitCast(@as(u32, 0xfff0_0000)),
+    );
+    try expectF64x2UnLaneHigh(
+        0xED,
+        .{ 0x0000_0000_0000_0001, 0x3ff0_0000_0000_0000 },
+        0,
+        @bitCast(@as(u32, 0x8000_0000)),
+    );
+    try expectF64x2UnLaneLow(
+        0xED,
+        .{ 0x0000_0000_0000_0001, 0x3ff0_0000_0000_0000 },
+        0,
+        1,
+    );
+    try expectF64x2UnLaneHigh(
+        0xEF,
+        .{ 0x8000_0000_0000_0000, 0x7ff0_0000_0000_0000 },
+        0,
+        @bitCast(@as(u32, 0x8000_0000)),
+    );
+    try expectF64x2UnLaneHigh(
+        0xEF,
+        .{ 0x8000_0000_0000_0000, 0x7ff0_0000_0000_0000 },
+        1,
+        0x7ff0_0000,
+    );
+    try expectF64x2UnLaneHigh(
+        0xEF,
+        .{ 0x0000_0000_0000_0001, 0x3ff0_0000_0000_0000 },
+        0,
+        0x1e60_0000,
+    );
+    try expectF64x2UnLaneLow(
+        0xEF,
+        .{ 0x0000_0000_0000_0001, 0x3ff0_0000_0000_0000 },
+        0,
+        0,
+    );
+}
+
+test "differential SIMD: f64x2 unary NaN behavior matches interpreter" {
+    try expectF64x2UnLaneHigh(
+        0xEC,
+        .{ 0xfff8_0000_0000_1234, 0x3ff0_0000_0000_0000 },
+        0,
+        0x7ff8_0000,
+    );
+    try expectF64x2UnLaneLow(
+        0xEC,
+        .{ 0xfff8_0000_0000_1234, 0x3ff0_0000_0000_0000 },
+        0,
+        0x1234,
+    );
+    try expectF64x2UnLaneHigh(
+        0xED,
+        .{ 0x7ff8_0000_0000_1234, 0x3ff0_0000_0000_0000 },
+        0,
+        @bitCast(@as(u32, 0xfff8_0000)),
+    );
+    try expectF64x2UnLaneLow(
+        0xED,
+        .{ 0x7ff8_0000_0000_1234, 0x3ff0_0000_0000_0000 },
+        0,
+        0x1234,
+    );
+    try expectF64x2UnLaneHigh(
+        0xEF,
+        .{ 0x7ff8_0000_0000_1234, 0xc010_0000_0000_0000 },
+        0,
+        0x7ff8_0000,
+    );
+    try expectF64x2UnLaneLow(
+        0xEF,
+        .{ 0x7ff8_0000_0000_1234, 0xc010_0000_0000_0000 },
+        0,
+        0,
+    );
+    try expectF64x2UnLaneHigh(
+        0xEF,
+        .{ 0x7ff8_0000_0000_1234, 0xc010_0000_0000_0000 },
+        1,
+        0x7ff8_0000,
+    );
+    try expectF64x2UnLaneLow(
+        0xEF,
+        .{ 0x7ff8_0000_0000_1234, 0xc010_0000_0000_0000 },
+        1,
         0,
     );
 }

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -369,6 +369,21 @@ const cases = [_]BenchCase{
         .build = buildSimdF32x4SqrtLane0Module,
     },
     .{
+        .name = "simd_f64x2_abs_lane0_high",
+        .simd = true,
+        .build = buildSimdF64x2AbsLane0HighModule,
+    },
+    .{
+        .name = "simd_f64x2_neg_lane0_high",
+        .simd = true,
+        .build = buildSimdF64x2NegLane0HighModule,
+    },
+    .{
+        .name = "simd_f64x2_sqrt_lane0_high",
+        .simd = true,
+        .build = buildSimdF64x2SqrtLane0HighModule,
+    },
+    .{
         .name = "simd_f32x4_ceil_lane0",
         .simd = true,
         .build = buildSimdF32x4CeilLane0Module,
@@ -2013,6 +2028,32 @@ fn buildSimdF32x4NegLane0Module(allocator: Allocator) ![]u8 {
 
 fn buildSimdF32x4SqrtLane0Module(allocator: Allocator) ![]u8 {
     return buildSimdF32x4UnLane0Module(allocator, 0xE3);
+}
+
+fn buildSimdF64x2UnLane0HighModule(allocator: Allocator, simd_opcode: u32, lanes: [2]u64) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI64x2(&instr, allocator, lanes);
+    try appendSimdOpcode(&instr, allocator, simd_opcode);
+    try appendI64x2ExtractLane(&instr, allocator, 0);
+    try appendI64Const(&instr, allocator, 32);
+    try appendI64ShrU(&instr, allocator);
+    try appendI32WrapI64(&instr, allocator);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdF64x2AbsLane0HighModule(allocator: Allocator) ![]u8 {
+    return buildSimdF64x2UnLane0HighModule(allocator, 0xEC, .{ 0xc010_0000_0000_0000, 0x4000_0000_0000_0000 });
+}
+
+fn buildSimdF64x2NegLane0HighModule(allocator: Allocator) ![]u8 {
+    return buildSimdF64x2UnLane0HighModule(allocator, 0xED, .{ 0x4010_0000_0000_0000, 0x4000_0000_0000_0000 });
+}
+
+fn buildSimdF64x2SqrtLane0HighModule(allocator: Allocator) ![]u8 {
+    return buildSimdF64x2UnLane0HighModule(allocator, 0xEF, .{ 0x4010_0000_0000_0000, 0x4000_0000_0000_0000 });
 }
 
 fn buildSimdF32x4RoundLane0Module(allocator: Allocator, simd_opcode: u32) ![]u8 {


### PR DESCRIPTION
Closes #300.

## Summary
- add `f64x2_unop` IR/frontend lowering for `f64x2.abs`, `f64x2.neg`, and `f64x2.sqrt`
- emit AArch64 `FABS`/`FNEG`/`FSQRT Vd.2D,Vn.2D`, with NaN canonicalization for sqrt lanes
- add scheduler/analysis/pass plumbing, x86_64 unsupported handling, differential tests, emitter/codegen coverage, and SIMD bench rows

## Validation
- `zig build test`
- `zig build`
- `zig build simd-bench -- --iterations 1`