### PR TITLE
scripts(bench): surface subprocess stdout/stderr on failure

### DIFF
--- a/scripts/bench_coremark.py
+++ b/scripts/bench_coremark.py
@@ -30,14 +30,39 @@ ITER_PATTERN = re.compile(r"Iterations/Sec\s*:\s*([0-9]+(?:\.[0-9]+)?)")
 
 
 def run(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> str:
-    proc = subprocess.run(
-        cmd,
-        cwd=cwd,
-        env=env,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=cwd,
+            env=env,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        # The default str() on CalledProcessError omits the captured output,
+        # which makes CI failures of `zig build run-aot` (and similar) opaque.
+        # Surface stdout + stderr verbatim before re-raising so the actual
+        # error (e.g. a wasm trap printed by the underlying tool) is visible
+        # in the workflow log.
+        sys.stderr.write(
+            f"\n[harness] command failed (exit {exc.returncode}): "
+            f"{' '.join(str(c) for c in cmd)}\n"
+        )
+        if cwd is not None:
+            sys.stderr.write(f"[harness]   cwd: {cwd}\n")
+        if exc.stdout:
+            sys.stderr.write("[harness] --- stdout ---\n")
+            sys.stderr.write(exc.stdout)
+            if not exc.stdout.endswith("\n"):
+                sys.stderr.write("\n")
+        if exc.stderr:
+            sys.stderr.write("[harness] --- stderr ---\n")
+            sys.stderr.write(exc.stderr)
+            if not exc.stderr.endswith("\n"):
+                sys.stderr.write("\n")
+        sys.stderr.flush()
+        raise
     return proc.stdout + proc.stderr
 
 

--- a/scripts/bench_simd.py
+++ b/scripts/bench_simd.py
@@ -45,14 +45,39 @@ class Measurement:
 
 
 def run(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> str:
-    proc = subprocess.run(
-        cmd,
-        cwd=cwd,
-        env=env,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=cwd,
+            env=env,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        # The default str() on CalledProcessError omits the captured output,
+        # which makes CI failures of `zig build ...` (and similar) opaque.
+        # Surface stdout + stderr verbatim before re-raising so the actual
+        # error (e.g. a wasm trap printed by the underlying tool) is visible
+        # in the workflow log.
+        sys.stderr.write(
+            f"\n[harness] command failed (exit {exc.returncode}): "
+            f"{' '.join(str(c) for c in cmd)}\n"
+        )
+        if cwd is not None:
+            sys.stderr.write(f"[harness]   cwd: {cwd}\n")
+        if exc.stdout:
+            sys.stderr.write("[harness] --- stdout ---\n")
+            sys.stderr.write(exc.stdout)
+            if not exc.stdout.endswith("\n"):
+                sys.stderr.write("\n")
+        if exc.stderr:
+            sys.stderr.write("[harness] --- stderr ---\n")
+            sys.stderr.write(exc.stderr)
+            if not exc.stderr.endswith("\n"):
+                sys.stderr.write("\n")
+        sys.stderr.flush()
+        raise
     return proc.stdout + proc.stderr
 
 


### PR DESCRIPTION
Both `scripts/bench_coremark.py` and `scripts/bench_simd.py` wrap their zig invocations through a `run()` helper that uses `subprocess.run(check=True, capture_output=True)`. On non-zero exit, the resulting `CalledProcessError` propagates with the default `str()` representation, which omits stdout and stderr entirely.

That made the CoreMark regression in #371 opaque: every recent PR's workflow log showed only

```
subprocess.CalledProcessError: Command [...] returned non-zero exit status 1
```

with no indication that the underlying wamr binary had printed `wasm trap: out of bounds memory access` to its own stderr just before exiting. The trap message was captured but discarded.

This PR wraps the `subprocess.run` call in a try/except that prints the failed command, cwd, and the captured stdout + stderr to our own stderr before re-raising. Behaviour on success is unchanged.

## Verification

Smoke test of the new error path:

```
[harness] command failed (exit 7): sh -c echo to-stdout; echo to-stderr >&2; exit 7
[harness] --- stdout ---
to-stdout
[harness] --- stderr ---
to-stderr
caught: rc=7
```

Context: #376 (regression diagnosis), #377 (revert that fixes the symptom).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
