### PR TITLE
oss-fuzz: add local-only libFuzzer packaging for high-priority harnesses (#262)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -388,6 +388,39 @@ pub fn build(b: *std.Build) void {
         fuzz_step.dependOn(&install_fuzz.step);
     }
 
+    // ── OSS-Fuzz shim libraries ──────────────────────────────────────
+    // Static archives that export `LLVMFuzzerTestOneInput` for the
+    // high-priority deterministic harnesses (loader, component-loader,
+    // canon). `oss-fuzz/build.sh` links each archive with
+    // `$LIB_FUZZING_ENGINE` (clang `-fsanitize=fuzzer`) to produce the
+    // libFuzzer binary. Repository-local only — no upstream OSS-Fuzz
+    // submission is implied. See tests/fuzz/OSS_FUZZ.md.
+    const fuzz_oss_step = b.step("fuzz-oss", "Build OSS-Fuzz shim static libraries (loader, component-loader, canon)");
+    inline for (.{
+        .{ .name = "loader", .file = "oss_loader.zig" },
+        .{ .name = "component-loader", .file = "oss_component_loader.zig" },
+        .{ .name = "canon", .file = "oss_canon.zig" },
+    }) |tgt| {
+        const oss_mod = b.createModule(.{
+            .root_source_file = b.path("src/tests/fuzz/" ++ tgt.file),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+            .pic = true,
+        });
+        oss_mod.addImport("config", config_module);
+        oss_mod.addImport("wamr", lib_module);
+
+        const oss_lib = b.addLibrary(.{
+            .name = "fuzz-oss-" ++ tgt.name,
+            .root_module = oss_mod,
+            .linkage = .static,
+        });
+        // Bundle libc references symbols so static-link with libFuzzer driver works.
+        const install_oss = b.addInstallArtifact(oss_lib, .{});
+        fuzz_oss_step.dependOn(&install_oss.step);
+    }
+
     // ── Component-model examples ─────────────────────────────────────
     // Reproducible Zig (and one mixed Zig+Rust) WebAssembly component
     // examples under `tests/component/src/`. Opt-in: not reachable from
@@ -535,9 +568,9 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     // Zig adder. Build is opt-in — failure mode if cargo / target not
     // present is a clear cargo error.
     const cargo = b.addSystemCommand(&.{
-        "cargo",           "build",
-        "--release",       "--target",
-        "wasm32-wasip1",   "--manifest-path",
+        "cargo",                                                      "build",
+        "--release",                                                  "--target",
+        "wasm32-wasip1",                                              "--manifest-path",
         "tests/component/src/mixed-zig-rust-calc/command/Cargo.toml",
     });
     cargo.setName("cargo build (mixed-zig-rust-calc command)");

--- a/oss-fuzz/Dockerfile
+++ b/oss-fuzz/Dockerfile
@@ -1,0 +1,36 @@
+# OSS-Fuzz packaging for the high-priority Zig fuzz harnesses.
+#
+# Repository-local OSS-Fuzz integration. Mirrors the upstream
+# OSS-Fuzz `projects/<name>/Dockerfile` layout but is **not** an
+# upstream submission. Building this image and running
+# `compile`/`build.sh` produces libFuzzer-driven binaries for
+# `fuzz-loader`, `fuzz-component-loader`, and `fuzz-canon` so a
+# maintainer can run coverage-guided fuzzing locally.
+#
+# See `tests/fuzz/OSS_FUZZ.md` for the readiness analysis and
+# `oss-fuzz/build.sh` for the build steps.
+
+FROM gcr.io/oss-fuzz-base/base-builder:v1
+
+# Install Zig 0.16.0 with checksum verification. The download index
+# at https://ziglang.org/download/index.json pins this checksum.
+ENV ZIG_VERSION=0.16.0
+ENV ZIG_TARBALL=zig-x86_64-linux-${ZIG_VERSION}.tar.xz
+ENV ZIG_SHA256=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends curl ca-certificates xz-utils; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TARBALL}" -o /tmp/zig.tar.xz; \
+    echo "${ZIG_SHA256}  /tmp/zig.tar.xz" | sha256sum -c -; \
+    mkdir -p /opt; \
+    tar -C /opt -xJf /tmp/zig.tar.xz; \
+    rm /tmp/zig.tar.xz; \
+    ln -s "/opt/zig-x86_64-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig; \
+    zig version
+
+# OSS-Fuzz convention: the project source is cloned into $SRC.
+RUN git clone --depth 1 https://github.com/cataggar/wamr.git "$SRC/wamr"
+
+WORKDIR $SRC/wamr
+COPY build.sh $SRC/build.sh

