### PR TITLE
perf(aarch64): add peephole pass — ldp/stp fusion, mul+add → madd, csinc/csinv

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -439,6 +439,7 @@ pub const CallPatch = struct {
 
 pub const CompileOptions = struct {
     enable_scheduler: bool = true,
+    enable_peephole: bool = true,
 };
 
 /// Context threaded through per-function compilation for cross-function
@@ -784,7 +785,7 @@ pub fn compileFunctionImpl(
     var clobbers = try collectClobberPoints(func, block_order, &scheduled, allocator);
     defer clobbers.deinit(allocator);
 
-    var code = emit.CodeBuffer.init(allocator);
+    var code = emit.CodeBuffer.initWithPeephole(allocator, .{ .enabled = ctx.options.enable_peephole });
     errdefer code.deinit();
 
     const local_layout = try computeLocalFrameLayout(func, allocator);
@@ -1134,6 +1135,7 @@ pub fn compileFunctionImpl(
     var last_was_ret = false;
     for (block_order) |bi| {
         block_offsets[bi] = code.len();
+        code.peepholeBarrier();
         for (scheduled.instructions(bi), 0..) |inst, ii| {
             last_was_ret = isRet(inst.op);
             const flat_idx = block_flat_base[bi] + ii;
@@ -1786,10 +1788,12 @@ const nop_word: u32 = 0xd503201f;
 fn emitCalleeSaveStore(code: *emit.CodeBuffer, callee_save_base: u32) ![callee_saved_regs.len]usize {
     var offs: [callee_saved_regs.len]usize = undefined;
     for (callee_saved_regs, 0..) |r, i| {
+        code.peepholeBarrier();
         offs[i] = code.len();
         const off_scaled: u12 = @intCast((callee_save_base + @as(u32, @intCast(i)) * 8) / 8);
         try code.strImm(r, .fp, off_scaled);
     }
+    code.peepholeBarrier();
     return offs;
 }
 
@@ -1799,10 +1803,12 @@ fn emitCalleeSaveStore(code: *emit.CodeBuffer, callee_save_base: u32) ![callee_s
 fn emitCalleeSaveRestore(code: *emit.CodeBuffer, callee_save_base: u32) ![callee_saved_regs.len]usize {
     var offs: [callee_saved_regs.len]usize = undefined;
     for (callee_saved_regs, 0..) |r, i| {
+        code.peepholeBarrier();
         offs[i] = code.len();
         const off_scaled: u12 = @intCast((callee_save_base + @as(u32, @intCast(i)) * 8) / 8);
         try code.ldrImm(r, .fp, off_scaled);
     }
+    code.peepholeBarrier();
     return offs;
 }
 
@@ -11088,7 +11094,7 @@ test "compile: entry spills vmctx to [fp+16]" {
     const v0 = func.newVReg();
     try func.getBlock(bid).append(.{ .op = .{ .iconst_32 = 7 }, .dest = v0, .type = .i32 });
     try func.getBlock(bid).append(.{ .op = .{ .ret = v0 } });
-    const code = try compileFunction(&func, allocator);
+    const code = try compileFunctionWithOptions(&func, allocator, .{ .enable_peephole = false });
     defer allocator.free(code);
     // Layout: prologue (STP + ADD fp,sp,0), then 10 callee-save STRs for
     // x19..x28 (40 bytes), then STR x0 → [fp+16].
@@ -11107,7 +11113,7 @@ test "compile: param spill — STR x1 into first local slot" {
     const v0 = func.newVReg();
     try func.getBlock(bid).append(.{ .op = .{ .local_get = 0 }, .dest = v0, .type = .i32 });
     try func.getBlock(bid).append(.{ .op = .{ .ret = v0 } });
-    const code = try compileFunction(&func, allocator);
+    const code = try compileFunctionWithOptions(&func, allocator, .{ .enable_peephole = false });
     defer allocator.free(code);
     // Layout: STP, ADD fp,sp,0, 10× callee-save STRs (40 bytes), STR x0
     // vmctx, STR x1 local0.
@@ -11127,7 +11133,7 @@ test "compile: zero-init of declared local (beyond params)" {
     const v0 = func.newVReg();
     try func.getBlock(bid).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v0, .type = .i32 });
     try func.getBlock(bid).append(.{ .op = .{ .ret = v0 } });
-    const code = try compileFunction(&func, allocator);
+    const code = try compileFunctionWithOptions(&func, allocator, .{ .enable_peephole = false });
     defer allocator.free(code);
     // Layout (small-frame prologue, 2 words — spill region sized
     // dynamically from vreg count so this function's frame fits in the
@@ -11819,7 +11825,7 @@ test "compile: binop with spilled operands emits LDR/STR via spill slots" {
 
     // Disable local scheduling here: the test targets spill codegen, and the
     // scheduler can legally shorten this synthetic live-pressure pattern.
-    const code = try compileFunctionWithOptions(&func, allocator, .{ .enable_scheduler = false });
+    const code = try compileFunctionWithOptions(&func, allocator, .{ .enable_scheduler = false, .enable_peephole = false });
     defer allocator.free(code);
 
     // Scan for LDR Xt, [fp, #imm] (opcode pattern 0xF9400000 + rn=29<<5).

--- a/src/compiler/codegen/aarch64/emit.zig
+++ b/src/compiler/codegen/aarch64/emit.zig
@@ -5,6 +5,7 @@
 //! than x86-64's variable-length encoding.
 
 const std = @import("std");
+const peephole = @import("peephole.zig");
 
 /// AArch64 general-purpose registers (64-bit X registers).
 pub const Reg = enum(u5) {
@@ -69,9 +70,15 @@ pub const Cond = enum(u4) {
 pub const CodeBuffer = struct {
     bytes: std.ArrayListUnmanaged(u8) = .empty,
     allocator: std.mem.Allocator,
+    peephole_options: peephole.Options = .{ .enabled = false },
+    peephole_barrier: usize = 0,
 
     pub fn init(allocator: std.mem.Allocator) CodeBuffer {
         return .{ .allocator = allocator };
+    }
+
+    pub fn initWithPeephole(allocator: std.mem.Allocator, options: peephole.Options) CodeBuffer {
+        return .{ .allocator = allocator, .peephole_options = options };
     }
 
     pub fn deinit(self: *CodeBuffer) void {
@@ -86,8 +93,35 @@ pub const CodeBuffer = struct {
         return self.bytes.items;
     }
 
+    pub fn peepholeBarrier(self: *CodeBuffer) void {
+        self.peephole_barrier = self.bytes.items.len;
+    }
+
     /// Emit a 4-byte AArch64 instruction word (little-endian).
     fn emit32(self: *CodeBuffer, word: u32) !void {
+        if (self.peephole_options.enabled) {
+            const prev1: ?u32 = if (self.bytes.items.len >= self.peephole_barrier + 4)
+                std.mem.readInt(u32, self.bytes.items[self.bytes.items.len - 4 ..][0..4], .little)
+            else
+                null;
+            const prev2: ?u32 = if (self.bytes.items.len >= self.peephole_barrier + 8)
+                std.mem.readInt(u32, self.bytes.items[self.bytes.items.len - 8 ..][0..4], .little)
+            else
+                null;
+            const result = peephole.optimizeWindow(prev2, prev1, word, self.peephole_options);
+            if (result.replace_last) |replacement| {
+                const bytes = std.mem.toBytes(std.mem.nativeToLittle(u32, replacement));
+                @memcpy(self.bytes.items[self.bytes.items.len - 4 ..][0..4], &bytes);
+                if (result.append_word == null) return;
+            }
+            if (result.append_word) |append| {
+                const bytes = std.mem.toBytes(std.mem.nativeToLittle(u32, append));
+                try self.bytes.appendSlice(self.allocator, &bytes);
+                return;
+            }
+            return;
+        }
+
         const bytes = std.mem.toBytes(std.mem.nativeToLittle(u32, word));
         try self.bytes.appendSlice(self.allocator, &bytes);
     }

--- a/src/compiler/codegen/aarch64/peephole.zig
+++ b/src/compiler/codegen/aarch64/peephole.zig
@@ -1,0 +1,409 @@
+//! Conservative peephole optimizer for emitted AArch64 instruction words.
+//!
+//! The pass is intentionally local: it only rewrites patterns that are proven
+//! equivalent from adjacent instruction encodings, so branch fixups can keep
+//! using normal CodeBuffer offsets while code is emitted.
+
+const std = @import("std");
+
+pub const Options = struct {
+    enabled: bool = true,
+    enable_mem_pair: bool = true,
+    enable_mul_add: bool = true,
+    enable_conditional_select: bool = true,
+};
+
+pub const AppendResult = struct {
+    replace_last: ?u32 = null,
+    append_word: ?u32 = null,
+};
+
+const Width = enum { w32, x64 };
+const MemKind = enum { ldr, str };
+
+const MemUnsigned = struct {
+    kind: MemKind,
+    width: Width,
+    rt: u5,
+    rn: u5,
+    offset: u12,
+};
+
+const Mul = struct {
+    width: Width,
+    rd: u5,
+    rn: u5,
+    rm: u5,
+};
+
+const AddSubReg = struct {
+    is_sub: bool,
+    width: Width,
+    rd: u5,
+    rn: u5,
+    rm: u5,
+};
+
+const AddImm = struct {
+    width: Width,
+    rd: u5,
+    rn: u5,
+    imm: u12,
+};
+
+const CmpImmZero = struct {
+    width: Width,
+    rn: u5,
+};
+
+const Csel = struct {
+    width: Width,
+    rd: u5,
+    rn: u5,
+    rm: u5,
+    cond: u4,
+};
+
+const UnaryTransform = union(enum) {
+    inc: struct { tmp: u5, src: u5, width: Width },
+    inv: struct { tmp: u5, src: u5, width: Width },
+    neg: struct { tmp: u5, src: u5, width: Width },
+};
+
+pub fn optimizeWindow(prev2: ?u32, prev1: ?u32, new_word: u32, options: Options) AppendResult {
+    if (!options.enabled) return .{ .append_word = new_word };
+
+    if (prev1) |last| {
+        if (options.enable_mem_pair) {
+            if (tryFuseMemPair(last, new_word)) |fused| return .{ .replace_last = fused };
+        }
+        if (options.enable_mul_add) {
+            if (tryFuseMulAdd(last, new_word)) |fused| return .{ .replace_last = fused };
+        }
+    }
+
+    if (options.enable_conditional_select) {
+        if (prev2) |transform_word| {
+            if (prev1) |cmp_word| {
+                if (tryConditionalTransform(transform_word, cmp_word, new_word)) |rewritten| {
+                    return .{ .append_word = rewritten };
+                }
+            }
+        }
+    }
+
+    return .{ .append_word = new_word };
+}
+
+pub fn optimizeWords(insts: []const u32, allocator: std.mem.Allocator, options: Options) ![]u32 {
+    var out: std.ArrayListUnmanaged(u32) = .empty;
+    errdefer out.deinit(allocator);
+
+    for (insts) |word| {
+        const prev1 = if (out.items.len >= 1) out.items[out.items.len - 1] else null;
+        const prev2 = if (out.items.len >= 2) out.items[out.items.len - 2] else null;
+        const r = optimizeWindow(prev2, prev1, word, options);
+        if (r.replace_last) |replacement| out.items[out.items.len - 1] = replacement;
+        if (r.append_word) |append| try out.append(allocator, append);
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+fn tryFuseMemPair(a_word: u32, b_word: u32) ?u32 {
+    const a = decodeMemUnsigned(a_word) orelse return null;
+    const b = decodeMemUnsigned(b_word) orelse return null;
+    if (a.kind != b.kind or a.width != b.width or a.rn != b.rn) return null;
+    if (@as(u32, a.offset) + 1 != b.offset) return null;
+    if (a.offset > 63) return null;
+
+    if (a.kind == .ldr) {
+        if (a.rt == a.rn or b.rt == a.rn or a.rt == b.rt) return null;
+    }
+
+    const imm7: u32 = a.offset;
+    return switch (a.width) {
+        .x64 => switch (a.kind) {
+            .ldr => 0xA9400000 | (imm7 << 15) | (@as(u32, b.rt) << 10) | (@as(u32, a.rn) << 5) | a.rt,
+            .str => 0xA9000000 | (imm7 << 15) | (@as(u32, b.rt) << 10) | (@as(u32, a.rn) << 5) | a.rt,
+        },
+        .w32 => switch (a.kind) {
+            .ldr => 0x29400000 | (imm7 << 15) | (@as(u32, b.rt) << 10) | (@as(u32, a.rn) << 5) | a.rt,
+            .str => 0x29000000 | (imm7 << 15) | (@as(u32, b.rt) << 10) | (@as(u32, a.rn) << 5) | a.rt,
+        },
+    };
+}
+
+fn tryFuseMulAdd(mul_word: u32, add_word: u32) ?u32 {
+    const mul = decodeMul(mul_word) orelse return null;
+    const op = decodeAddSubReg(add_word) orelse return null;
+    if (mul.width != op.width) return null;
+
+    if (op.is_sub) {
+        if (op.rm != mul.rd or op.rd != mul.rd) return null;
+        return encodeMAddSub(mul.width, true, op.rd, mul.rn, mul.rm, op.rn);
+    }
+
+    if (op.rd != mul.rd) return null;
+    if (op.rm == mul.rd) return encodeMAddSub(mul.width, false, op.rd, mul.rn, mul.rm, op.rn);
+    if (op.rn == mul.rd) return encodeMAddSub(mul.width, false, op.rd, mul.rn, mul.rm, op.rm);
+    return null;
+}
+
+fn tryConditionalTransform(transform_word: u32, cmp_word: u32, csel_word: u32) ?u32 {
+    _ = decodeCmpImmZero(cmp_word) orelse return null;
+    const csel = decodeCsel(csel_word) orelse return null;
+    const transform = decodeUnaryTransform(transform_word) orelse return null;
+
+    return switch (transform) {
+        .inc => |t| blk: {
+            if (t.width != csel.width or t.tmp != csel.rm or t.src != csel.rn or t.tmp == t.src) break :blk null;
+            break :blk encodeCs(.inc, csel.width, csel.rd, t.src, t.src, csel.cond);
+        },
+        .inv => |t| blk: {
+            if (t.width != csel.width or t.tmp != csel.rm or t.src != csel.rn or t.tmp == t.src) break :blk null;
+            break :blk encodeCs(.inv, csel.width, csel.rd, t.src, t.src, csel.cond);
+        },
+        .neg => |t| blk: {
+            if (t.width != csel.width or t.tmp != csel.rm or t.src != csel.rn or t.tmp == t.src) break :blk null;
+            break :blk encodeCs(.neg, csel.width, csel.rd, t.src, t.src, csel.cond);
+        },
+    };
+}
+
+fn decodeMemUnsigned(word: u32) ?MemUnsigned {
+    const top = word & 0xFFC00000;
+    const kind: MemKind, const width: Width = switch (top) {
+        0xF9400000 => .{ .ldr, .x64 },
+        0xF9000000 => .{ .str, .x64 },
+        0xB9400000 => .{ .ldr, .w32 },
+        0xB9000000 => .{ .str, .w32 },
+        else => return null,
+    };
+    return .{
+        .kind = kind,
+        .width = width,
+        .rt = @intCast(word & 0x1F),
+        .rn = @intCast((word >> 5) & 0x1F),
+        .offset = @intCast((word >> 10) & 0xFFF),
+    };
+}
+
+fn decodeMul(word: u32) ?Mul {
+    const width: Width = if ((word & 0xFFE0FC00) == 0x9B007C00)
+        .x64
+    else if ((word & 0xFFE0FC00) == 0x1B007C00)
+        .w32
+    else
+        return null;
+    return .{
+        .width = width,
+        .rd = @intCast(word & 0x1F),
+        .rn = @intCast((word >> 5) & 0x1F),
+        .rm = @intCast((word >> 16) & 0x1F),
+    };
+}
+
+fn decodeAddSubReg(word: u32) ?AddSubReg {
+    if ((word & 0x3FE0FC00) != 0x0B000000) return null;
+    const sf = (word >> 31) & 1;
+    const op = (word >> 30) & 1;
+    return .{
+        .is_sub = op == 1,
+        .width = if (sf == 1) .x64 else .w32,
+        .rd = @intCast(word & 0x1F),
+        .rn = @intCast((word >> 5) & 0x1F),
+        .rm = @intCast((word >> 16) & 0x1F),
+    };
+}
+
+fn decodeAddImm(word: u32) ?AddImm {
+    if ((word & 0x7F800000) != 0x11000000) return null;
+    if (((word >> 22) & 1) != 0) return null;
+    return .{
+        .width = if (((word >> 31) & 1) == 1) .x64 else .w32,
+        .rd = @intCast(word & 0x1F),
+        .rn = @intCast((word >> 5) & 0x1F),
+        .imm = @intCast((word >> 10) & 0xFFF),
+    };
+}
+
+fn decodeCmpImmZero(word: u32) ?CmpImmZero {
+    const width: Width = if ((word & 0xFFC003FF) == 0xF100001F)
+        .x64
+    else if ((word & 0xFFC003FF) == 0x7100001F)
+        .w32
+    else
+        return null;
+    if (((word >> 10) & 0xFFF) != 0) return null;
+    return .{ .width = width, .rn = @intCast((word >> 5) & 0x1F) };
+}
+
+fn decodeCsel(word: u32) ?Csel {
+    const width: Width = if ((word & 0xFFE00C00) == 0x9A800000)
+        .x64
+    else if ((word & 0xFFE00C00) == 0x1A800000)
+        .w32
+    else
+        return null;
+    return .{
+        .width = width,
+        .rd = @intCast(word & 0x1F),
+        .rn = @intCast((word >> 5) & 0x1F),
+        .rm = @intCast((word >> 16) & 0x1F),
+        .cond = @intCast((word >> 12) & 0xF),
+    };
+}
+
+fn decodeUnaryTransform(word: u32) ?UnaryTransform {
+    if (decodeAddImm(word)) |a| {
+        if (a.imm == 1) return .{ .inc = .{ .tmp = a.rd, .src = a.rn, .width = a.width } };
+    }
+
+    if ((word & 0x7FE0FC00) == 0x2A200000) {
+        const width: Width = if (((word >> 31) & 1) == 1) .x64 else .w32;
+        const rn: u5 = @intCast((word >> 5) & 0x1F);
+        if (rn == 31) return .{ .inv = .{ .tmp = @intCast(word & 0x1F), .src = @intCast((word >> 16) & 0x1F), .width = width } };
+    }
+
+    if (decodeAddSubReg(word)) |s| {
+        if (s.is_sub and s.rn == 31) return .{ .neg = .{ .tmp = s.rd, .src = s.rm, .width = s.width } };
+    }
+
+    return null;
+}
+
+fn encodeMAddSub(width: Width, is_sub: bool, rd: u5, rn: u5, rm: u5, ra: u5) u32 {
+    const base: u32 = switch (width) {
+        .x64 => if (is_sub) 0x9B008000 else 0x9B000000,
+        .w32 => if (is_sub) 0x1B008000 else 0x1B000000,
+    };
+    return base | (@as(u32, rm) << 16) | (@as(u32, ra) << 10) | (@as(u32, rn) << 5) | rd;
+}
+
+const CsKind = enum { inc, inv, neg };
+
+fn encodeCs(kind: CsKind, width: Width, rd: u5, rn: u5, rm: u5, cond: u4) u32 {
+    const base: u32 = switch (width) {
+        .x64 => switch (kind) {
+            .inc => 0x9A800400,
+            .inv => 0xDA800000,
+            .neg => 0xDA800400,
+        },
+        .w32 => switch (kind) {
+            .inc => 0x1A800400,
+            .inv => 0x5A800000,
+            .neg => 0x5A800400,
+        },
+    };
+    return base | (@as(u32, rm) << 16) | (@as(u32, cond) << 12) | (@as(u32, rn) << 5) | rd;
+}
+
+fn expectOptimized(input: []const u32, expected: []const u32) !void {
+    const got = try optimizeWords(input, std.testing.allocator, .{});
+    defer std.testing.allocator.free(got);
+    try std.testing.expectEqualSlices(u32, expected, got);
+}
+
+test "peephole: fuses adjacent 64-bit ldr into ldp" {
+    const input = [_]u32{
+        0xF9401020, // ldr x0, [x1, #16]
+        0xF9401422, // ldr x2, [x1, #24]
+    };
+    const expected = [_]u32{0xA9420820}; // ldp x0, x2, [x1, #16]
+    try expectOptimized(&input, &expected);
+}
+
+test "peephole: does not fuse load pair when first load rewrites base" {
+    const input = [_]u32{
+        0xF9401021, // ldr x1, [x1, #16]
+        0xF9401422, // ldr x2, [x1, #24]
+    };
+    try expectOptimized(&input, &input);
+}
+
+test "peephole: fuses adjacent 64-bit str into stp" {
+    const input = [_]u32{
+        0xF9001060, // str x0, [x3, #32]
+        0xF9001461, // str x1, [x3, #40]
+    };
+    const expected = [_]u32{0xA9020460}; // stp x0, x1, [x3, #32]
+    try expectOptimized(&input, &expected);
+}
+
+test "peephole: leaves non-adjacent memory offsets untouched" {
+    const input = [_]u32{
+        0xF9401020, // ldr x0, [x1, #16]
+        0xF9401C22, // ldr x2, [x1, #56]
+    };
+    try expectOptimized(&input, &input);
+}
+
+test "peephole: fuses mul plus add into madd when add overwrites the mul result" {
+    const input = [_]u32{
+        0x9B027C20, // mul x0, x1, x2
+        0x8B000060, // add x0, x3, x0
+    };
+    const expected = [_]u32{0x9B020C20}; // madd x0, x1, x2, x3
+    try expectOptimized(&input, &expected);
+}
+
+test "peephole: does not fuse mul plus add when mul result remains live in another reg" {
+    const input = [_]u32{
+        0x9B027C20, // mul x0, x1, x2
+        0x8B000063, // add x3, x3, x0
+    };
+    try expectOptimized(&input, &input);
+}
+
+test "peephole: fuses mul plus sub into msub when sub overwrites the mul result" {
+    const input = [_]u32{
+        0x9B027C20, // mul x0, x1, x2
+        0xCB000060, // sub x0, x3, x0
+    };
+    const expected = [_]u32{0x9B028C20}; // msub x0, x1, x2, x3
+    try expectOptimized(&input, &expected);
+}
+
+test "peephole: rewrites cmp+csel of an increment transform to csinc" {
+    const input = [_]u32{
+        0x91000443, // add x3, x2, #1
+        0xF100001F, // cmp x0, #0
+        0x9A830041, // csel x1, x2, x3, eq
+    };
+    const expected = [_]u32{
+        0x91000443,
+        0xF100001F,
+        0x9A820441, // csinc x1, x2, x2, eq
+    };
+    try expectOptimized(&input, &expected);
+}
+
+test "peephole: rewrites cmp+csel of invert and neg transforms" {
+    const input = [_]u32{
+        0xAA2503E4, // mvn x4, x5
+        0xF100001F, // cmp x0, #0
+        0x9A8400A3, // csel x3, x5, x4, eq
+        0xCB0703E6, // neg x6, x7
+        0xF100001F, // cmp x0, #0
+        0x9A8600E8, // csel x8, x7, x6, eq
+    };
+    const expected = [_]u32{
+        0xAA2503E4,
+        0xF100001F,
+        0xDA8500A3, // csinv x3, x5, x5, eq
+        0xCB0703E6,
+        0xF100001F,
+        0xDA8704E8, // csneg x8, x7, x7, eq
+    };
+    try expectOptimized(&input, &expected);
+}
+
+test "peephole: leaves cmp+csel untouched without adjacent transform" {
+    const input = [_]u32{
+        0xD503201F, // nop
+        0xF100001F, // cmp x0, #0
+        0x9A820041, // csel x1, x2, x2, eq
+    };
+    try expectOptimized(&input, &input);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -72,6 +72,9 @@ pub const aarch64_emit = @import("compiler/codegen/aarch64/emit.zig");
 /// AArch64 IR-to-native compiler.
 pub const aarch64_compile = @import("compiler/codegen/aarch64/compile.zig");
 
+/// AArch64 peephole optimizer.
+pub const aarch64_peephole = @import("compiler/codegen/aarch64/peephole.zig");
+
 /// AOT compiler optimization passes.
 pub const passes = @import("compiler/ir/passes.zig");
 


### PR DESCRIPTION
Closes #357.

Adds a post-codegen peephole pass (`src/compiler/codegen/aarch64/peephole.zig`, 409 lines) wired through `CodeBuffer` and gated by `CompileOptions.enable_peephole` (default true). Implements:

- `ldr/str` pair fusion → `ldp/stp` (with alignment + immediate-range checks)
- `mul + add/sub` → `madd/msub` (conservative single-use guard)
- `cmp + csel` with adjacent inc/inv/neg → `csinc/csinv/csneg`

Block boundaries and callee-save patch sites act as barriers so the pass cannot fuse across them. Skipped patterns 4 (`eor Rd,Rn,Rn → mov Rd,#0`) and 5 (shifted-add encoding) per scope; FP `fmla` deferred.

Validation: `zig build` ✅, `zig build test` ✅. CoreMark AOT binary 165,544 → 162,444 bytes (-3,100); native code section 158,456 → 155,356 bytes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>