### PR TITLE
perf(aarch64): lower f64x2 rounding

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -2510,6 +2510,22 @@ fn emitF64x2UnOp(
             try code.fsqrt2d(dest_reg, vector_reg);
             try canonicalizeF64x2NaNs(code, dest_reg);
         },
+        .ceil => {
+            try code.frint2d(.ceil, dest_reg, vector_reg);
+            try canonicalizeF64x2NaNs(code, dest_reg);
+        },
+        .floor => {
+            try code.frint2d(.floor, dest_reg, vector_reg);
+            try canonicalizeF64x2NaNs(code, dest_reg);
+        },
+        .trunc => {
+            try code.frint2d(.trunc, dest_reg, vector_reg);
+            try canonicalizeF64x2NaNs(code, dest_reg);
+        },
+        .nearest => {
+            try code.frint2d(.nearest, dest_reg, vector_reg);
+            try canonicalizeF64x2NaNs(code, dest_reg);
+        },
     }
 }
 
@@ -7999,6 +8015,10 @@ test "compile: f64x2 unary ops emit NEON instructions" {
     const abs = func.newVReg();
     const neg = func.newVReg();
     const sqrt = func.newVReg();
+    const ceil = func.newVReg();
+    const floor = func.newVReg();
+    const trunc = func.newVReg();
+    const nearest = func.newVReg();
     const lane = func.newVReg();
     const wrapped = func.newVReg();
 
@@ -8006,8 +8026,12 @@ test "compile: f64x2 unary ops emit NEON instructions" {
     try func.getBlock(bid).append(.{ .op = .{ .f64x2_unop = .{ .op = .abs, .vector = a } }, .dest = abs, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f64x2_unop = .{ .op = .neg, .vector = abs } }, .dest = neg, .type = .v128 });
     try func.getBlock(bid).append(.{ .op = .{ .f64x2_unop = .{ .op = .sqrt, .vector = neg } }, .dest = sqrt, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_unop = .{ .op = .ceil, .vector = sqrt } }, .dest = ceil, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_unop = .{ .op = .floor, .vector = ceil } }, .dest = floor, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_unop = .{ .op = .trunc, .vector = floor } }, .dest = trunc, .type = .v128 });
+    try func.getBlock(bid).append(.{ .op = .{ .f64x2_unop = .{ .op = .nearest, .vector = trunc } }, .dest = nearest, .type = .v128 });
     try func.getBlock(bid).append(.{
-        .op = .{ .i64x2_extract_lane = .{ .vector = sqrt, .lane = 0 } },
+        .op = .{ .i64x2_extract_lane = .{ .vector = nearest, .lane = 0 } },
         .dest = lane,
         .type = .i64,
     });
