### PR TITLE
perf(aarch64): lower f64x2 lane ops

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -604,6 +604,8 @@ fn isSupportedV128Def(inst: ir.Inst) bool {
         .i64x2_replace_lane,
         .f64x2_unop,
         .f64x2_binop,
+        .f64x2_splat,
+        .f64x2_replace_lane,
         => inst.type == .v128,
         else => false,
     };
@@ -672,6 +674,8 @@ fn functionHasUnsupportedV128(func: *const ir.IrFunction, allocator: std.mem.All
                 .i64x2_replace_lane,
                 .f64x2_unop,
                 .f64x2_binop,
+                .f64x2_splat,
+                .f64x2_replace_lane,
                 => {
                     if (!isSupportedV128Def(inst)) return true;
                 },
@@ -682,6 +686,7 @@ fn functionHasUnsupportedV128(func: *const ir.IrFunction, allocator: std.mem.All
                 .i8x16_extract_lane,
                 .i16x8_extract_lane,
                 .i64x2_extract_lane,
+                .f64x2_extract_lane,
                 => {},
                 else => {},
             }
@@ -1504,6 +1509,9 @@ fn isV128Inst(inst: ir.Inst) bool {
         .i64x2_replace_lane,
         .f64x2_unop,
         .f64x2_binop,
+        .f64x2_splat,
+        .f64x2_extract_lane,
+        .f64x2_replace_lane,
         => true,
         else => false,
     };
@@ -1708,6 +1716,9 @@ fn compileInst(
         .i64x2_replace_lane => |lane| try emitI64x2ReplaceLane(code, inst, lane, reg_map, v128_map, v128_cache, fctx),
         .f64x2_unop => |un| try emitF64x2UnOp(code, inst, un, v128_map, v128_cache, fctx),
         .f64x2_binop => |bin| try emitF64x2BinOp(code, inst, bin, v128_map, v128_cache, fctx),
+        .f64x2_splat => |src| try emitF64x2Splat(code, inst, src, reg_map, v128_map, v128_cache),
+        .f64x2_extract_lane => |lane| try emitF64x2ExtractLane(code, inst, lane, reg_map, v128_map, v128_cache),
+        .f64x2_replace_lane => |lane| try emitF64x2ReplaceLane(code, inst, lane, reg_map, v128_map, v128_cache, fctx),
 
         .add => |bin| if (inst.type == .f32 or inst.type == .f64)
             try emitFBinOp(code, inst, bin, reg_map, .add)
@@ -3726,6 +3737,50 @@ fn emitI64x2ReplaceLane(
     code: *emit.CodeBuffer,
     inst: ir.Inst,
     lane: ir.Inst.I64x2ReplaceLane,
+    reg_map: *const RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+    fctx: *const FuncCompileCtx,
+) !void {
+    const vector_reg = try v128_cache.ensure(code, v128_map, lane.vector, null);
+    const dest_reg = try prepareV128UnaryDest(code, inst, lane.vector, vector_reg, v128_map, v128_cache, fctx);
+    const val_reg = try useInto(code, reg_map, lane.val, RegMap.tmp0);
+    try code.insDFromGp64(dest_reg, lane.lane, val_reg);
+}
+
+fn emitF64x2Splat(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    src: ir.VReg,
+    reg_map: *const RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+) !void {
+    const dest = inst.dest orelse return;
+    const dest_reg = try v128_cache.defineFresh(code, v128_map, dest, null);
+    const src_reg = try useInto(code, reg_map, src, RegMap.tmp0);
+    try code.dup2dFromGp64(dest_reg, src_reg);
+}
+
+fn emitF64x2ExtractLane(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    lane: ir.Inst.F64x2ExtractLane,
+    reg_map: *RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+) !void {
+    const dest = inst.dest orelse return;
+    const vector_reg = try v128_cache.ensure(code, v128_map, lane.vector, null);
+    const info = try destBegin(reg_map, dest, RegMap.tmp0);
+    try code.umovXFromD(info.reg, vector_reg, lane.lane);
+    try destCommit(code, reg_map, info);
+}
+
+fn emitF64x2ReplaceLane(
+    code: *emit.CodeBuffer,
+    inst: ir.Inst,
+    lane: ir.Inst.F64x2ReplaceLane,
     reg_map: *const RegMap,
     v128_map: *V128StackMap,
     v128_cache: *V128RegCache,
@@ -7378,6 +7433,56 @@ test "compile: i64x2 lane ops emit NEON instructions" {
         .type = .i64,
     });
     try func.getBlock(bid).append(.{ .op = .{ .wrap_i64 = lane }, .dest = wrapped, .type = .i32 });
+    try func.getBlock(bid).append(.{ .op = .{ .ret = wrapped } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    var found_dup = false;
+    var found_ins = false;
+    var found_umov = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFFFFFC00) == 0x4E080C00) found_dup = true;
+        if ((w & 0xFFFFFC00) == 0x4E181C00) found_ins = true;
+        if ((w & 0xFFFFFC00) == 0x4E183C00) found_umov = true;
+    }
+
+    try std.testing.expect(found_dup);
+    try std.testing.expect(found_ins);
+    try std.testing.expect(found_umov);
+}
+
+test "compile: f64x2 lane ops emit bit-preserving NEON instructions" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const bid = try func.newBlock();
+
+    const scalar = func.newVReg();
+    const splat = func.newVReg();
+    const replacement = func.newVReg();
+    const replaced = func.newVReg();
+    const lane = func.newVReg();
+    const bits = func.newVReg();
+    const wrapped = func.newVReg();
+
+    try func.getBlock(bid).append(.{ .op = .{ .fconst_64 = @bitCast(@as(u64, 0x7FF8_0123_4567_89AB)) }, .dest = scalar, .type = .f64 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_splat = scalar }, .dest = splat, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .fconst_64 = @bitCast(@as(u64, 0x8000_0000_0000_0000)) }, .dest = replacement, .type = .f64 });
+    try func.getBlock(bid).append(.{
+        .op = .{ .f64x2_replace_lane = .{ .vector = splat, .val = replacement, .lane = 1 } },
+        .dest = replaced,
+        .type = .v128,
+    });
+    try func.getBlock(bid).append(.{
+        .op = .{ .f64x2_extract_lane = .{ .vector = replaced, .lane = 1 } },
+        .dest = lane,
+        .type = .f64,
+    });
+    try func.getBlock(bid).append(.{ .op = .{ .reinterpret = lane }, .dest = bits, .type = .i64 });
+    try func.getBlock(bid).append(.{ .op = .{ .wrap_i64 = bits }, .dest = wrapped, .type = .i32 });
     try func.getBlock(bid).append(.{ .op = .{ .ret = wrapped } });
 
     const code = try compileFunction(&func, allocator);

