### PR TITLE
build: portable codegen-bench timer for aarch64-macos / aarch64-windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -275,6 +275,10 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/compiler/bench_codegen.zig"),
         .target = target,
         .optimize = .ReleaseFast,
+        // Darwin's clock_gettime lives in libSystem; the timer needs libc
+        // linked. Linux uses a raw syscall and Windows uses ntdll, so libc
+        // is only required here.
+        .link_libc = if (target.result.os.tag.isDarwin()) true else null,
     });
 
     const bench_exe = b.addExecutable(.{

--- a/src/compiler/bench_codegen.zig
+++ b/src/compiler/bench_codegen.zig
@@ -23,6 +23,7 @@ fn sampleUnit() []const u8 {
 }
 
 /// Read the fastest available monotonic-ish sample source for benchmark timing.
+/// Returns CPU cycles on x86 (via rdtsc) and nanoseconds on every other target.
 inline fn sampleTicks() u64 {
     if (comptime usesCycleCounter()) {
         var lo: u32 = undefined;
@@ -33,14 +34,38 @@ inline fn sampleTicks() u64 {
         );
         return (@as(u64, hi) << 32) | lo;
     }
-    if (comptime builtin.os.tag == .linux) {
-        const linux = std.os.linux;
-        var ts: linux.timespec = undefined;
-        const rc = linux.clock_gettime(.MONOTONIC, &ts);
-        if (rc != 0) @panic("clock_gettime(CLOCK_MONOTONIC) failed");
-        return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
-    }
-    @compileError("codegen benchmark needs a portable timer for this non-x86 target");
+    return switch (comptime builtin.os.tag) {
+        .linux => blk: {
+            const linux = std.os.linux;
+            var ts: linux.timespec = undefined;
+            const rc = linux.clock_gettime(.MONOTONIC, &ts);
+            if (rc != 0) @panic("clock_gettime(CLOCK_MONOTONIC) failed");
+            break :blk @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+        },
+        .macos, .ios, .tvos, .watchos, .visionos => blk: {
+            // Darwin: clock_gettime(CLOCK_MONOTONIC) lives in libSystem; the
+            // bench module is built with link_libc=true on these targets.
+            var ts: std.c.timespec = undefined;
+            if (std.c.clock_gettime(.MONOTONIC, &ts) != 0) {
+                @panic("clock_gettime(CLOCK_MONOTONIC) failed");
+            }
+            break :blk @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+        },
+        .windows => blk: {
+            // Windows: convert QueryPerformanceCounter ticks to nanoseconds so
+            // the reported unit ("ns/op") is meaningful regardless of the
+            // host's perf-counter frequency.
+            const ntdll = std.os.windows.ntdll;
+            var counter: std.os.windows.LARGE_INTEGER = undefined;
+            var freq: std.os.windows.LARGE_INTEGER = undefined;
+            _ = ntdll.RtlQueryPerformanceCounter(&counter);
+            _ = ntdll.RtlQueryPerformanceFrequency(&freq);
+            const ticks: u128 = @intCast(counter);
+            const hz: u128 = @intCast(freq);
+            break :blk @as(u64, @truncate(ticks * std.time.ns_per_s / hz));
+        },
+        else => @compileError("codegen benchmark needs a portable timer for this target"),
+    };
 }
 
 const BenchResult = struct {


### PR DESCRIPTION
## Why

Release `v3.0.0-dev.9` failed on **aarch64-macos** and **aarch64-windows** because `codegen-bench` couldn't compile. PR #312 widened `bench_target` from x86_64-only to all `aot_executable_target` arches and added a Linux `clock_gettime` fallback to the timer, but on Darwin and Windows the timer falls through to `@compileError`.

Failing run: https://github.com/cataggar/wamr/actions/runs/25492155701

## Fix

Add per-OS branches in `sampleTicks()` so all release-matrix targets compile:

- **Linux** — unchanged (`std.os.linux.clock_gettime(.MONOTONIC)`).
- **Darwin** (macOS / iOS / tvOS / watchOS / visionOS) — `std.c.clock_gettime(.MONOTONIC)` via libSystem. Because that needs libc linked, the bench module now sets `.link_libc = true` on Darwin targets in `build.zig`.
- **Windows** — `RtlQueryPerformanceCounter` + `RtlQueryPerformanceFrequency` from ntdll, with ticks converted to nanoseconds (via u128 intermediate) so the reported `ns/op` unit remains consistent regardless of the host's QPC frequency.
- **Else** — `@compileError` (for any future target without monotonic plumbing).

## Verification

Cross-compiled all three release-matrix targets locally:

```
zig build -Dtarget=aarch64-linux   -Doptimize=ReleaseFast install   # OK
zig build -Dtarget=aarch64-macos   -Doptimize=ReleaseSafe -Dstrip=true -Dstack-protector=true -Dversion=3.0.0-dev.9 install  # OK
zig build -Dtarget=aarch64-windows -Doptimize=ReleaseSafe -Dstrip=true -Dstack-protector=true -Dversion=3.0.0-dev.9 install  # OK
```

Smoke-ran `./zig-out/bin/codegen-bench` on aarch64-linux (output unchanged: `atomic_fence ~24,829 ns/op`, etc.). `zig build test` passes.

## Follow-up

After this lands, retag `v3.0.0-dev.9` (or move to `dev.10` if preferred) so the release workflow picks up the fix.