### PR TITLE
build: switch wasm-tools to cataggar/wabt v3.0.0-dev.3

### DIFF
--- a/.github/actions/install-wasi-sdk-wabt/action.yml
+++ b/.github/actions/install-wasi-sdk-wabt/action.yml
@@ -3,13 +3,13 @@
 
 # Get URLs from:
 #   - https://github.com/WebAssembly/wasi-sdk/releases
-#   - https://github.com/WebAssembly/wabt/releases
+#   - https://github.com/cataggar/wabt/releases
 
 # Install WASI-SDK and WABT at /opt
 # /opt is the assumed location widely used in the project
 name: Install WASI-SDK and WABT
 
-description: A composite action to download and install wasi-sdk and wabt on Ubuntu, macOS.
+description: A composite action to download and install wasi-sdk and cataggar/wabt on Ubuntu, macOS, and Windows.
 
 inputs:
   os:
@@ -37,17 +37,17 @@ runs:
         sudo tar -xf wasi-sdk.tar.gz
         sudo ln -sf  wasi-sdk-25.0-x86_64-linux/ wasi-sdk
 
-        echo "Downloading wabt for Ubuntu..."
-        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/1.0.37/wabt-1.0.37-ubuntu-20.04.tar.gz
+        echo "Downloading cataggar/wabt for Ubuntu..."
+        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/cataggar/wabt/releases/download/v3.0.0-dev.3/wabt-3.0.0-dev.3-linux-x64.tar.gz
 
         echo "Extracting wabt..."
         sudo tar -xf wabt.tar.gz
-        sudo ln -sf  wabt-1.0.37 wabt
+        sudo ln -sf  wabt-3.0.0-dev.3-linux-x64 wabt
 
         /opt/wasi-sdk/bin/clang --version
-        /opt/wabt/bin/wasm-interp --version
+        /opt/wabt/bin/wabt version
 
-        echo "::notice::wasi-sdk-25 and wabt-1.0.37 installed on ubuntu"
+        echo "::notice::wasi-sdk-25 and cataggar/wabt v3.0.0-dev.3 installed on ubuntu"
       working-directory: /opt
 
     - name: Set up wasi-sdk and wabt on macOS on Intel
@@ -61,17 +61,17 @@ runs:
         sudo tar -xf wasi-sdk.tar.gz
         sudo ln -sf  wasi-sdk-25.0-x86_64-macos wasi-sdk
 
-        echo "Downloading wabt for macOS on Intel..."
-        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/1.0.36/wabt-1.0.36-macos-12.tar.gz
+        echo "Downloading cataggar/wabt for macOS on Intel..."
+        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/cataggar/wabt/releases/download/v3.0.0-dev.3/wabt-3.0.0-dev.3-macos-x64.tar.gz
 
         echo "Extracting wabt..."
         sudo tar -xf wabt.tar.gz
-        sudo ln -sf  wabt-1.0.36 wabt
+        sudo ln -sf  wabt-3.0.0-dev.3-macos-x64 wabt
 
         /opt/wasi-sdk/bin/clang --version
-        /opt/wabt/bin/wasm-interp --version
+        /opt/wabt/bin/wabt version
 
-        echo "::notice::wasi-sdk-25 and wabt-1.0.36 installed on ${{ inputs.os }}"
+        echo "::notice::wasi-sdk-25 and cataggar/wabt v3.0.0-dev.3 installed on ${{ inputs.os }}"
       working-directory: /opt
 
     - name: Set up wasi-sdk and wabt on macOS on ARM
@@ -85,17 +85,17 @@ runs:
         sudo tar -xf wasi-sdk.tar.gz
         sudo ln -sf  wasi-sdk-25.0-arm64-macos wasi-sdk
 
-        echo "Downloading wabt for macOS on ARM..."
-        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/1.0.37/wabt-1.0.37-macos-14.tar.gz
+        echo "Downloading cataggar/wabt for macOS on ARM..."
+        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/cataggar/wabt/releases/download/v3.0.0-dev.3/wabt-3.0.0-dev.3-macos-arm64.tar.gz
 
         echo "Extracting wabt..."
         sudo tar -xf wabt.tar.gz
-        sudo ln -sf  wabt-1.0.37 wabt
+        sudo ln -sf  wabt-3.0.0-dev.3-macos-arm64 wabt
 
         /opt/wasi-sdk/bin/clang --version
-        /opt/wabt/bin/wasm-interp --version
+        /opt/wabt/bin/wabt version
 
-        echo "::notice::wasi-sdk-25 and wabt-1.0.37 installed on ${{ inputs.os }}"
+        echo "::notice::wasi-sdk-25 and cataggar/wabt v3.0.0-dev.3 installed on ${{ inputs.os }}"
       working-directory: /opt
 
     - name: Set up wasi-sdk and wabt on Windows
@@ -113,13 +113,13 @@ runs:
         echo "Extracting wasi-sdk..."
         tar --strip-components=1 -xf wasi-sdk.tar.gz -C /opt/wasi-sdk
 
-        echo "Downloading wabt for Windows..."
-        wget -O wabt.tar.gz --progress=dot:giga https://github.com/WebAssembly/wabt/releases/download/1.0.37/wabt-1.0.37-windows.tar.gz
+        echo "Downloading cataggar/wabt for Windows..."
+        wget -O wabt.tar.gz --progress=dot:giga https://github.com/cataggar/wabt/releases/download/v3.0.0-dev.3/wabt-3.0.0-dev.3-windows-x64.tar.gz
 
         echo "Extracting wabt..."
         tar --strip-components=1 -xf wabt.tar.gz -C /opt/wabt
 
         /opt/wasi-sdk/bin/clang --version
-        /opt/wabt/bin/wasm-interp --version
+        /opt/wabt/bin/wabt version
 