--- a/src/compiler/codegen/aarch64/schedule.zig
+++ b/src/compiler/codegen/aarch64/schedule.zig
@@ -300,6 +300,9 @@ fn opClass(inst: ir.Inst) Class {
         .i64x2_replace_lane,
         .f64x2_unop,
         .f64x2_binop,
+        .f64x2_splat,
+        .f64x2_extract_lane,
+        .f64x2_replace_lane,
         .f64x2_convert_low_i32x4,
         .f64x2_promote_low_f32x4,
         => if (def != null) .alu else .barrier,
@@ -688,6 +691,12 @@ pub fn forEachUse(
         .i64x2_splat => |v| try visit(context, v),
         .i64x2_extract_lane => |lane| try visit(context, lane.vector),
         .i64x2_replace_lane => |lane| {
+            try visit(context, lane.vector);
+            try visit(context, lane.val);
+        },
+        .f64x2_splat => |v| try visit(context, v),
+        .f64x2_extract_lane => |lane| try visit(context, lane.vector),
+        .f64x2_replace_lane => |lane| {
             try visit(context, lane.vector);
             try visit(context, lane.val);
         },

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1312,6 +1312,9 @@ fn compileInst(
         .i64x2_replace_lane,
         .f64x2_unop,
         .f64x2_binop,
+        .f64x2_splat,
+        .f64x2_extract_lane,
+        .f64x2_replace_lane,
         => return error.UnsupportedV128,
         // Phi must be lowered before codegen.
         .phi => unreachable,
@@ -1625,6 +1628,9 @@ fn functionUsesV128(func: *const ir.IrFunction) bool {
                 .i64x2_replace_lane,
                 .f64x2_unop,
                 .f64x2_binop,
+                .f64x2_splat,
+                .f64x2_extract_lane,
+                .f64x2_replace_lane,
                 => return true,
                 else => {},
             }

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -2940,6 +2940,48 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                         });
                         try vreg_stack.append(allocator, dest);
                     },
