### PR TITLE
wamr/wamrc CLI: subcommand-based, .aot → .cwasm

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -62,8 +62,8 @@ jobs:
       - name: CoreMark (if available)
         continue-on-error: true
         run: |
-          if [ -f coremark.aot ]; then
-            ./zig-out/bin/spec-test-runner --mode=aot coremark.aot 2>&1 | tee coremark.txt || true
+          if [ -f coremark.cwasm ]; then
+            ./zig-out/bin/spec-test-runner --mode=aot coremark.cwasm 2>&1 | tee coremark.txt || true
           fi
 
       - name: Upload bench results

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ See [INSTALL.md](INSTALL.md) for alternative installation methods (winget, uv, p
 
 ## Tools
 
- - **wamrc**: AOT compiler — compile a `.wasm` module to a native `.aot` binary
- - **wamr**: run a WebAssembly module — either a `.wasm` file via the stack-based interpreter, or a precompiled `.aot` file produced by `wamrc`
+ - **wamrc**: AOT compiler — compile a `.wasm` module to a native `.cwasm` binary (`wamrc compile foo.wasm`)
+ - **wamr**: run a WebAssembly module — either a `.wasm` file via the stack-based interpreter, or a precompiled `.cwasm` file produced by `wamrc` (`wamr run foo.wasm`)
 
 ## Building
 

--- a/build.zig
+++ b/build.zig
@@ -216,6 +216,46 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_exe_unit_tests.step);
 
