### PR TITLE
build: bump cataggar/wabt v3.0.0-dev.3 → v3.0.0-dev.4 + ghr install

### DIFF
--- a/.github/actions/install-wasi-sdk-wabt/action.yml
+++ b/.github/actions/install-wasi-sdk-wabt/action.yml
@@ -5,15 +5,16 @@
 #   - https://github.com/WebAssembly/wasi-sdk/releases
 #   - https://github.com/cataggar/wabt/releases
 
-# Install WASI-SDK and WABT at /opt
-# /opt is the assumed location widely used in the project
-name: Install WASI-SDK and WABT
+# Install WASI-SDK at /opt and wabt via ghr (cataggar/wabt v3.0.0-dev.4).
+# /opt is the assumed location widely used in the project for wasi-sdk;
+# wabt lands in $HOME/.local/bin via ghr (added to GITHUB_PATH).
+name: Install WASI-SDK and wabt
 
 description: A composite action to download and install wasi-sdk and cataggar/wabt on Ubuntu, macOS, and Windows.
 
 inputs:
   os:
-    description: "Operating system to install on (ubuntu, macos)"
+    description: "Operating system to install on (ubuntu, macos, windows)"
     required: true
 
 runs:
@@ -26,7 +27,7 @@ runs:
         echo "::error title=⛔ error hint::Support Ubuntu, Windows, and macOS Only"
         exit 1
 
-    - name: Set up wasi-sdk and wabt on Ubuntu
+    - name: Set up wasi-sdk on Ubuntu
       if: ${{ startsWith(inputs.os, 'ubuntu') }}
       shell: bash
       run: |
@@ -37,20 +38,12 @@ runs:
         sudo tar -xf wasi-sdk.tar.gz
         sudo ln -sf  wasi-sdk-25.0-x86_64-linux/ wasi-sdk
 
-        echo "Downloading cataggar/wabt for Ubuntu..."
-        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/cataggar/wabt/releases/download/v3.0.0-dev.3/wabt-3.0.0-dev.3-linux-x64.tar.gz
-
-        echo "Extracting wabt..."
-        sudo tar -xf wabt.tar.gz
-        sudo ln -sf  wabt-3.0.0-dev.3-linux-x64 wabt
-
         /opt/wasi-sdk/bin/clang --version
-        /opt/wabt/bin/wabt version
 
-        echo "::notice::wasi-sdk-25 and cataggar/wabt v3.0.0-dev.3 installed on ubuntu"
+        echo "::notice::wasi-sdk-25 installed on ubuntu"
       working-directory: /opt
 
-    - name: Set up wasi-sdk and wabt on macOS on Intel
+    - name: Set up wasi-sdk on macOS on Intel
       if: ${{ inputs.os == 'macos-15-intel' }}
       shell: bash
       run: |
@@ -61,20 +54,12 @@ runs:
         sudo tar -xf wasi-sdk.tar.gz
         sudo ln -sf  wasi-sdk-25.0-x86_64-macos wasi-sdk
 
-        echo "Downloading cataggar/wabt for macOS on Intel..."
-        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/cataggar/wabt/releases/download/v3.0.0-dev.3/wabt-3.0.0-dev.3-macos-x64.tar.gz
-
-        echo "Extracting wabt..."
-        sudo tar -xf wabt.tar.gz
-        sudo ln -sf  wabt-3.0.0-dev.3-macos-x64 wabt
-
         /opt/wasi-sdk/bin/clang --version
-        /opt/wabt/bin/wabt version
 
-        echo "::notice::wasi-sdk-25 and cataggar/wabt v3.0.0-dev.3 installed on ${{ inputs.os }}"
+        echo "::notice::wasi-sdk-25 installed on ${{ inputs.os }}"
       working-directory: /opt
 
-    - name: Set up wasi-sdk and wabt on macOS on ARM
+    - name: Set up wasi-sdk on macOS on ARM
       if: ${{ inputs.os == 'macos-15' }}
       shell: bash
       run: |