-        echo "::notice::wasi-sdk-25 and wabt-1.0.37 installed on Windows"
+        echo "::notice::wasi-sdk-25 and cataggar/wabt v3.0.0-dev.3 installed on Windows"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,25 +44,15 @@ jobs:
       - name: Configure Zig caches
         uses: ./.github/actions/zig-cache
 
-      - name: Install wabt (wat2wasm / wasm-validate / wasm-objdump)
+      - name: Install cataggar/wabt v3.0.0-dev.3 (component CLI)
         run: |
           set -euo pipefail
-          ver=1.0.36
-          url=https://github.com/WebAssembly/wabt/releases/download/${ver}/wabt-${ver}-ubuntu-20.04.tar.gz
+          ver=3.0.0-dev.3
+          url=https://github.com/cataggar/wabt/releases/download/v${ver}/wabt-${ver}-linux-x64.tar.gz
           curl -fsSL "$url" -o /tmp/wabt.tgz
-          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/wabt.tgz
-          wat2wasm --version
-          wasm-validate --version
-
-      - name: Install wasm-tools (smith, validate, print, mutate)
-        run: |
-          set -euo pipefail
-          ver=1.219.0
-          url=https://github.com/bytecodealliance/wasm-tools/releases/download/v${ver}/wasm-tools-${ver}-x86_64-linux.tar.gz
-          curl -fsSL "$url" -o /tmp/wasm-tools.tgz
-          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/wasm-tools.tgz \
-            wasm-tools-${ver}-x86_64-linux/wasm-tools
-          wasm-tools --version
+          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/wabt.tgz \
+            wabt-${ver}-linux-x64/bin/wabt
+          wabt version
 
       - name: Cache Zig global cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -60,15 +60,6 @@ jobs:
       - name: Configure Zig caches
         uses: ./.github/actions/zig-cache
 
-      - name: Install wasm-tools (generator + validator)
-        run: |
-          set -euo pipefail
-          ver=1.219.0
-          url=https://github.com/bytecodealliance/wasm-tools/releases/download/v${ver}/wasm-tools-${ver}-x86_64-linux.tar.gz
-          curl -fsSL "$url" -o /tmp/wasm-tools.tgz
-          sudo tar -C /usr/local/bin --strip-components=1 -xzf /tmp/wasm-tools.tgz \
-            wasm-tools-${ver}-x86_64-linux/wasm-tools
-
       - name: Restore fuzz corpus
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/build.zig
+++ b/build.zig
@@ -550,7 +550,8 @@ pub fn build(b: *std.Build) void {
 ///
 /// Pinned versions:
 ///   * Wasmtime preview1 → component adapter v36.0.9 (sha256 verified)
-///   * `wasm-tools` ≥ 1.220 expected on PATH (also provides `validate`/`compose`)
+///   * `cataggar/wabt` ≥ v3.0.0-dev.3 on PATH (provides `component embed`,
+///     `component new`, `component compose`, `validate`)
 ///   * `cargo` with `wasm32-wasip1` target for the mixed example
 fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     const adapter_url =
@@ -616,19 +617,20 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
         .exports = &.{"docs:adder/add@0.1.0#add"},
         .output = "zig-adder.core.wasm",
     });
-    const adder_embed = b.addSystemCommand(&.{ "wasm-tools", "component", "embed", "--world", "adder" });
+    const adder_embed = b.addSystemCommand(&.{ "wabt", "component", "embed", "--world", "adder" });
     adder_embed.addDirectoryArg(b.path("examples/components/zig-adder/wit"));
     adder_embed.addFileArg(adder_core);
     adder_embed.addArg("-o");
     const adder_embedded = adder_embed.addOutputFileArg("zig-adder.embed.wasm");
 
-    const adder_new = b.addSystemCommand(&.{ "wasm-tools", "component", "new" });
+    const adder_new = b.addSystemCommand(&.{ "wabt", "component", "new" });
     adder_new.addFileArg(adder_embedded);
     adder_new.addArg("-o");
-    // `wasm-tools compose` requires kebab-case file basenames (no dots
-    // before the .wasm extension). Emit `zig-adder.wasm` for use as a
-    // compose dependency below; the install copy uses the more
-    // descriptive `.component.wasm` suffix for end-user discoverability.
+    // `wabt component compose` (like `wasm-tools compose`) requires
+    // kebab-case file basenames (no dots before the .wasm extension).
+    // Emit `zig-adder.wasm` for use as a compose dependency below; the
+    // install copy uses the more descriptive `.component.wasm` suffix
+    // for end-user discoverability.
     const adder = adder_new.addOutputFileArg("zig-adder.wasm");
     installAndValidate(b, examples_step, adder, "zig-adder.component.wasm");
 
@@ -639,24 +641,22 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
         .exports = &.{"_start"},
         .output = "zig-calculator-cmd.core.wasm",
     });
-    const calc_embed = b.addSystemCommand(&.{ "wasm-tools", "component", "embed", "--world", "app" });
+    const calc_embed = b.addSystemCommand(&.{ "wabt", "component", "embed", "--world", "app" });
     calc_embed.addDirectoryArg(b.path("examples/components/zig-calculator-cmd/wit"));
     calc_embed.addFileArg(calc_core);
     calc_embed.addArg("-o");
     const calc_embedded = calc_embed.addOutputFileArg("zig-calculator-cmd.embed.wasm");
 
-    const calc_new = b.addSystemCommand(&.{ "wasm-tools", "component", "new" });
+    const calc_new = b.addSystemCommand(&.{ "wabt", "component", "new" });
     calc_new.addFileArg(calc_embedded);
     calc_new.addArg("--adapt");
     calc_new.addPrefixedFileArg("wasi_snapshot_preview1=", adapter);
     calc_new.addArg("-o");