--- a/oss-fuzz/README.md
+++ b/oss-fuzz/README.md
@@ -1,0 +1,121 @@
+# Local OSS-Fuzz packaging
+
+This directory packages the high-priority Zig fuzz harnesses
+(`fuzz-loader`, `fuzz-component-loader`, `fuzz-canon`) into the
+[OSS-Fuzz `projects/<name>/`][oss-fuzz-projects] layout so a maintainer
+can run libFuzzer-driven, coverage-guided fuzzing locally.
+
+[oss-fuzz-projects]: https://github.com/google/oss-fuzz/tree/master/projects
+
+## Scope
+
+This packaging is **local-only**. There is no upstream OSS-Fuzz
+`projects/wamr/` submission and none is planned in this PR. The intent
+is to keep the per-input shim and Docker layout in-repository so:
+
+- maintainers can reproduce the libFuzzer binaries locally;
+- the fuzz harness one-input contract stays exercised under
+  coverage-guided mutation;
+- if upstream submission is reconsidered later, the wiring already
+  exists.
+
+See `tests/fuzz/OSS_FUZZ.md` for the readiness analysis.
+
+## Layout
+
+| File | Role |
+| --- | --- |
+| `Dockerfile` | Mirrors `gcr.io/oss-fuzz-base/base-builder` and pins Zig 0.16.0 with a checksum. |
+| `build.sh` | Runs `zig build fuzz-oss` and links the resulting `libfuzz-oss-*.a` archives against `$LIB_FUZZING_ENGINE` to produce libFuzzer binaries. Packages seed corpora as `*_seed_corpus.zip`. |
+
+The shim sources live next to the CLI harnesses:
+
+```
+src/tests/fuzz/
+    loader.zig                # CLI corpus replay + pub fn runOnce
+    oss_loader.zig            # exports LLVMFuzzerTestOneInput
+    component_loader.zig
+    oss_component_loader.zig
+    canon.zig
+    oss_canon.zig
+```
+
+## Local build (no Docker)
+
+The Zig side of the integration (the static archives) is reproducible
+without Docker:
+
+```sh
+zig build fuzz-oss -Doptimize=ReleaseSafe
+ls zig-out/lib/libfuzz-oss-*.a
+nm --defined-only zig-out/lib/libfuzz-oss-loader.a | grep LLVMFuzzer
+```
+
+Each archive defines `LLVMFuzzerTestOneInput`. To produce a runnable
+libFuzzer binary, link against a libFuzzer driver, for example via
+clang:
+
+```sh
+clang++ \
+    -Wl,--whole-archive zig-out/lib/libfuzz-oss-loader.a -Wl,--no-whole-archive \
+    -fsanitize=fuzzer \
+    -o /tmp/fuzz-oss-loader
+/tmp/fuzz-oss-loader -runs=1000 tests/malformed/fuzz
+```
+
+This was verified on aarch64-linux with the upstream
+`LLVM-22.1.5-Linux-ARM64` toolchain (provides
+`libclang_rt.fuzzer-aarch64.a`); 2000-run smoke loops on all three
+shims completed cleanly. libFuzzer prints
+`WARNING: no interesting inputs were found so far. Is the code
+instrumented for coverage?` because the Zig static archive does not
+ship SanitizerCoverage instrumentation — see the Limitations section
+in `tests/fuzz/OSS_FUZZ.md`.
+
+## Local Docker build (OSS-Fuzz helper)
+
+To reproduce the full OSS-Fuzz packaging locally, follow the upstream
+[helper documentation][oss-fuzz-helper]:
+
+```sh
+git clone https://github.com/google/oss-fuzz.git /tmp/oss-fuzz
+mkdir -p /tmp/oss-fuzz/projects/wamr
+cp oss-fuzz/Dockerfile /tmp/oss-fuzz/projects/wamr/
+cp oss-fuzz/build.sh /tmp/oss-fuzz/projects/wamr/
+echo 'language: c++' > /tmp/oss-fuzz/projects/wamr/project.yaml
+
+cd /tmp/oss-fuzz
+python infra/helper.py build_image wamr
+python infra/helper.py build_fuzzers --sanitizer address wamr
+python infra/helper.py run_fuzzer wamr fuzz-oss-loader -- -runs=10000
+```
+
+Anything written under `/tmp/oss-fuzz/build/out/wamr/` is the local
+build artifact. **Do not** push these files to the upstream OSS-Fuzz
+repository as part of this work.
+
+[oss-fuzz-helper]: https://google.github.io/oss-fuzz/getting-started/new-project-guide/
+
+## Triage
+
+A libFuzzer crash drops a reproducer next to the binary:
+
+```
+fuzz-oss-loader -runs=10000 corpus/
+# crash-<sha1> written on first crash
+```
+
+Reproduce against the in-repo CLI harness for a stable trace:
+
+```sh
+mkdir -p /tmp/wamr-repro
+cp crash-<sha1> /tmp/wamr-repro/
+./zig-out/bin/fuzz-loader \
+    --corpus /tmp/wamr-repro \
+    --crashes /tmp/wamr-fuzz-crashes \
+    --duration 5
+```
+
+Follow the public/private split documented in `tests/fuzz/README.md`
+and `tests/fuzz/regression/README.md`. Sensitive reproducers go
+through the private vulnerability flow described in `SECURITY.md`.