@@ -8020,6 +8044,10 @@ test "compile: f64x2 unary ops emit NEON instructions" {
     var found_fabs = false;
     var found_fneg = false;
     var found_fsqrt = false;
+    var found_frintp = false;
+    var found_frintm = false;
+    var found_frintz = false;
+    var found_frintn = false;
     var found_fcmeq = false;
     var found_mvn = false;
     var found_bsl = false;
@@ -8029,6 +8057,10 @@ test "compile: f64x2 unary ops emit NEON instructions" {
         if ((w & 0xFFFFFC00) == 0x4EE0F800) found_fabs = true;
         if ((w & 0xFFFFFC00) == 0x6EE0F800) found_fneg = true;
         if ((w & 0xFFFFFC00) == 0x6EE1F800) found_fsqrt = true;
+        if ((w & 0xFFFFFC00) == 0x4EE18800) found_frintp = true;
+        if ((w & 0xFFFFFC00) == 0x4E619800) found_frintm = true;
+        if ((w & 0xFFFFFC00) == 0x4EE19800) found_frintz = true;
+        if ((w & 0xFFFFFC00) == 0x4E618800) found_frintn = true;
         if ((w & 0xFFE0FC00) == 0x4E60E400) found_fcmeq = true;
         if ((w & 0xFFFFFC00) == 0x6E205800) found_mvn = true;
         if ((w & 0xFFE0FC00) == 0x6E601C00) found_bsl = true;
@@ -8037,6 +8069,10 @@ test "compile: f64x2 unary ops emit NEON instructions" {
     try std.testing.expect(found_fabs);
     try std.testing.expect(found_fneg);
     try std.testing.expect(found_fsqrt);
+    try std.testing.expect(found_frintp);
+    try std.testing.expect(found_frintm);
+    try std.testing.expect(found_frintz);
+    try std.testing.expect(found_frintn);
     try std.testing.expect(found_fcmeq);
     try std.testing.expect(found_mvn);
     try std.testing.expect(found_bsl);

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -1200,9 +1200,13 @@ pub const CodeBuffer = struct {
         abs = 0x4EE0F800,
         neg = 0x6EE0F800,
         sqrt = 0x6EE1F800,
+        frintn = 0x4E618800,
+        frintp = 0x4EE18800,
+        frintm = 0x4E619800,
+        frintz = 0x4EE19800,
     };
 
-    /// Floating-point 2D unary vector op: FABS/FNEG/FSQRT.
+    /// Floating-point 2D unary vector op: FABS/FNEG/FSQRT/FRINT*.
     pub fn f64x2UnOp(self: *CodeBuffer, op: F64x2UnaryOp, vd: u5, vn: u5) !void {
         try self.emit32(@intFromEnum(op) |
             (@as(u32, vn) << 5) |
@@ -1222,6 +1226,37 @@ pub const CodeBuffer = struct {
     /// FSQRT Vd.2D, Vn.2D.
     pub fn fsqrt2d(self: *CodeBuffer, vd: u5, vn: u5) !void {
         return self.f64x2UnOp(.sqrt, vd, vn);
+    }
+
+    /// FRINTN/P/M/Z Vd.2D, Vn.2D — round each f64 lane to integral.
+    pub fn frint2d(self: *CodeBuffer, mode: FRoundMode, vd: u5, vn: u5) !void {
+        const op: F64x2UnaryOp = switch (mode) {
+            .nearest => .frintn,
+            .ceil => .frintp,
+            .floor => .frintm,
+            .trunc => .frintz,
+        };
+        return self.f64x2UnOp(op, vd, vn);
+    }
+
+    /// FRINTP Vd.2D, Vn.2D.
+    pub fn frintp2d(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.frint2d(.ceil, vd, vn);
+    }
+
+    /// FRINTM Vd.2D, Vn.2D.
+    pub fn frintm2d(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.frint2d(.floor, vd, vn);
+    }
+
+    /// FRINTZ Vd.2D, Vn.2D.
+    pub fn frintz2d(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.frint2d(.trunc, vd, vn);
+    }
+
+    /// FRINTN Vd.2D, Vn.2D.
+    pub fn frintn2d(self: *CodeBuffer, vd: u5, vn: u5) !void {
+        return self.frint2d(.nearest, vd, vn);
     }
 
     /// Floating-point 2D binary vector op: FADD/FSUB/FMUL/FDIV/FMAX/FMIN.
@@ -3406,6 +3441,30 @@ test "emit: f64x2 vector unary ops" {
         defer code.deinit();
         try code.fsqrt2d(16, 17);
         try expectWord(0x6EE1FA30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.frintp2d(16, 17);
+        try expectWord(0x4EE18A30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.frintm2d(16, 17);
+        try expectWord(0x4E619A30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.frintz2d(16, 17);
+        try expectWord(0x4EE19A30, &code);
+    }
+    {
+        var code = CodeBuffer.init(std.testing.allocator);
+        defer code.deinit();
+        try code.frintn2d(16, 17);
+        try expectWord(0x4E618A30, &code);
     }
 }
 

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -2108,6 +2108,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .f64x2_abs,
                     .f64x2_neg,
                     .f64x2_sqrt,
+                    .f64x2_ceil,
+                    .f64x2_floor,
+                    .f64x2_trunc,
+                    .f64x2_nearest,
                     => {
                         const vector = safePop(&vreg_stack);
                         const dest = ir_func.newVReg();
@@ -2116,6 +2120,10 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                                 .f64x2_abs => .abs,
                                 .f64x2_neg => .neg,
                                 .f64x2_sqrt => .sqrt,
+                                .f64x2_ceil => .ceil,
+                                .f64x2_floor => .floor,
+                                .f64x2_trunc => .trunc,
+                                .f64x2_nearest => .nearest,
                                 else => unreachable,
                             },
                             .vector = vector,
@@ -5694,6 +5702,10 @@ test "lower f64x2 unary opcodes" {
         expected: ir.Inst.F64x2UnaryOp,
     };
     const cases = [_]Case{
+        .{ .opcode = 0x74, .expected = .ceil },
+        .{ .opcode = 0x75, .expected = .floor },
+        .{ .opcode = 0x7A, .expected = .trunc },
+        .{ .opcode = 0x94, .expected = .nearest },
         .{ .opcode = 0xEC, .expected = .abs },
         .{ .opcode = 0xED, .expected = .neg },
         .{ .opcode = 0xEF, .expected = .sqrt },

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -468,6 +468,10 @@ pub const Inst = struct {
         abs,
         neg,
         sqrt,
+        ceil,
+        floor,
+        trunc,
+        nearest,
     };
 
     pub const V128Mem = struct {

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -1761,6 +1761,47 @@ test "differential SIMD: f64x2 unary NaN behavior matches interpreter" {
     );
 }
 
+test "differential SIMD: f64x2 rounding fractions match interpreter" {
+    const lanes = [_]u64{ f64Bits(1.5), f64Bits(-1.5) };
+    try expectF64x2UnLaneHigh(0x74, lanes, 0, 0x4000_0000);
+    try expectF64x2UnLaneHigh(0x74, lanes, 1, @bitCast(@as(u32, 0xbff0_0000)));
+    try expectF64x2UnLaneHigh(0x75, lanes, 0, 0x3ff0_0000);
+    try expectF64x2UnLaneHigh(0x75, lanes, 1, @bitCast(@as(u32, 0xc000_0000)));
+    try expectF64x2UnLaneHigh(0x7A, .{ f64Bits(1.75), f64Bits(-1.75) }, 0, 0x3ff0_0000);
+    try expectF64x2UnLaneHigh(0x7A, .{ f64Bits(1.75), f64Bits(-1.75) }, 1, @bitCast(@as(u32, 0xbff0_0000)));
+}
+
+test "differential SIMD: f64x2 nearest ties to even matches interpreter" {
+    try expectF64x2UnLaneHigh(0x94, .{ f64Bits(0.5), f64Bits(-0.5) }, 0, 0);
+    try expectF64x2UnLaneHigh(0x94, .{ f64Bits(0.5), f64Bits(-0.5) }, 1, @bitCast(@as(u32, 0x8000_0000)));
+    try expectF64x2UnLaneHigh(0x94, .{ f64Bits(1.5), f64Bits(-1.5) }, 0, 0x4000_0000);
+    try expectF64x2UnLaneHigh(0x94, .{ f64Bits(1.5), f64Bits(-1.5) }, 1, @bitCast(@as(u32, 0xc000_0000)));
+    try expectF64x2UnLaneHigh(0x94, .{ f64Bits(2.5), f64Bits(-2.5) }, 0, 0x4000_0000);
+    try expectF64x2UnLaneHigh(0x94, .{ f64Bits(2.5), f64Bits(-2.5) }, 1, @bitCast(@as(u32, 0xc000_0000)));
+}
+
+test "differential SIMD: f64x2 rounding signed zeros infinities and NaNs match interpreter" {
+    try expectF64x2UnLaneHigh(0x74, .{ f64Bits(-0.0), f64Bits(0.0) }, 0, @bitCast(@as(u32, 0x8000_0000)));
+    try expectF64x2UnLaneHigh(0x75, .{ f64Bits(-0.0), f64Bits(0.0) }, 1, 0);
+    try expectF64x2UnLaneHigh(0x7A, .{ f64Bits(-0.0), f64Bits(0.0) }, 0, @bitCast(@as(u32, 0x8000_0000)));
+    try expectF64x2UnLaneHigh(0x94, .{ f64Bits(-0.0), f64Bits(0.0) }, 1, 0);
+    try expectF64x2UnLaneHigh(0x74, .{ f64Bits(-0.5), f64Bits(0.5) }, 0, @bitCast(@as(u32, 0x8000_0000)));
+    try expectF64x2UnLaneHigh(0x75, .{ f64Bits(-0.5), f64Bits(0.5) }, 1, 0);
+    try expectF64x2UnLaneHigh(0x7A, .{ f64Bits(-0.5), f64Bits(0.5) }, 0, @bitCast(@as(u32, 0x8000_0000)));
+    try expectF64x2UnLaneHigh(0x94, .{ f64Bits(-0.5), f64Bits(0.5) }, 0, @bitCast(@as(u32, 0x8000_0000)));
+    try expectF64x2UnLaneHigh(0x74, .{ 0x7ff0_0000_0000_0000, 0xfff0_0000_0000_0000 }, 0, 0x7ff0_0000);
+    try expectF64x2UnLaneHigh(0x75, .{ 0x7ff0_0000_0000_0000, 0xfff0_0000_0000_0000 }, 1, @bitCast(@as(u32, 0xfff0_0000)));
+    const nans = [_]u64{ 0x7ff8_0000_0000_1234, 0xfff8_0000_0000_5678 };
+    try expectF64x2UnLaneHigh(0x74, nans, 0, 0x7ff8_0000);
+    try expectF64x2UnLaneLow(0x74, nans, 0, 0);
+    try expectF64x2UnLaneHigh(0x75, nans, 1, 0x7ff8_0000);
+    try expectF64x2UnLaneLow(0x75, nans, 1, 0);
+    try expectF64x2UnLaneHigh(0x7A, nans, 0, 0x7ff8_0000);
+    try expectF64x2UnLaneLow(0x7A, nans, 0, 0);
+    try expectF64x2UnLaneHigh(0x94, nans, 1, 0x7ff8_0000);
+    try expectF64x2UnLaneLow(0x94, nans, 1, 0);
+}
+
 fn expectF64x2Lane0Part(opcode: u32, lhs: [2]u64, rhs: [2]u64, shift: u6, expected: i32) !void {
     var body: std.ArrayList(u8) = .empty;
     defer body.deinit(testing.allocator);

--- a/src/tests/simd_bench_runner.zig
+++ b/src/tests/simd_bench_runner.zig
@@ -399,6 +399,26 @@ const cases = [_]BenchCase{
         .build = buildSimdF64x2SqrtLane0HighModule,
     },
     .{
+        .name = "simd_f64x2_ceil_lane0_high",
+        .simd = true,
+        .build = buildSimdF64x2CeilLane0HighModule,
+    },
+    .{
+        .name = "simd_f64x2_floor_lane0_high",
+        .simd = true,
+        .build = buildSimdF64x2FloorLane0HighModule,
+    },
+    .{
+        .name = "simd_f64x2_trunc_lane0_high",
+        .simd = true,
+        .build = buildSimdF64x2TruncLane0HighModule,
+    },
+    .{
+        .name = "simd_f64x2_nearest_lane0_high",
+        .simd = true,
+        .build = buildSimdF64x2NearestLane0HighModule,
+    },
+    .{
         .name = "simd_f32x4_ceil_lane0",
         .simd = true,
         .build = buildSimdF32x4CeilLane0Module,
@@ -2062,6 +2082,7 @@ const f32x4_arith_lhs_bits: [4]u32 = .{ 0x4140_0000, 0x4000_0000, 0x4040_0000, 0
 const f32x4_arith_rhs_bits: [4]u32 = .{ 0x4080_0000, 0x40a0_0000, 0x40c0_0000, 0x4100_0000 };
 const f32x4_unary_bits: [4]u32 = .{ 0x4110_0000, 0x4000_0000, 0x4080_0000, 0x40c0_0000 };
 const f32x4_rounding_bits: [4]u32 = .{ 0x3fe0_0000, 0xbfa0_0000, 0x4020_0000, 0xc060_0000 };
+const f64x2_rounding_bits: [2]u64 = .{ 0x3ff8_0000_0000_0000, 0xbff8_0000_0000_0000 };
 
 fn buildSimdF32x4UnLane0Module(allocator: Allocator, simd_opcode: u32) ![]u8 {
     var instr: std.ArrayList(u8) = .empty;
@@ -2110,6 +2131,26 @@ fn buildSimdF64x2NegLane0HighModule(allocator: Allocator) ![]u8 {
 
 fn buildSimdF64x2SqrtLane0HighModule(allocator: Allocator) ![]u8 {
     return buildSimdF64x2UnLane0HighModule(allocator, 0xEF, .{ 0x4010_0000_0000_0000, 0x4000_0000_0000_0000 });
+}
+
+fn buildSimdF64x2RoundLane0HighModule(allocator: Allocator, simd_opcode: u32) ![]u8 {
+    return buildSimdF64x2UnLane0HighModule(allocator, simd_opcode, f64x2_rounding_bits);
+}
+
+fn buildSimdF64x2CeilLane0HighModule(allocator: Allocator) ![]u8 {
+    return buildSimdF64x2RoundLane0HighModule(allocator, 0x74);
+}
+
+fn buildSimdF64x2FloorLane0HighModule(allocator: Allocator) ![]u8 {
+    return buildSimdF64x2RoundLane0HighModule(allocator, 0x75);
+}
+
+fn buildSimdF64x2TruncLane0HighModule(allocator: Allocator) ![]u8 {
+    return buildSimdF64x2RoundLane0HighModule(allocator, 0x7A);
+}
+
+fn buildSimdF64x2NearestLane0HighModule(allocator: Allocator) ![]u8 {
+    return buildSimdF64x2RoundLane0HighModule(allocator, 0x94);
 }
 
 fn buildSimdF32x4RoundLane0Module(allocator: Allocator, simd_opcode: u32) ![]u8 {


### PR DESCRIPTION
Closes #303

Implements AArch64 AOT lowering for f64x2.ceil/floor/trunc/nearest using FRINTP/M/Z/N .2D, with NaN canonicalization to match interpreter results. Adds frontend, emitter/codegen, differential, and SIMD bench coverage.