+    // wamrc unit tests (subcommand parsing, deriveOutputPath).
+    const wamrc_test_module = b.createModule(.{
+        .root_source_file = b.path("src/compiler/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    wamrc_test_module.addImport("config", config_module);
+    wamrc_test_module.addImport("wamr", lib_module);
+    const wamrc_unit_tests = b.addTest(.{
+        .root_module = wamrc_test_module,
+    });
+    const run_wamrc_unit_tests = b.addRunArtifact(wamrc_unit_tests);
+    test_step.dependOn(&run_wamrc_unit_tests.step);
+
+    // CLI smoke assertions: subcommand layout, exit codes, version stdout.
+    {
+        const wamr_version_line = b.fmt("wamr {s}\n", .{version_string});
+        const wamrc_version_line = b.fmt("wamrc {s}\n", .{version_string});
+
+        const wamr_version_run = b.addRunArtifact(exe);
+        wamr_version_run.addArg("version");
+        wamr_version_run.expectExitCode(0);
+        wamr_version_run.expectStdOutEqual(wamr_version_line);
+        test_step.dependOn(&wamr_version_run.step);
+
+        const wamrc_version_run = b.addRunArtifact(wamrc);
+        wamrc_version_run.addArg("version");
+        wamrc_version_run.expectExitCode(0);
+        wamrc_version_run.expectStdOutEqual(wamrc_version_line);
+        test_step.dependOn(&wamrc_version_run.step);
+
+        const wamr_no_subcmd = b.addRunArtifact(exe);
+        wamr_no_subcmd.expectExitCode(1);
+        test_step.dependOn(&wamr_no_subcmd.step);
+
+        const wamrc_no_subcmd = b.addRunArtifact(wamrc);
+        wamrc_no_subcmd.expectExitCode(1);
+        test_step.dependOn(&wamrc_no_subcmd.step);
+    }
+
     // Compiler IR passes tests (separate module to avoid root/wamr conflict)
     const passes_test_module = b.createModule(.{
         .root_source_file = b.path("src/compiler/ir/passes.zig"),
@@ -493,6 +533,7 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     // fd 2 today; tracking issue separate from this PR). Pin the
     // assertion to the observed behaviour so the run step is stable.
     const run_hello = b.addRunArtifact(wamr_exe);
+    run_hello.addArg("run");
     run_hello.addFileArg(hello);
     run_hello.expectExitCode(0);
     run_hello.expectStdErrEqual("hello from zig component\n");
@@ -561,6 +602,7 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     // that this composed command needs to reach its `wasi:cli/run`
     // export.
     const run_calc = b.addRunArtifact(wamr_exe);
+    run_calc.addArg("run");
     run_calc.addFileArg(calc_final);
     run_calc.expectExitCode(0);
     run_calc.expectStdErrEqual("40 + 2 = 42\n100 + 200 = 300\n");
@@ -613,6 +655,7 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     // path as `zig-calculator-cmd` (issue #355); produces the same
     // two-line output, again on host stderr.
     const run_mixed = b.addRunArtifact(wamr_exe);
+    run_mixed.addArg("run");
     run_mixed.addFileArg(mixed_final);
     run_mixed.expectExitCode(0);
     run_mixed.expectStdErrEqual("40 + 2 = 42\n100 + 200 = 300\n");

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -1,6 +1,7 @@
 //! wamrc — WebAssembly AOT Compiler (Zig implementation)
 //!
-//! Compiles .wasm files to WAMR AOT format using the Zig-native compiler backend.
+//! Compiles .wasm files to a `.cwasm` AOT-compiled binary using the
+//! Zig-native compiler backend.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -12,18 +13,43 @@ const passes = wamr.passes;
 
 const TargetArch = passes.TargetArch;
 
+const Subcommand = enum { compile, version, help };
+
+fn parseSubcommand(s: []const u8) ?Subcommand {
+    if (std.mem.eql(u8, s, "compile")) return .compile;
+    if (std.mem.eql(u8, s, "version")) return .version;
+    if (std.mem.eql(u8, s, "help")) return .help;
+    return null;
+}
+
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
-
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
-    if (args.len < 3) {
-        std.debug.print("Usage: wamrc <input.wasm> -o <output.aot>\n", .{});
-        std.debug.print("       wamrc [--aarch64-no-scheduler] [--aarch64-no-xreg-alloc] [--target aarch64|x86_64] <input.wasm> -o <output.aot>\n", .{});
-        std.debug.print("\nWebAssembly AOT Compiler (Zig)\n", .{});
+    if (args.len < 2) {
+        std.debug.print("error: missing subcommand — try `wamrc help`\n", .{});
         std.process.exit(1);
     }
 
+    const subcmd = parseSubcommand(args[1]) orelse {
+        std.debug.print("error: unknown subcommand '{s}' — try `wamrc help`\n", .{args[1]});
+        std.process.exit(1);
+    };
+
+    switch (subcmd) {
+        .version => {
+            writeStdout(init.io, "wamrc " ++ wamr.version.string ++ "\n");
+            return;
+        },
+        .help => {
+            runHelp(init.io, args[2..]);
+            return;
+        },
+        .compile => try runCompile(init, allocator, args[2..]),
+    }
+}
+
+fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
     var input_path: ?[]const u8 = null;
     var output_path: ?[]const u8 = null;
     var optimize = true;
@@ -34,39 +60,62 @@ pub fn main(init: std.process.Init) !void {
         else => .x86_64,
     };
 
-    var i: usize = 1;
-    while (i < args.len) : (i += 1) {
-        if (std.mem.eql(u8, args[i], "-o") and i + 1 < args.len) {
+    var i: usize = 0;
+    while (i < sub_args.len) : (i += 1) {
+        const a = sub_args[i];
+        if (std.mem.eql(u8, a, "-h") or std.mem.eql(u8, a, "--help")) {
+            runHelp(init.io, &.{"compile"});
+            return;
+        } else if (std.mem.eql(u8, a, "-o") and i + 1 < sub_args.len) {
             i += 1;
-            output_path = args[i];
-        } else if (std.mem.eql(u8, args[i], "-O0")) {
+            output_path = sub_args[i];
+        } else if (std.mem.eql(u8, a, "-O0")) {
             optimize = false;
-        } else if (std.mem.eql(u8, args[i], "--target") and i + 1 < args.len) {
+        } else if (std.mem.eql(u8, a, "--target") and i + 1 < sub_args.len) {
             i += 1;
-            if (std.mem.eql(u8, args[i], "aarch64")) {
+            if (std.mem.eql(u8, sub_args[i], "aarch64")) {
                 target_arch = .aarch64;
-            } else if (std.mem.eql(u8, args[i], "x86_64") or std.mem.eql(u8, args[i], "x86-64")) {
+            } else if (std.mem.eql(u8, sub_args[i], "x86_64") or std.mem.eql(u8, sub_args[i], "x86-64")) {
                 target_arch = .x86_64;
             } else {
-                std.debug.print("Error: unknown target '{s}' (supported: x86_64, aarch64)\n", .{args[i]});
+                std.debug.print("error: unknown target '{s}' (supported: x86_64, aarch64)\n", .{sub_args[i]});
                 std.process.exit(1);
             }
-        } else if (std.mem.eql(u8, args[i], "--aarch64-no-scheduler")) {
+        } else if (std.mem.startsWith(u8, a, "--target=")) {
+            const t = a["--target=".len..];
+            if (std.mem.eql(u8, t, "aarch64")) {
+                target_arch = .aarch64;
+            } else if (std.mem.eql(u8, t, "x86_64") or std.mem.eql(u8, t, "x86-64")) {
+                target_arch = .x86_64;
+            } else {
+                std.debug.print("error: unknown target '{s}' (supported: x86_64, aarch64)\n", .{t});
+                std.process.exit(1);
+            }
+        } else if (std.mem.eql(u8, a, "--aarch64-no-scheduler")) {
             enable_aarch64_scheduler = false;
-        } else if (std.mem.eql(u8, args[i], "--aarch64-no-xreg-alloc")) {
+        } else if (std.mem.eql(u8, a, "--aarch64-no-xreg-alloc")) {
             enable_aarch64_xreg_alloc = false;
+        } else if (a.len > 0 and a[0] == '-') {
+            std.debug.print("error: unknown option '{s}' — try `wamrc help compile`\n", .{a});
+            std.process.exit(1);
+        } else if (input_path == null) {
+            input_path = a;
         } else {
-            input_path = args[i];
+            std.debug.print("error: unexpected positional argument '{s}'\n", .{a});
+            std.process.exit(1);
         }
     }
 
     const in_path = input_path orelse {
-        std.debug.print("Error: no input file specified\n", .{});
+        std.debug.print("error: missing input wasm file — usage: wamrc compile <input.wasm> [-o <output.cwasm>]\n", .{});
         std.process.exit(1);
     };
-    const out_path = output_path orelse {
-        std.debug.print("Error: no output file specified (use -o)\n", .{});
-        std.process.exit(1);
+    var derived_out_path: ?[]u8 = null;
+    defer if (derived_out_path) |p| allocator.free(p);
+    const out_path: []const u8 = if (output_path) |p| p else blk: {
+        const d = try deriveOutputPath(allocator, in_path);
+        derived_out_path = d;
+        break :blk d;
     };
 
     // 1. Read input wasm
@@ -347,4 +396,108 @@ fn valueToV128(v: wamr.types.Value) u128 {
         .v128 => |x| x,
         else => 0,
     };
+}
+
+fn writeStdout(io: std.Io, text: []const u8) void {
+    var stdout_file = std.Io.File.stdout();
+    stdout_file.writeStreamingAll(io, text) catch {};
+}
+
+const top_usage =
+    \\wamrc - WebAssembly AOT Compiler
+    \\
+    \\Usage: wamrc <subcommand> [args...]
+    \\
+    \\Subcommands:
+    \\  compile   Compile a .wasm module to a .cwasm AOT binary
+    \\  version   Print version and exit
+    \\  help      Print this help; `wamrc help <subcommand>` for details
+    \\
+;
+
+const compile_usage =
+    \\Usage: wamrc compile [options] <input.wasm> [-o <output.cwasm>]
+    \\
+    \\Compile a .wasm module to a .cwasm AOT binary. If `-o` is omitted,
+    \\the output filename is derived by replacing the `.wasm` suffix on the
+    \\input with `.cwasm` (or appending `.cwasm` if no `.wasm` suffix).
+    \\
+    \\Options:
+    \\  -o <path>                     Output .cwasm path (default: <input>.cwasm)
+    \\  --target=<x86_64|aarch64>     Target architecture (default: host)
+    \\  -O0                           Disable IR optimizations
+    \\  --aarch64-no-scheduler        Disable AArch64 instruction scheduler
+    \\  --aarch64-no-xreg-alloc       Disable AArch64 X-register allocator
+    \\  -h, --help                    Show this help
+    \\
+;
+
+const version_usage =
+    \\Usage: wamrc version
+    \\
+    \\Print the wamrc version and exit.
+    \\
+;
+
+const help_usage =
+    \\Usage: wamrc help [subcommand]
+    \\
+    \\Print top-level help, or help for a specific subcommand.
+    \\
+;
+
+fn runHelp(io: std.Io, args: []const []const u8) void {
+    if (args.len == 0) {
+        writeStdout(io, top_usage);
+        return;
+    }
+    const sub = parseSubcommand(args[0]) orelse {
+        std.debug.print("error: unknown subcommand '{s}' — try `wamrc help`\n", .{args[0]});
+        std.process.exit(1);
+    };
+    writeStdout(io, switch (sub) {
+        .compile => compile_usage,
+        .version => version_usage,
+        .help => help_usage,
+    });
+}
+
+/// Derive an output `.cwasm` path from the input wasm path. Strips a
+/// trailing `.wasm` suffix and appends `.cwasm`; if there is no
+/// `.wasm` suffix, just appends `.cwasm`. Caller owns the returned slice.
+fn deriveOutputPath(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
+    const stem = if (std.mem.endsWith(u8, input, ".wasm"))
+        input[0 .. input.len - ".wasm".len]
+    else
+        input;
+    return std.mem.concat(allocator, u8, &.{ stem, ".cwasm" });
+}
+
+test "subcommand parsing" {
+    try std.testing.expectEqual(@as(?Subcommand, .compile), parseSubcommand("compile"));
+    try std.testing.expectEqual(@as(?Subcommand, .version), parseSubcommand("version"));
+    try std.testing.expectEqual(@as(?Subcommand, .help), parseSubcommand("help"));
+    try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand("--help"));
+    try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand("foo.wasm"));
+    try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand(""));
+}
+
+test "deriveOutputPath strips .wasm and appends .cwasm" {
+    const a = std.testing.allocator;
+
+    const r1 = try deriveOutputPath(a, "foo.wasm");
+    defer a.free(r1);
+    try std.testing.expectEqualStrings("foo.cwasm", r1);
+
+    const r2 = try deriveOutputPath(a, "/tmp/path/to/bar.wasm");
+    defer a.free(r2);
+    try std.testing.expectEqualStrings("/tmp/path/to/bar.cwasm", r2);
+
+    const r3 = try deriveOutputPath(a, "noext");
+    defer a.free(r3);
+    try std.testing.expectEqualStrings("noext.cwasm", r3);
+
+    const r4 = try deriveOutputPath(a, "weird.wasm.bin");
+    defer a.free(r4);
+    try std.testing.expectEqualStrings("weird.wasm.bin.cwasm", r4);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,38 +7,66 @@ const aot_supported = switch (builtin.cpu.arch) {
     else => false,
 };
 
+const Subcommand = enum { run, version, help };
+
+fn parseSubcommand(s: []const u8) ?Subcommand {
+    if (std.mem.eql(u8, s, "run")) return .run;
+    if (std.mem.eql(u8, s, "version")) return .version;
+    if (std.mem.eql(u8, s, "help")) return .help;
+    return null;
+}
+
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
-
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
-    // Parse arguments
+    if (args.len < 2) {
+        std.debug.print("error: missing subcommand — try `wamr help`\n", .{});
+        std.process.exit(1);
+    }
+
+    const subcmd = parseSubcommand(args[1]) orelse {
+        std.debug.print("error: unknown subcommand '{s}' — try `wamr help`\n", .{args[1]});
+        std.process.exit(1);
+    };
+
+    switch (subcmd) {
+        .version => {
+            writeStdout(init.io, "wamr " ++ wamr.version.string ++ "\n");
+            return;
+        },
+        .help => {
+            runHelp(init.io, args[2..]);
+            return;
+        },
+        .run => try runRun(init, allocator, args[2..]),
+    }
+}
+
+fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []const []const u8) !void {
     var wasm_path: ?[]const u8 = null;
     var wasm_args: std.ArrayListUnmanaged([]const u8) = .empty;
     defer wasm_args.deinit(allocator);
-    var show_version = false;
     var listen_address: ?std.Io.net.IpAddress = null;
     var stack_size: u32 = 64 * 1024;
     var past_options = false;
 
-    var i: usize = 1;
-    while (i < args.len) : (i += 1) {
-        const arg = args[i];
+    var i: usize = 0;
+    while (i < run_args.len) : (i += 1) {
+        const arg = run_args[i];
         if (!past_options and arg.len > 0 and arg[0] == '-') {
-            if (std.mem.eql(u8, arg, "-v") or std.mem.eql(u8, arg, "--version")) {
-                show_version = true;
-            } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-                printUsage();
+            if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+                runHelp(init.io, &.{"run"});
                 return;
             } else if (std.mem.startsWith(u8, arg, "--stack-size=")) {
                 stack_size = std.fmt.parseInt(u32, arg["--stack-size=".len..], 10) catch {
-                    std.debug.print("Error: invalid --stack-size value\n", .{});
+                    std.debug.print("error: invalid --stack-size value\n", .{});
                     std.process.exit(1);
                 };
             } else if (std.mem.startsWith(u8, arg, "--listen=")) {
                 const spec = arg["--listen=".len..];
                 listen_address = parseListenAddress(spec) catch {
-                    std.debug.print("Error: invalid --listen address '{s}'\n", .{spec});
+                    std.debug.print("error: invalid --listen address '{s}'\n", .{spec});
                     std.process.exit(1);
                 };
             } else if (std.mem.startsWith(u8, arg, "--heap-size=")) {
@@ -46,8 +74,7 @@ pub fn main(init: std.process.Init) !void {
             } else if (std.mem.eql(u8, arg, "--")) {
                 past_options = true;
             } else {
-                std.debug.print("Error: unknown option '{s}'\n", .{arg});
-                printUsage();
+                std.debug.print("error: unknown option '{s}' — try `wamr help run`\n", .{arg});
                 std.process.exit(1);
             }
         } else if (wasm_path == null) {
@@ -58,17 +85,11 @@ pub fn main(init: std.process.Init) !void {
         }
     }
 
-    if (show_version) {
-        printVersion();
-        if (wasm_path == null) return;
-    }
-
     const path = wasm_path orelse {
-        printUsage();
-        return;
+        std.debug.print("error: missing wasm/cwasm file — usage: wamr run <file> [args...]\n", .{});
+        std.process.exit(1);
     };
 
-    // Load wasm binary
     const io = init.io;
     const cwd = std.Io.Dir.cwd();
     const wasm_data = cwd.readFileAlloc(io, path, allocator, @enumFromInt(256 * 1024 * 1024)) catch |err| {
@@ -343,30 +364,69 @@ fn runWasm(
     };
 }
 
-fn versionLine() []const u8 {
-    return "wamr " ++ wamr.version.string ++ "\n";
+fn writeStdout(io: std.Io, text: []const u8) void {
+    var stdout_file = std.Io.File.stdout();
+    stdout_file.writeStreamingAll(io, text) catch {};
 }
 
-fn printVersion() void {
-    std.debug.print("{s}", .{versionLine()});
+const top_usage =
+    \\wamr - WebAssembly Micro Runtime
+    \\
+    \\Usage: wamr <subcommand> [args...]
+    \\
+    \\Subcommands:
+    \\  run       Run a .wasm or .cwasm file
+    \\  version   Print version and exit
+    \\  help      Print this help; `wamr help <subcommand>` for details
+    \\
+;
+
+const run_usage =
+    \\Usage: wamr run [options] <file.wasm|file.cwasm> [args...]
+    \\
+    \\Options:
+    \\  --stack-size=<bytes>   Stack size for the interpreter (default: 65536)
+    \\  --heap-size=<bytes>    Reserved (currently ignored)
+    \\  --listen=<ip:port>     Serve a WASI HTTP component on a TCP address
+    \\  -h, --help             Show this help
+    \\
+;
+
+const version_usage =
+    \\Usage: wamr version
+    \\
+    \\Print the wamr version and exit.
+    \\
+;
+
+const help_usage =
+    \\Usage: wamr help [subcommand]
+    \\
+    \\Print top-level help, or help for a specific subcommand.
+    \\
+;
+
+fn runHelp(io: std.Io, args: []const []const u8) void {
+    if (args.len == 0) {
+        writeStdout(io, top_usage);
+        return;
+    }
+    const sub = parseSubcommand(args[0]) orelse {
+        std.debug.print("error: unknown subcommand '{s}' — try `wamr help`\n", .{args[0]});
+        std.process.exit(1);
+    };
+    writeStdout(io, switch (sub) {
+        .run => run_usage,
+        .version => version_usage,
+        .help => help_usage,
+    });
 }
 
-fn printUsage() void {
-    std.debug.print(
-        \\wamr - WebAssembly Micro Runtime
-        \\
-        \\Usage: wamr [options] <file.wasm> [args...]
-        \\
-        \\Options:
-        \\  -v, --version           Show version
-        \\  -h, --help              Show this help
-        \\  --stack-size=<bytes>     Set stack size (default: 65536)
-        \\  --heap-size=<bytes>     Set heap size (default: 262144)
-        \\  --listen=<ip:port>       Serve a WASI HTTP component on a TCP address
-        \\
-    , .{});
-}
-
-test "version line uses wamr name and build version" {
-    try std.testing.expectEqualStrings("wamr " ++ wamr.version.string ++ "\n", versionLine());
+test "subcommand parsing" {
+    try std.testing.expectEqual(@as(?Subcommand, .run), parseSubcommand("run"));
+    try std.testing.expectEqual(@as(?Subcommand, .version), parseSubcommand("version"));
+    try std.testing.expectEqual(@as(?Subcommand, .help), parseSubcommand("help"));
+    try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand("--version"));
+    try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand("foo.wasm"));
+    try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand(""));
 }

--- a/tests/benchmarks/coremark/build.zig
+++ b/tests/benchmarks/coremark/build.zig
@@ -70,14 +70,14 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(wasm_exe);
 
-    // ── AOT compilation (wamrc: .wasm → .aot) ────────────────────────
-    const aot_cmd = b.addSystemCommand(&.{wamrc_path});
+    // ── AOT compilation (wamrc compile: .wasm → .cwasm) ──────────────
+    const aot_cmd = b.addSystemCommand(&.{ wamrc_path, "compile" });
     aot_cmd.addArg("-o");
-    const aot_output = aot_cmd.addOutputFileArg("coremark.aot");
+    const aot_output = aot_cmd.addOutputFileArg("coremark.cwasm");
     aot_cmd.addFileArg(wasm_exe.getEmittedBin());
 
-    const install_aot = b.addInstallFile(aot_output, "bin/coremark.aot");
-    const aot_step = b.step("aot", "Compile CoreMark .wasm to .aot via wamrc");
+    const install_aot = b.addInstallFile(aot_output, "bin/coremark.cwasm");
+    const aot_step = b.step("aot", "Compile CoreMark .wasm to .cwasm via wamrc");
     aot_step.dependOn(&install_aot.step);
 
     // ── Run steps ─────────────────────────────────────────────────────
@@ -85,12 +85,12 @@ pub fn build(b: *std.Build) void {
     const run_native_step = b.step("run-native", "Run CoreMark native");
     run_native_step.dependOn(&run_native.step);
 
-    const run_aot = b.addSystemCommand(&.{wamr_path});
+    const run_aot = b.addSystemCommand(&.{ wamr_path, "run" });
     run_aot.addFileArg(aot_output);
     const run_aot_step = b.step("run-aot", "Run CoreMark via WAMR AOT");
     run_aot_step.dependOn(&run_aot.step);
 
-    const run_interp = b.addSystemCommand(&.{wamr_path});
+    const run_interp = b.addSystemCommand(&.{ wamr_path, "run" });
     run_interp.addFileArg(wasm_exe.getEmittedBin());
     const run_interp_step = b.step("run-interp", "Run CoreMark via WAMR interpreter");
     run_interp_step.dependOn(&run_interp.step);


### PR DESCRIPTION
Restructures both binaries around a Wasmtime-shaped, Zig-styled subcommand layout:

```
wamr  run <file.wasm|file.cwasm> [args...] [--stack-size=N] [--listen=ip:port]
wamr  version
wamr  help [subcommand]

wamrc compile <input.wasm> [-o <output.cwasm>] [--target=x86_64|aarch64] [-O0]
              [--aarch64-no-scheduler] [--aarch64-no-xreg-alloc]
wamrc version
wamrc help [subcommand]
```

## Why

The previous CLI mixed `--version`/`-v`/`-h` top-level flags with positional file args; `wamrc` required `-o` and emitted `.aot`. Aligning with [Wasmtime's `compile` → `.cwasm`](https://docs.wasmtime.dev/cli-compile.html) and the broader bytecode-alliance convention puts wamr alongside the rest of the ecosystem; using bare-word subcommands matches `zig version` / `zig build` / `zig run` without `--`.

## What changed

**CLI shape — clean break, no compat aliases:**
- Subcommands are bare words (no `--` prefix).
- No implicit default subcommand — `wamr foo.wasm` is now an error pointing at `wamr help`.
- `version` prints `<tool> <version>\n` to **stdout** (was stderr via `std.debug.print`).
- `wamrc compile` defaults output filename to `<input-stem>.cwasm` when `-o` is omitted.

**File format — unchanged.** `.cwasm` is byte-identical to the old `.aot` (still `\0aot` magic). Wasmtime uses `.cwasm` for "compiled wasm" and the runtime detects format by magic bytes, so this is a cosmetic rename.

**Test coverage:**
- Inline `parseSubcommand` tests for both binaries.
- Inline `deriveOutputPath` test for the new default-output logic.
- New build-step CLI smoke assertions: `wamr version` / `wamrc version` produce the expected stdout, bare `wamr` / `wamrc` exit 1.
- New `wamrc-unit-tests` test step (previously `src/compiler/main.zig` had no `zig build test` coverage at all).

**Build / CI:**
- `tests/benchmarks/coremark/build.zig` now invokes `wamrc compile` / `wamr run`, emits `coremark.cwasm`.
- `build.zig`'s component-examples run steps prepend `"run"`.
- `.github/workflows/bench.yml` refers to `coremark.cwasm`.
- `README.md` Tools section documents new syntax.

## Verified

- `zig build` ✅
- `zig build test` ✅ (includes new CLI smoke + wamrc unit tests)
- `zig build coremark-aot` ✅ (full CoreMark compile-and-run via new CLI)
- `zig build component-examples-run` ✅ (zig-hello, zig-calculator-cmd, mixed-zig-rust-calc all run via `wamr run`)
- Manual: `wamrc compile foo.wasm` → produces `foo.cwasm` next to input; `wamrc compile foo.wasm -o bar.cwasm` → produces `bar.cwasm`; `wamr run foo.cwasm` → executes via AOT path; `wamr run foo.wasm` → executes via interpreter; `wamr version` / `wamrc version` → stdout-only single-line output.