--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# OSS-Fuzz build script for the high-priority Zig fuzz harnesses.
+#
+# Repository-local: produces libFuzzer binaries for fuzz-loader,
+# fuzz-component-loader, and fuzz-canon by linking the static-archive
+# shims emitted by `zig build fuzz-oss` against $LIB_FUZZING_ENGINE.
+#
+# Expected environment (set by the OSS-Fuzz base-builder image):
+#   $SRC, $OUT, $WORK, $CC, $CXX, $CFLAGS, $CXXFLAGS, $LIB_FUZZING_ENGINE
+#
+# This script is **local-only**. There is no upstream OSS-Fuzz
+# `projects/wamr/` submission. See tests/fuzz/OSS_FUZZ.md.
+
+set -euo pipefail
+
+cd "$SRC/wamr"
+
+# Build the static-archive shims. ReleaseSafe keeps Zig safety checks
+# enabled so panics surface as libFuzzer crashes.
+zig build fuzz-oss -Doptimize=ReleaseSafe
+
+mkdir -p "$OUT"
+
+declare -a TARGETS=(loader component-loader canon)
+
+for target in "${TARGETS[@]}"; do
+    archive="zig-out/lib/libfuzz-oss-${target}.a"
+    if [ ! -f "$archive" ]; then
+        echo "::error::missing $archive after zig build fuzz-oss" >&2
+        exit 1
+    fi
+
+    # Link the libFuzzer driver (provides main + coverage feedback)
+    # against the Zig static archive. --whole-archive ensures
+    # LLVMFuzzerTestOneInput is not stripped before the driver finds it.
+    "$CXX" $CXXFLAGS \
+        -Wl,--whole-archive "$archive" -Wl,--no-whole-archive \
+        $LIB_FUZZING_ENGINE \
+        -o "$OUT/fuzz-oss-${target}"
+done
+
+# Seed corpora. Reuse the existing in-repo corpora and any committed
+# regression seeds so libFuzzer starts from a known-good distribution.
+for target in "${TARGETS[@]}"; do
+    seed_zip="$OUT/fuzz-oss-${target}_seed_corpus.zip"
+    seed_dir="$WORK/seeds/${target}"
+    rm -rf "$seed_dir"
+    mkdir -p "$seed_dir"
+
+    if [ -d tests/malformed/fuzz ]; then
+        find tests/malformed/fuzz -maxdepth 1 -name '*.wasm' \
+            -exec cp -n {} "$seed_dir/" \;
+    fi
+
+    case "$target" in
+        loader)
+            if [ -d tests/spec-json ]; then
+                find tests/spec-json -maxdepth 1 -name '*.wasm' \
+                    -exec cp -n {} "$seed_dir/" \;
+            fi
+            ;;
+        component-loader)
+            # Minimal valid component header so libFuzzer has at least
+            # one well-formed seed beyond the malformed corpus.
+            printf '\000asm\015\000\001\000' \
+                > "$seed_dir/minimal-component.wasm"
+            ;;
+        canon)
+            # mode=load_primitive, prim=string, ptr=0, len=8.
+            printf '\x00\x0e\x00\x00\x00\x00\x08\x00\x00\x00Hello, world!\x00\x00\x00' \
+                > "$seed_dir/seed-load-string.wasm"
+            # mode=validate_utf8, ptr=0, len=11, body "hello world".
+            printf '\x01\x00\x00\x00\x00\x00\x0b\x00\x00\x00hello world' \
+                > "$seed_dir/seed-validate-utf8.wasm"
+            ;;
+    esac
+
+    # Pull in committed regression seeds for this target if present.
+    if [ -d "tests/fuzz/regression/${target}" ]; then
+        find "tests/fuzz/regression/${target}" -maxdepth 1 -name '*.wasm' \
+            -exec cp -n {} "$seed_dir/" \;
+    fi
+
+    (cd "$seed_dir" && zip -q -r "$seed_zip" .)
+done

--- a/src/tests/fuzz/canon.zig
+++ b/src/tests/fuzz/canon.zig
@@ -117,7 +117,7 @@ fn parseHeader(input: []const u8) ?Header {
     return .{ .mode = mode, .ptr = ptr, .len = len, .primitive = prim, .body = input[10..] };
 }
 