+                    .f64x2_splat => {
+                        const val = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .f64x2_splat = val },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
+                    .f64x2_extract_lane => {
+                        const lane_raw = try readByte(code, &ip);
+                        if (lane_raw >= 2) return error.InvalidBytecode;
+                        const vector = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .f64x2_extract_lane = .{
+                                .vector = vector,
+                                .lane = @intCast(lane_raw),
+                            } },
+                            .dest = dest,
+                            .type = .f64,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
+                    .f64x2_replace_lane => {
+                        const lane_raw = try readByte(code, &ip);
+                        if (lane_raw >= 2) return error.InvalidBytecode;
+                        const val = safePop(&vreg_stack);
+                        const vector = safePop(&vreg_stack);
+                        const dest = ir_func.newVReg();
+                        try ir_func.getBlock(current_block).append(.{
+                            .op = .{ .f64x2_replace_lane = .{
+                                .vector = vector,
+                                .val = val,
+                                .lane = @intCast(lane_raw),
+                            } },
+                            .dest = dest,
+                            .type = .v128,
+                        });
+                        try vreg_stack.append(allocator, dest);
+                    },
                     .i8x16_splat => {
                         const val = safePop(&vreg_stack);
                         const dest = ir_func.newVReg();
@@ -5107,6 +5149,126 @@ test "reject invalid i64x2 lane immediates" {
     };
 
     try std.testing.expectError(error.InvalidBytecode, lowerModule(&wasm_module, allocator));
+}
+
+test "lower f64x2 dynamic lane opcodes" {
+    const allocator = std.testing.allocator;
+
+    const func_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.i32},
+    };
+    const code = [_]u8{
+        0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F, // f64.const 1.0
+        0xFD, 0x14, // f64x2.splat
+        0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, // f64.const -0.0
+        0xFD, 0x22, 0x01, // f64x2.replace_lane 1
+        0xFD, 0x21, 0x01, // f64x2.extract_lane 1
+        0xBD, // i64.reinterpret_f64
+        0xA7, // i32.wrap_i64
+        0x0B,
+    };
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &code,
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+    try std.testing.expectEqual(@as(usize, 8), insts.len);
+    try std.testing.expectEqual(@as(u64, 0x3FF0_0000_0000_0000), @as(u64, @bitCast(insts[0].op.fconst_64)));
+    try std.testing.expectEqual(ir.IrType.v128, insts[1].type);
+    try std.testing.expectEqual(insts[0].dest.?, insts[1].op.f64x2_splat);
+    try std.testing.expectEqual(@as(u64, 0x8000_0000_0000_0000), @as(u64, @bitCast(insts[2].op.fconst_64)));
+    try std.testing.expectEqual(insts[1].dest.?, insts[3].op.f64x2_replace_lane.vector);
+    try std.testing.expectEqual(insts[2].dest.?, insts[3].op.f64x2_replace_lane.val);
+    try std.testing.expectEqual(@as(u1, 1), insts[3].op.f64x2_replace_lane.lane);
+    try std.testing.expectEqual(insts[3].dest.?, insts[4].op.f64x2_extract_lane.vector);
+    try std.testing.expectEqual(@as(u1, 1), insts[4].op.f64x2_extract_lane.lane);
+    try std.testing.expectEqual(ir.IrType.f64, insts[4].type);
+    try std.testing.expectEqual(insts[4].dest.?, insts[5].op.reinterpret);
+    try std.testing.expectEqual(ir.IrType.i64, insts[5].type);
+    try std.testing.expectEqual(insts[5].dest.?, insts[6].op.wrap_i64);
+    try std.testing.expectEqual(ir.IrType.i32, insts[6].type);
+    try std.testing.expect(insts[7].op.ret != null);
+}
+
+test "reject invalid f64x2 lane immediates" {
+    const allocator = std.testing.allocator;
+
+    const extract_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.f64},
+    };
+    const extract_code = [_]u8{
+        0xFD, 0x0C, // v128.const
+        0x00, 0x00,
+        0x00, 0x00,
+        0x00, 0x00,
+        0xF0, 0x3F,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x00, 0x40,
+        0xFD, 0x21, 0x02, // f64x2.extract_lane 2
+        0x0B,
+    };
+    const extract_func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = extract_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &extract_code,
+    };
+    const extract_module = types.WasmModule{
+        .types = &[_]types.FuncType{extract_type},
+        .functions = &[_]types.WasmFunction{extract_func},
+    };
+    try std.testing.expectError(error.InvalidBytecode, lowerModule(&extract_module, allocator));
+
+    const replace_type = types.FuncType{
+        .params = &.{},
+        .results = &.{.f64},
+    };
+    const replace_code = [_]u8{
+        0xFD, 0x0C, // v128.const
+        0x00, 0x00,
+        0x00, 0x00,
+        0x00, 0x00,
+        0xF0, 0x3F,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x00, 0x40,
+        0x44, 0x00,
+        0x00, 0x00,
+        0x00,
+        0x00, 0x00, 0x08, 0x40, // f64.const 3.0
+        0xFD, 0x22, 0x02, // f64x2.replace_lane 2
+        0xFD, 0x21, 0x00,
+        0x0B,
+    };
+    const replace_func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = replace_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &replace_code,
+    };
+    const replace_module = types.WasmModule{
+        .types = &[_]types.FuncType{replace_type},
+        .functions = &[_]types.WasmFunction{replace_func},
+    };
+    try std.testing.expectError(error.InvalidBytecode, lowerModule(&replace_module, allocator));
 }
 
 test "lower i32x4 scalar-count shift opcodes" {

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -315,6 +315,7 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
         .i8x16_splat,
         .i16x8_splat,
         .i64x2_splat,
+        .f64x2_splat,
         => |vreg| live.put(vreg, {}) catch {},
         .simd_all_true => |op| live.put(op.vector, {}) catch {},
         .simd_bitmask => |op| live.put(op.vector, {}) catch {},
@@ -323,6 +324,7 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
         .i8x16_extract_lane => |lane| live.put(lane.vector, {}) catch {},
         .i16x8_extract_lane => |lane| live.put(lane.vector, {}) catch {},
         .i64x2_extract_lane => |lane| live.put(lane.vector, {}) catch {},
+        .f64x2_extract_lane => |lane| live.put(lane.vector, {}) catch {},
         .i32x4_replace_lane => |lane| {
             live.put(lane.vector, {}) catch {};
             live.put(lane.val, {}) catch {};
@@ -340,6 +342,10 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
             live.put(lane.val, {}) catch {};
         },
         .i64x2_replace_lane => |lane| {
+            live.put(lane.vector, {}) catch {};
+            live.put(lane.val, {}) catch {};
+        },
+        .f64x2_replace_lane => |lane| {
             live.put(lane.vector, {}) catch {};
             live.put(lane.val, {}) catch {};
         },
@@ -762,6 +768,7 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
         .i8x16_splat,
         .i16x8_splat,
         .i64x2_splat,
+        .f64x2_splat,
         => |vreg| last_use.put(vreg, pos) catch {},
         .simd_all_true => |op| last_use.put(op.vector, pos) catch {},
         .simd_bitmask => |op| last_use.put(op.vector, pos) catch {},
@@ -770,6 +777,7 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
         .i8x16_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
         .i16x8_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
         .i64x2_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
+        .f64x2_extract_lane => |lane| last_use.put(lane.vector, pos) catch {},
         .i32x4_replace_lane => |lane| {
             last_use.put(lane.vector, pos) catch {};
             last_use.put(lane.val, pos) catch {};
@@ -787,6 +795,10 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
             last_use.put(lane.val, pos) catch {};
         },
         .i64x2_replace_lane => |lane| {
+            last_use.put(lane.vector, pos) catch {};
+            last_use.put(lane.val, pos) catch {};
+        },
+        .f64x2_replace_lane => |lane| {
             last_use.put(lane.vector, pos) catch {};
             last_use.put(lane.val, pos) catch {};
         },

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -126,6 +126,9 @@ pub const Inst = struct {
         i64x2_replace_lane: I64x2ReplaceLane,
         f64x2_unop: F64x2UnOp,
         f64x2_binop: F64x2BinOp,
+        f64x2_splat: VReg,
+        f64x2_extract_lane: F64x2ExtractLane,
+        f64x2_replace_lane: F64x2ReplaceLane,
         f64x2_convert_low_i32x4: SimdIntToFloatConvert,
         f64x2_promote_low_f32x4: SimdFloatPrecisionConvert,
 
@@ -797,6 +800,11 @@ pub const Inst = struct {
         lane: u1,
     };
 
+    pub const F64x2ExtractLane = struct {
+        vector: VReg,
+        lane: u1,
+    };
+
     pub const I32x4ReplaceLane = struct {
         vector: VReg,
         val: VReg,
@@ -822,6 +830,12 @@ pub const Inst = struct {
     };
 
     pub const I64x2ReplaceLane = struct {
+        vector: VReg,
+        val: VReg,
+        lane: u1,
+    };
+
+    pub const F64x2ReplaceLane = struct {
         vector: VReg,
         val: VReg,
         lane: u1,
@@ -1445,6 +1459,30 @@ test "Inst: first v128 op family preserves operand shape" {
         .type = .v128,
     };
     try std.testing.expectEqual(@as(VReg, 26), f64_promote.op.f64x2_promote_low_f32x4.vector);
+
+    const f64_splat = Inst{
+        .op = .{ .f64x2_splat = 28 },
+        .dest = 29,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(@as(VReg, 28), f64_splat.op.f64x2_splat);
+
+    const f64_extract = Inst{
+        .op = .{ .f64x2_extract_lane = .{ .vector = 29, .lane = 1 } },
+        .dest = 30,
+        .type = .f64,
+    };
+    try std.testing.expectEqual(@as(VReg, 29), f64_extract.op.f64x2_extract_lane.vector);
+    try std.testing.expectEqual(@as(u1, 1), f64_extract.op.f64x2_extract_lane.lane);
+
+    const f64_replace = Inst{
+        .op = .{ .f64x2_replace_lane = .{ .vector = 29, .val = 30, .lane = 0 } },
+        .dest = 31,
+        .type = .v128,
+    };
+    try std.testing.expectEqual(@as(VReg, 29), f64_replace.op.f64x2_replace_lane.vector);
+    try std.testing.expectEqual(@as(VReg, 30), f64_replace.op.f64x2_replace_lane.val);
+    try std.testing.expectEqual(@as(u1, 0), f64_replace.op.f64x2_replace_lane.lane);
 
     const i64_splat = Inst{
         .op = .{ .i64x2_splat = 26 },

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -275,6 +275,7 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
         .i8x16_splat,
         .i16x8_splat,
         .i64x2_splat,
+        .f64x2_splat,
         => |vreg| list.append(vreg),
         .simd_all_true => |op| list.append(op.vector),
         .simd_bitmask => |op| list.append(op.vector),
@@ -283,6 +284,7 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
         .i8x16_extract_lane => |lane| list.append(lane.vector),
         .i16x8_extract_lane => |lane| list.append(lane.vector),
         .i64x2_extract_lane => |lane| list.append(lane.vector),
+        .f64x2_extract_lane => |lane| list.append(lane.vector),
         .i32x4_replace_lane => |lane| {
             list.append(lane.vector);
             list.append(lane.val);
@@ -300,6 +302,10 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
             list.append(lane.val);
         },
         .i64x2_replace_lane => |lane| {
+            list.append(lane.vector);
+            list.append(lane.val);
+        },
+        .f64x2_replace_lane => |lane| {
             list.append(lane.vector);
             list.append(lane.val);
         },
@@ -673,6 +679,7 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
         .i8x16_splat,
         .i16x8_splat,
         .i64x2_splat,
+        .f64x2_splat,
         => |*vreg| if (vreg.* == old) {
             vreg.* = new;
         },
@@ -697,6 +704,9 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
         .i64x2_extract_lane => |*lane| if (lane.vector == old) {
             lane.vector = new;
         },
+        .f64x2_extract_lane => |*lane| if (lane.vector == old) {
+            lane.vector = new;
+        },
         .i32x4_replace_lane => |*lane| {
             if (lane.vector == old) lane.vector = new;
             if (lane.val == old) lane.val = new;
@@ -714,6 +724,10 @@ fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
             if (lane.val == old) lane.val = new;
         },
         .i64x2_replace_lane => |*lane| {
+            if (lane.vector == old) lane.vector = new;
+            if (lane.val == old) lane.val = new;
+        },
+        .f64x2_replace_lane => |*lane| {
             if (lane.vector == old) lane.vector = new;
             if (lane.val == old) lane.val = new;
         },
@@ -1977,6 +1991,9 @@ fn isPure(inst: ir.Inst) bool {
         .i64x2_splat,
         .i64x2_extract_lane,
         .i64x2_replace_lane,
+        .f64x2_splat,
+        .f64x2_extract_lane,
+        .f64x2_replace_lane,
         => true,
         else => false,
     };
@@ -2119,6 +2136,9 @@ fn sameOp(a: ir.Inst, b: ir.Inst) bool {
         .i64x2_splat => |v| v == b.op.i64x2_splat,
         .i64x2_extract_lane => |lane| lane.vector == b.op.i64x2_extract_lane.vector and lane.lane == b.op.i64x2_extract_lane.lane,
         .i64x2_replace_lane => |lane| lane.vector == b.op.i64x2_replace_lane.vector and lane.val == b.op.i64x2_replace_lane.val and lane.lane == b.op.i64x2_replace_lane.lane,
+        .f64x2_splat => |v| v == b.op.f64x2_splat,
+        .f64x2_extract_lane => |lane| lane.vector == b.op.f64x2_extract_lane.vector and lane.lane == b.op.f64x2_extract_lane.lane,
+        .f64x2_replace_lane => |lane| lane.vector == b.op.f64x2_replace_lane.vector and lane.val == b.op.f64x2_replace_lane.val and lane.lane == b.op.f64x2_replace_lane.lane,
         // div/rem: covered by isPure+hasSideEffect guard; float variants
         // (side-effect-free) reach here.
         .div_s => |bin| bin.lhs == b.op.div_s.lhs and bin.rhs == b.op.div_s.rhs,
@@ -3832,6 +3852,7 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
         .i8x16_splat,
         .i16x8_splat,
         .i64x2_splat,
+        .f64x2_splat,
         => |*vreg| vreg.* += offset,
         .simd_all_true => |*op| op.vector += offset,
         .simd_bitmask => |*op| op.vector += offset,
@@ -3840,6 +3861,7 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
         .i8x16_extract_lane => |*lane| lane.vector += offset,
         .i16x8_extract_lane => |*lane| lane.vector += offset,
         .i64x2_extract_lane => |*lane| lane.vector += offset,
+        .f64x2_extract_lane => |*lane| lane.vector += offset,
         .i32x4_replace_lane => |*lane| {
             lane.vector += offset;
             lane.val += offset;
@@ -3857,6 +3879,10 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
             lane.val += offset;
         },
         .i64x2_replace_lane => |*lane| {
+            lane.vector += offset;
+            lane.val += offset;
+        },
+        .f64x2_replace_lane => |*lane| {
             lane.vector += offset;
             lane.val += offset;
         },

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -491,6 +491,66 @@ fn expectF32x4ReplaceExtractBits(lanes: [4]u32, scalar_bits: u32, replace_lane: 
     try expectSimdDiffI32(wasm, "f", bitsI32(expected_bits));
 }
 
+fn expectF64x2SplatExtractPart(bits: u64, lane: u8, shift: u6, expected: i32) !void {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendF64ConstBits(&body, testing.allocator, bits);
+    try appendF64x2Splat(&body, testing.allocator);
+    try appendF64x2ExtractLane(&body, testing.allocator, lane);
+    try appendI64ReinterpretF64(&body, testing.allocator);
+    if (shift != 0) {
+        try appendI64Const(&body, testing.allocator, shift);
+        try appendI64ShrU(&body, testing.allocator);
+    }
+    try appendI32WrapI64(&body, testing.allocator);
+    try body.append(testing.allocator, 0x0B);
+
+    const wasm = try buildCustomModule(testing.allocator, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", expected);
+}
+
+fn expectF64x2ExtractPart(lanes: [2]u64, lane: u8, shift: u6, expected: i32) !void {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendV128ConstI64x2(&body, testing.allocator, lanes);
+    try appendF64x2ExtractLane(&body, testing.allocator, lane);
+    try appendI64ReinterpretF64(&body, testing.allocator);
+    if (shift != 0) {
+        try appendI64Const(&body, testing.allocator, shift);
+        try appendI64ShrU(&body, testing.allocator);
+    }
+    try appendI32WrapI64(&body, testing.allocator);
+    try body.append(testing.allocator, 0x0B);
+
+    const wasm = try buildCustomModule(testing.allocator, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", expected);
+}
+
+fn expectF64x2ReplaceExtractPart(lanes: [2]u64, scalar_bits: u64, replace_lane: u8, extract_lane: u8, shift: u6, expected: i32) !void {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendV128ConstI64x2(&body, testing.allocator, lanes);
+    try appendF64ConstBits(&body, testing.allocator, scalar_bits);
+    try appendF64x2ReplaceLane(&body, testing.allocator, replace_lane);
+    try appendF64x2ExtractLane(&body, testing.allocator, extract_lane);
+    try appendI64ReinterpretF64(&body, testing.allocator);
+    if (shift != 0) {
+        try appendI64Const(&body, testing.allocator, shift);
+        try appendI64ShrU(&body, testing.allocator);
+    }
+    try appendI32WrapI64(&body, testing.allocator);
+    try body.append(testing.allocator, 0x0B);
+
+    const wasm = try buildCustomModule(testing.allocator, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", expected);
+}
+
 test "differential SIMD: f32x4.splat preserves NaN payload across lanes" {
     try expectF32x4SplatExtractBits(0x7FC1_2345, 3);
 }
@@ -520,6 +580,61 @@ test "differential SIMD: f32x4.replace_lane preserves untouched lanes" {
         2,
         0,
         0x7FC1_2345,
+    );
+}
+
+test "differential SIMD: f64x2.splat preserves NaN payload across lanes" {
+    const bits: u64 = 0x7FF8_0123_4567_89AB;
+    try expectF64x2SplatExtractPart(bits, 0, 0, bitsI64Low(bits));
+    try expectF64x2SplatExtractPart(bits, 0, 32, bitsI64High(bits));
+    try expectF64x2SplatExtractPart(bits, 1, 0, bitsI64Low(bits));
+    try expectF64x2SplatExtractPart(bits, 1, 32, bitsI64High(bits));
+}
+
+test "differential SIMD: f64x2.extract_lane respects lane ordering and signed zeros" {
+    const lanes = [2]u64{ 0x3FF8_0000_0000_0000, 0x8000_0000_0000_0000 };
+    try expectF64x2ExtractPart(lanes, 0, 32, bitsI64High(lanes[0]));
+    try expectF64x2ExtractPart(lanes, 1, 0, bitsI64Low(lanes[1]));
+    try expectF64x2ExtractPart(lanes, 1, 32, bitsI64High(lanes[1]));
+}
+
+test "differential SIMD: f64x2.replace_lane updates selected lane bits" {
+    const replacement: u64 = 0x7FF8_0123_4567_89AB;
+    try expectF64x2ReplaceExtractPart(
+        .{ 0x3FF0_0000_0000_0000, 0x4000_0000_0000_0000 },
+        replacement,
+        1,
+        1,
+        0,
+        bitsI64Low(replacement),
+    );
+    try expectF64x2ReplaceExtractPart(
+        .{ 0x3FF0_0000_0000_0000, 0x4000_0000_0000_0000 },
+        replacement,
+        1,
+        1,
+        32,
+        bitsI64High(replacement),
+    );
+}
+
+test "differential SIMD: f64x2.replace_lane preserves untouched lanes" {
+    const untouched: u64 = 0x8000_0000_0000_0000;
+    try expectF64x2ReplaceExtractPart(
+        .{ untouched, 0x4000_0000_0000_0000 },
+        0x7FF8_0123_4567_89AB,
+        1,
+        0,
+        0,
+        bitsI64Low(untouched),
+    );
+    try expectF64x2ReplaceExtractPart(
+        .{ untouched, 0x4000_0000_0000_0000 },
+        0x7FF8_0123_4567_89AB,
+        1,
+        0,
+        32,
+        bitsI64High(untouched),
     );
 }
 
@@ -751,6 +866,14 @@ fn f64Bits(value: f64) u64 {
 
 fn bitsI32(bits: u32) i32 {
     return @bitCast(bits);
+}
+
+fn bitsI64Low(bits: u64) i32 {
+    return bitsI32(@as(u32, @truncate(bits)));
+}
+
+fn bitsI64High(bits: u64) i32 {
+    return bitsI32(@as(u32, @truncate(bits >> 32)));
 }
 
 fn expectF32x4BinLaneBits(opcode: u32, lhs: [4]u32, rhs: [4]u32, lane: u8, expected_bits: u32) !void {
@@ -2751,6 +2874,10 @@ fn appendF32x4Splat(buf: *std.ArrayList(u8), allocator: std.mem.Allocator) !void
     try appendSimdOpcode(buf, allocator, 0x13);
 }
 
+fn appendF64x2Splat(buf: *std.ArrayList(u8), allocator: std.mem.Allocator) !void {
+    try appendSimdOpcode(buf, allocator, 0x14);
+}
+
 fn appendI32Const(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, value: i64) !void {
     try buf.append(allocator, 0x41);
     try encodeSLEB128(buf, allocator, value);
@@ -2762,8 +2889,18 @@ fn appendF32ConstBits(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, bit
     try buf.appendSlice(allocator, std.mem.asBytes(&le));
 }
 
+fn appendF64ConstBits(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, bits: u64) !void {
+    try buf.append(allocator, 0x44);
+    var le = std.mem.nativeToLittle(u64, bits);
+    try buf.appendSlice(allocator, std.mem.asBytes(&le));
+}
+
 fn appendI32ReinterpretF32(buf: *std.ArrayList(u8), allocator: std.mem.Allocator) !void {
     try buf.append(allocator, 0xBC);
+}
+
+fn appendI64ReinterpretF64(buf: *std.ArrayList(u8), allocator: std.mem.Allocator) !void {
+    try buf.append(allocator, 0xBD);
 }
 
 fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
@@ -2773,6 +2910,11 @@ fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator,
 
 fn appendF32x4ExtractLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x1F);
+    try buf.append(allocator, lane);
+}
+
+fn appendF64x2ExtractLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x21);
     try buf.append(allocator, lane);
 }
 
@@ -2793,6 +2935,11 @@ fn appendI32x4ReplaceLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator,
 
 fn appendF32x4ReplaceLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x20);
+    try buf.append(allocator, lane);
+}
+
+fn appendF64x2ReplaceLane(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x22);
     try buf.append(allocator, lane);
 }
 

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -354,6 +354,21 @@ const cases = [_]BenchCase{
         .build = buildSimdF32x4ReplaceLane2Module,
     },
     .{
+        .name = "simd_f64x2_splat_lane1_low",
+        .simd = true,
+        .build = buildSimdF64x2SplatLane1LowModule,
+    },
+    .{
+        .name = "simd_f64x2_extract_lane1_high",
+        .simd = true,
+        .build = buildSimdF64x2ExtractLane1HighModule,
+    },
+    .{
+        .name = "simd_f64x2_replace_lane1_low",
+        .simd = true,
+        .build = buildSimdF64x2ReplaceLane1LowModule,
+    },
+    .{
         .name = "simd_f32x4_abs_lane0",
         .simd = true,
         .build = buildSimdF32x4AbsLane0Module,
@@ -1998,6 +2013,47 @@ fn buildSimdF32x4ReplaceLane2Module(allocator: Allocator) ![]u8 {
     try appendF32x4ReplaceLane(&instr, allocator, 2);
     try appendF32x4ExtractLane(&instr, allocator, 2);
     try appendI32ReinterpretF32(&instr, allocator);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdF64x2SplatLane1LowModule(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendF64ConstBits(&instr, allocator, 0x7FF8_0123_4567_89AB);
+    try appendF64x2Splat(&instr, allocator);
+    try appendF64x2ExtractLane(&instr, allocator, 1);
+    try appendI64ReinterpretF64(&instr, allocator);
+    try appendI32WrapI64(&instr, allocator);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdF64x2ExtractLane1HighModule(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI64x2(&instr, allocator, .{ 0x3FF0_0000_0000_0000, 0x8000_0000_0000_0000 });
+    try appendF64x2ExtractLane(&instr, allocator, 1);
+    try appendI64ReinterpretF64(&instr, allocator);
+    try appendI64Const(&instr, allocator, 32);
+    try appendI64ShrU(&instr, allocator);
+    try appendI32WrapI64(&instr, allocator);
+
+    return buildRunI32Module(allocator, instr.items, .{});
+}
+
+fn buildSimdF64x2ReplaceLane1LowModule(allocator: Allocator) ![]u8 {
+    var instr: std.ArrayList(u8) = .empty;
+    defer instr.deinit(allocator);
+
+    try appendV128ConstI64x2(&instr, allocator, .{ 0x3FF0_0000_0000_0000, 0x4000_0000_0000_0000 });
+    try appendF64ConstBits(&instr, allocator, 0x7FF8_0123_4567_89AB);
+    try appendF64x2ReplaceLane(&instr, allocator, 1);
+    try appendF64x2ExtractLane(&instr, allocator, 1);
+    try appendI64ReinterpretF64(&instr, allocator);
+    try appendI32WrapI64(&instr, allocator);
 
     return buildRunI32Module(allocator, instr.items, .{});
 }
@@ -4856,6 +4912,12 @@ fn appendF32ConstBits(buf: *std.ArrayList(u8), allocator: Allocator, bits: u32) 
     try buf.appendSlice(allocator, std.mem.asBytes(&le));
 }
 
+fn appendF64ConstBits(buf: *std.ArrayList(u8), allocator: Allocator, bits: u64) !void {
+    try buf.append(allocator, 0x44); // f64.const
+    var le = std.mem.nativeToLittle(u64, bits);
+    try buf.appendSlice(allocator, std.mem.asBytes(&le));
+}
+
 fn appendV128ConstI64x2(buf: *std.ArrayList(u8), allocator: Allocator, lanes: [2]u64) !void {
     try appendSimdOpcode(buf, allocator, 0x0C); // v128.const
     for (lanes) |lane| {
@@ -4894,6 +4956,10 @@ fn appendF32x4Splat(buf: *std.ArrayList(u8), allocator: Allocator) !void {
     try appendSimdOpcode(buf, allocator, 0x13); // f32x4.splat
 }
 
+fn appendF64x2Splat(buf: *std.ArrayList(u8), allocator: Allocator) !void {
+    try appendSimdOpcode(buf, allocator, 0x14); // f64x2.splat
+}
+
 fn appendI64x2Splat(buf: *std.ArrayList(u8), allocator: Allocator) !void {
     try appendSimdOpcode(buf, allocator, 0x12); // i64x2.splat
 }
@@ -4913,6 +4979,11 @@ fn appendI32x4ExtractLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u
 
 fn appendF32x4ExtractLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x1F); // f32x4.extract_lane
+    try buf.append(allocator, lane);
+}
+
+fn appendF64x2ExtractLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x21); // f64x2.extract_lane
     try buf.append(allocator, lane);
 }
 
@@ -4955,6 +5026,11 @@ fn appendF32x4ReplaceLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u
     try buf.append(allocator, lane);
 }
 
+fn appendF64x2ReplaceLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
+    try appendSimdOpcode(buf, allocator, 0x22); // f64x2.replace_lane
+    try buf.append(allocator, lane);
+}
+
 fn appendI64x2ReplaceLane(buf: *std.ArrayList(u8), allocator: Allocator, lane: u8) !void {
     try appendSimdOpcode(buf, allocator, 0x1E); // i64x2.replace_lane
     try buf.append(allocator, lane);
@@ -4986,6 +5062,10 @@ fn appendI64ShrU(buf: *std.ArrayList(u8), allocator: Allocator) !void {
 
 fn appendI32WrapI64(buf: *std.ArrayList(u8), allocator: Allocator) !void {
     try buf.append(allocator, 0xA7); // i32.wrap_i64
+}
+
+fn appendI64ReinterpretF64(buf: *std.ArrayList(u8), allocator: Allocator) !void {
+    try buf.append(allocator, 0xBD); // i64.reinterpret_f64
 }
 
 fn appendLocalGet(buf: *std.ArrayList(u8), allocator: Allocator, index: u32) !void {


### PR DESCRIPTION
## Summary
- Lower f64x2.splat/extract_lane/replace_lane through the frontend, IR, optimizer/liveness/scheduler, and AArch64 backend.
- Preserve f64 bit patterns with AArch64 64-bit lane moves: DUP Vd.2D, Xn; UMOV Xd, Vn.D[lane]; INS Vd.D[lane], Xn.
- Add focused frontend, codegen, differential, and SIMD bench coverage for NaN payloads, signed zeros, lane order, and replacement behavior.

Fixes #302.

## Validation
- git diff --check && zig build test && zig build && zig build simd-bench -- --iterations 1