@@ -85,27 +70,18 @@ runs:
         sudo tar -xf wasi-sdk.tar.gz
         sudo ln -sf  wasi-sdk-25.0-arm64-macos wasi-sdk
 
-        echo "Downloading cataggar/wabt for macOS on ARM..."
-        sudo wget -O wabt.tar.gz     --progress=dot:giga https://github.com/cataggar/wabt/releases/download/v3.0.0-dev.3/wabt-3.0.0-dev.3-macos-arm64.tar.gz
-
-        echo "Extracting wabt..."
-        sudo tar -xf wabt.tar.gz
-        sudo ln -sf  wabt-3.0.0-dev.3-macos-arm64 wabt
-
         /opt/wasi-sdk/bin/clang --version
-        /opt/wabt/bin/wabt version
 
-        echo "::notice::wasi-sdk-25 and cataggar/wabt v3.0.0-dev.3 installed on ${{ inputs.os }}"
+        echo "::notice::wasi-sdk-25 installed on ${{ inputs.os }}"
       working-directory: /opt
 
-    - name: Set up wasi-sdk and wabt on Windows
+    - name: Set up wasi-sdk on Windows
       if: ${{ startsWith(inputs.os, 'windows') }}
       shell: bash
       run: |
         choco install -y wget
 
         mkdir -p /opt/wasi-sdk
-        mkdir -p /opt/wabt
 
         echo "Downloading wasi-sdk for Windows..."
         wget -O wasi-sdk.tar.gz --progress=dot:giga https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-windows.tar.gz
@@ -113,13 +89,30 @@ runs:
         echo "Extracting wasi-sdk..."
         tar --strip-components=1 -xf wasi-sdk.tar.gz -C /opt/wasi-sdk
 
-        echo "Downloading cataggar/wabt for Windows..."
-        wget -O wabt.tar.gz --progress=dot:giga https://github.com/cataggar/wabt/releases/download/v3.0.0-dev.3/wabt-3.0.0-dev.3-windows-x64.tar.gz
-
-        echo "Extracting wabt..."
-        tar --strip-components=1 -xf wabt.tar.gz -C /opt/wabt
-
         /opt/wasi-sdk/bin/clang --version
-        /opt/wabt/bin/wabt version
 
