### PR TITLE
Fix CoreMark AOT branch-fold regression

### DIFF
--- a/.github/workflows/coremark-aarch64.yml
+++ b/.github/workflows/coremark-aarch64.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Run CoreMark comparison
         id: bench
+        continue-on-error: true
         env:
           BASELINE: ${{ steps.refs.outputs.baseline }}
           TARGET: ${{ steps.refs.outputs.target }}
@@ -79,22 +80,29 @@ jobs:
             --baseline "$BASELINE" \
             --target   "$TARGET" \
             --runs     "$RUNS" \
+            --min-delta-pct=-5.0 \
             --out      coremark-table.md \
             --emit     github
 
       - name: Upload table
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coremark-aarch64-${{ github.sha }}
           path: coremark-table.md
+          if-no-files-found: ignore
           retention-days: 90
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const fs = require('fs');
+            if (!fs.existsSync('coremark-table.md')) {
+              core.warning('coremark-table.md was not produced');
+              return;
+            }
             const body = fs.readFileSync('coremark-table.md', 'utf8');
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -102,3 +110,7 @@ jobs:
               repo: context.repo.repo,
               body,
             });
+
+      - name: Fail on CoreMark regression
+        if: steps.bench.outcome == 'failure'
+        run: exit 1

--- a/scripts/bench_coremark.py
+++ b/scripts/bench_coremark.py
@@ -69,16 +69,16 @@ def make_worktree(repo: Path, ref: str, root: Path) -> Path:
 
 
 def worktree_env(wt: Path) -> dict:
-    """Return an environment that keeps Zig local caches isolated per worktree."""
+    """Return an environment that keeps Zig caches isolated per worktree."""
     env = os.environ.copy()
-    inherited_local = env.pop("ZIG_LOCAL_CACHE_DIR", None)
-    # Some self-hosted runners set both Zig caches to the checkout's .zig-cache.
-    # That is unsafe for this script because it builds multiple git worktrees in
+    # setup-zig exports both cache dirs to the checkout's .zig-cache. That is
+    # unsafe for this script because it builds multiple git worktrees in
     # sequence; the target ref can otherwise reuse baseline build artifacts.
-    if inherited_local and env.get("ZIG_GLOBAL_CACHE_DIR") == inherited_local:
-        global_cache = wt.parent / "zig-global-cache"
-        global_cache.mkdir(exist_ok=True)
-        env["ZIG_GLOBAL_CACHE_DIR"] = str(global_cache)
+    # Keep each ref's local and global Zig caches independent.
+    env.pop("ZIG_LOCAL_CACHE_DIR", None)
+    global_cache = wt / ".zig-global-cache"
+    global_cache.mkdir(exist_ok=True)
+    env["ZIG_GLOBAL_CACHE_DIR"] = str(global_cache)
     return env
 
 

--- a/scripts/bench_coremark.py
+++ b/scripts/bench_coremark.py
@@ -68,9 +68,23 @@ def make_worktree(repo: Path, ref: str, root: Path) -> Path:
     return wt
 
 
+def worktree_env(wt: Path) -> dict:
+    """Return an environment that keeps Zig local caches isolated per worktree."""
+    env = os.environ.copy()
+    inherited_local = env.pop("ZIG_LOCAL_CACHE_DIR", None)
+    # Some self-hosted runners set both Zig caches to the checkout's .zig-cache.
+    # That is unsafe for this script because it builds multiple git worktrees in
+    # sequence; the target ref can otherwise reuse baseline build artifacts.
+    if inherited_local and env.get("ZIG_GLOBAL_CACHE_DIR") == inherited_local:
+        global_cache = wt.parent / "zig-global-cache"
+        global_cache.mkdir(exist_ok=True)
+        env["ZIG_GLOBAL_CACHE_DIR"] = str(global_cache)
+    return env
+
+
 def build_and_run(wt: Path, runs: int, coremark_src: Path) -> list[float]:
     """Build wamr + AOT-compile + run CoreMark `runs` times, return iter/s list."""
-    env = os.environ.copy()
+    env = worktree_env(wt)
     # Each worktree owns its own .zig-cache (already on /work for our runner).
     print(f"[harness] building {wt.name} (ReleaseFast)", file=sys.stderr)
     run(["zig", "build", "-Doptimize=ReleaseFast"], cwd=wt, env=env)

--- a/scripts/bench_coremark.py
+++ b/scripts/bench_coremark.py
@@ -104,6 +104,10 @@ def fmt_stats(values: list[float]) -> tuple[float, float, float]:
     return statistics.fmean(values), min(values), max(values)
 
 
