### PR TITLE
cli: friendly errors for IsDir / FileNotFound / AccessDenied

### DIFF
--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -122,8 +122,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
     const io = init.io;
     const cwd = std.Io.Dir.cwd();
     const wasm_data = cwd.readFileAlloc(io, in_path, allocator, @enumFromInt(64 * 1024 * 1024)) catch |err| {
-        std.debug.print("Error reading {s}: {}\n", .{ in_path, err });
-        std.process.exit(1);
+        wamr.utils.read_file.dieReadFileError(in_path, err);
     };
     defer allocator.free(wasm_data);
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -133,8 +133,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     const io = init.io;
     const cwd = std.Io.Dir.cwd();
     const wasm_data = cwd.readFileAlloc(io, path, allocator, @enumFromInt(256 * 1024 * 1024)) catch |err| {
-        std.debug.print("Error: cannot read '{s}': {}\n", .{ path, err });
-        std.process.exit(1);
+        wamr.utils.read_file.dieReadFileError(path, err);
     };
     defer allocator.free(wasm_data);
 

--- a/src/shared/utils/read_file.zig
+++ b/src/shared/utils/read_file.zig
@@ -24,6 +24,42 @@ pub fn readFileToBufferWithLimit(io: Io, path: []const u8, allocator: std.mem.Al
     return try dir.readFileAlloc(io, path, allocator, Io.Limit.limited(max_size));
 }
 
+// ── Friendly CLI error formatting (issue #401) ─────────────────────────
+
+const isdir_fmt =
+    "Error: '{s}' is a directory, not a .wasm or .cwasm file\n" ++
+    "       Hint: pass the wasm artifact directly, e.g. target/wasm32-wasip2/debug/<name>.wasm\n";
+const not_found_fmt = "Error: '{s}' does not exist\n";
+const perm_fmt = "Error: '{s}' could not be read (permission denied)\n";
+const generic_fmt = "Error: cannot read '{s}': {}\n";
+
+/// Format a file-read error in human-readable form. Maps the common
+/// `error.IsDir`, `error.FileNotFound`, and `error.AccessDenied` /
+/// `error.PermissionDenied` cases to actionable messages and falls
+/// through to the existing `cannot read '<path>': <err>` shape for
+/// everything else. Writes to `w`.
+pub fn formatReadFileError(w: *Io.Writer, path: []const u8, err: anyerror) Io.Writer.Error!void {
+    switch (err) {
+        error.IsDir => try w.print(isdir_fmt, .{path}),
+        error.FileNotFound => try w.print(not_found_fmt, .{path}),
+        error.AccessDenied, error.PermissionDenied => try w.print(perm_fmt, .{path}),
+        else => try w.print(generic_fmt, .{ path, err }),
+    }
+}
+
+/// Print a friendly file-read error to stderr and exit the process with
+/// status 1. Convenience for CLI entry points; mirrors the format of
+/// `formatReadFileError` so tests of the latter lock both behaviors.
+pub fn dieReadFileError(path: []const u8, err: anyerror) noreturn {
+    switch (err) {
+        error.IsDir => std.debug.print(isdir_fmt, .{path}),
+        error.FileNotFound => std.debug.print(not_found_fmt, .{path}),
+        error.AccessDenied, error.PermissionDenied => std.debug.print(perm_fmt, .{path}),
+        else => std.debug.print(generic_fmt, .{ path, err }),
+    }
+    std.process.exit(1);
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 test "round-trip: write then read" {
@@ -72,5 +108,29 @@ test "readFileToBufferWithLimit: limit exceeded" {
     {
         const stat = try test_dir.dir.statFile(io, "big_file.txt", .{});
         try std.testing.expect(stat.size > 10);
+    }
+}
+
+test "formatReadFileError: friendly messages" {
+    const allocator = std.testing.allocator;
+
+    const Case = struct { err: anyerror, want: []const u8 };
+    const cases = [_]Case{
+        .{
+            .err = error.IsDir,
+            .want = "Error: './build/' is a directory, not a .wasm or .cwasm file\n" ++
+                "       Hint: pass the wasm artifact directly, e.g. target/wasm32-wasip2/debug/<name>.wasm\n",
+        },
+        .{ .err = error.FileNotFound, .want = "Error: './build/' does not exist\n" },
+        .{ .err = error.AccessDenied, .want = "Error: './build/' could not be read (permission denied)\n" },
+        .{ .err = error.PermissionDenied, .want = "Error: './build/' could not be read (permission denied)\n" },
+        .{ .err = error.FileTooBig, .want = "Error: cannot read './build/': error.FileTooBig\n" },
+    };
+
+    for (cases) |c| {
+        var aw: Io.Writer.Allocating = .init(allocator);
+        defer aw.deinit();
+        try formatReadFileError(&aw.writer, "./build/", c.err);
+        try std.testing.expectEqualStrings(c.want, aw.writer.buffered());
     }
 }


### PR DESCRIPTION
Closes #401

Maps the common file-read errors to actionable messages instead of leaking raw Zig error names:

- `error.IsDir` → `'<path>' is a directory, not a .wasm or .cwasm file` + hint pointing at the wasm artifact
- `error.FileNotFound` → `'<path>' does not exist`
- `error.AccessDenied` / `error.PermissionDenied` → `'<path>' could not be read (permission denied)`
- everything else → existing `cannot read '<path>': <err>` (preserved)

Adds `formatReadFileError` (writer-based, unit-testable) and a `dieReadFileError` noreturn convenience in `shared/utils/read_file.zig`. Wires both CLI entry points (`wamr` run, `wamrc` compile) onto it.

### Verification
- `zig build test` → 1696/1696 pass (includes new branch test covering all four cases).
- Manual smoke:
  ```
  $ wamr ./
  Error: './' is a directory, not a .wasm or .cwasm file
         Hint: pass the wasm artifact directly, e.g. target/wasm32-wasip2/debug/<name>.wasm
  $ wamr /no/such/file.wasm
  Error: '/no/such/file.wasm' does not exist
  $ wamr <chmod-0 file>
  Error: '<path>' could not be read (permission denied)
  ```