### PR TITLE
aarch64 aot: support v128 globals

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -451,6 +451,11 @@ const FuncCompileCtx = struct {
     /// Per-local type table, params first. Missing entries are treated as
     /// scalar 8-byte slots for compatibility with hand-built IR tests.
     local_types: []const ir.IrType = &.{},
+    /// Wasm-flat global types and byte offsets (imports first, then locals).
+    /// Missing entries fall back to the legacy 8-byte-per-index layout used by
+    /// older hand-built IR tests.
+    global_types: []const ir.IrType = &.{},
+    global_offsets: []const u32 = &.{},
     /// FP-relative byte offset of the call-save region where caller-save
     /// physregs (x0..x15) are spilled around BL instructions.
     call_save_base: u32 = 0,
@@ -557,6 +562,7 @@ pub fn compileFunctionWithOptions(
 fn isSupportedV128Def(inst: ir.Inst) bool {
     return switch (inst.op) {
         .local_get,
+        .global_get,
         .v128_const,
         .v128_load,
         .v128_load_splat,
@@ -711,7 +717,6 @@ fn functionHasUnsupportedV128(func: *const ir.IrFunction, allocator: std.mem.All
                 .ret_multi => |vals| {
                     for (vals) |v| if ((vreg_types.get(v) orelse .void) == .v128) return true;
                 },
-                .global_set => |gs| if ((vreg_types.get(gs.val) orelse .void) == .v128) return true,
                 .select => |sel| {
                     if ((vreg_types.get(sel.if_true) orelse .void) == .v128 or
                         (vreg_types.get(sel.if_false) orelse .void) == .v128)
@@ -1908,8 +1913,8 @@ fn compileInst(
         .ret_multi => |vregs| try emitRetMulti(code, vregs, reg_map, fctx, frame_size),
         .call_result => |idx| try emitCallResult(code, inst, idx, reg_map, fctx),
         .@"unreachable" => try emitTrapHelperCall(code, vmctx_trap_unreachable_fn_slot),
-        .global_get => |idx| try emitGlobalGet(code, inst, idx, reg_map),
-        .global_set => |gs| try emitGlobalSet(code, gs, reg_map),
+        .global_get => |idx| try emitGlobalGet(code, inst, idx, reg_map, v128_map, v128_cache, fctx),
+        .global_set => |gs| try emitGlobalSet(code, inst, gs, reg_map, v128_map, v128_cache, fctx),
         .memory_size => try emitMemorySize(code, inst, reg_map),
         .memory_grow => |pages_vreg| try emitMemoryGrow(code, inst, pages_vreg, reg_map, fctx),
         .memory_fill => |mf| try emitMemoryFill(code, mf, reg_map, fctx),
@@ -4909,43 +4914,105 @@ const table_info_ptr_off: u32 = 0;
 const table_info_len_off: u32 = 8;
 const table_info_type_backing_off: u32 = 16;
 
-/// Globals are a packed array of 8-byte slots indexed by global index.
-/// For i32/f32 we read/write the low 32 bits with W-form LDR/STR; for
-/// i64/f64 we use the 64-bit forms. This matches x86-64 which uses an
-/// 8-byte slot per global.
+fn globalTypeAt(fctx: *const FuncCompileCtx, idx: u32, fallback: ir.IrType) ir.IrType {
+    const i: usize = @intCast(idx);
+    if (i < fctx.global_types.len) return fctx.global_types[i];
+    return fallback;
+}
+
+fn globalByteOffset(fctx: *const FuncCompileCtx, idx: u32) !u32 {
+    const i: usize = @intCast(idx);
+    if (i < fctx.global_offsets.len) return fctx.global_offsets[i];
+    if (idx > std.math.maxInt(u32) / 8) return error.GlobalIndexOutOfRange;
+    return idx * 8;
+}
+
+fn addGlobalByteOffset(code: *emit.CodeBuffer, base: emit.Reg, offset: u32, scratch: emit.Reg) !void {
+    if (offset == 0) return;
+    if (offset <= 4095) {
+        try code.addImm(base, base, @intCast(offset));
+    } else if ((offset & 0xFFF) == 0 and (offset >> 12) <= 4095) {
+        try code.addImmShift12(base, base, @intCast(offset >> 12));
+    } else {
+        try emitMovImm64(code, scratch, offset);
+        try code.addRegReg(base, base, scratch);
+    }
+}
+
+/// Globals are a byte-addressed storage area. Scalar/reference globals keep
+/// 8-byte slots; v128 globals are 16-byte aligned and 16 bytes wide.
 fn emitGlobalGet(
     code: *emit.CodeBuffer,
     inst: ir.Inst,
     idx: u32,
     reg_map: *RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+    fctx: *const FuncCompileCtx,
 ) !void {
     const dest = inst.dest orelse return;
+    const ty = globalTypeAt(fctx, idx, inst.type);
+    const byte_offset = try globalByteOffset(fctx, idx);
+    if (ty == .v128) {
+        const vt = try v128_cache.defineFresh(code, v128_map, dest, null);
+        try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
+        try code.ldrImm(RegMap.tmp0, RegMap.tmp0, vmctx_globals_slot);
+        try addGlobalByteOffset(code, RegMap.tmp0, byte_offset, RegMap.tmp1);
+        try code.ldrQ(vt, RegMap.tmp0);
+        return;
+    }
+
     // tmp0 = vmctx; tmp0 = globals_base
     try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
     try code.ldrImm(RegMap.tmp0, RegMap.tmp0, vmctx_globals_slot);
 
     const info = try destBegin(reg_map, dest, RegMap.tmp1);
-    const is32 = (inst.type == .i32 or inst.type == .f32);
-    // Byte offset = idx * 8. LDR scaled-imm requires idx fit in u12.
-    if (idx > 0xFFF) return error.GlobalIndexOutOfRange;
-    if (is32) try code.ldrImm32(info.reg, RegMap.tmp0, @intCast(idx * 2)) else try code.ldrImm(info.reg, RegMap.tmp0, @intCast(idx));
+    const is32 = (ty == .i32 or ty == .f32);
+    if (is32 and byte_offset % 4 == 0 and byte_offset / 4 <= 0xFFF) {
+        try code.ldrImm32(info.reg, RegMap.tmp0, @intCast(byte_offset / 4));
+    } else if (!is32 and byte_offset % 8 == 0 and byte_offset / 8 <= 0xFFF) {
+        try code.ldrImm(info.reg, RegMap.tmp0, @intCast(byte_offset / 8));
+    } else {
+        const scratch = if (info.reg == RegMap.tmp1) RegMap.tmp2 else RegMap.tmp1;
+        try addGlobalByteOffset(code, RegMap.tmp0, byte_offset, scratch);
+        if (is32) try code.ldrImm32(info.reg, RegMap.tmp0, 0) else try code.ldrImm(info.reg, RegMap.tmp0, 0);
+    }
     try destCommit(code, reg_map, info);
 }
 
 fn emitGlobalSet(
     code: *emit.CodeBuffer,
+    inst: ir.Inst,
     gs: @TypeOf(@as(ir.Inst.Op, undefined).global_set),
     reg_map: *RegMap,
+    v128_map: *V128StackMap,
+    v128_cache: *V128RegCache,
+    fctx: *const FuncCompileCtx,
 ) !void {
+    const ty = globalTypeAt(fctx, gs.idx, inst.type);
+    const byte_offset = try globalByteOffset(fctx, gs.idx);
+    if (ty == .v128) {
+        const vt = try v128_cache.ensure(code, v128_map, gs.val, null);
+        try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
+        try code.ldrImm(RegMap.tmp0, RegMap.tmp0, vmctx_globals_slot);
+        try addGlobalByteOffset(code, RegMap.tmp0, byte_offset, RegMap.tmp1);
+        try code.strQ(vt, RegMap.tmp0);
+        return;
+    }
+
     const val_r = try useInto(code, reg_map, gs.val, RegMap.tmp1);
     // tmp0 = vmctx; tmp0 = globals_base
     try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
     try code.ldrImm(RegMap.tmp0, RegMap.tmp0, vmctx_globals_slot);
-    if (gs.idx > 0xFFF) return error.GlobalIndexOutOfRange;
-    // Type width inferred from the val's IR type is not available here;
-    // always store 8 bytes (safe: the interpreter allocates 8 bytes per
-    // global slot, and i32/f32 are zero-extended or host-padded).
-    try code.strImm(val_r, RegMap.tmp0, @intCast(gs.idx));
+    // Scalar/reference globals use 8-byte slots. i32/f32 consumers read the
+    // low 32 bits, matching the pre-v128 layout and preserving old behaviour.
+    if (byte_offset % 8 == 0 and byte_offset / 8 <= 0xFFF) {
+        try code.strImm(val_r, RegMap.tmp0, @intCast(byte_offset / 8));
+    } else {
+        const scratch = if (val_r == RegMap.tmp1) RegMap.tmp2 else RegMap.tmp1;
+        try addGlobalByteOffset(code, RegMap.tmp0, byte_offset, scratch);
+        try code.strImm(val_r, RegMap.tmp0, 0);
+    }
 }
 
 /// `memory.size` — 32-bit load of VmCtx.memory_pages.
@@ -6443,6 +6510,8 @@ pub fn compileModuleWithOptions(
         const ctx: FuncCompileCtx = .{
             .import_count = ir_module.import_count,
             .call_patches = &func_patches,
+            .global_types = ir_module.global_types orelse &.{},
+            .global_offsets = ir_module.global_offsets orelse &.{},
             .options = options,
             .allocator = allocator,
         };
@@ -6725,6 +6794,39 @@ test "compileFunction: global_get then global_set round-trips" {
     defer allocator.free(code);
     try std.testing.expect(code.len > 0);
     try std.testing.expect(code.len % 4 == 0);
+}
+
+test "compileFunction: v128 global_get/global_set emit Q loads and stores" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    try block.append(.{ .op = .{ .global_get = 1 }, .dest = v0, .type = .v128 });
+    try block.append(.{ .op = .{ .global_set = .{ .idx = 3, .val = v0 } }, .type = .v128 });
+    try block.append(.{ .op = .{ .ret = null } });
+
+    const global_types = [_]ir.IrType{ .i32, .v128, .i64, .v128 };
+    const global_offsets = [_]u32{ 0, 16, 32, 48 };
+    const code = try compileFunctionImpl(&func, .{
+        .allocator = allocator,
+        .global_types = &global_types,
+        .global_offsets = &global_offsets,
+    }, allocator);
+    defer allocator.free(code);
+
+    var saw_ldr_q = false;
+    var saw_str_q = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const word = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((word & 0xFFC00000) == 0x3DC00000) saw_ldr_q = true;
+        if ((word & 0xFFC00000) == 0x3D800000) saw_str_q = true;
+    }
+    try std.testing.expect(saw_ldr_q);
+    try std.testing.expect(saw_str_q);
 }
 
 test "compileFunction: div_s by zero codegen produces trap path" {

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1446,7 +1446,7 @@ pub fn compileModule(ir_module: *const ir.IrModule, allocator: std.mem.Allocator
         try offsets.append(allocator, @intCast(func_start));
 
         // Compile function using register allocator
-        const result = try compileFunctionRA(&func, ir_module.import_count, allocator);
+        const result = try compileFunctionRAWithGlobalOffsets(&func, ir_module.import_count, ir_module.global_offsets orelse &.{}, allocator);
         defer allocator.free(result.code);
         defer allocator.free(result.call_patches);
 
@@ -1639,10 +1639,29 @@ fn functionUsesV128(func: *const ir.IrFunction) bool {
     return false;
 }
 
+fn globalByteOffset(global_offsets: []const u32, idx: u32) !i32 {
+    const i: usize = @intCast(idx);
+    if (i < global_offsets.len) {
+        if (global_offsets[i] > @as(u32, @intCast(std.math.maxInt(i32)))) return error.GlobalIndexOutOfRange;
+        return @intCast(global_offsets[i]);
+    }
+    if (idx > @as(u32, @intCast(std.math.maxInt(i32) / 8))) return error.GlobalIndexOutOfRange;
+    return @intCast(idx * 8);
+}
+
 /// Compile an IR function using the linear scan register allocator.
 /// VRegs are assigned to physical registers; instructions operate directly
 /// on assigned registers without push/pop through a CachedStack.
 pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocator: std.mem.Allocator) !FuncCompileResult {
+    return compileFunctionRAWithGlobalOffsets(func, import_count, &.{}, allocator);
+}
+
+fn compileFunctionRAWithGlobalOffsets(
+    func: *const ir.IrFunction,
+    import_count: u32,
+    global_offsets: []const u32,
+    allocator: std.mem.Allocator,
+) !FuncCompileResult {
     if (functionUsesV128(func)) return error.UnsupportedV128;
 
     // Compute block emission order ONCE, before anything that uses global
@@ -1838,7 +1857,7 @@ pub fn compileFunctionRA(func: *const ir.IrFunction, import_count: u32, allocato
         const next_block_id: ?ir.BlockId = if (order_idx + 1 < block_order.len) block_order[order_idx + 1] else null;
         for (block.instructions.items) |inst| {
             last_was_ret = isRet(inst.op);
-            try compileInstRA(&code, inst, &alloc_result, &const_vals, &branch_patches, &call_patches, &table_patches, import_count, &used_caller_saved, &used_callee_saved, func.local_count);
+            try compileInstRA(&code, inst, &alloc_result, &const_vals, &branch_patches, &call_patches, &table_patches, import_count, &used_caller_saved, &used_callee_saved, func.local_count, global_offsets);
         }
         // C3 fall-through peephole: if the block's terminator emitted a
         // trailing `E9 disp32` (br, or br_if's unconditional else) whose
@@ -2201,6 +2220,7 @@ fn compileInstRA(
     used_caller_saved: *const [caller_saved_alloc.len]bool,
     used_callee_saved: *const [callee_saved_alloc.len]bool,
     local_count: u32,
+    global_offsets: []const u32,
 ) !void {
     switch (inst.op) {
         // ── Constants ─────────────────────────────────────────────────
@@ -3565,14 +3585,14 @@ fn compileInstRA(
             // Load globals_base from VmCtx, then load global value
             try code.movRegMem(.r10, .rbp, vmctx_offset); // VmCtx*
             try code.movRegMem(.r10, .r10, vmctx_globals_field); // globals_base
-            try code.movRegMem(dr, .r10, @as(i32, @intCast(idx * 8))); // global[idx]
+            try code.movRegMem(dr, .r10, try globalByteOffset(global_offsets, idx)); // global[idx]
             try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .global_set => |gs| {
             const val_reg = try useVReg(code, alloc_result, gs.val, .rax);
             try code.movRegMem(.r10, .rbp, vmctx_offset); // VmCtx*
             try code.movRegMem(.r10, .r10, vmctx_globals_field); // globals_base
-            try code.movMemReg(.r10, @as(i32, @intCast(gs.idx * 8)), val_reg); // global[idx] = val
+            try code.movMemReg(.r10, try globalByteOffset(global_offsets, gs.idx), val_reg); // global[idx] = val
         },
 
         .@"unreachable" => {

--- a/src/compiler/emit_aot.zig
+++ b/src/compiler/emit_aot.zig
@@ -59,7 +59,8 @@ pub const MemoryEntry = struct {
 pub const GlobalEntry = struct {
     val_type: u8,
     mutability: u8,
-    init_i64: i64,
+    init_i64: i64 = 0,
+    init_v128: u128 = 0,
 };
 
 pub const ElemEntry = struct {
@@ -208,7 +209,8 @@ pub fn emit(
         }
     }
 
-    // Section 10: globals (val_type, mutability, init_i64 per entry)
+    // Section 10: globals (val_type, mutability, init payload per entry).
+    // Scalar/reference globals carry 8 bytes; v128 globals carry 16 bytes.
     if (globals) |global_list| {
         if (global_list.len > 0) {
             var tmp: std.ArrayList(u8) = .empty;
@@ -217,7 +219,11 @@ pub fn emit(
             for (global_list) |g| {
                 try tmp.append(allocator, g.val_type);
                 try tmp.append(allocator, g.mutability);
-                try tmp.appendSlice(allocator, &std.mem.toBytes(std.mem.nativeToLittle(i64, g.init_i64)));
+                if (g.val_type == 0x7B) {
+                    try tmp.appendSlice(allocator, &std.mem.toBytes(std.mem.nativeToLittle(u128, g.init_v128)));
+                } else {
+                    try tmp.appendSlice(allocator, &std.mem.toBytes(std.mem.nativeToLittle(i64, g.init_i64)));
+                }
             }
             try emitSection(allocator, &buf, 10, tmp.items);
         }
@@ -451,6 +457,29 @@ test "emit: memory section round-trip" {
     try std.testing.expect(module.memories[0].limits.max == null);
     try std.testing.expectEqual(@as(u64, 1), module.memories[1].limits.min);
     try std.testing.expectEqual(@as(u64, 256), module.memories[1].limits.max.?);
+}
+
+test "emit: v128 global init payload round-trip" {
+    const allocator = std.testing.allocator;
+    const aot_loader = @import("../runtime/aot/loader.zig");
+
+    const init_bits: u128 = 0x0011_2233_4455_6677_8899_AABB_CCDD_EEFF;
+    const globals = [_]GlobalEntry{
+        .{ .val_type = 0x7F, .mutability = 0, .init_i64 = 0x1234 },
+        .{ .val_type = 0x7B, .mutability = 1, .init_v128 = init_bits },
+    };
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, &globals, null, null, null, null);
+    defer allocator.free(data);
+
+    const module = try aot_loader.load(data, allocator);
+    defer aot_loader.unload(&module, allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), module.global_inits.len);
+    try std.testing.expectEqual(@as(u8, 0x7F), module.global_inits[0].val_type);
+    try std.testing.expectEqual(@as(i64, 0x1234), module.global_inits[0].init_i64);
+    try std.testing.expectEqual(@as(u8, 0x7B), module.global_inits[1].val_type);
+    try std.testing.expectEqual(@as(u8, 1), module.global_inits[1].mutability);
+    try std.testing.expectEqual(init_bits, module.global_inits[1].init_v128);
 }
 
 test "emit: type section and function type indices round-trip" {

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -93,12 +93,62 @@ fn globalValTypeByIdx(wasm_module: *const types.WasmModule, idx: u32) ?types.Val
     return wasm_module.globals[local_idx].global_type.val_type;
 }
 
+fn globalSlotAlignment(ty: ir.IrType) u32 {
+    return switch (ty) {
+        .v128 => 16,
+        .void => 8,
+        else => 8,
+    };
+}
+
+fn globalSlotSize(ty: ir.IrType) u32 {
+    return switch (ty) {
+        .v128 => 16,
+        .void => 0,
+        else => 8,
+    };
+}
+
+fn alignForwardU32(value: u32, alignment: u32) u32 {
+    std.debug.assert(alignment != 0 and (alignment & (alignment - 1)) == 0);
+    return (value + alignment - 1) & ~(alignment - 1);
+}
+
 /// Lower an entire Wasm module into IR.
 pub fn lowerModule(wasm_module: *const types.WasmModule, allocator: std.mem.Allocator) LowerError!ir.IrModule {
     var ir_module = ir.IrModule.init(allocator);
     errdefer ir_module.deinit();
 
     ir_module.import_count = wasm_module.import_function_count;
+
+    var global_types: std.ArrayList(ir.IrType) = .empty;
+    errdefer global_types.deinit(allocator);
+    for (wasm_module.imports) |imp| {
+        if (imp.kind != .global) continue;
+        const gt = imp.global_type orelse continue;
+        try global_types.append(allocator, valTypeToIr(gt.val_type));
+    }
+    for (wasm_module.globals) |g| {
+        try global_types.append(allocator, valTypeToIr(g.global_type.val_type));
+    }
+    if (global_types.items.len > 0) {
+        const owned_types = try global_types.toOwnedSlice(allocator);
+        errdefer allocator.free(owned_types);
+
+        const offsets = try allocator.alloc(u32, owned_types.len);
+        errdefer allocator.free(offsets);
+
+        var next: u32 = 0;
+        for (owned_types, 0..) |ty, i| {
+            next = alignForwardU32(next, globalSlotAlignment(ty));
+            offsets[i] = next;
+            next += globalSlotSize(ty);
+        }
+
+        ir_module.global_types = owned_types;
+        ir_module.global_offsets = offsets;
+        ir_module.global_storage_size = next;
+    }
 
     for (wasm_module.functions) |func| {
         const func_type = wasm_module.types[func.type_idx];
@@ -840,7 +890,9 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
             .global_set => {
                 const idx = readU32(code, &ip);
                 const val = safePop(&vreg_stack);
-                try ir_func.getBlock(current_block).append(.{ .op = .{ .global_set = .{ .idx = idx, .val = val } } });
+                const gt = globalValTypeByIdx(wasm_module, idx) orelse .i32;
+                const ir_ty = valTypeToIr(gt);
+                try ir_func.getBlock(current_block).append(.{ .op = .{ .global_set = .{ .idx = idx, .val = val } }, .type = ir_ty });
             },
             // ── Load variants ────────────────────────────────────────────
             .i32_load,
@@ -3886,6 +3938,76 @@ test "lower declared v128 local get and tee preserve v128 type" {
     try std.testing.expectEqual(@as(u32, 0), insts[1].op.local_set.idx);
     try std.testing.expectEqual(insts[0].dest.?, insts[1].op.local_set.val);
     try std.testing.expectEqual(insts[0].dest.?, insts[2].op.i32x4_extract_lane.vector);
+}
+
+test "lower v128 globals preserve types and aligned wasm-flat layout" {
+    const allocator = std.testing.allocator;
+
+    const import_global_type = types.GlobalType{ .val_type = .i32, .mutability = .immutable };
+    const local_v128_type = types.GlobalType{ .val_type = .v128, .mutability = .mutable };
+    const local_i64_type = types.GlobalType{ .val_type = .i64, .mutability = .immutable };
+    const imports = [_]types.ImportDesc{.{
+        .module_name = "env",
+        .field_name = "g",
+        .kind = .global,
+        .global_type = import_global_type,
+    }};
+    const v128_init = [_]u8{
+        0xFD, 0x0C,
+        0x11, 0x00,
+        0x00, 0x00,
+        0x22, 0x00,
+        0x00, 0x00,
+        0x33, 0x00,
+        0x00, 0x00,
+        0x44, 0x00,
+        0x00, 0x00,
+    };
+    const globals = [_]types.WasmGlobal{
+        .{ .global_type = local_v128_type, .init_expr = .{ .bytecode = &v128_init } },
+        .{ .global_type = local_i64_type, .init_expr = .{ .i64_const = 99 } },
+    };
+    const func_type = types.FuncType{ .params = &.{}, .results = &.{.i32} };
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_type,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &[_]u8{
+            0x23, 0x01, // global.get 1 (local v128; imported global is index 0)
+            0xFD, 0x1B, 0x02, // i32x4.extract_lane 2
+            0xFD, 0x0C, // v128.const
+            0x55, 0x00,
+            0x00, 0x00,
+            0x66, 0x00,
+            0x00, 0x00,
+            0x77, 0x00,
+            0x00, 0x00,
+            0x88, 0x00,
+            0x00, 0x00,
+            0x24, 0x01, // global.set 1
+            0x0B,
+        },
+    };
+    const wasm_module = types.WasmModule{
+        .types = &[_]types.FuncType{func_type},
+        .imports = &imports,
+        .globals = &globals,
+        .functions = &[_]types.WasmFunction{func},
+    };
+
+    var ir_module = try lowerModule(&wasm_module, allocator);
+    defer ir_module.deinit();
+
+    try std.testing.expectEqualSlices(ir.IrType, &.{ .i32, .v128, .i64 }, ir_module.global_types.?);
+    try std.testing.expectEqualSlices(u32, &.{ 0, 16, 32 }, ir_module.global_offsets.?);
+    try std.testing.expectEqual(@as(u32, 40), ir_module.global_storage_size);
+
+    const insts = ir_module.functions.items[0].blocks.items[0].instructions.items;
+    try std.testing.expectEqual(ir.IrType.v128, insts[0].type);
+    try std.testing.expectEqual(@as(u32, 1), insts[0].op.global_get);
+    try std.testing.expectEqual(ir.IrType.v128, insts[3].type);
+    try std.testing.expectEqual(@as(u32, 1), insts[3].op.global_set.idx);
 }
 
 test "lower selected SIMD first-family opcodes" {

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -939,6 +939,14 @@ pub const IrModule = struct {
     /// but call instructions use module-level indices where
     /// indices < import_count refer to imports.
     import_count: u32 = 0,
+    /// Wasm-flat global types (imported globals first, then local globals).
+    /// Populated by the frontend so codegen can use the same byte offsets as
+    /// the AOT runtime when globals include 16-byte v128 slots.
+    global_types: ?[]const IrType = null,
+    /// Byte offset for each wasm-flat global in the AOT globals storage.
+    global_offsets: ?[]const u32 = null,
+    /// Total byte size of the AOT globals storage.
+    global_storage_size: u32 = 0,
 
     pub fn init(allocator: std.mem.Allocator) IrModule {
         return .{
@@ -949,6 +957,8 @@ pub const IrModule = struct {
     pub fn deinit(self: *IrModule) void {
         for (self.functions.items) |*func| func.deinit();
         self.functions.deinit(self.allocator);
+        if (self.global_types) |gt| self.allocator.free(gt);
+        if (self.global_offsets) |go| self.allocator.free(go);
     }
 
     pub fn addFunction(self: *IrModule, func: IrFunction) !u32 {

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -185,21 +185,39 @@ pub fn main(init: std.process.Init) !void {
         });
     }
 
-    // Build global entries from the parsed wasm module
+    // Build global entries in wasm-flat order (imported globals first, then
+    // local globals) so codegen offsets match runtime storage.
     var global_entries: std.ArrayList(emit_aot.GlobalEntry) = .empty;
     defer global_entries.deinit(allocator);
+    var tmp_globals: std.ArrayList(*wamr.types.GlobalInstance) = .empty;
+    defer {
+        for (tmp_globals.items) |g| allocator.destroy(g);
+        tmp_globals.deinit(allocator);
+    }
+    for (module.imports) |imp| {
+        if (imp.kind != .global) continue;
+        const gt = imp.global_type orelse continue;
+        const val = defaultZeroValue(gt.val_type);
+        const gi = try allocator.create(wamr.types.GlobalInstance);
+        gi.* = .{ .global_type = gt, .value = val };
+        try tmp_globals.append(allocator, gi);
+        try global_entries.append(allocator, .{
+            .val_type = @intFromEnum(gt.val_type),
+            .mutability = if (gt.mutability == .mutable) @as(u8, 1) else @as(u8, 0),
+            .init_i64 = valueToI64(val),
+            .init_v128 = valueToV128(val),
+        });
+    }
     for (module.globals) |g| {
-        const init_val: i64 = switch (g.init_expr) {
-            .i32_const => |v| @as(i64, v),
-            .i64_const => |v| v,
-            .f32_const => |v| @as(i64, @as(i32, @bitCast(v))),
-            .f64_const => |v| @bitCast(v),
-            else => 0,
-        };
+        const val = wamr.instance.evalInitExpr(g.init_expr, tmp_globals.items, null) catch defaultZeroValue(g.global_type.val_type);
+        const gi = try allocator.create(wamr.types.GlobalInstance);
+        gi.* = .{ .global_type = g.global_type, .value = val };
+        try tmp_globals.append(allocator, gi);
         try global_entries.append(allocator, .{
             .val_type = @intFromEnum(g.global_type.val_type),
             .mutability = if (g.global_type.mutability == .mutable) @as(u8, 1) else @as(u8, 0),
-            .init_i64 = init_val,
+            .init_i64 = valueToI64(val),
+            .init_v128 = valueToV128(val),
         });
     }
 
@@ -291,4 +309,38 @@ pub fn main(init: std.process.Init) !void {
     };
 
     std.debug.print("Written {s} ({d} bytes)\n", .{ out_path, aot_binary.len });
+}
+
+fn defaultZeroValue(vt: wamr.types.ValType) wamr.types.Value {
+    return switch (vt) {
+        .i32 => .{ .i32 = 0 },
+        .i64 => .{ .i64 = 0 },
+        .f32 => .{ .f32 = 0 },
+        .f64 => .{ .f64 = 0 },
+        .v128 => .{ .v128 = 0 },
+        .funcref => .{ .funcref = null },
+        .externref => .{ .externref = null },
+        .nonfuncref => .{ .nonfuncref = null },
+        .nonexternref => .{ .nonexternref = null },
+        else => .{ .i64 = 0 },
+    };
+}
+
+fn valueToI64(v: wamr.types.Value) i64 {
+    return switch (v) {
+        .i32 => |x| @as(i64, @as(u32, @bitCast(x))),
+        .i64 => |x| x,
+        .f32 => |x| @as(i64, @as(u32, @bitCast(x))),
+        .f64 => |x| @as(i64, @bitCast(x)),
+        .funcref, .nonfuncref => |maybe| if (maybe) |x| @as(i64, @as(u32, x)) + 1 else 0,
+        .externref, .nonexternref => |maybe| if (maybe) |x| @as(i64, @as(u32, x)) + 1 else 0,
+        else => 0,
+    };
+}
+
+fn valueToV128(v: wamr.types.Value) u128 {
+    return switch (v) {
+        .v128 => |x| x,
+        else => 0,
+    };
 }

--- a/src/runtime/aot/loader.zig
+++ b/src/runtime/aot/loader.zig
@@ -23,7 +23,7 @@ pub const AotSectionType = enum(u32) {
     data = 5,
     relocation = 6,
     name = 7,
-    @"import" = 8,
+    import = 8,
     memory = 9,
     global = 10,
     elem = 11,
@@ -66,7 +66,8 @@ pub const AotImportDesc = struct {
 pub const AotGlobalInit = struct {
     val_type: u8,
     mutability: u8,
-    init_i64: i64,
+    init_i64: i64 = 0,
+    init_v128: u128 = 0,
 };
 
 /// An element segment parsed from the AOT element section.
@@ -211,7 +212,7 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!AotModule 
             .data => {
                 try parseDataSection(&reader, section_size, &module, allocator);
             },
-            .@"import" => {
+            .import => {
                 try parseImportSection(&reader, section_size, &module, allocator);
             },
             .memory => {
@@ -507,12 +508,20 @@ fn parseGlobalSection(reader: *BinaryReader, section_size: u32, module: *AotModu
     for (0..count) |i| {
         const val_type = try reader.readByte();
         const mutability = try reader.readByte();
-        const init_bytes = try reader.readBytes(8);
-        const init_i64 = std.mem.readInt(i64, init_bytes[0..8], .little);
+        var init_i64: i64 = 0;
+        var init_v128: u128 = 0;
+        if (val_type == 0x7B) {
+            const init_bytes = try reader.readBytes(16);
+            init_v128 = std.mem.readInt(u128, init_bytes[0..16], .little);
+        } else {
+            const init_bytes = try reader.readBytes(8);
+            init_i64 = std.mem.readInt(i64, init_bytes[0..8], .little);
+        }
         inits[i] = .{
             .val_type = val_type,
             .mutability = mutability,
             .init_i64 = init_i64,
+            .init_v128 = init_v128,
         };
     }
 

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -251,7 +251,8 @@ pub const VmCtx = extern struct {
     memory_base: usize = 0,
     /// Size of linear memory in bytes (current, may grow).
     memory_size: usize = 0,
-    /// Pointer to flat globals values array (each global is an i64 at index * 8).
+    /// Pointer to flat globals storage. Scalar/reference globals use 8-byte
+    /// slots; v128 globals use 16-byte aligned, 16-byte slots.
     globals_ptr: usize = 0,
     /// Pointer to array of host function pointers (one per import).
     host_functions_ptr: usize = 0,
@@ -878,6 +879,10 @@ pub const AotInstance = struct {
     memories: []*types.MemoryInstance,
     tables: []*types.TableInstance,
     globals: []*types.GlobalInstance,
+    /// Byte offset for each wasm-flat global in `VmCtx.globals_ptr`.
+    global_offsets: []u32 = &.{},
+    /// Total byte size of the globals storage described by `global_offsets`.
+    global_storage_size: u32 = 0,
     allocator: std.mem.Allocator,
     /// Base address of the mapped executable code (null if not yet mapped).
     code_base: ?[*]const u8 = null,
@@ -1015,6 +1020,10 @@ pub fn instantiate(module: *const aot_loader.AotModule, allocator: std.mem.Alloc
 
     inst.globals = try allocateGlobals(module, allocator);
     errdefer freeGlobals(inst.globals, allocator);
+    const global_layout = try computeGlobalLayout(module.global_inits, allocator);
+    inst.global_offsets = global_layout.offsets;
+    inst.global_storage_size = global_layout.size;
+    errdefer if (inst.global_offsets.len > 0) allocator.free(inst.global_offsets);
 
     // Resolve AOT host functions for imports
     inst.host_functions = try resolveHostFunctions(module, allocator);
@@ -1079,11 +1088,12 @@ pub fn destroy(inst: *AotInstance) void {
     const allocator = inst.allocator;
     // Unmap executable code if mapped.
     if (inst.code_base) |base| {
-        platform.munmap(@constCast(@ptrCast(base)), inst.code_size);
+        platform.munmap(@ptrCast(@constCast(base)), inst.code_size);
     }
     freeMemories(inst.memories, allocator);
     freeTables(inst.tables, allocator);
     freeGlobals(inst.globals, allocator);
+    if (inst.global_offsets.len > 0) allocator.free(inst.global_offsets);
     if (inst.host_functions.len > 0) allocator.free(inst.host_functions);
     // inst.func_table aliases tables[0].native_backing (freed by TableInstance.release).
     if (inst.funcptrs.len > 0) allocator.free(inst.funcptrs);
@@ -1362,12 +1372,11 @@ pub fn callFunc(inst: *AotInstance, func_idx: u32, comptime Result: type) Runtim
             return error.FunctionNotFound;
     };
 
-    // Build flat globals array for AOT access
-    var globals_buf: [256]i64 = std.mem.zeroes([256]i64);
-    const n_globals = @min(inst.globals.len, globals_buf.len);
-    for (0..n_globals) |i| {
-        globals_buf[i] = globalValueToI64(inst, inst.globals[i].value);
-    }
+    // Build flat globals storage for AOT access.
+    const globals_words = inst.allocator.alloc(u128, globalStorageWordCount(inst)) catch return error.OutOfMemory;
+    defer inst.allocator.free(globals_words);
+    const globals_buf = std.mem.sliceAsBytes(globals_words);
+    writeGlobalsToStorage(inst, globals_buf);
 
     // Build VMContext for the compiled function
     var vmctx = VmCtx{};
@@ -1379,8 +1388,8 @@ pub fn callFunc(inst: *AotInstance, func_idx: u32, comptime Result: type) Runtim
     }
     // Always provide a valid globals pointer — compiled code may access globals
     // even if none are explicitly initialized (they default to zero).
-    vmctx.globals_ptr = @intFromPtr(&globals_buf);
-    vmctx.globals_count = @intCast(n_globals);
+    vmctx.globals_ptr = @intFromPtr(globals_buf.ptr);
+    vmctx.globals_count = @intCast(inst.globals.len);
     if (inst.host_functions.len > 0) {
         vmctx.host_functions_ptr = @intFromPtr(inst.host_functions.ptr);
         vmctx.host_functions_count = @intCast(inst.host_functions.len);
@@ -1436,10 +1445,8 @@ pub fn callFunc(inst: *AotInstance, func_idx: u32, comptime Result: type) Runtim
     }
     const result = func_ptr(&vmctx);
 
-    // Sync globals back from flat array to GlobalInstance objects
-    for (0..n_globals) |i| {
-        inst.globals[i].value = globalValueFromI64(inst, inst.globals[i].value, globals_buf[i]);
-    }
+    // Sync globals back from flat storage to GlobalInstance objects.
+    readGlobalsFromStorage(inst, globals_buf);
 
     return result;
 }
@@ -1502,10 +1509,52 @@ fn isScalarValType(t: types.ValType) bool {
     };
 }
 
-/// Pack a global's typed value into a raw 64-bit slot for the flat globals_buf
-/// that AOT code accesses via `movRegMem(dr, globals_base, idx*8)`. The tag
-/// determines the bit-cast; using `.value.i64` would be UB when the active
-/// tag is `.f32` / `.f64`.
+pub fn globalStorageWordCount(inst: *const AotInstance) usize {
+    const bytes = if (inst.global_storage_size == 0) @as(u32, 16) else inst.global_storage_size;
+    return (@as(usize, bytes) + 15) / 16;
+}
+
+fn globalOffsetAt(inst: *const AotInstance, idx: usize) ?usize {
+    if (idx < inst.global_offsets.len) return inst.global_offsets[idx];
+    const off = idx * 8;
+    if (off + 8 <= inst.global_storage_size) return off;
+    return null;
+}
+
+pub fn writeGlobalsToStorage(inst: *const AotInstance, storage: []u8) void {
+    @memset(storage, 0);
+    for (inst.globals, 0..) |g, i| {
+        const off = globalOffsetAt(inst, i) orelse continue;
+        switch (g.value) {
+            .v128 => |x| {
+                if (off + 16 <= storage.len) std.mem.writeInt(u128, storage[off..][0..16], x, .little);
+            },
+            else => {
+                if (off + 8 <= storage.len) std.mem.writeInt(i64, storage[off..][0..8], globalValueToI64(inst, g.value), .little);
+            },
+        }
+    }
+}
+
+pub fn readGlobalsFromStorage(inst: *AotInstance, storage: []const u8) void {
+    for (inst.globals, 0..) |g, i| {
+        const off = globalOffsetAt(inst, i) orelse continue;
+        g.value = switch (g.value) {
+            .v128 => if (off + 16 <= storage.len)
+                .{ .v128 = std.mem.readInt(u128, storage[off..][0..16], .little) }
+            else
+                g.value,
+            else => if (off + 8 <= storage.len)
+                globalValueFromI64(inst, g.value, std.mem.readInt(i64, storage[off..][0..8], .little))
+            else
+                g.value,
+        };
+    }
+}
+
+/// Pack a global's typed value into a raw 64-bit scalar/reference slot for the
+/// flat globals storage. The tag determines the bit-cast; using `.value.i64`
+/// would be UB when the active tag is `.f32` / `.f64`.
 pub fn globalValueToI64(inst: *const AotInstance, v: types.Value) i64 {
     const r: i64 = switch (v) {
         .i32 => |x| @as(i64, @as(u32, @bitCast(x))),
@@ -1658,12 +1707,11 @@ pub fn callFuncScalar(
             return error.FunctionNotFound;
     };
 
-    // Build flat globals array for AOT access (mirrors callFunc).
-    var globals_buf: [256]i64 = std.mem.zeroes([256]i64);
-    const n_globals = @min(inst.globals.len, globals_buf.len);
-    for (0..n_globals) |i| {
-        globals_buf[i] = globalValueToI64(inst, inst.globals[i].value);
-    }
+    // Build flat globals storage for AOT access (mirrors callFunc).
+    const globals_words = inst.allocator.alloc(u128, globalStorageWordCount(inst)) catch return error.OutOfMemory;
+    defer inst.allocator.free(globals_words);
+    const globals_buf = std.mem.sliceAsBytes(globals_words);
+    writeGlobalsToStorage(inst, globals_buf);
 
     var vmctx = VmCtx{};
     if (inst.memories.len > 0) {
@@ -1672,8 +1720,8 @@ pub fn callFuncScalar(
         vmctx.memory_max_size = inst.memories[0].data.len;
         vmctx.memory_pages = inst.memories[0].current_pages;
     }
-    vmctx.globals_ptr = @intFromPtr(&globals_buf);
-    vmctx.globals_count = @intCast(n_globals);
+    vmctx.globals_ptr = @intFromPtr(globals_buf.ptr);
+    vmctx.globals_count = @intCast(inst.globals.len);
     if (inst.host_functions.len > 0) {
         vmctx.host_functions_ptr = @intFromPtr(inst.host_functions.ptr);
         vmctx.host_functions_count = @intCast(inst.host_functions.len);
@@ -1770,9 +1818,7 @@ pub fn callFuncScalar(
             if (@atomicLoad(u32, &g_last_trap_code, .seq_cst) == 0xC00000FD) {
                 resetStackGuardPage();
             }
-            for (0..n_globals) |i| {
-                inst.globals[i].value = globalValueFromI64(inst, inst.globals[i].value, globals_buf[i]);
-            }
+            readGlobalsFromStorage(inst, globals_buf);
             return error.WasmTrap;
         }
     }
@@ -1838,9 +1884,7 @@ pub fn callFuncScalar(
     }
 
     // Sync globals back.
-    for (0..n_globals) |i| {
-        inst.globals[i].value = globalValueFromI64(inst, inst.globals[i].value, globals_buf[i]);
-    }
+    readGlobalsFromStorage(inst, globals_buf);
 
     if (result_types.len == 0) return results_out[0..0];
 
@@ -1985,6 +2029,47 @@ fn allocateTables(module: *const aot_loader.AotModule, allocator: std.mem.Alloca
     return tables;
 }
 
+const GlobalLayout = struct {
+    offsets: []u32,
+    size: u32,
+};
+
+fn alignForwardU32(value: u32, alignment: u32) u32 {
+    std.debug.assert(alignment != 0 and (alignment & (alignment - 1)) == 0);
+    return (value + alignment - 1) & ~(alignment - 1);
+}
+
+fn globalSlotAlignment(vt: types.ValType) u32 {
+    return switch (vt) {
+        .v128 => 16,
+        else => 8,
+    };
+}
+
+fn globalSlotSize(vt: types.ValType) u32 {
+    return switch (vt) {
+        .v128 => 16,
+        else => 8,
+    };
+}
+
+fn computeGlobalLayout(inits: []const aot_loader.AotGlobalInit, allocator: std.mem.Allocator) RuntimeError!GlobalLayout {
+    if (inits.len == 0) return .{ .offsets = &.{}, .size = 0 };
+
+    const offsets = allocator.alloc(u32, inits.len) catch return error.OutOfMemory;
+    errdefer allocator.free(offsets);
+
+    var next: u32 = 0;
+    for (inits, 0..) |ginit, i| {
+        const vt: types.ValType = @enumFromInt(ginit.val_type);
+        next = alignForwardU32(next, globalSlotAlignment(vt));
+        offsets[i] = next;
+        next += globalSlotSize(vt);
+    }
+
+    return .{ .offsets = offsets, .size = next };
+}
+
 fn allocateGlobals(module: *const aot_loader.AotModule, allocator: std.mem.Allocator) RuntimeError![]*types.GlobalInstance {
     if (module.global_inits.len == 0) return &.{};
 
@@ -2007,6 +2092,7 @@ fn allocateGlobals(module: *const aot_loader.AotModule, allocator: std.mem.Alloc
             .i64 => .{ .i64 = ginit.init_i64 },
             .f32 => .{ .f32 = @bitCast(@as(u32, @truncate(@as(u64, @bitCast(ginit.init_i64))))) },
             .f64 => .{ .f64 = @bitCast(ginit.init_i64) },
+            .v128 => .{ .v128 = ginit.init_v128 },
             .funcref => .{ .funcref = if (ginit.init_i64 == 0) null else @as(u32, @truncate(@as(u64, @bitCast(ginit.init_i64)) - 1)) },
             .nonfuncref => .{ .nonfuncref = if (ginit.init_i64 == 0) null else @as(u32, @truncate(@as(u64, @bitCast(ginit.init_i64)) - 1)) },
             .externref => .{ .externref = if (ginit.init_i64 == 0) null else @as(u32, @truncate(@as(u64, @bitCast(ginit.init_i64)) - 1)) },
@@ -2053,6 +2139,35 @@ test "instantiate: empty module" {
     try std.testing.expectEqual(@as(usize, 0), inst.tables.len);
     try std.testing.expectEqual(@as(usize, 0), inst.globals.len);
     try std.testing.expectEqual(@as(?[*]const u8, null), inst.code_base);
+}
+
+test "globals storage packs v128 globals on 16-byte aligned offsets" {
+    const inits = [_]aot_loader.AotGlobalInit{
+        .{ .val_type = @intFromEnum(types.ValType.i32), .mutability = 0, .init_i64 = 5 },
+        .{ .val_type = @intFromEnum(types.ValType.v128), .mutability = 1, .init_v128 = 0x0011_2233_4455_6677_8899_AABB_CCDD_EEFF },
+        .{ .val_type = @intFromEnum(types.ValType.i64), .mutability = 0, .init_i64 = 9 },
+    };
+    const module = aot_loader.AotModule{ .global_inits = &inits };
+    const inst = try instantiate(&module, std.testing.allocator);
+    defer destroy(inst);
+
+    try std.testing.expectEqualSlices(u32, &.{ 0, 16, 32 }, inst.global_offsets);
+    try std.testing.expectEqual(@as(u32, 40), inst.global_storage_size);
+    try std.testing.expectEqual(@as(usize, 3), globalStorageWordCount(inst));
+
+    const storage_words = try std.testing.allocator.alloc(u128, globalStorageWordCount(inst));
+    defer std.testing.allocator.free(storage_words);
+    const storage = std.mem.sliceAsBytes(storage_words);
+    writeGlobalsToStorage(inst, storage);
+
+    try std.testing.expectEqual(@as(i64, 5), std.mem.readInt(i64, storage[0..8], .little));
+    try std.testing.expectEqual(inits[1].init_v128, std.mem.readInt(u128, storage[16..][0..16], .little));
+    try std.testing.expectEqual(@as(i64, 9), std.mem.readInt(i64, storage[32..][0..8], .little));
+
+    const updated: u128 = 0xFFEEDDCC_BBAA9988_77665544_33221100;
+    std.mem.writeInt(u128, storage[16..][0..16], updated, .little);
+    readGlobalsFromStorage(inst, storage);
+    try std.testing.expectEqual(updated, inst.globals[1].value.v128);
 }
 
 test "findExportFunc: returns null for missing export" {

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -230,7 +230,7 @@ pub const Harness = struct {
     /// trampoline that loads this pointer so the callee sees the
     /// exporter's memory/tables/globals instead of the caller's.
     persistent_vmctx: ?*aot_runtime.VmCtx = null,
-    persistent_globals: ?[]i64 = null,
+    persistent_globals: ?[]u128 = null,
     /// Executable trampoline stubs (mmap'd). Each stub loads
     /// persistent_vmctx into param_regs[0] and jumps to the real func.
     trampoline_pages: ?[*]u8 = null,
@@ -628,17 +628,14 @@ pub const Harness = struct {
             vmctx.memory_max_size = inst.memories[0].data.len;
             vmctx.memory_pages = inst.memories[0].current_pages;
         }
-        const n_globals = @min(inst.globals.len, @as(usize, 256));
-        const globals_buf = allocator.alloc(i64, 256) catch {
+        const globals_buf = allocator.alloc(u128, aot_runtime.globalStorageWordCount(inst)) catch {
             allocator.destroy(vmctx);
             return;
         };
-        @memset(globals_buf, 0);
-        for (0..n_globals) |i| {
-            globals_buf[i] = aot_runtime.globalValueToI64(inst, inst.globals[i].value);
-        }
-        vmctx.globals_ptr = @intFromPtr(globals_buf.ptr);
-        vmctx.globals_count = @intCast(n_globals);
+        const globals_bytes = std.mem.sliceAsBytes(globals_buf);
+        aot_runtime.writeGlobalsToStorage(inst, globals_bytes);
+        vmctx.globals_ptr = @intFromPtr(globals_bytes.ptr);
+        vmctx.globals_count = @intCast(inst.globals.len);
         if (inst.host_functions.len > 0) {
             vmctx.host_functions_ptr = @intFromPtr(inst.host_functions.ptr);
             vmctx.host_functions_count = @intCast(inst.host_functions.len);
@@ -1118,6 +1115,7 @@ fn compileToAot(
             .val_type = @intFromEnum(gt.val_type),
             .mutability = if (gt.mutability == .mutable) @as(u8, 1) else @as(u8, 0),
             .init_i64 = valueToI64(val),
+            .init_v128 = valueToV128(val),
         });
     }
 
@@ -1131,6 +1129,7 @@ fn compileToAot(
             .val_type = @intFromEnum(g.global_type.val_type),
             .mutability = if (g.global_type.mutability == .mutable) @as(u8, 1) else @as(u8, 0),
             .init_i64 = valueToI64(val),
+            .init_v128 = valueToV128(val),
         });
     }
 
@@ -1243,6 +1242,7 @@ fn defaultZeroValue(vt: types.ValType) types.Value {
         .i64 => .{ .i64 = 0 },
         .f32 => .{ .f32 = 0 },
         .f64 => .{ .f64 = 0 },
+        .v128 => .{ .v128 = 0 },
         else => .{ .i64 = 0 },
     };
 }
@@ -1314,9 +1314,8 @@ fn resolveFuncIdxFromExpr(
     };
 }
 
-/// Pack a typed Value into an i64 for the globals_buf layout expected by
-/// AOT code. Must stay in sync with `globalValueToI64` in
-/// runtime/aot/runtime.zig.
+/// Pack a typed scalar/reference Value into the 8-byte global init payload.
+/// Must stay in sync with `globalValueToI64` in runtime/aot/runtime.zig.
 fn valueToI64(v: types.Value) i64 {
     return switch (v) {
         .i32 => |x| @as(i64, @as(u32, @bitCast(x))),
@@ -1329,6 +1328,13 @@ fn valueToI64(v: types.Value) i64 {
         // `allocateGlobals` with the matching `-1` shift.
         .funcref, .nonfuncref => |maybe| if (maybe) |x| @as(i64, @as(u32, x)) + 1 else 0,
         .externref, .nonexternref => |maybe| if (maybe) |x| @as(i64, @as(u32, x)) + 1 else 0,
+        else => 0,
+    };
+}
+
+fn valueToV128(v: types.Value) u128 {
+    return switch (v) {
+        .v128 => |x| x,
         else => 0,
     };
 }

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -461,6 +461,133 @@ test "differential SIMD: v128 local set/get" {
     try expectSimdDiffI32(wasm, "f", 19);
 }
 
+test "differential SIMD: v128 immutable global get" {
+    var init: std.ArrayList(u8) = .empty;
+    defer init.deinit(testing.allocator);
+    try appendV128ConstI32x4(&init, testing.allocator, .{ 17, 18, 19, 20 });
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendGlobalGet(&body, testing.allocator, 0);
+    try appendI32x4ExtractLane(&body, testing.allocator, 2);
+    try body.append(testing.allocator, 0x0B);
+
+    const globals = [_]TestGlobal{.{ .val_type = 0x7B, .mutable = false, .init_expr = init.items }};
+    const wasm = try buildCustomGlobalModule(testing.allocator, &globals, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", 19);
+}
+
+test "differential SIMD: v128 mutable global set/get" {
+    var init: std.ArrayList(u8) = .empty;
+    defer init.deinit(testing.allocator);
+    try appendV128ConstI32x4(&init, testing.allocator, .{ 1, 2, 3, 4 });
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendV128ConstI32x4(&body, testing.allocator, .{ 31, 32, 33, 34 });
+    try appendGlobalSet(&body, testing.allocator, 0);
+    try appendGlobalGet(&body, testing.allocator, 0);
+    try appendI32x4ExtractLane(&body, testing.allocator, 3);
+    try body.append(testing.allocator, 0x0B);
+
+    const globals = [_]TestGlobal{.{ .val_type = 0x7B, .mutable = true, .init_expr = init.items }};
+    const wasm = try buildCustomGlobalModule(testing.allocator, &globals, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", 34);
+}
+
+test "differential SIMD: mixed scalar and v128 globals use aligned storage" {
+    var init_i32_a: std.ArrayList(u8) = .empty;
+    defer init_i32_a.deinit(testing.allocator);
+    try appendI32Const(&init_i32_a, testing.allocator, 5);
+    var init_v128: std.ArrayList(u8) = .empty;
+    defer init_v128.deinit(testing.allocator);
+    try appendV128ConstI32x4(&init_v128, testing.allocator, .{ 10, 20, 30, 40 });
+    var init_i32_b: std.ArrayList(u8) = .empty;
+    defer init_i32_b.deinit(testing.allocator);
+    try appendI32Const(&init_i32_b, testing.allocator, 12);
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendGlobalGet(&body, testing.allocator, 1);
+    try appendI32x4ExtractLane(&body, testing.allocator, 2);
+    try appendGlobalGet(&body, testing.allocator, 2);
+    try body.append(testing.allocator, 0x6A); // i32.add
+    try body.append(testing.allocator, 0x0B);
+
+    const globals = [_]TestGlobal{
+        .{ .val_type = 0x7F, .mutable = false, .init_expr = init_i32_a.items },
+        .{ .val_type = 0x7B, .mutable = true, .init_expr = init_v128.items },
+        .{ .val_type = 0x7F, .mutable = false, .init_expr = init_i32_b.items },
+    };
+    const wasm = try buildCustomGlobalModule(testing.allocator, &globals, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", 42);
+}
+
+test "differential: scalar global after v128 global uses aligned offset" {
+    var init_v128: std.ArrayList(u8) = .empty;
+    defer init_v128.deinit(testing.allocator);
+    try appendV128ConstI32x4(&init_v128, testing.allocator, .{ 1, 2, 3, 4 });
+    var init_i32: std.ArrayList(u8) = .empty;
+    defer init_i32.deinit(testing.allocator);
+    try appendI32Const(&init_i32, testing.allocator, 123);
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendGlobalGet(&body, testing.allocator, 1);
+    try body.append(testing.allocator, 0x0B);
+
+    const globals = [_]TestGlobal{
+        .{ .val_type = 0x7B, .mutable = false, .init_expr = init_v128.items },
+        .{ .val_type = 0x7F, .mutable = false, .init_expr = init_i32.items },
+    };
+    const wasm = try buildCustomGlobalModule(testing.allocator, &globals, body.items);
+    defer testing.allocator.free(wasm);
+    try expectDiffI32(wasm, "f", 123);
+}
+
+test "differential SIMD: v128 global preserves f32 signed zero bits" {
+    var init: std.ArrayList(u8) = .empty;
+    defer init.deinit(testing.allocator);
+    try appendV128ConstF32x4Bits(&init, testing.allocator, .{ 0x8000_0000, 0x3F80_0000, 0, 0 });
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendGlobalGet(&body, testing.allocator, 0);
+    try appendI32x4ExtractLane(&body, testing.allocator, 0);
+    try body.append(testing.allocator, 0x0B);
+
+    const globals = [_]TestGlobal{.{ .val_type = 0x7B, .mutable = false, .init_expr = init.items }};
+    const wasm = try buildCustomGlobalModule(testing.allocator, &globals, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", @bitCast(@as(u32, 0x8000_0000)));
+}
+
+test "differential SIMD: v128 global preserves f32 NaN payload bits" {
+    var init: std.ArrayList(u8) = .empty;
+    defer init.deinit(testing.allocator);
+    try appendV128ConstF32x4Bits(&init, testing.allocator, .{ 0x3F80_0000, 0x7FC1_2345, 0, 0 });
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(testing.allocator);
+    try body.append(testing.allocator, 0x00);
+    try appendGlobalGet(&body, testing.allocator, 0);
+    try appendI32x4ExtractLane(&body, testing.allocator, 1);
+    try body.append(testing.allocator, 0x0B);
+
+    const globals = [_]TestGlobal{.{ .val_type = 0x7B, .mutable = false, .init_expr = init.items }};
+    const wasm = try buildCustomGlobalModule(testing.allocator, &globals, body.items);
+    defer testing.allocator.free(wasm);
+    try expectSimdDiffI32(wasm, "f", @bitCast(@as(u32, 0x7FC1_2345)));
+}
+
 test "differential SIMD: v128 local tee preserves stack value" {
     var body: std.ArrayList(u8) = .empty;
     defer body.deinit(testing.allocator);
@@ -2859,6 +2986,51 @@ fn buildCustomModule(allocator: std.mem.Allocator, bytecode: []const u8) ![]u8 {
     return out.toOwnedSlice(allocator);
 }
 
+const TestGlobal = struct {
+    val_type: u8,
+    mutable: bool,
+    init_expr: []const u8,
+};
+
+fn buildCustomGlobalModule(
+    allocator: std.mem.Allocator,
+    globals: []const TestGlobal,
+    bytecode: []const u8,
+) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, &[_]u8{ 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00 });
+    try out.appendSlice(allocator, &[_]u8{
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7F,
+    });
+    try out.appendSlice(allocator, &[_]u8{ 0x03, 0x02, 0x01, 0x00 });
+
+    var global_payload: std.ArrayList(u8) = .empty;
+    defer global_payload.deinit(allocator);
+    try encodeULEB128(&global_payload, allocator, @intCast(globals.len));
+    for (globals) |global| {
+        try global_payload.append(allocator, global.val_type);
+        try global_payload.append(allocator, if (global.mutable) 1 else 0);
+        try global_payload.appendSlice(allocator, global.init_expr);
+        try global_payload.append(allocator, 0x0B);
+    }
+    try appendSection(&out, allocator, 0x06, global_payload.items);
+
+    try out.appendSlice(allocator, &[_]u8{
+        0x07, 0x05, 0x01, 0x01, 'f', 0x00, 0x00,
+    });
+
+    var code: std.ArrayList(u8) = .empty;
+    defer code.deinit(allocator);
+    try code.append(allocator, 0x01);
+    try encodeULEB128(&code, allocator, @intCast(bytecode.len));
+    try code.appendSlice(allocator, bytecode);
+
+    try appendSection(&out, allocator, 0x0A, code.items);
+    return out.toOwnedSlice(allocator);
+}
+
 fn appendSection(out: *std.ArrayList(u8), allocator: std.mem.Allocator, id: u8, payload: []const u8) !void {
     try out.append(allocator, id);
     try encodeULEB128(out, allocator, @intCast(payload.len));
@@ -3078,6 +3250,16 @@ fn appendLocalGet(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, index: 
 
 fn appendLocalSet(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, index: u32) !void {
     try buf.append(allocator, 0x21);
+    try encodeULEB128(buf, allocator, index);
+}
+
+fn appendGlobalGet(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, index: u32) !void {
+    try buf.append(allocator, 0x23);
+    try encodeULEB128(buf, allocator, index);
+}
+
+fn appendGlobalSet(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, index: u32) !void {
+    try buf.append(allocator, 0x24);
     try encodeULEB128(buf, allocator, index);
 }
 


### PR DESCRIPTION
Closes #287.

## Summary
- add wasm-flat global layout metadata with 16-byte-aligned v128 slots
- lower AArch64 v128 global.get/set through LDR Q / STR Q
- carry v128 global init payloads through AOT emit/load/runtime storage
- add frontend, codegen, runtime, emit/load, and differential coverage

## Validation
- git diff --check
- zig build test
- zig build
- zig build simd-bench -- --iterations 1