### PR TITLE
ci: add coremark-skip workflow to satisfy required check on path-filtered PRs

### DIFF
--- a/.github/workflows/coremark-skip.yml
+++ b/.github/workflows/coremark-skip.yml
@@ -1,0 +1,46 @@
+name: CoreMark (skip)
+
+# Companion to coremark-x86_64.yml / coremark-aarch64.yml.
+#
+# Branch protection on `main` requires a `coremark` status check, but the
+# real CoreMark workflows have `paths:` filters and only run when sources
+# that can affect benchmark numbers change. Without this companion, PRs
+# that don't touch those paths (e.g. component-only or docs-only changes)
+# would be blocked indefinitely waiting for a `coremark` check that never
+# gets posted.
+#
+# This workflow uses the inverse `paths-ignore:` filter and posts a
+# trivially-successful `coremark` check so such PRs can merge. The job is
+# named `coremark` so the resulting check-run name matches the required
+# context.
+#
+# When a PR touches both relevant and irrelevant paths, all three workflows
+# fire and produce same-named check-runs; the real benchmark workflows
+# finish well after this no-op skip, so they remain authoritative for
+# branch protection (latest check-run with a given name wins).
+#
+# Reference:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+on:
+  pull_request:
+    paths-ignore:
+      - src/compiler/**
+      - src/runtime/**
+      - tests/benchmarks/coremark/**
+      - scripts/bench_coremark.py
+      - .github/workflows/coremark-x86_64.yml
+      - .github/workflows/coremark-aarch64.yml
+
+concurrency:
+  group: coremark-skip-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  coremark:
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "CoreMark check skipped — PR does not touch compiler/runtime/coremark sources."


### PR DESCRIPTION
## Why

Branch protection on `main` requires the `coremark` status check. The real
coremark workflows ([coremark-x86_64.yml](../blob/main/.github/workflows/coremark-x86_64.yml) and
[coremark-aarch64.yml](../blob/main/.github/workflows/coremark-aarch64.yml)) have `paths:` filters and
only run when sources that can affect benchmark numbers change.

PRs that don't touch those paths — e.g. component-only changes like #410 —
are blocked indefinitely waiting for a `coremark` check that never gets posted.

## What

Add a companion workflow with the inverse `paths-ignore:` filter and a single
job named `coremark` that emits a trivially-successful check-run, per GitHub's
[handling skipped but required checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/troubleshooting-required-status-checks#handling-skipped-but-required-checks)
guidance.

## Path-filter matrix

| PR touches… | x86_64 | aarch64 | skip | result |
| --- | --- | --- | --- | --- |
| only relevant paths | ✓ | ✓ | — | real `coremark` check posted |
| only irrelevant paths | — | — | ✓ | success `coremark` check posted |
| both | ✓ | ✓ | ✓ | real workflows finish later → authoritative |

## Bootstrap

This PR's only changed file is `.github/workflows/coremark-skip.yml`, which is
**not** in the workflow's own `paths-ignore` list, so the new workflow triggers
on its own PR and unblocks its own merge.

After this lands, push or rebase #410 to re-evaluate triggers and let the new
skip workflow post the required check there.