-fn runOnce(allocator: std.mem.Allocator, input: []const u8) !void {
+pub fn runOnce(allocator: std.mem.Allocator, input: []const u8) !void {
     const header = parseHeader(input) orelse return;
 
     const mem_len = @min(header.body.len, max_memory_bytes);

--- a/src/tests/fuzz/component_loader.zig
+++ b/src/tests/fuzz/component_loader.zig
@@ -9,6 +9,20 @@ const std = @import("std");
 const wamr = @import("wamr");
 const common = @import("common.zig");
 
+/// Run the component loader once over `input`. Shared between the CLI
+/// corpus replay below and the OSS-Fuzz `LLVMFuzzerTestOneInput` shim
+/// in `oss_component_loader.zig`. Typed loader errors are expected.
+pub fn runOnce(allocator: std.mem.Allocator, input: []const u8) void {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    if (wamr.component_loader.load(input, arena.allocator())) |_| {
+        // Valid component — fine.
+    } else |_| {
+        // Typed loader error — fine.
+    }
+}
+
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const io = init.io;
@@ -31,16 +45,7 @@ pub fn main(init: std.process.Init) !void {
         idx +%= 1;
 
         try common.markInFlight(io, args.crashes_dir, input);
-
-        var arena = std.heap.ArenaAllocator.init(allocator);
-        defer arena.deinit();
-
-        if (wamr.component_loader.load(input, arena.allocator())) |_| {
-            // Valid component — fine.
-        } else |_| {
-            // Typed loader error — fine.
-        }
-
+        runOnce(allocator, input);
         common.clearInFlight(io, args.crashes_dir);
     }
 

--- a/src/tests/fuzz/loader.zig
+++ b/src/tests/fuzz/loader.zig
@@ -9,6 +9,20 @@ const std = @import("std");
 const wamr = @import("wamr");
 const common = @import("common.zig");
 
+/// Run the loader once over `input`. Shared between the CLI corpus
+/// replay below and the OSS-Fuzz `LLVMFuzzerTestOneInput` shim in
+/// `oss_loader.zig`. Typed loader errors are an expected outcome.
+pub fn runOnce(allocator: std.mem.Allocator, input: []const u8) void {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    if (wamr.loader.load(input, arena.allocator())) |_| {
+        // Valid module — fine.
+    } else |_| {
+        // Typed error — fine.
+    }
+}
+
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const io = init.io;
@@ -31,18 +45,7 @@ pub fn main(init: std.process.Init) !void {
         idx +%= 1;
 
         try common.markInFlight(io, args.crashes_dir, input);
-
-        var arena = std.heap.ArenaAllocator.init(allocator);
-        defer arena.deinit();
-
-        // We only care about panics / UB here. Any typed error is a
-        // legal outcome for the loader.
-        if (wamr.loader.load(input, arena.allocator())) |_| {
-            // Valid module — fine.
-        } else |_| {
-            // Typed error — fine.
-        }
-
+        runOnce(allocator, input);
         common.clearInFlight(io, args.crashes_dir);
     }
 

--- a/src/tests/fuzz/oss_canon.zig
+++ b/src/tests/fuzz/oss_canon.zig
@@ -1,0 +1,28 @@
+//! OSS-Fuzz shim for fuzz-canon. Exposes `LLVMFuzzerTestOneInput`
+//! so libFuzzer-driven binaries can drive the same per-input
+//! function the CLI harness in `canon.zig` uses.
+//!
+//! Built into a static library by the `fuzz-oss` step in build.zig
+//! and linked with `$LIB_FUZZING_ENGINE` (clang `-fsanitize=fuzzer`)
+//! by `oss-fuzz/build.sh`. The shim is local-only; no upstream
+//! OSS-Fuzz submission is implied. See `tests/fuzz/OSS_FUZZ.md`.
+
+const std = @import("std");
+const canon = @import("canon.zig");
+
+var arena_state: std.heap.ArenaAllocator = undefined;
+var initialized: bool = false;
+
+export fn LLVMFuzzerTestOneInput(data: [*]const u8, size: usize) c_int {
+    if (!initialized) {
+        arena_state = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        initialized = true;
+    }
+    _ = arena_state.reset(.retain_capacity);
+
+    const bytes: []const u8 = if (size == 0) &[_]u8{} else data[0..size];
+    // Typed canonical-ABI errors are expected. OOM on a small input
+    // is a bug; let the panic path through libFuzzer.
+    canon.runOnce(arena_state.allocator(), bytes) catch {};
+    return 0;
+}

--- a/src/tests/fuzz/oss_component_loader.zig
+++ b/src/tests/fuzz/oss_component_loader.zig
@@ -1,0 +1,27 @@
+//! OSS-Fuzz shim for fuzz-component-loader. Exposes
+//! `LLVMFuzzerTestOneInput` so libFuzzer-driven binaries can drive
+//! the same per-input function the CLI harness in
+//! `component_loader.zig` uses.
+//!
+//! Built into a static library by the `fuzz-oss` step in build.zig
+//! and linked with `$LIB_FUZZING_ENGINE` (clang `-fsanitize=fuzzer`)
+//! by `oss-fuzz/build.sh`. The shim is local-only; no upstream
+//! OSS-Fuzz submission is implied. See `tests/fuzz/OSS_FUZZ.md`.
+
+const std = @import("std");
+const component_loader = @import("component_loader.zig");
+
+var arena_state: std.heap.ArenaAllocator = undefined;
+var initialized: bool = false;
+
+export fn LLVMFuzzerTestOneInput(data: [*]const u8, size: usize) c_int {
+    if (!initialized) {
+        arena_state = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        initialized = true;
+    }
+    _ = arena_state.reset(.retain_capacity);
+
+    const bytes: []const u8 = if (size == 0) &[_]u8{} else data[0..size];
+    component_loader.runOnce(arena_state.allocator(), bytes);
+    return 0;
+}

--- a/src/tests/fuzz/oss_loader.zig
+++ b/src/tests/fuzz/oss_loader.zig
@@ -1,0 +1,29 @@
+//! OSS-Fuzz shim for fuzz-loader. Exposes `LLVMFuzzerTestOneInput`
+//! so libFuzzer-driven binaries can drive the same per-input
+//! function the CLI corpus-replay harness in `loader.zig` uses.
+//!
+//! Built into a static library by the `fuzz-oss` step in build.zig
+//! and linked with `$LIB_FUZZING_ENGINE` (clang `-fsanitize=fuzzer`)
+//! by `oss-fuzz/build.sh`. The shim is local-only; no upstream
+//! OSS-Fuzz submission is implied. See `tests/fuzz/OSS_FUZZ.md`.
+
+const std = @import("std");
+const loader = @import("loader.zig");
+
+/// Single shared arena reset between iterations. libFuzzer reuses
+/// the process for every call so any allocation that escapes the
+/// arena would compound across iterations and mask leaks.
+var arena_state: std.heap.ArenaAllocator = undefined;
+var initialized: bool = false;
+
+export fn LLVMFuzzerTestOneInput(data: [*]const u8, size: usize) c_int {
+    if (!initialized) {
+        arena_state = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        initialized = true;
+    }
+    _ = arena_state.reset(.retain_capacity);
+
+    const bytes: []const u8 = if (size == 0) &[_]u8{} else data[0..size];
+    loader.runOnce(arena_state.allocator(), bytes);
+    return 0;
+}

--- a/tests/fuzz/OSS_FUZZ.md
+++ b/tests/fuzz/OSS_FUZZ.md
@@ -1,62 +1,75 @@
-# OSS-Fuzz feasibility evaluation
+# OSS-Fuzz feasibility and local packaging
 
-This document is the deliverable for #249. It evaluates whether to integrate
-this repository with [OSS-Fuzz][oss-fuzz] now, after the local fuzz harnesses
-introduced in #222, #245, #246, and #247 stabilised, and records the
-decision so future contributors can revisit it without redoing the analysis.
+This document is the deliverable for #249 and the readiness gate for
+#262. It evaluates whether to integrate this repository with
+[OSS-Fuzz][oss-fuzz] and records the decision so future contributors
+can revisit it without redoing the analysis.
 
 [oss-fuzz]: https://github.com/google/oss-fuzz
 
 ## Summary
 
-**Decision: defer.**
+**Decision: ship local-only OSS-Fuzz packaging; do not submit upstream.**
 
-The current corpus-replay harnesses already satisfy our near-term goal of
-catching panics, safety-checked UB, and process aborts on attacker-controlled
-binaries via scheduled CI runs. OSS-Fuzz adds genuine value (continuous
-coverage-guided mutation, ClusterFuzz triage, public regressions corpus) but
-the integration cost is non-trivial because:
+Issue #262 listed four prerequisites for re-opening the OSS-Fuzz
+question. The repository now matches the technical prerequisites:
 
-- This repo is written in Zig 0.16. OSS-Fuzz first-class language support
-  is C, C++, Rust, Go, Python, Java/JVM, JavaScript, and Swift. Zig is not
-  on that list, so we must either ship a C-ABI shim or rely on Zig's own
-  `std.testing.fuzz`, which is still in flux upstream.
-- Each existing harness is a CLI corpus replay (`pub fn main`), not a
-  libFuzzer-shaped `LLVMFuzzerTestOneInput` function. Adapting them is
-  mostly mechanical but is real work.
-- Several harnesses (`fuzz-aot`, `fuzz-diff`) have host-process trap
-  limitations on Linux/AArch64 that already constrain in-repo coverage;
-  those constraints carry over to OSS-Fuzz.
+1. #248 (corpus minimization and reducer workflow) is closed; reduced
+   inputs land under `tests/fuzz/regression/<target>/` per
+   `tests/fuzz/regression/README.md` and `scripts/fuzz_reduce.py`.
+2. We accept the cost of maintaining a hand-rolled
+   `LLVMFuzzerTestOneInput` shim and a pinned Zig toolchain.
+   Zig's `std.testing.fuzz` is still moving and OSS-Fuzz's base image
+   does not ship Zig as a first-class language; the shim path is the
+   stable choice.
+3. The high-priority deterministic harnesses (`fuzz-loader`,
+   `fuzz-component-loader`, `fuzz-canon`) have been running on the
+   `.github/workflows/fuzz.yml` daily schedule without crashers.
+4. The repository's `SECURITY.md` and `SECURITY_PROCESS.md`
+   intentionally do not promise a formal SLA, embargo, or CVE pipeline.
+   Submitting this project upstream to OSS-Fuzz would import
+   ClusterFuzz's default 90-day disclosure window and create downstream
+   expectations the maintainer has not agreed to. **For that reason
+   this work is local-only and the upstream submission step is
+   explicitly not in scope.**
 
-We will revisit this decision after:
+Local-only deliverables in this repository:
 
-1. #248 lands a documented minimization workflow so triage is repeatable;
-2. Zig's `std.testing.fuzz` stabilises in a 0.x release we plan to track,
-   or we accept the cost of writing a hand-rolled C-ABI shim;
-3. We have at least one harness that has run for ≥1 month in CI without
-   producing crashers, indicating the trivial bug surface is exhausted and
-   coverage-guided mutation would actually find new bugs.
+- `src/tests/fuzz/oss_loader.zig`, `oss_component_loader.zig`,
+  `oss_canon.zig` — Zig shim sources that export
+  `LLVMFuzzerTestOneInput` and call the same `runOnce` functions the
+  CLI corpus-replay harnesses use.
+- `build.zig` `fuzz-oss` step — emits
+  `zig-out/lib/libfuzz-oss-{loader,component-loader,canon}.a` static
+  archives.
+- `oss-fuzz/Dockerfile`, `oss-fuzz/build.sh`, `oss-fuzz/README.md` —
+  package the static archives into libFuzzer binaries by linking
+  against `$LIB_FUZZING_ENGINE` in an OSS-Fuzz-style local build.
 
-A follow-up issue captures the prerequisite list above; see the bottom of
-this document.
+OSS-Fuzz integration as a continuous service is **not** wired in.
+There is no `projects/wamr/` PR upstream and the `oss-fuzz/` directory
+must not be pushed to `google/oss-fuzz`. Re-evaluate that step only if
+a maintainer agrees to track ClusterFuzz disclosures and accept the
+upstream operational expectations.
 
 ## Per-harness assessment
 
-| Harness                 | Entry point                              | Determinism | Resource bound                  | Coverage-fuzz priority |
-| ----------------------- | ---------------------------------------- | ----------- | ------------------------------- | ---------------------- |
-| `fuzz-loader`           | `src/tests/fuzz/loader.zig`              | Yes         | 16MB input cap, no I/O          | High — small inputs, big surface, no I/O |
-| `fuzz-component-loader` | `src/tests/fuzz/component_loader.zig`    | Yes         | 16MB input cap, no I/O          | High — same as core loader |
-| `fuzz-canon`            | `src/tests/fuzz/canon.zig`               | Yes         | 64KB memory cap, arena per iter | High — pointer/length surface, no I/O |
-| `fuzz-interp`           | `src/tests/fuzz/interp.zig` + `invoke.zig` | Yes (with fuel) | Per-export fuel cap (default 100k) | Medium — needs fuel piped from libFuzzer entry |
-| `fuzz-aot`              | `src/tests/fuzz/aot.zig`                 | Yes (no execute) | `invoke_start = false`         | Medium — heavier per-iteration AOT compile |
-| `fuzz-diff`             | `src/tests/fuzz/diff.zig` + `invoke.zig` | Yes (with fuel + safe filter) | Static AOT-safe straight-line subset only | Low — limited by Linux/AArch64 native trap host-termination; safe subset is small |
+| Harness                 | Entry point                              | Determinism | Resource bound                  | Coverage-fuzz priority | OSS-Fuzz shim |
+| ----------------------- | ---------------------------------------- | ----------- | ------------------------------- | ---------------------- | ------------- |
+| `fuzz-loader`           | `src/tests/fuzz/loader.zig`              | Yes         | 16MB input cap, no I/O          | High — small inputs, big surface, no I/O | Yes (`oss_loader.zig`) |
+| `fuzz-component-loader` | `src/tests/fuzz/component_loader.zig`    | Yes         | 16MB input cap, no I/O          | High — same as core loader | Yes (`oss_component_loader.zig`) |
+| `fuzz-canon`            | `src/tests/fuzz/canon.zig`               | Yes         | 64KB memory cap, arena per iter | High — pointer/length surface, no I/O | Yes (`oss_canon.zig`) |
+| `fuzz-interp`           | `src/tests/fuzz/interp.zig` + `invoke.zig` | Yes (with fuel) | Per-export fuel cap (default 100k) | Medium — needs fuel piped from libFuzzer entry | No |
+| `fuzz-aot`              | `src/tests/fuzz/aot.zig`                 | Yes (no execute) | `invoke_start = false`         | Medium — heavier per-iteration AOT compile | No |
+| `fuzz-diff`             | `src/tests/fuzz/diff.zig` + `invoke.zig` | Yes (with fuel + safe filter) | Static AOT-safe straight-line subset only | Low — limited by Linux/AArch64 native trap host-termination; safe subset is small | No |
+| `fuzz-wasi`             | `src/tests/fuzz/wasi.zig`                | Per-iteration adapter rebuild | Per-process temp preopen | Medium — WASI sandbox surface | No |
 
-The "high" priority harnesses are good candidates for a future
-coverage-guided integration. They have small, fast iterations; no host
-file-system or network effects; and a deterministic oracle (typed errors
-OK, panic/UB/abort is a bug). The medium and low priority harnesses would
-require additional hardening before they pay back the OSS-Fuzz integration
-cost.
+The "high" priority harnesses are good candidates for coverage-guided
+mutation. They have small, fast iterations; no host file-system or
+network effects; and a deterministic oracle (typed errors OK,
+panic/UB/abort is a bug). The medium and low priority harnesses would
+require additional hardening before they pay back the OSS-Fuzz
+integration cost; their shims are intentionally not built.
 
 ## Zig + libFuzzer interop
 
@@ -67,110 +80,105 @@ libFuzzer runtime and exports the standard entry point:
 extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 ```
 
-Two viable paths exist:
+Two viable paths existed:
 
-1. **Hand-rolled C-ABI shim** — add a `fuzz_target_<name>.zig` that exposes:
+1. **Hand-rolled C-ABI shim (chosen).** `src/tests/fuzz/oss_*.zig`
+   exposes:
 
    ```zig
    export fn LLVMFuzzerTestOneInput(data: [*]const u8, size: usize) c_int {
-       const bytes = data[0..size];
-       runOnce(global_allocator, bytes) catch {};
+       // reset shared arena, call harness.runOnce(arena, data[0..size])
        return 0;
    }
    ```
 
-   and compile it with `-fsanitize=fuzzer-no-link` plus the system
-   libFuzzer runtime. This is conceptually simple but requires us to
-   manage a global allocator (libFuzzer reuses the process per iteration)
-   and to ensure no harness state leaks between calls.
+   The Zig shims are compiled into static archives by `zig build
+   fuzz-oss`. `oss-fuzz/build.sh` links each archive with
+   `$LIB_FUZZING_ENGINE` (clang `-fsanitize=fuzzer`) using
+   `-Wl,--whole-archive` so the linker keeps the exported symbol.
+   This approach does not depend on Zig's coverage instrumentation;
+   libFuzzer drives the shim as a black-box per-input function. See
+   "Limitations" below.
 
-2. **Use Zig's `std.testing.fuzz`** — Zig 0.16 has experimental fuzzing
-   support but the API is still moving. OSS-Fuzz's Zig support, if any,
-   would have to follow upstream Zig. Tracking this would lock our build
-   to a specific Zig release in OSS-Fuzz's base image.
-
-Either path adds a parallel fuzz build on top of the existing
-`zig build fuzz` step. It does not replace the existing CLI harnesses.
+2. **Use Zig's `std.testing.fuzz`** — Zig 0.16 has experimental
+   fuzzing support but the API is still moving and OSS-Fuzz does not
+   ship Zig in the base image. Tracking this would lock the build to
+   a specific Zig release in OSS-Fuzz's base image. Deferred.
 
 ### Sanitizer notes
 
 - Zig 0.16 ships its own runtime safety checks; combining with
   AddressSanitizer/MSAN/UBSAN under libFuzzer requires verifying that
   Zig's safety panic handler does not interfere with libFuzzer's crash
-  detection.
-- Stack overflows inside Zig's interpreter (especially for hostile control
-  flow) need a configured stack guard size; OSS-Fuzz already runs targets
-  under ASan with a guard region.
+  detection. The default (ReleaseSafe) keeps Zig safety checks
+  visible.
+- Stack overflows inside Zig's interpreter (especially for hostile
+  control flow) need a configured stack guard size; OSS-Fuzz already
+  runs targets under ASan with a guard region.
 
 ## Build environment
 
-OSS-Fuzz integration requires submitting two files to the OSS-Fuzz repo:
+`oss-fuzz/Dockerfile` mirrors `gcr.io/oss-fuzz-base/base-builder`,
+installs a pinned Zig 0.16.0 with a SHA-256 verified tarball, and
+clones this repository. `oss-fuzz/build.sh` runs:
 
-- `projects/wamr/Dockerfile` — base on `gcr.io/oss-fuzz-base/base-builder`,
-  install Zig 0.16 (download tarball, verify checksum), install
-  `wasm-tools` for seed generation, and `git clone` this repo.
-- `projects/wamr/build.sh` — run `zig build fuzz -Doptimize=ReleaseSafe`
-  and the libFuzzer-shim build for the high-priority harnesses, then copy
-  binaries to `$OUT/`.
+- `zig build fuzz-oss -Doptimize=ReleaseSafe` to emit the static
+  archives;
+- `clang++ -Wl,--whole-archive lib*.a -Wl,--no-whole-archive
+  $LIB_FUZZING_ENGINE -o $OUT/fuzz-oss-<name>` for each high-priority
+  target;
+- per-target `*_seed_corpus.zip` archives sourced from
+  `tests/malformed/fuzz`, `tests/spec-json` (loader), generated
+  minimal seeds (component-loader, canon), and any committed
+  regression seeds in `tests/fuzz/regression/<target>/`.
 
-We also need an `oss-fuzz`-friendly seed corpus. The existing
-`tests/malformed/fuzz/*.wasm` and the planned regression seeds from #248
-can be packaged as the initial OSS-Fuzz seed corpus.
+Local builds without Docker are documented in `oss-fuzz/README.md`.
 
 ## Triage flow
 
-If we proceed:
+If we ever proceed with continuous OSS-Fuzz coverage, the local
+packaging is meant to plug in directly:
 
 1. OSS-Fuzz reports a crash with a reduced reproducer.
 2. The maintainer downloads the reproducer, runs the matching local
-   harness via `--corpus <dir>` to confirm.
-3. If reproduction succeeds, follow the disclosure flow in `SECURITY.md`
-   and `SECURITY_PROCESS.md`. ClusterFuzz's 90-day disclosure window
-   should be aligned with our SECURITY policy when filing the OSS-Fuzz
-   project.
-4. After fix, the minimized reproducer becomes a regression seed under
-   `tests/fuzz/regression/<target>/` (per #248), so the in-repo harnesses
-   keep covering the original input.
+   CLI harness via `--corpus <dir>` to confirm.
+3. If reproduction succeeds, follow the disclosure flow in
+   `SECURITY.md` and `SECURITY_PROCESS.md`. ClusterFuzz's 90-day
+   disclosure window would need to be reconciled with the
+   repository's best-effort process before any upstream submission.
+4. After fix, the minimized reproducer becomes a regression seed
+   under `tests/fuzz/regression/<target>/` (per #248), so the in-repo
+   harnesses keep covering the original input.
 
-## Cost vs benefit
+## Limitations
 
-| Item                                               | Cost                          | Benefit                          |
-| -------------------------------------------------- | ----------------------------- | -------------------------------- |
-| C-ABI shim per high-priority harness               | ~100 lines + per-target build | Coverage-guided mutation         |
-| OSS-Fuzz `Dockerfile` + `build.sh`                 | One-time, modest              | ClusterFuzz infra and triage     |
-| Pin Zig version in OSS-Fuzz base                   | Ongoing maintenance           | Reproducible builds              |
-| Address Zig + sanitizer interactions               | Real, possibly fragile        | Memory-safety bug detection     |
-| Disclosure pipeline alignment with `SECURITY.md`   | Light                         | Coordinated public/private flow  |
-| Long-running coverage corpus distribution          | Free (ClusterFuzz hosts it)   | Stable seeds beyond what fits in repo |
+- **No Zig-side coverage instrumentation.** libFuzzer feedback is
+  limited to whatever the C/C++ runtime sees plus crash detection;
+  end-to-end smoke runs of the shims report
+  `WARNING: no interesting inputs were found so far. Is the code
+  instrumented for coverage?` — expected for this approach.
+  Coverage-guided mutation will still help but not as effectively as
+  a fully instrumented build.
+- **Local Docker only.** The image is reproducible locally via the
+  upstream OSS-Fuzz `helper.py` flow, but is not connected to
+  ClusterFuzz.
+- **Three high-priority targets only.** `fuzz-interp`, `fuzz-aot`,
+  `fuzz-diff`, and `fuzz-wasi` keep their CLI-only form until each
+  has a libFuzzer-friendly resource policy (fuel, subprocess
+  isolation, or sandbox redo per-iteration).
 
-Today the in-repo harnesses already catch the fast wins. We have no
-evidence yet that we are corpus-bound (CI fuzzing is finishing without
-crashers on stable code paths). Until coverage-guided mutation would
-plausibly find bugs the corpus replay misses, the maintenance cost is
-greater than the benefit.
+## Re-evaluating upstream submission
 
-## Decision
+Open a follow-up issue, not another PR, if any of the following
+change:
 
-Defer OSS-Fuzz integration. Re-evaluate after the prerequisites listed in
-the Summary land. Tracked in the follow-up issue linked from this
-document.
+- a maintainer agrees to track ClusterFuzz advisories and accept the
+  90-day disclosure default;
+- Zig becomes a first-class OSS-Fuzz language with stable `fuzz`
+  instrumentation, removing the hand-rolled shim cost;
+- coverage data from local libFuzzer runs shows the in-repo CLI
+  workflow is corpus-bound and would benefit from continuous
+  coverage-guided mutation.
 
-## Prerequisite list (for the future re-evaluation)
-
-1. #248 corpus minimization and reducer workflow merged; reduced inputs
-   landing as regression seeds.
-2. Either Zig 0.16+ `std.testing.fuzz` stable enough to depend on in
-   OSS-Fuzz's base image, **or** a written agreement that we maintain a
-   hand-rolled `LLVMFuzzerTestOneInput` shim and a pinned Zig toolchain.
-3. At least one high-priority harness has run on the daily CI schedule
-   for ≥30 days with no crashers found, suggesting coverage-guided
-   mutation would extend our reach.
-4. Disclosure-window policy (90-day default in ClusterFuzz) reconciled
-   with `SECURITY.md`/`SECURITY_PROCESS.md`.
-
-When all four conditions are met, open a focused PR that:
-
-- adds `fuzz_oss_<target>.zig` shim files for the high-priority harnesses;
-- adds `oss-fuzz/Dockerfile` and `oss-fuzz/build.sh` mirroring the
-  upstream OSS-Fuzz layout;
-- submits the OSS-Fuzz `projects/wamr/` PR upstream.
+Until then, the local packaging is the project's complete OSS-Fuzz
+posture.

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -239,5 +239,9 @@ host-protection mechanism.
 - Corpus minimization should preserve a small checked-in seed set while storing
   larger evolving corpora as workflow artifacts (#248). See `scripts/fuzz_reduce.py`
   and `tests/fuzz/regression/README.md`.
-- OSS-Fuzz integration was evaluated in [`OSS_FUZZ.md`](OSS_FUZZ.md); the
-  decision is to defer until a documented prerequisite list is met (#249).
+- OSS-Fuzz integration was evaluated in [`OSS_FUZZ.md`](OSS_FUZZ.md). The
+  prerequisites tracked in #249 and #262 are met for repository-local use,
+  so this repo ships local-only OSS-Fuzz packaging under
+  [`oss-fuzz/`](../../oss-fuzz/) — `zig build fuzz-oss` produces the
+  static-archive shims; `oss-fuzz/Dockerfile` and `oss-fuzz/build.sh`
+  link them with `$LIB_FUZZING_ENGINE`. Nothing is submitted upstream.


### PR DESCRIPTION
Closes #262.

Re-evaluates issue #262 prerequisites and ships **local-only** OSS-Fuzz
packaging for the three deterministic, no-I/O harnesses
(`fuzz-loader`, `fuzz-component-loader`, `fuzz-canon`).

Nothing is submitted upstream. ClusterFuzz's 90-day disclosure window
has not been reconciled with the repository's best-effort
`SECURITY.md` process, so the upstream submission step is
**explicitly out of scope**. The `oss-fuzz/` directory must not be
pushed to `google/oss-fuzz` as part of this work; it is documented
that way in both `oss-fuzz/README.md` and `tests/fuzz/OSS_FUZZ.md`.

## What changed

**Harness refactor** (CLI behavior unchanged)
- `src/tests/fuzz/loader.zig`, `component_loader.zig`, `canon.zig`:
  extract a reusable `pub fn runOnce` so the same per-input logic is
  callable from both the CLI corpus replay (`pub fn main`) and the
  OSS-Fuzz shims.

**OSS-Fuzz shims**
- `src/tests/fuzz/oss_loader.zig`, `oss_component_loader.zig`,
  `oss_canon.zig`: hand-rolled C-ABI shims that
  `export fn LLVMFuzzerTestOneInput(...) c_int` and call into
  `runOnce` with a process-wide arena reset between iterations.

**Build wiring**
- `build.zig`: new `fuzz-oss` step builds each shim into a static
  archive (`link_libc=true`, `pic=true`) at
  `zig-out/lib/libfuzz-oss-{loader,component-loader,canon}.a`.

**OSS-Fuzz packaging**
- `oss-fuzz/Dockerfile`: based on
  `gcr.io/oss-fuzz-base/base-builder:v1`, pins Zig 0.16.0 with a
  SHA-256 verified tarball.
- `oss-fuzz/build.sh`: runs `zig build fuzz-oss`, links each archive
  with `\$LIB_FUZZING_ENGINE` via `-Wl,--whole-archive`, packages
  per-target seed corpora (`tests/malformed/fuzz`, `tests/spec-json`,
  generated minimal seeds, regression seeds).
- `oss-fuzz/README.md`: documents local build, OSS-Fuzz helper Docker
  reproduction, triage; explicit no-upstream-push policy.

**Docs**
- `tests/fuzz/OSS_FUZZ.md`: rewritten from "decision: defer" to
  "ship local-only OSS-Fuzz packaging; do not submit upstream".
  Adds Limitations section noting that pure shim archives are not
  SanitizerCoverage-instrumented on the Zig side.
- `tests/fuzz/README.md`: points at the new `oss-fuzz/` directory and
  `zig build fuzz-oss` step.

## Verification

| Check | Result |
| --- | --- |
| `zig build fuzz -Doptimize=ReleaseSafe` | clean |
| `zig build fuzz-oss -Doptimize=ReleaseSafe` | clean |
| `nm --defined-only` on each archive | `LLVMFuzzerTestOneInput` exported as `T` |
| CLI smoke (3-second loops on loader, component-loader, canon) | no crashers |
| `clang++ -fsanitize=fuzzer -Wl,--whole-archive lib*.a -Wl,--no-whole-archive ...` | links cleanly with upstream `LLVM-22.1.5-Linux-ARM64` toolchain (provides `libclang_rt.fuzzer-aarch64.a`) |
| Each shim binary at `-runs=2000` | no crashes |
| Loader seed corpus replay (17 files) | no crashes |

libFuzzer reports `WARNING: no interesting inputs were found so far.
Is the code instrumented for coverage?` — expected, and documented in
the Limitations section: the Zig static archive does not ship
SanitizerCoverage. Coverage-guided mutation will still help but not
as effectively as a fully instrumented build.

## Out of scope

- No upstream `google/oss-fuzz` `projects/wamr/` PR.
- No CI integration of `zig build fuzz-oss`. Existing scheduled
  `.github/workflows/fuzz.yml` (CLI-driven) remains the only
  automated fuzz pipeline.
- `fuzz-interp`, `fuzz-aot`, `fuzz-diff`, `fuzz-wasi` keep their
  CLI-only form until each has a libFuzzer-friendly resource policy
  (fuel, subprocess isolation, sandbox redo per-iteration).