+def compute_delta_pct(baseline_vals: list[float], target_vals: list[float]) -> float:
+    return (statistics.fmean(target_vals) / statistics.fmean(baseline_vals) - 1.0) * 100.0
+
+
 def render_table(
     baseline_ref: str,
     baseline_vals: list[float],
@@ -112,7 +116,7 @@ def render_table(
 ) -> str:
     bm, bmin, bmax = fmt_stats(baseline_vals)
     tm, tmin, tmax = fmt_stats(target_vals)
-    delta_pct = (tm / bm - 1.0) * 100.0
+    delta_pct = compute_delta_pct(baseline_vals, target_vals)
     sign = "+" if delta_pct >= 0 else ""
     lines = [
         "### CoreMark AOT comparison",
@@ -149,6 +153,12 @@ def main() -> int:
         default="markdown",
         help="`github` also appends to $GITHUB_STEP_SUMMARY when present",
     )
+    p.add_argument(
+        "--min-delta-pct",
+        type=float,
+        default=None,
+        help="fail if target mean is below baseline by more than this percent delta",
+    )
     args = p.parse_args()
 
     repo = args.repo
@@ -178,6 +188,16 @@ def main() -> int:
         if summary:
             with open(summary, "a") as fh:
                 fh.write(table + "\n")
+
+    if args.min_delta_pct is not None:
+        delta_pct = compute_delta_pct(baseline_vals, target_vals)
+        if delta_pct < args.min_delta_pct:
+            print(
+                f"CoreMark AOT regression: {delta_pct:.2f}% is below "
+                f"allowed minimum {args.min_delta_pct:.2f}%",
+                file=sys.stderr,
+            )
+            return 1
 
     return 0
 

--- a/scripts/bench_simd.py
+++ b/scripts/bench_simd.py
@@ -69,18 +69,16 @@ def make_worktree(repo: Path, ref: str, root: Path, label: str) -> Path:
 
 
 def worktree_env(wt: Path) -> dict:
-    """Return an environment that keeps Zig local caches isolated per worktree."""
+    """Return an environment that keeps Zig caches isolated per worktree."""
     env = os.environ.copy()
-    inherited_local = env.pop("ZIG_LOCAL_CACHE_DIR", None)
     # setup-zig exports both cache dirs to the checkout's .zig-cache. This
-    # script builds two temporary worktrees; sharing that local cache lets the
-    # target ref reuse baseline artifacts, so leave each worktree on its own
-    # default .zig-cache. If the global cache aliases that local cache, move it
-    # to the comparison temp root instead.
-    if inherited_local and env.get("ZIG_GLOBAL_CACHE_DIR") == inherited_local:
-        global_cache = wt.parent / "zig-global-cache"
-        global_cache.mkdir(exist_ok=True)
-        env["ZIG_GLOBAL_CACHE_DIR"] = str(global_cache)
+    # script builds two temporary worktrees; sharing cache state can let the
+    # target ref reuse baseline artifacts. Keep each ref's local and global Zig
+    # caches independent.
+    env.pop("ZIG_LOCAL_CACHE_DIR", None)
+    global_cache = wt / ".zig-global-cache"
+    global_cache.mkdir(exist_ok=True)
+    env["ZIG_GLOBAL_CACHE_DIR"] = str(global_cache)
     return env
 
 

--- a/scripts/bench_simd.py
+++ b/scripts/bench_simd.py
@@ -68,6 +68,22 @@ def make_worktree(repo: Path, ref: str, root: Path, label: str) -> Path:
     return wt
 
 
+def worktree_env(wt: Path) -> dict:
+    """Return an environment that keeps Zig local caches isolated per worktree."""
+    env = os.environ.copy()
+    inherited_local = env.pop("ZIG_LOCAL_CACHE_DIR", None)
+    # setup-zig exports both cache dirs to the checkout's .zig-cache. This
+    # script builds two temporary worktrees; sharing that local cache lets the
+    # target ref reuse baseline artifacts, so leave each worktree on its own
+    # default .zig-cache. If the global cache aliases that local cache, move it
+    # to the comparison temp root instead.
+    if inherited_local and env.get("ZIG_GLOBAL_CACHE_DIR") == inherited_local:
+        global_cache = wt.parent / "zig-global-cache"
+        global_cache.mkdir(exist_ok=True)
+        env["ZIG_GLOBAL_CACHE_DIR"] = str(global_cache)
+    return env
+
+
 def overlay_harness(source_repo: Path, wt: Path) -> None:
     for rel in HARNESS_OVERLAY:
         src = source_repo / rel
@@ -118,7 +134,7 @@ def build_and_run(
     wasmtime_path: str,
     wasmtime_iterations: int | None,
 ) -> list[Measurement]:
-    env = os.environ.copy()
+    env = worktree_env(wt)
     overlay_harness(source_repo, wt)
 
     print(f"[harness] building {wt.name} (ReleaseFast)", file=sys.stderr)

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -4786,7 +4786,10 @@ pub const default_passes: []const PassFn = &.{
     &strengthReduceDivRem,
     &foldConstantBranches,
     &foldInverseCompareEqz,
-    &foldBranchOnEqz,
+    // `foldBranchOnEqz` is semantically valid, but on AArch64 it flips hot
+    // CoreMark loop branches into the taken conditional path and regresses AOT
+    // throughput heavily. Keep the pass available for future target-aware use,
+    // but do not enable it in the target-independent default pipeline.
     &threadChainedConditionalBranches,
     &foldSelectOnEqz,
     &foldSignExtendingLoad,
@@ -7361,6 +7364,12 @@ test "foldBranchOnEqz: pipeline drops dead eqz after DCE" {
     // eqz should be gone; only the br_if remains.
     try std.testing.expectEqual(@as(usize, 1), func.getBlock(b0).instructions.items.len);
     try std.testing.expect(func.getBlock(b0).instructions.items[0].op == .br_if);
+}
+
+test "default pipeline excludes foldBranchOnEqz until branch layout is target-aware" {
+    for (default_passes) |pass| {
+        try std.testing.expect(pass != &foldBranchOnEqz);
+    }
 }
 
 test "threadChainedConditionalBranches: true edge jumps to inner true target" {


### PR DESCRIPTION
## Summary
- disable `foldBranchOnEqz` in the target-independent default IR pass pipeline because it regresses AArch64 CoreMark AOT by flipping hot loop branch polarity
- keep the pass implementation and direct unit tests available for future target-aware branch-layout work
- add a default-pipeline unit guard so the pass cannot be accidentally re-enabled
- make the AArch64 CoreMark workflow fail PRs whose target mean regresses more than 5% vs baseline while still uploading/commenting the comparison table

## Validation
- `zig build test`
- `python3 -m py_compile scripts/bench_coremark.py`
- patched branch direct CoreMark AOT: `8619.389316` iter/s
- comparison gate: baseline `4667.5` iter/s, target `8655.6` iter/s, Δ `+85.44%`