-    // Kebab-case basename for `wasm-tools compose` consumption.
+    // Kebab-case basename for `wabt component compose` consumption.
     const calc_cmd = calc_new.addOutputFileArg("zig-calculator-cmd.wasm");
 
     // Compose: link `docs:adder/add@0.1.0` import against the Zig adder.
-    // wasm-tools compose is deprecated upstream in favour of `wac`; we use
-    // it because it ships with wasm-tools 1.220.
-    const calc_compose = b.addSystemCommand(&.{ "wasm-tools", "compose", "-d" });
+    const calc_compose = b.addSystemCommand(&.{ "wabt", "component", "compose", "-d" });
     calc_compose.addFileArg(adder);
     calc_compose.addFileArg(calc_cmd);
     calc_compose.addArg("-o");
@@ -679,9 +679,9 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
 
     // ── mixed-zig-rust-calc (Zig adder + Rust command, composed) ───
     // Rust command builds via cargo on `wasm32-wasip1`; we then run the
-    // standard wasm-tools embed/new pipeline and compose against the
-    // Zig adder. Build is opt-in — failure mode if cargo / target not
-    // present is a clear cargo error.
+    // standard wabt component embed/new pipeline and compose against
+    // the Zig adder. Build is opt-in — failure mode if cargo / target
+    // not present is a clear cargo error.
     const cargo = b.addSystemCommand(&.{
         "cargo",                                                      "build",
         "--release",                                                  "--target",
@@ -699,21 +699,21 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     cargo_pickup.step.dependOn(&cargo.step);
     const rust_core = cargo_pickup.addOutputFileArg("mixed_zig_rust_command.core.wasm");
 
-    const rust_embed = b.addSystemCommand(&.{ "wasm-tools", "component", "embed", "--world", "app" });
+    const rust_embed = b.addSystemCommand(&.{ "wabt", "component", "embed", "--world", "app" });
     rust_embed.addDirectoryArg(b.path("examples/components/mixed-zig-rust-calc/command/wit"));
     rust_embed.addFileArg(rust_core);
     rust_embed.addArg("-o");
     const rust_embedded = rust_embed.addOutputFileArg("mixed-rust-command.embed.wasm");
 
-    const rust_new = b.addSystemCommand(&.{ "wasm-tools", "component", "new" });
+    const rust_new = b.addSystemCommand(&.{ "wabt", "component", "new" });
     rust_new.addFileArg(rust_embedded);
     rust_new.addArg("--adapt");
     rust_new.addPrefixedFileArg("wasi_snapshot_preview1=", adapter);
     rust_new.addArg("-o");
-    // Kebab-case basename for `wasm-tools compose`.
+    // Kebab-case basename for `wabt component compose`.
     const rust_cmd = rust_new.addOutputFileArg("mixed-rust-command.wasm");
 
-    const mixed_compose = b.addSystemCommand(&.{ "wasm-tools", "compose", "-d" });
+    const mixed_compose = b.addSystemCommand(&.{ "wabt", "component", "compose", "-d" });
     mixed_compose.addFileArg(adder);
     mixed_compose.addFileArg(rust_cmd);
     mixed_compose.addArg("-o");
@@ -766,9 +766,9 @@ const CommandComponent = struct {
     adapter: std.Build.LazyPath,
 };
 
-/// Wraps `wasm-tools component new --adapt wasi_snapshot_preview1=<adapter>`.
+/// Wraps `wabt component new --adapt wasi_snapshot_preview1=<adapter>`.
 fn makeCommandComponent(b: *std.Build, opts: CommandComponent) std.Build.LazyPath {
-    const cmd = b.addSystemCommand(&.{ "wasm-tools", "component", "new" });
+    const cmd = b.addSystemCommand(&.{ "wabt", "component", "new" });
     cmd.addFileArg(opts.core);
     cmd.addArg("--adapt");
     cmd.addPrefixedFileArg("wasi_snapshot_preview1=", opts.adapter);
@@ -784,9 +784,9 @@ fn installAndValidate(
     component: std.Build.LazyPath,
     install_basename: []const u8,
 ) void {
-    const validate = b.addSystemCommand(&.{ "wasm-tools", "validate" });
+    const validate = b.addSystemCommand(&.{ "wabt", "validate" });
     validate.addFileArg(component);
-    validate.setName(b.fmt("wasm-tools validate {s}", .{install_basename}));
+    validate.setName(b.fmt("wabt validate {s}", .{install_basename}));
 
     const install = b.addInstallFileWithDir(
         component,

--- a/examples/components/README.md
+++ b/examples/components/README.md
@@ -2,12 +2,13 @@
 
 Source-only Zig (and one mixed Zig+Rust) examples that exercise the
 [bytecodealliance Component-Model][bca] story end-to-end through
-`wasm-tools` and wamr. The examples mirror the structure of the
+[`cataggar/wabt`][cw] and wamr. The examples mirror the structure of the
 [component-docs][cd] adder/calculator/command tutorial — Zig is the
 language column the upstream docs do not yet cover.
 
 [bca]: https://component-model.bytecodealliance.org/
-[cd]: https://github.com/bytecodealliance/component-docs/tree/main/component-model
+[cd]: https://github.com/bytecodealliance/component-docs/tree/main/component-model/examples/tutorial
+[cw]: https://github.com/cataggar/wabt
 
 No `.wasm` artifacts are checked in; everything is built reproducibly
 from the sources in this directory via the repo's root `build.zig`.
@@ -54,7 +55,7 @@ zig-out/component-examples/
 | Tool                                  | Version    | Notes                                                    |
 |---------------------------------------|-----------:|----------------------------------------------------------|
 | Zig                                   | 0.16.x     | Toolchain already required by the rest of the repo.       |
-| `wasm-tools`                          | ≥ 1.220    | Provides `component embed/new`, `validate`, `compose`.    |
+| `wabt` (cataggar/wabt)                | v3.0.0-dev.3 | Provides `component embed/new`, `validate`, `component compose`. |
 | Wasmtime preview1→component adapter   | v36.0.9    | Auto-fetched + sha256-pinned by the build (`build.zig`). |
 | Rust toolchain (`cargo`, `rustup`)    | recent stable | Mixed example only.                                  |
 | `wasm32-wasip1` Rust target           | —          | `rustup target add wasm32-wasip1`. Mixed example only.    |
@@ -63,19 +64,16 @@ zig-out/component-examples/
 
 | Example                   | Builds | Validates | Runs in wamr today | Notes                                                      |
 |---------------------------|:------:|:---------:|:------------------:|------------------------------------------------------------|
-| `zig-hello`               |   ✓    |     ✓     |         ✓          | Full end-to-end (greeting written via the captured-stdout flush). |
+| `zig-hello`               |   ✓    |     ✓     |         ✓          | End-to-end (greeting written via the captured-stdout flush). |
 | `zig-adder`               |   ✓    |     ✓     |        n/a         | Library component — no `wasi:cli/run`.                     |
-| `zig-calculator-cmd` (composed) | ✓ |     ✓     |         ✗          | Aliased-instance gap, see below.                           |
-| `mixed-zig-rust-calc`     |   ✓    |     ✓     |         ✗          | Same gap.                                                  |
+| `zig-calculator-cmd` (composed) | ✓ |     ✓     |         ✓          | Composed end-to-end through `wabt component compose`.       |
+| `mixed-zig-rust-calc`     |   ✓    |     ✓     |         ✓          | Composed end-to-end through `wabt component compose`.       |
 
-The composed examples produce valid components that run in
-[Wasmtime][wasmtime] today. Under wamr they currently fail with
-`error.NoRunExport` — `wasm-tools compose` emits the top-level
-`wasi:cli/run@0.2.x` export as an *aliased* instance, while wamr's
-`registerInstanceExport` (in
-[`src/component/instance.zig`](../../src/component/instance.zig))
-currently only walks `.local` instance refs. Closing that gap is
-runtime work distinct from this examples set.
+All composed examples produce valid components that run in
+[Wasmtime][wasmtime] and on wamr today. `wabt component compose` emits
+the cross-component plumbing in the inline-export form (rather than the
+aliased-instance form `wasm-tools compose` historically used); both
+shapes are spec-valid, and wamr's component loader handles both.
 
 The `zig-hello` runtime test asserts that wamr exits 0 and emits the
 greeting. Note that the captured-stdout flush in
@@ -86,10 +84,6 @@ stderr fd; the assertion is pinned to that observed behaviour.
 
 ## Caveats
 
-- `wasm-tools compose` is deprecated upstream in favour of
-  [`wac`](https://github.com/bytecodealliance/wac); we use `compose`
-  because it ships in `wasm-tools` 1.220 with no extra install. Either
-  is acceptable as a producer; the linker semantics match.
 - Component-Model support in wamr is still in **preview**; behaviour
   may shift between releases. Each example's README pins its
   expectations to the current state of the runtime.

--- a/examples/components/mixed-zig-rust-calc/README.md
+++ b/examples/components/mixed-zig-rust-calc/README.md
@@ -2,7 +2,7 @@
 
 A polyglot WebAssembly component composition: a **Zig** library
 component (the [`zig-adder`](../zig-adder)) is linked into a **Rust**
-command component (`command/`) via `wasm-tools compose`. The pair
+command component (`command/`) via `wabt component compose`. The pair
 produces a runnable WASI command whose `add` lift is implemented in Zig
 and whose CLI / IO logic is implemented in Rust.
 
@@ -35,22 +35,22 @@ live under this directory.
 zig build-exe -target wasm32-freestanding -O ReleaseSmall \
     -fno-entry --export="docs:adder/add@0.1.0#add" \
     ../zig-adder/src/main.zig
-wasm-tools component embed --world adder ../zig-adder/wit main.wasm \
+wabt component embed --world adder ../zig-adder/wit main.wasm \
     -o adder.embed.wasm
-wasm-tools component new adder.embed.wasm -o zig-adder.component.wasm
+wabt component new adder.embed.wasm -o zig-adder.component.wasm
 
 # 2. Build the Rust command (wasi-preview1 binary).
 (cd command && cargo build --release --target wasm32-wasip1)
-wasm-tools component embed --world app command/wit \
+wabt component embed --world app command/wit \
     command/target/wasm32-wasip1/release/mixed_zig_rust_command.wasm \
     -o command.embed.wasm
-wasm-tools component new command.embed.wasm \
-    --adapt wasi_snapshot_preview1.command.wasm \
+wabt component new command.embed.wasm \
+    --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.command.wasm \
     -o rust-command.component.wasm
 
 # 3. Compose — wires the Rust command's `docs:adder/add@0.1.0` import
 #    against the Zig adder's matching export.
-wasm-tools compose -d zig-adder.component.wasm rust-command.component.wasm \
+wabt component compose -d zig-adder.component.wasm rust-command.component.wasm \
     -o mixed-zig-rust-calc.composed.wasm
 ```
 
@@ -65,7 +65,7 @@ That step produces `zig-out/component-examples/mixed-zig-rust-calc.composed.wasm
 ## Prerequisites
 
 - Zig 0.16.x (already required for the rest of the repo).
-- `wasm-tools` 1.220+ on `PATH`.
+- `wabt` (cataggar/wabt v3.0.0-dev.3+) on `PATH`.
 - A Rust toolchain with the `wasm32-wasip1` target installed:
   `rustup target add wasm32-wasip1`.
 - The `wasi_snapshot_preview1.command.wasm` adapter (downloaded by the
@@ -74,13 +74,10 @@ That step produces `zig-out/component-examples/mixed-zig-rust-calc.composed.wasm
 
 ## Runtime status
 
-The composed component validates with `wasm-tools validate` and runs in
-[Wasmtime][wasmtime]. On wamr's current preview-state runtime it loads
-but does not execute, for the same reason described in
-[`../zig-calculator-cmd/README.md`](../zig-calculator-cmd/README.md):
-`wasm-tools compose` emits the top-level `wasi:cli/run@0.2.x` export as
-an *aliased* instance, while wamr's `registerInstanceExport` currently
-only walks `.local` instance refs.
+The composed component validates with `wabt validate` and runs in both
+[Wasmtime][wasmtime] and wamr. `zig build component-examples-run` runs
+this example end-to-end through `./zig-out/bin/wamr` and asserts the
+expected two-line output.
 
 [wasmtime]: https://wasmtime.dev/
 
@@ -92,4 +89,4 @@ already has a well-documented build path (cargo + `wit-bindgen`); the
 Zig half being the implementation of `add` is the more interesting
 artifact in a wamr-flavoured tutorial. (The reverse direction —
 Rust adder + Zig command — is left as an exercise; it would compose
-identically using the same `wasm-tools` recipe.)
+identically using the same `wabt` recipe.)

--- a/examples/components/mixed-zig-rust-calc/command/src/lib.rs
+++ b/examples/components/mixed-zig-rust-calc/command/src/lib.rs
@@ -1,10 +1,10 @@
 //! Rust half of the `mixed-zig-rust-calc` example: a `wasm32-wasip1`
 //! binary that imports `docs:adder/add@0.1.0` via `wit-bindgen` and
-//! prints two sample sums to stdout. After `wasm-tools component
+//! prints two sample sums to stdout. After `wabt component
 //! embed/new` (with the wasi-preview1 adapter) it becomes a Component
 //! Model command component whose only non-WASI import is the adder
-//! interface — letting `wasm-tools compose` link it against the Zig
-//! adder in `../../zig-adder`.
+//! interface — letting `wabt component compose` link it against the
+//! Zig adder in `../../zig-adder`.
 
 wit_bindgen::generate!({
     path: "wit",

--- a/examples/components/zig-adder/README.md
+++ b/examples/components/zig-adder/README.md
@@ -18,7 +18,7 @@ world adder {
 ```
 
 The Zig source is a single function whose name uses the canonical-ABI
-mangled form `"docs:adder/add@0.1.0#add"`, which `wasm-tools component
+mangled form `"docs:adder/add@0.1.0#add"`, which `wabt component
 embed --world adder` recognises as the lift target for the `add` function
 in the `docs:adder/add@0.1.0` interface. The component has no imports.
 
@@ -29,8 +29,8 @@ zig build-exe -target wasm32-freestanding -O ReleaseSmall \
     -fno-entry --export="docs:adder/add@0.1.0#add" \
     src/main.zig
 
-wasm-tools component embed --world adder wit main.wasm -o main.embed.wasm
-wasm-tools component new main.embed.wasm -o zig-adder.component.wasm
+wabt component embed --world adder wit main.wasm -o main.embed.wasm
+wabt component new main.embed.wasm -o zig-adder.component.wasm
 ```
 
 Or via the repo's root `build.zig`:

--- a/examples/components/zig-adder/src/main.zig
+++ b/examples/components/zig-adder/src/main.zig
@@ -4,15 +4,15 @@
 //! Build pipeline:
 //!   1. `zig build-exe -target wasm32-freestanding -fno-entry \
 //!         --export="docs:adder/add@0.1.0#add" -O ReleaseSmall src/main.zig`
-//!   2. `wasm-tools component embed --world adder wit main.wasm \
+//!   2. `wabt component embed --world adder wit main.wasm \
 //!         -o main.embed.wasm`
-//!   3. `wasm-tools component new main.embed.wasm \
+//!   3. `wabt component new main.embed.wasm \
 //!         -o zig-adder.component.wasm`
 //!
 //! No WASI imports — the canonical-ABI core export name
 //! `"docs:adder/add@0.1.0#add"` is the only public surface. The pkg/iface
 //! prefix matches the WIT in `wit/world.wit` and is what
-//! `wasm-tools component embed` recognises as the lift target for the
+//! `wabt component embed` recognises as the lift target for the
 //! `add` function in interface `docs:adder/add@0.1.0`.
 //!
 //! Saturating add (`+%`) avoids a signed-overflow trap on host-driven

--- a/examples/components/zig-calculator-cmd/README.md
+++ b/examples/components/zig-calculator-cmd/README.md
@@ -25,7 +25,7 @@ The Zig source declares the import directly with `extern "pkg:ns/iface@ver"`:
 extern "docs:adder/add@0.1.0" fn add(x: u32, y: u32) u32;
 ```
 
-After `wasm-tools component embed --world app …` the import becomes a
+After `wabt component embed --world app …` the import becomes a
 component-level `docs:adder/add@0.1.0::add` import, which any
 implementation of the adder world (including
 [`../zig-adder`](../zig-adder)) can satisfy. The wasi-preview1 adapter
@@ -40,15 +40,15 @@ zig build-exe -target wasm32-wasi -O ReleaseSmall \
     -fno-entry --export=_start src/main.zig
 
 # 2. embed the world so component new can recognise the docs:adder import.
-wasm-tools component embed --world app wit main.wasm -o main.embed.wasm
+wabt component embed --world app wit main.wasm -o main.embed.wasm
 
 # 3. encode + adapt.
-wasm-tools component new main.embed.wasm \
-    --adapt wasi_snapshot_preview1.command.wasm \
+wabt component new main.embed.wasm \
+    --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.command.wasm \
     -o zig-calculator-cmd.component.wasm
 
 # 4. compose with an adder implementation (e.g. ../zig-adder).
-wasm-tools compose -d zig-adder.component.wasm \
+wabt component compose -d zig-adder.component.wasm \
     zig-calculator-cmd.component.wasm \
     -o final.component.wasm
 ```
@@ -66,22 +66,12 @@ Zig adder linked in.
 
 ## Runtime status
 
-The composed component validates with `wasm-tools validate` and runs in
-[Wasmtime][wasmtime] (and other modern component runtimes). On wamr's
-current preview-state runtime it loads but does not execute, because
-`wasm-tools compose` emits the top-level `wasi:cli/run@0.2.x` export as
-an *aliased* instance, while wamr's
-[`registerInstanceExport` in `src/component/instance.zig`][regfn] only
-walks `.local` (inline `.exports` / `.instantiate`) instance refs and
-not `.aliased` ones.
-
-The pre-compose component (with the unresolved adder import) already
-uses the inline `.instantiate` shim shape that wamr does support — the
-limitation is purely about composed output. The aliased-instance gap
-will be addressed alongside the issue #142 follow-up.
+The composed component validates with `wabt validate` and runs in both
+[Wasmtime][wasmtime] and wamr. `zig build component-examples-run` runs
+this example end-to-end through `./zig-out/bin/wamr` and asserts the
+expected two-line output.
 
 [wasmtime]: https://wasmtime.dev/
-[regfn]: ../../../../src/component/instance.zig
 
 ## Notes
 
@@ -92,6 +82,5 @@ will be addressed alongside the issue #142 follow-up.
 - Argument parsing is omitted; the example focuses on the import linkage.
   A future variant could parse `argv` via `std.os.wasi.args_sizes_get` /
   `args_get` to match the BCA tutorial's `1 2 add → "1 + 2 = 3"` shape.
-- `wasm-tools compose` is deprecated upstream in favour of
-  [`wac`](https://github.com/bytecodealliance/wac); both produce
-  equivalent component shapes for this example.
+- `wabt component compose` and `wac` produce equivalent component
+  shapes for this example; wamr's component loader accepts both.

--- a/examples/components/zig-calculator-cmd/src/main.zig
+++ b/examples/components/zig-calculator-cmd/src/main.zig
@@ -3,20 +3,20 @@
 //! `command` half of the bytecodealliance `component-docs` adder /
 //! calculator / command tutorial (simplified to skip the calculator
 //! intermediary), and is composed with `../zig-adder` (or the equivalent
-//! Rust adder, in `../mixed-zig-rust-calc`) via `wasm-tools compose`.
+//! Rust adder, in `../mixed-zig-rust-calc`) via `wabt component compose`.
 //!
 //! Build pipeline (driven by the repo's root `build.zig`):
 //!   1. zig build-exe -target wasm32-wasi -O ReleaseSmall \
 //!         -fno-entry --export=_start src/main.zig
-//!   2. wasm-tools component embed --world app wit main.wasm \
+//!   2. wabt component embed --world app wit main.wasm \
 //!         -o main.embed.wasm
-//!   3. wasm-tools component new main.embed.wasm \
-//!         --adapt wasi_snapshot_preview1.command.wasm \
+//!   3. wabt component new main.embed.wasm \
+//!         --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.command.wasm \
 //!         -o zig-calculator-cmd.component.wasm
 //!
 //! The `extern "docs:adder/add@0.1.0" fn add(...)` declaration becomes a
 //! component-level import of `docs:adder/add@0.1.0::add` after the embed
-//! step, which `wasm-tools compose` later wires to the Zig adder's
+//! step, which `wabt component compose` later wires to the Zig adder's
 //! matching export. We deliberately keep a hand-rolled `_start` (instead
 //! of `pub fn main`) for the same reason as the `zig-hello` example — it
 //! avoids `proc_exit` so the run unwinds cleanly through the adapter.

--- a/examples/components/zig-hello/README.md
+++ b/examples/components/zig-hello/README.md
@@ -16,8 +16,8 @@ zig build-exe -target wasm32-wasi -O ReleaseSmall \
     src/main.zig
 
 # 2. Wrap it as a component using the wasi-preview1 command adapter.
-wasm-tools component new main.wasm \
-    --adapt wasi_snapshot_preview1.command.wasm \
+wabt component new main.wasm \
+    --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.command.wasm \
     -o zig-hello.component.wasm
 ```
 
@@ -41,7 +41,7 @@ This example runs end-to-end through wamr today (exit code 0).
 
 - Zig 0.16 producing a `wasm32-wasi` core module with no use of
   `std.start.startWasi` (so no `proc_exit`).
-- `wasm-tools component new --adapt` wrapping a preview1 core into a
+- `wabt component new --adapt` wrapping a preview1 core into a
   Component-Model component.
 - wamr's `wasi:cli/run` instance-export lifting and `wasi:cli/stdout`
   + `wasi:io/streams` host adapters.

--- a/scripts/fuzz_reduce.py
+++ b/scripts/fuzz_reduce.py
@@ -9,8 +9,11 @@ directory.
 
 Two reduction strategies are attempted in order:
 
-1. ``wasm-tools shrink`` if the binary is on ``PATH``. The predicate is a
-   tiny shell wrapper that re-invokes this script in ``--predicate-mode``.
+1. ``wabt shrink`` (preferred) or ``wasm-tools shrink`` (back-compat) if
+   either binary is on ``PATH``. ``wabt shrink`` is a drop-in replacement
+   for ``wasm-tools shrink`` (matching positional argument order and
+   ``--output`` flag). The predicate is a tiny shell wrapper that
+   re-invokes this script in ``--predicate-mode``.
 2. A built-in byte-level shrinker that deletes contiguous ranges of bytes
    and accepts the shorter candidate when it still reproduces.
 
@@ -131,22 +134,37 @@ def byte_level_shrink(
     return best
 
 
-def try_wasm_tools_shrink(
+def detect_external_shrinker() -> str | None:
+    """Return the name of the preferred external shrinker on PATH.
+
+    Prefers ``wabt`` (cataggar/wabt v3.x: ``wabt shrink``) and falls back
+    to ``wasm-tools`` (``wasm-tools shrink``) for back-compat.
+    """
+    if shutil.which("wabt") is not None:
+        return "wabt"
+    if shutil.which("wasm-tools") is not None:
+        return "wasm-tools"
+    return None
+
+
+def try_external_shrink(
     target: str,
     harness: Path,
     input_path: Path,
     out_path: Path,
     duration: int,
     extra_args: list[str],
+    binary: str,
 ) -> bool:
-    """Use ``wasm-tools shrink`` when available.
+    """Use ``wabt shrink`` (or ``wasm-tools shrink``) when available.
 
-    Returns True if it ran. The predicate script re-invokes this module in
-    predicate mode so a single Python file is enough.
+    ``wabt shrink`` is documented as a drop-in for ``wasm-tools shrink``
+    (same positional argument order, same ``--output`` flag), so the
+    same argv works for both. Returns True if it ran.
     """
-    if shutil.which("wasm-tools") is None:
+    if shutil.which(binary) is None:
         return False
-    with tempfile.TemporaryDirectory(prefix="fuzz-reduce-wt-") as tmp:
+    with tempfile.TemporaryDirectory(prefix="fuzz-reduce-shrink-") as tmp:
         tmp_path = Path(tmp)
         predicate = tmp_path / "predicate.sh"
         predicate.write_text(
@@ -165,7 +183,7 @@ def try_wasm_tools_shrink(
         try:
             subprocess.run(
                 [
-                    "wasm-tools",
+                    binary,
                     "shrink",
                     str(predicate),
                     str(input_path),
@@ -176,7 +194,7 @@ def try_wasm_tools_shrink(
             )
             return out_path.exists()
         except Exception as e:  # noqa: BLE001
-            print(f"wasm-tools shrink failed: {e}", file=sys.stderr)
+            print(f"{binary} shrink failed: {e}", file=sys.stderr)
             return False
 
 
@@ -205,14 +223,14 @@ def main(argv: list[str]) -> int:
         help="maximum number of byte-level shrink passes",
     )
     parser.add_argument(
-        "--no-wasm-tools",
+        "--no-external-shrink",
         action="store_true",
-        help="skip wasm-tools shrink even if installed",
+        help="skip wabt/wasm-tools shrink even if installed",
     )
     parser.add_argument(
         "--predicate-mode",
         action="store_true",
-        help="internal: run as a wasm-tools shrink predicate",
+        help="internal: run as a wabt/wasm-tools shrink predicate",
     )
     parser.add_argument(
         "--harness",
@@ -223,7 +241,7 @@ def main(argv: list[str]) -> int:
         "predicate_input",
         nargs="?",
         type=Path,
-        help="internal: candidate wasm passed by wasm-tools shrink",
+        help="internal: candidate wasm passed by wabt/wasm-tools shrink",
     )
     args = parser.parse_args(argv)
 
@@ -248,18 +266,19 @@ def main(argv: list[str]) -> int:
     out = args.out or args.input.with_suffix(".reduced.wasm")
     best = initial
 
-    if not args.no_wasm_tools and shutil.which("wasm-tools") is not None:
-        print("attempting wasm-tools shrink...", file=sys.stderr)
-        wt_out = out.with_suffix(".wt.wasm")
-        if try_wasm_tools_shrink(args.target, harness, args.input, wt_out, args.duration, args.extra):
-            wt_bytes = wt_out.read_bytes()
-            if reproduces(harness, wt_bytes, args.duration, args.extra) and len(wt_bytes) < len(best):
+    shrinker = None if args.no_external_shrink else detect_external_shrinker()
+    if shrinker is not None:
+        print(f"attempting {shrinker} shrink...", file=sys.stderr)
+        ext_out = out.with_suffix(".ext.wasm")
+        if try_external_shrink(args.target, harness, args.input, ext_out, args.duration, args.extra, shrinker):
+            ext_bytes = ext_out.read_bytes()
+            if reproduces(harness, ext_bytes, args.duration, args.extra) and len(ext_bytes) < len(best):
                 print(
-                    f"  wasm-tools: {len(initial)} -> {len(wt_bytes)} bytes",
+                    f"  {shrinker}: {len(initial)} -> {len(ext_bytes)} bytes",
                     file=sys.stderr,
                 )
-                best = wt_bytes
-            wt_out.unlink(missing_ok=True)
+                best = ext_bytes
+            ext_out.unlink(missing_ok=True)
 
     print("running byte-level shrinker...", file=sys.stderr)
     best = byte_level_shrink(harness, best, args.duration, args.extra, args.max_passes)

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -415,7 +415,9 @@ fn parseInstance(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!
             const count = try reader.readU32();
             const exps = try allocator.alloc(ctypes.InlineExport, count);
             for (exps) |*e| {
-                e.name = try reader.readName();
+                // inlineexport ::= n:<exportname'> si:<sortidx>
+                // exportname' carries a 0x00/0x01/0x02 prefix tag — must use readExternName.
+                e.name = try readExternName(reader);
                 e.sort_idx = try readSortIdx(reader);
             }
             return .{ .exports = exps };
@@ -952,6 +954,43 @@ test "parseTypeDef: instance type rejects import decl" {
     const data = [_]u8{ 0x42, 0x01, 0x03 };
     var reader = BinaryReader{ .data = &data };
     try std.testing.expectError(error.InvalidEncoding, parseTypeDef(&reader, std.testing.allocator));
+}
+
+test "parseInstance: inline-export form expects exportname' (0x00 prefix) on each name" {
+    // Regression test for `wabt component compose` interop:
+    //
+    // Component-model spec:
+    //   instance       ::= 0x00 c arg* | 0x01 ie*
+    //   inlineexport   ::= n:<exportname'> si:<sortidx>
+    //   exportname'    ::= 0x00 en:<exportname>          ; tagged form
+    //
+    // wabt's `component compose` emits the inline-export form (tag 0x01)
+    // for sub-component instantiation, while wasm-tools always uses the
+    // `instantiate` form (tag 0x00). The bug fixed alongside this test
+    // had `parseInstance` reading the inline-export name with bare
+    // `readName` (vec(byte)), which mis-aligned into the sortidx and
+    // surfaced as `error.InvalidSectionSize` from the section-end check.
+    const data = [_]u8{
+        // tag = 0x01 (inline-export form)
+        0x01,
+        // count of inline-exports = 1
+        0x01,
+        // exportname' = 0x00 prefix, len=3, "add"
+        0x00, 0x03, 'a', 'd', 'd',
+        // sortidx = sort=0x01 (func), idx=0
+        0x01, 0x00,
+    };
+    var reader = BinaryReader{ .data = &data };
+    const inst = try parseInstance(&reader, std.testing.allocator);
+    defer std.testing.allocator.free(inst.exports);
+    try std.testing.expect(inst == .exports);
+    try std.testing.expectEqual(@as(usize, 1), inst.exports.len);
+    try std.testing.expectEqualStrings("add", inst.exports[0].name);
+    try std.testing.expect(inst.exports[0].sort_idx.sort == .func);
+    try std.testing.expectEqual(@as(u32, 0), inst.exports[0].sort_idx.idx);
+    // Reader must have consumed every byte — the section-end check in
+    // `load` enforces this for the real call site.
+    try std.testing.expectEqual(data.len, reader.pos);
 }
 
 test "load: real wasm32-wasip2 Rust component (stdio-echo)" {

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -149,9 +149,10 @@ scripts/fuzz_reduce.py <target> <crasher.wasm> [--duration 2] [--extra --fuel --
 ```
 
 The script verifies the input still reproduces, optionally invokes
-`wasm-tools shrink` if it is on `PATH`, then runs a built-in byte-level
-delta-debug pass. The smallest reproducer is written next to the input as
-`<crasher>.reduced.wasm` (override with `--out`).
+`wabt shrink` (or `wasm-tools shrink`) if either is on `PATH`, then runs
+a built-in byte-level delta-debug pass. The smallest reproducer is
+written next to the input as `<crasher>.reduced.wasm` (override with
+`--out`).
 
 A candidate "still reproduces" when the harness exits non-zero (process
 abort) or leaves a named crasher file like `diff-mismatch-*.wasm`. Pass


### PR DESCRIPTION
Migrates the WebAssembly Component-Model build pipeline off `wasm-tools` and onto the unified [`cataggar/wabt`](https://github.com/cataggar/wabt) v3.0.0-dev.3 binary.

## Summary

`cataggar/wabt` v3 absorbs the component CLI surface (`embed`, `new`, `compose`, `validate`, `shrink`) so a single `wabt` binary replaces the wasm-tools dependency for all build, validation, fuzzing, and example-component flows.

## Commits

1. **`fix(component/loader): accept inline-export form in parseInstance tag 0x01`**
   - `parseInstance` tag `0x01` was reading bare `name` instead of `exportname'` (`0x00`-prefixed).
   - Hidden because `wasm-tools compose` emits the instantiate form (tag `0x00`); `wabt compose` emits the inline-export form (tag `0x01`), exposing the bug.
   - Spec ref: `inlineexport ::= n:<exportname'> si:<sortidx>` and `exportname' ::= 0x00 en:<exportname>`.
   - Includes a regression test for the inline-export wire shape.

2. **`build: switch wasm-tools to cataggar/wabt v3.0.0-dev.3`**
   - **`build.zig`** — 11 call-site swaps (`wasm-tools component {embed,new}` → `wabt component {embed,new}`, `wasm-tools compose` → `wabt component compose`, `wasm-tools validate` → `wabt validate`).
   - **CI** — `.github/workflows/copilot-setup-steps.yml` + `.github/actions/install-wasi-sdk-wabt/action.yml` updated to `cataggar/wabt@v3.0.0-dev.3`; `fuzz.yml` drops the never-invoked wasm-tools install.
   - **`scripts/fuzz_reduce.py`** — `try_external_shrink` prefers `wabt shrink` and falls back to `wasm-tools shrink` for back-compat; `--no-wasm-tools` renamed to `--no-external-shrink`.
   - **Docs** — example READMEs and source comment doc-blocks refreshed; runtime-status table corrected (composed examples now run end-to-end on wamr).

## Verification

- ✅ `zig build component-examples-run` — all 4 components (`zig-hello`, `zig-adder`, `zig-calculator-cmd`, `mixed-zig-rust-calc`) build via `wabt` and run through `wamr` with expected output.
- ✅ `zig build test --summary all` — 1738/1738 tests pass (baseline 1737 + 1 new `parseInstance` inline-export regression test).
- ✅ All 4 wabt-built component artifacts validate via `wabt validate`.

## Notes

- The `cataggar/wabt` v2.2.0 **library** (Zig-module) dependency in `build.zig.zon` (used by `wast_runner.zig`) is unchanged; out of scope for this migration.
- The `install-wasi-sdk-wabt` action is currently orphan (no workflow consumers); refreshed for symmetry.