### PR TITLE
ci: relocate Zig caches outside $GITHUB_WORKSPACE

### DIFF
--- a/.github/actions/zig-cache/action.yml
+++ b/.github/actions/zig-cache/action.yml
@@ -1,0 +1,77 @@
+name: 'Configure Zig caches'
+description: >-
+  Move ZIG_GLOBAL_CACHE_DIR and ZIG_LOCAL_CACHE_DIR out of $GITHUB_WORKSPACE.
+  mlugg/setup-zig unconditionally exports both to <workspace>/.zig-cache,
+  which (1) conflates the global and local cache, (2) puts the global cache
+  inside a checkout it does not belong in, and (3) collides between worktrees
+  spawned by perf scripts (scripts/bench_coremark.py, scripts/bench_simd.py,
+  which already pop these env vars). This composite action runs immediately
+  after setup-zig and replaces those exports with sane values:
+    * ZIG_GLOBAL_CACHE_DIR -> a stable path outside the workspace.
+    * ZIG_LOCAL_CACHE_DIR  -> a separate per-job scratch path outside the
+                              workspace. We do not unset it (an empty value
+                              makes Zig dump its h/ o/ tmp/ z/ subdirs into
+                              the current working directory).
+
+inputs:
+  global-cache-dir:
+    description: >-
+      Override for the global Zig cache directory. If empty, the action picks
+      `/work/zig-cache` when `/work` is mounted (Azure self-hosted runners
+      with the NVMe layout) and `$RUNNER_TEMP/zig-global-cache` otherwise.
+    required: false
+    default: ''
+  local-cache-dir:
+    description: >-
+      Override for the local (per-job) Zig cache directory. If empty, the
+      action uses `$RUNNER_TEMP/zig-local-cache`.
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Configure Zig cache directories
+      shell: bash
+      env:
+        OVERRIDE_GLOBAL: ${{ inputs.global-cache-dir }}
+        OVERRIDE_LOCAL: ${{ inputs.local-cache-dir }}
+      run: |
+        set -euo pipefail
+        if [ -n "${OVERRIDE_GLOBAL:-}" ]; then
+          GLOBAL="$OVERRIDE_GLOBAL"
+        elif [ -d /work ] && [ -w /work ]; then
+          # Azure self-hosted runner convention: /work is the NVMe scratch
+          # mount that survives between jobs.
+          GLOBAL=/work/zig-cache
+        else
+          # GitHub-hosted runners: use the per-job scratch dir. We do not
+          # rely on this surviving between jobs; cache restoration of this
+          # path is the caller's responsibility (e.g. via actions/cache).
+          GLOBAL="${RUNNER_TEMP:-/tmp}/zig-global-cache"
+        fi
+        if [ -n "${OVERRIDE_LOCAL:-}" ]; then
+          LOCAL="$OVERRIDE_LOCAL"
+        else
+          LOCAL="${RUNNER_TEMP:-/tmp}/zig-local-cache"
+        fi
+        if [ "$GLOBAL" = "$LOCAL" ]; then
+          echo "[zig-cache] global and local cache directories must differ" >&2
+          exit 1
+        fi
+        case "$GLOBAL" in "${GITHUB_WORKSPACE:-/__nope__}"|"${GITHUB_WORKSPACE:-/__nope__}"/*)
+          echo "[zig-cache] refusing to put global cache inside GITHUB_WORKSPACE: $GLOBAL" >&2
+          exit 1 ;;
+        esac
+        case "$LOCAL" in "${GITHUB_WORKSPACE:-/__nope__}"|"${GITHUB_WORKSPACE:-/__nope__}"/*)
+          echo "[zig-cache] refusing to put local cache inside GITHUB_WORKSPACE: $LOCAL" >&2
+          exit 1 ;;
+        esac
+        mkdir -p "$GLOBAL" "$LOCAL"
+        {
+          echo "ZIG_GLOBAL_CACHE_DIR=$GLOBAL"
+          echo "ZIG_LOCAL_CACHE_DIR=$LOCAL"
+        } >> "$GITHUB_ENV"
+        echo "[zig-cache] ZIG_GLOBAL_CACHE_DIR=$GLOBAL"
+        echo "[zig-cache] ZIG_LOCAL_CACHE_DIR=$LOCAL"
+

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,8 +35,10 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+          use-cache: false
 
-      # ── Baseline (merge-base of PR, or HEAD~1 on push) ──────────
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
       - name: Baseline bench
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
 
       - name: Build (Debug)
         continue-on-error: true
@@ -101,6 +105,10 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
 
       - name: Install wasmtime
         run: |

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -22,6 +22,10 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
 
       - name: Check formatting
         run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,6 +39,10 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
 
       - name: Install wabt (wat2wasm / wasm-validate / wasm-objdump)
         run: |
@@ -63,7 +67,7 @@ jobs:
       - name: Cache Zig global cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: ~/.cache/zig
+          path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}
           key: zig-cache-${{ runner.os }}-0.16.0-${{ hashFiles('build.zig', 'build.zig.zon') }}
           restore-keys: |
             zig-cache-${{ runner.os }}-0.16.0-

--- a/.github/workflows/coremark-aarch64.yml
+++ b/.github/workflows/coremark-aarch64.yml
@@ -50,6 +50,10 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
 
       - name: Resolve refs
         id: refs

--- a/.github/workflows/coremark-x86_64.yml
+++ b/.github/workflows/coremark-x86_64.yml
@@ -50,6 +50,10 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
 
       - name: Resolve refs
         id: refs

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -55,6 +55,10 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
 
       - name: Install wasm-tools (generator + validator)
         run: |

--- a/.github/workflows/perf-investigate.yml
+++ b/.github/workflows/perf-investigate.yml
@@ -66,6 +66,11 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        if: steps.guard.outputs.skip != 'true'
+        uses: ./.github/actions/zig-cache
 
       - name: Build and benchmark baseline
         if: steps.guard.outputs.skip != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
 
       - name: Get version
         id: version


### PR DESCRIPTION
## Problem

`mlugg/setup-zig` unconditionally exports both `ZIG_GLOBAL_CACHE_DIR` and `ZIG_LOCAL_CACHE_DIR` to `${GITHUB_WORKSPACE}/.zig-cache`, with no input to disable or relocate ([source](https://github.com/mlugg/setup-zig/blob/d1434d08867e3ee9daa34448df10607b98908d29/main.js#L185-L187)). This is a problem for two reasons:

1. **Conflates cache roots.** Zig has two distinct cache directories: a *global* cache (shared package + build cache, OK to share between builds) and a *local* cache (per-project incremental build artifacts, must be unique per build root). Pointing both at the same directory defeats Zig's cache layering.
2. **Pollutes the workspace.** Worktree-based perf scripts (`scripts/bench_coremark.py`, `scripts/bench_simd.py`) treat each worktree as an independent build root and expect the worktree's own `.zig-cache` to be the local cache. A workflow-level override that points the local cache at a single shared location across all worktrees breaks incremental builds and can cause cross-worktree contention.

## Fix

New composite action `.github/actions/zig-cache` runs after every `setup-zig` step and overwrites both env vars:

| Var | Self-hosted (`/work` writable) | GH-hosted |
|---|---|---|
| `ZIG_GLOBAL_CACHE_DIR` | `/work/zig-cache` (NVMe) | `$RUNNER_TEMP/zig-global-cache` |
| `ZIG_LOCAL_CACHE_DIR` | `$RUNNER_TEMP/zig-local-cache` | `$RUNNER_TEMP/zig-local-cache` |

The action also validates that:
- the two paths differ (Zig requires they be distinct);
- neither path lives inside `$GITHUB_WORKSPACE` (so cache contents never get committed/uploaded as artifacts).

`use-cache: false` is set on every `setup-zig` invocation since the bundled `actions/cache` wrap targets the now-empty workspace path.

## Why setting LOCAL is necessary, not just unsetting it

GitHub Actions has no syntax to *unset* an env var via `$GITHUB_ENV`; you can only overwrite it. And Zig's behavior with an empty `ZIG_LOCAL_CACHE_DIR=` is surprising — it does **not** fall back to the default `<cwd>/.zig-cache`, but instead treats the current directory itself as the cache root, dumping `h/`, `o/`, `tmp/`, `z/` directly into cwd. So the action has to set an explicit, non-workspace path.

## Coverage

All 9 workflows that use `setup-zig` are updated (10 invocations total — `ci.yml` has two):

- `bench.yml`
- `ci.yml` (build + wasm-via-wasmtime)
- `coding_guidelines.yml`
- `copilot-setup-steps.yml`
- `coremark-aarch64.yml` (self-hosted)
- `coremark-x86_64.yml` (self-hosted)
- `fuzz.yml`
- `perf-investigate.yml` (preserves the existing `steps.guard.outputs.skip` guard)
- `release.yml`

`copilot-setup-steps.yml`'s pre-existing `Cache Zig global cache` step is updated to track `$ZIG_GLOBAL_CACHE_DIR` (it was previously caching `~/.cache/zig`, a path Zig was no longer using because setup-zig had already redirected it to the workspace — so that cache step has been a no-op for some time).

## Validation

- `python yaml.safe_load` on all 17 workflow + action files.
- Per-file 1:1 match between every `setup-zig` invocation and a following `Configure Zig caches` step + `use-cache: false`.
- Composite action shell logic smoke-tested standalone: happy path emits the expected env entries, validation correctly rejects (a) GLOBAL == LOCAL and (b) either path inside $GITHUB_WORKSPACE.
- Local Zig 0.16 build with the resulting env vars confirmed Zig creates `h/`, `o/`, `tmp/`, `z/` inside the local-cache dir and `b/h/o/tmp/z` in the global-cache dir, leaving the build root clean.

## Notes / follow-ups

- bench scripts already pop `ZIG_LOCAL_CACHE_DIR` and assign per-worktree `ZIG_GLOBAL_CACHE_DIR` — they're orthogonal to this PR.
- GH-hosted CI loses setup-zig's bundled cross-run cache restore. For self-hosted runners (which run the perf-sensitive workflows), `/work/zig-cache` persists across jobs anyway. If GH-hosted CI minutes regress, a follow-up can add an explicit `actions/cache` step targeting `$ZIG_GLOBAL_CACHE_DIR`.
- `coding_guidelines.yml` still uses the floating `@v2` tag for setup-zig; SHA-pinning it is a separate concern.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>