-        echo "::notice::wasi-sdk-25 and cataggar/wabt v3.0.0-dev.3 installed on Windows"
+        echo "::notice::wasi-sdk-25 installed on Windows"
+
+    - name: Install wabt via ghr (Ubuntu, macOS)
+      if: ${{ startsWith(inputs.os, 'ubuntu') || startsWith(inputs.os, 'macos') }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        # ghr-bin downloads sha256-verified GitHub release archives and
+        # links the chosen binary into ~/.local/bin. Pin both versions.
+        pipx install ghr-bin==0.1.6
+        ghr install cataggar/wabt@v3.0.0-dev.4
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        "$HOME/.local/bin/wabt" version
+        echo "::notice::cataggar/wabt v3.0.0-dev.4 installed on ${{ inputs.os }}"
+
+    - name: Install wabt via ghr (Windows)
+      if: ${{ startsWith(inputs.os, 'windows') }}
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        pipx install ghr-bin==0.1.6
+        ghr install cataggar/wabt@v3.0.0-dev.4
+        Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.local\bin"
+        & "$env:USERPROFILE\.local\bin\wabt.exe" version
+        Write-Host "::notice::cataggar/wabt v3.0.0-dev.4 installed on Windows"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,15 +44,17 @@ jobs:
       - name: Configure Zig caches
         uses: ./.github/actions/zig-cache
 
-      - name: Install cataggar/wabt v3.0.0-dev.3 (component CLI)
+      - name: Install cataggar/wabt v3.0.0-dev.4 (component CLI)
         run: |
           set -euo pipefail
-          ver=3.0.0-dev.3
-          url=https://github.com/cataggar/wabt/releases/download/v${ver}/wabt-${ver}-linux-x64.tar.gz
-          curl -fsSL "$url" -o /tmp/wabt.tgz
-          sudo tar -C /usr/local --strip-components=1 -xzf /tmp/wabt.tgz \
-            wabt-${ver}-linux-x64/bin/wabt
-          wabt version
+          # ghr-bin is a tiny PyPI wrapper that downloads sha256-verified
+          # GitHub release archives and links the chosen binary into
+          # ~/.local/bin. pipx is preinstalled on ubuntu-latest; pip is
+          # blocked by PEP 668. Pin both ghr-bin and the wabt release.
+          pipx install ghr-bin==0.1.6
+          ghr install cataggar/wabt@v3.0.0-dev.4
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/wabt" version
 
       - name: Cache Zig global cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/build.zig
+++ b/build.zig
@@ -159,10 +159,26 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(wamrc);
 
     // ── Spec test runner ─────────────────────────────────────────────
+    // wabt v3.0.0-dev.4 ships both a library and a CLI exe both named "wabt",
+    // so `wabt_dep.artifact("wabt")` panics with "artifact name 'wabt' is
+    // ambiguous", and the package no longer calls `b.addModule(...)` either.
+    // Build the wabt library module ourselves from the dep's `src/root.zig`,
+    // wired with a synthetic `build_options.version` (the only build option
+    // wabt's root.zig consumes).
     const wabt_dep = b.dependency("wabt", .{
         .target = target,
         .optimize = .ReleaseSafe,
     });
+
+    const wabt_build_options = b.addOptions();
+    wabt_build_options.addOption([]const u8, "version", "v3.0.0-dev.4");
+
+    const wabt_module = b.createModule(.{
+        .root_source_file = wabt_dep.path("src/root.zig"),
+        .target = target,
+        .optimize = .ReleaseSafe,
+    });
+    wabt_module.addImport("build_options", wabt_build_options.createModule());
 
     const spec_runner_module = b.createModule(.{
         .root_source_file = b.path("src/tests/run_spec_tests.zig"),
@@ -171,7 +187,7 @@ pub fn build(b: *std.Build) void {
     });
     spec_runner_module.addImport("config", config_module);
     spec_runner_module.addImport("wamr", lib_module);
-    spec_runner_module.addImport("wabt", wabt_dep.artifact("wabt").root_module);
+    spec_runner_module.addImport("wabt", wabt_module);
 
     const spec_runner_exe = b.addExecutable(.{
         .name = "spec-test-runner",
@@ -550,7 +566,7 @@ pub fn build(b: *std.Build) void {
 ///
 /// Pinned versions:
 ///   * Wasmtime preview1 → component adapter v36.0.9 (sha256 verified)
-///   * `cataggar/wabt` ≥ v3.0.0-dev.3 on PATH (provides `component embed`,
+///   * `cataggar/wabt` ≥ v3.0.0-dev.4 on PATH (provides `component embed`,
 ///     `component new`, `component compose`, `validate`)
 ///   * `cargo` with `wasm32-wasip1` target for the mixed example
 fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
@@ -784,9 +800,9 @@ fn installAndValidate(
     component: std.Build.LazyPath,
     install_basename: []const u8,
 ) void {
-    const validate = b.addSystemCommand(&.{ "wabt", "validate" });
+    const validate = b.addSystemCommand(&.{ "wabt", "module", "validate" });
     validate.addFileArg(component);
-    validate.setName(b.fmt("wabt validate {s}", .{install_basename}));
+    validate.setName(b.fmt("wabt module validate {s}", .{install_basename}));
 
     const install = b.addInstallFileWithDir(
         component,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .wabt = .{
-            .url = "https://github.com/cataggar/wabt/archive/refs/tags/v2.2.0.tar.gz",
-            .hash = "wabt-2.0.0-dev.1-eK3F5rgeMACcAUGPBBUX0UQz3sKqDPHP0clRvknrNNlj",
+            .url = "https://github.com/cataggar/wabt/archive/refs/tags/v3.0.0-dev.4.tar.gz",
+            .hash = "wabt-0.1.0-eK3F5oiaHQBElcjAXV1-6H7fgZUUvXP5_pDh-JqMUnRt",
         },
     },
     .paths = .{
@@ -15,5 +15,3 @@
         "src",
     },
 }
-
-

--- a/examples/components/README.md
+++ b/examples/components/README.md
@@ -55,7 +55,7 @@ zig-out/component-examples/
 | Tool                                  | Version    | Notes                                                    |
 |---------------------------------------|-----------:|----------------------------------------------------------|
 | Zig                                   | 0.16.x     | Toolchain already required by the rest of the repo.       |
-| `wabt` (cataggar/wabt)                | v3.0.0-dev.3 | Provides `component embed/new`, `validate`, `component compose`. |
+| `wabt` (cataggar/wabt)                | v3.0.0-dev.4 | Provides `component embed/new`, `validate`, `component compose`. |
 | Wasmtime preview1→component adapter   | v36.0.9    | Auto-fetched + sha256-pinned by the build (`build.zig`). |
 | Rust toolchain (`cargo`, `rustup`)    | recent stable | Mixed example only.                                  |
 | `wasm32-wasip1` Rust target           | —          | `rustup target add wasm32-wasip1`. Mixed example only.    |

--- a/examples/components/mixed-zig-rust-calc/README.md
+++ b/examples/components/mixed-zig-rust-calc/README.md
@@ -65,7 +65,7 @@ That step produces `zig-out/component-examples/mixed-zig-rust-calc.composed.wasm
 ## Prerequisites
 
 - Zig 0.16.x (already required for the rest of the repo).
-- `wabt` (cataggar/wabt v3.0.0-dev.3+) on `PATH`.
+- `wabt` (cataggar/wabt v3.0.0-dev.4+) on `PATH`.
 - A Rust toolchain with the `wasm32-wasip1` target installed:
   `rustup target add wasm32-wasip1`.
 - The `wasi_snapshot_preview1.command.wasm` adapter (downloaded by the

--- a/scripts/fuzz_reduce.py
+++ b/scripts/fuzz_reduce.py
@@ -9,11 +9,9 @@ directory.
 
 Two reduction strategies are attempted in order:
 
-1. ``wabt shrink`` (preferred) or ``wasm-tools shrink`` (back-compat) if
-   either binary is on ``PATH``. ``wabt shrink`` is a drop-in replacement
-   for ``wasm-tools shrink`` (matching positional argument order and
-   ``--output`` flag). The predicate is a tiny shell wrapper that
-   re-invokes this script in ``--predicate-mode``.
+1. ``wabt module shrink`` if the ``wabt`` binary (cataggar/wabt v3.x) is
+   on ``PATH``. The predicate is a tiny shell wrapper that re-invokes
+   this script in ``--predicate-mode``.
 2. A built-in byte-level shrinker that deletes contiguous ranges of bytes
    and accepts the shorter candidate when it still reproduces.
 
@@ -135,15 +133,12 @@ def byte_level_shrink(
 
 
 def detect_external_shrinker() -> str | None:
-    """Return the name of the preferred external shrinker on PATH.
+    """Return ``"wabt"`` if cataggar/wabt is on PATH, else ``None``.
 
-    Prefers ``wabt`` (cataggar/wabt v3.x: ``wabt shrink``) and falls back
-    to ``wasm-tools`` (``wasm-tools shrink``) for back-compat.
+    Uses ``wabt module shrink`` (v3.x subject/verb layout).
     """
     if shutil.which("wabt") is not None:
         return "wabt"
-    if shutil.which("wasm-tools") is not None:
-        return "wasm-tools"
     return None
 
 
@@ -156,11 +151,9 @@ def try_external_shrink(
     extra_args: list[str],
     binary: str,
 ) -> bool:
-    """Use ``wabt shrink`` (or ``wasm-tools shrink``) when available.
+    """Use ``wabt module shrink`` when available.
 
-    ``wabt shrink`` is documented as a drop-in for ``wasm-tools shrink``
-    (same positional argument order, same ``--output`` flag), so the
-    same argv works for both. Returns True if it ran.
+    Returns True if the shrinker ran and produced ``out_path``.
     """
     if shutil.which(binary) is None:
         return False
@@ -184,6 +177,7 @@ def try_external_shrink(
             subprocess.run(
                 [
                     binary,
+                    "module",
                     "shrink",
                     str(predicate),
                     str(input_path),
@@ -194,7 +188,7 @@ def try_external_shrink(
             )
             return out_path.exists()
         except Exception as e:  # noqa: BLE001
-            print(f"{binary} shrink failed: {e}", file=sys.stderr)
+            print(f"{binary} module shrink failed: {e}", file=sys.stderr)
             return False
 
 
@@ -225,12 +219,12 @@ def main(argv: list[str]) -> int:
     parser.add_argument(
         "--no-external-shrink",
         action="store_true",
-        help="skip wabt/wasm-tools shrink even if installed",
+        help="skip wabt module shrink even if installed",
     )
     parser.add_argument(
         "--predicate-mode",
         action="store_true",
-        help="internal: run as a wabt/wasm-tools shrink predicate",
+        help="internal: run as a wabt module shrink predicate",
     )
     parser.add_argument(
         "--harness",
@@ -241,7 +235,7 @@ def main(argv: list[str]) -> int:
         "predicate_input",
         nargs="?",
         type=Path,
-        help="internal: candidate wasm passed by wabt/wasm-tools shrink",
+        help="internal: candidate wasm passed by wabt module shrink",
     )
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
Bumps the wabt CLI and Zig dependency to **v3.0.0-dev.4** and switches every CI install to the pinned ghr-bin recipe. Drops the lingering `wasm-tools shrink` fallback in `fuzz_reduce.py`.

## What changed

### `build.zig.zon`
- Zig dep URL bumped to `v3.0.0-dev.4`; hash refreshed via `zig fetch --save`.

### `build.zig`
- v3.0.0-dev.4 ships both a library *and* a CLI exe both named `wabt`, so `wabt_dep.artifact("wabt")` panics with `artifact name 'wabt' is ambiguous`. The package no longer calls `b.addModule(...)` either. Workaround: build the wabt library module ourselves from the dep's `src/root.zig`, wired with a synthetic `build_options.version` (the only build option `root.zig` consumes).
- v3.0.0-dev.4 reorganises the CLI into a `<subject> <verb>` layout: `wabt validate` is now `wabt module validate`. Updated `installAndValidateComponent`.
- Bumped the pinned-version doc comment for `addComponentExamples`.

### CI install steps — ghr-bin replaces curl
- `.github/workflows/copilot-setup-steps.yml`: replace the curl/tar wabt install with `pipx install ghr-bin==0.1.6 && ghr install cataggar/wabt@v3.0.0-dev.4`. `ghr` verifies sha256 against the upstream sidecar so the pin is end-to-end. `pipx` is preinstalled on `ubuntu-latest` (PEP 668 blocks plain `pip` system installs).
- `.github/actions/install-wasi-sdk-wabt/action.yml`: split the composite into separate wasi-sdk and wabt halves. wasi-sdk `/opt` flow is untouched; the wabt half is replaced with a single ghr install (one bash step for ubuntu/macos, one pwsh step for windows).

### `scripts/fuzz_reduce.py`
- Drop the `wasm-tools shrink` fallback (the user explicitly asked that we stop using wasm-tools).
- Switch the wabt invocation to `wabt module shrink` for v3.0.0-dev.4's subject/verb layout.

### Docs
- `examples/components/README.md`, `examples/components/mixed-zig-rust-calc/README.md`: bump the documented wabt version pin from `v3.0.0-dev.3` to `v3.0.0-dev.4`.

## Verification

Verified locally on aarch64 Linux against ghr-installed `cataggar/wabt v3.0.0-dev.4`:
- `zig build` — clean rebuild ✅
- `zig build test` — full suite passes ✅
- `zig build component-examples` — all four component examples (zig-hello, zig-adder, zig-calculator-cmd, mixed-zig-rust-calc) build, encode, compose, and validate end-to-end via `wabt component embed/new/compose` + `wabt module validate` ✅