### PR TITLE
bench(coldstart): subprocess timing harness + CI gate

### DIFF
--- a/.github/workflows/coldstart-aarch64.yml
+++ b/.github/workflows/coldstart-aarch64.yml
@@ -1,0 +1,195 @@
+name: Cold-start (aarch64)
+
+# Per-PR cold-start latency comparison on the self-hosted aarch64 runner.
+# Runs `scripts/bench_coldstart.py` against the PR base, posts a sticky
+# delta table, and fails the job if the wamr CLI's median cold-start time
+# regresses by more than --regression-ratio (default 1.5×).
+#
+# Cold-start is one of WAMR's strongest selling points (~50× faster than
+# Wasmtime for a noop module — see issue #394). None of the existing
+# benches (codegen cycles/op, in-process CoreMark iter/s, spec tests)
+# observe CLI startup, so a PR adding eager init could 5–10× cold-start
+# with zero CI signal. This workflow guards against that.
+#
+# Reference baseline (issue #394, AArch64 D16pds_v6 commit ab887c59):
+#   wamr `noop.cwasm` median 0.78 ms (range 0.72–0.84)
+#   wamr `noop.wasm`  median 0.82 ms (range 0.77–0.98)
+#   wasmtime `.cwasm`        ~40 ms
+#   wasmtime `.wasm` (JIT)   ~44 ms
+#
+# Pinned to the self-hosted ARM64 runner: GitHub-hosted x86 noise easily
+# exceeds the ~1 ms wamr signal. Hosted runners are unsuitable for this
+# gate.
+
+on:
+  workflow_dispatch:
+    inputs:
+      baseline:
+        description: "Baseline git ref"
+        required: false
+        default: "origin/main"
+      target:
+        description: "Target git ref"
+        required: false
+        default: "HEAD"
+      samples:
+        description: "Timed invocations per (engine, module, variant)"
+        required: false
+        default: "50"
+      warmup:
+        description: "Warmup invocations discarded before timing"
+        required: false
+        default: "5"
+      regression_ratio:
+        description: "Fail if target_median / baseline_median exceeds this"
+        required: false
+        default: "1.5"
+  pull_request:
+    paths:
+      - src/main.zig
+      - src/runtime/**
+      - src/component/**
+      - src/wasi/**
+      - src/compiler/**
+      - build.zig
+      - build.zig.zon
+      - tests/coldstart/**
+      - scripts/bench_coldstart.py
+      - .github/workflows/coldstart-aarch64.yml
+
+concurrency:
+  # Serialize on the self-hosted runner: parallel cold-start invocations
+  # would contend on cores and skew measurements near 1 ms.
+  group: coldstart-aarch64
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  coldstart:
+    runs-on: [self-hosted, Linux, ARM64]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Need the base commit to compare against, so deepen the checkout.
+          fetch-depth: 0
+
+      - name: Install Zig 0.16.0
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
+
+      - name: Resolve refs
+        id: refs
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          INPUT_BASELINE: ${{ github.event.inputs.baseline }}
+          INPUT_TARGET: ${{ github.event.inputs.target }}
+        run: |
+          if [ "$EVENT" = "pull_request" ]; then
+            echo "baseline=$BASE_SHA" >> "$GITHUB_OUTPUT"
+            echo "target=$HEAD_SHA"   >> "$GITHUB_OUTPUT"
+          else
+            echo "baseline=${INPUT_BASELINE:-origin/main}" >> "$GITHUB_OUTPUT"
+            echo "target=${INPUT_TARGET:-HEAD}"            >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run cold-start comparison
+        id: bench
+        continue-on-error: true
+        env:
+          BASELINE: ${{ steps.refs.outputs.baseline }}
+          TARGET: ${{ steps.refs.outputs.target }}
+          SAMPLES: ${{ github.event.inputs.samples || '50' }}
+          WARMUP: ${{ github.event.inputs.warmup || '5' }}
+          REGRESSION_RATIO: ${{ github.event.inputs.regression_ratio || '1.5' }}
+        run: |
+          python3 scripts/bench_coldstart.py \
+            --baseline         "$BASELINE" \
+            --target           "$TARGET" \
+            --samples          "$SAMPLES" \
+            --warmup           "$WARMUP" \
+            --regression-ratio "$REGRESSION_RATIO" \
+            --out              coldstart-table.md \
+            --json             coldstart.json \
+            --emit             github
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coldstart-aarch64-${{ github.sha }}
+          path: |
+            coldstart-table.md
+            coldstart.json
+          if-no-files-found: ignore
+          retention-days: 90
+
+      - name: Sticky comment on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- coldstart-aarch64 -->';
+            const tablePath = 'coldstart-table.md';
+            const status = '${{ steps.bench.outcome }}';
+
+            let table = '';
+            if (fs.existsSync(tablePath)) {
+              table = fs.readFileSync(tablePath, 'utf8');
+            } else {
+              core.warning('coldstart-table.md was not produced');
+              table = '_No comparison table was produced._';
+            }
+
+            const verdict = status === 'success'
+              ? '✅ Cold-start within 1.5× of baseline.'
+              : '❌ Cold-start regressed beyond the 1.5× threshold — see job logs.';
+
+            const body = [
+              marker,
+              '## ❄️ Cold-start (aarch64)',
+              '',
+              verdict,
+              '',
+              table,
+              '',
+              '<sub>Self-hosted aarch64 runner. ' +
+                'See [`scripts/bench_coldstart.py`](../tree/main/scripts/bench_coldstart.py) ' +
+                'and issue #394 for context.</sub>',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+            const prior = existing.find(
+              (c) => c.user && c.user.type === 'Bot' && c.body && c.body.startsWith(marker),
+            );
+
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: prior.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+            }
+
+      - name: Fail on cold-start regression
+        if: steps.bench.outcome == 'failure'
+        run: exit 1

--- a/scripts/bench_coldstart.py
+++ b/scripts/bench_coldstart.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python3
+"""Compare CLI cold-start latency between two git refs.
+
+Builds ``wamr`` + ``wamrc`` at each ref in a throwaway worktree, then spawns
+the CLI ``--samples`` times against a tiny noop module and reports
+median/min/max/p95/σ. Optionally adds Wasmtime columns and a synthesized
+``add100`` module that surfaces JIT-startup cost more clearly.
+
+Companion to the in-process budget tests in ``src/tests/coldstart_test.zig``
+(issue #395). Subprocess timing is the user-visible total (process spawn +
+runtime startup + execute + exit), and is what regressions in eager
+initialization actually move.
+
+Intended for use both locally and from
+``.github/workflows/coldstart-aarch64.yml``.
+
+Usage
+-----
+::
+
+    scripts/bench_coldstart.py --baseline origin/main --target HEAD
+    scripts/bench_coldstart.py --baseline origin/main --target HEAD \\
+        --samples 50 --warmup 5 --regression-ratio 1.5 \\
+        --out coldstart-table.md --json coldstart.json --emit github
+    scripts/bench_coldstart.py --target HEAD --wasmtime --include-jit
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+# Modules in the order they should appear in tables / JSON output.
+NOOP_MODULE = "noop"
+ADD100_MODULE = "add100"
+
+# Engines in the order they should appear in tables.
+ENGINE_TARGET = "wamr-target"
+ENGINE_BASELINE = "wamr-baseline"
+ENGINE_WASMTIME_AOT = "wasmtime-aot"
+ENGINE_WASMTIME_JIT = "wasmtime-jit"
+
+WAMR_ENGINES = (ENGINE_TARGET, ENGINE_BASELINE)
+
+
+# ---------------------------------------------------------------------------
+# Subprocess + worktree helpers (mirroring bench_coremark.py / bench_simd.py).
+# ---------------------------------------------------------------------------
+
+
+def run(
+    cmd: list[str],
+    cwd: Path | None = None,
+    env: dict | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``cmd``, surfacing stdout+stderr verbatim on failure."""
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            env=env,
+            check=check,
+            text=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            f"\n[harness] command failed (exit {exc.returncode}): "
+            f"{' '.join(str(c) for c in cmd)}\n"
+        )
+        if cwd is not None:
+            sys.stderr.write(f"[harness]   cwd: {cwd}\n")
+        if exc.stdout:
+            sys.stderr.write("[harness] --- stdout ---\n")
+            sys.stderr.write(exc.stdout)
+            if not exc.stdout.endswith("\n"):
+                sys.stderr.write("\n")
+        if exc.stderr:
+            sys.stderr.write("[harness] --- stderr ---\n")
+            sys.stderr.write(exc.stderr)
+            if not exc.stderr.endswith("\n"):
+                sys.stderr.write("\n")
+        sys.stderr.flush()
+        raise
+
+
+def make_worktree(repo: Path, ref: str, root: Path, label: str) -> Path:
+    """Create a fresh detached worktree at ``ref`` under ``root``."""
+    sha = run(["git", "rev-parse", ref], cwd=repo).stdout.strip()
+    wt = root / f"{label}-{sha[:12]}"
+    if wt.exists():
+        try:
+            run(["git", "worktree", "remove", "--force", str(wt)], cwd=repo)
+        except subprocess.CalledProcessError:
+            shutil.rmtree(wt)
+    run(["git", "worktree", "add", "--detach", str(wt), sha], cwd=repo)
+    return wt
+
+
+def worktree_env(wt: Path) -> dict:
+    """Return an environment that keeps Zig caches isolated per worktree.
+
+    See repo memory: multi-ref perf worktrees must unset
+    ``ZIG_LOCAL_CACHE_DIR`` and set per-worktree ``ZIG_GLOBAL_CACHE_DIR``.
+    Sharing caches between baseline and target lets the second build reuse
+    the first's artifacts and hides or fabricates timing deltas.
+    """
+    env = os.environ.copy()
+    env.pop("ZIG_LOCAL_CACHE_DIR", None)
+    global_cache = wt / ".zig-global-cache"
+    global_cache.mkdir(exist_ok=True)
+    env["ZIG_GLOBAL_CACHE_DIR"] = str(global_cache)
+    return env
+
+
+def build_worktree(wt: Path) -> dict:
+    """``zig build -Doptimize=ReleaseFast`` and return the env to reuse."""
+    env = worktree_env(wt)
+    print(f"[harness] building {wt.name} (ReleaseFast)", file=sys.stderr)
+    run(["zig", "build", "-Doptimize=ReleaseFast"], cwd=wt, env=env)
+    wamr = wt / "zig-out/bin/wamr"
+    wamrc = wt / "zig-out/bin/wamrc"
+    if not wamr.exists():
+        raise RuntimeError(f"missing {wamr} after build")
+    if not wamrc.exists():
+        raise RuntimeError(f"missing {wamrc} after build")
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Module preparation: noop.wasm/cwasm + optional add100.wasm.
+# ---------------------------------------------------------------------------
+
+
+def find_wasm_tools() -> str | None:
+    return shutil.which("wasm-tools")
+
+
+def find_wasmtime(override: str | None) -> str | None:
+    if override is None:
+        return shutil.which("wasmtime")
+    candidate = shutil.which(override) or override
+    return candidate if Path(candidate).exists() else None
+
+
+def synthesize_add100_wat() -> str:
+    """A ~1 KB module: 99 helper i32.add functions + an exported ``_start``.
+
+    Surfaces JIT-startup cost more clearly than the 36-byte noop, while
+    staying small enough that AOT load time still dominates execution.
+    """
+    parts: list[str] = ["(module"]
+    for i in range(99):
+        parts.append(
+            f"  (func $f{i} (param i32 i32) (result i32) "
+            "local.get 0 local.get 1 i32.add)"
+        )
+    parts.append('  (func (export "_start") (result i32) i32.const 0)')
+    parts.append(")")
+    return "\n".join(parts) + "\n"
+
+
+def prepare_modules(
+    repo: Path,
+    target_wt: Path,
+    target_env: dict,
+    workdir: Path,
+    *,
+    include_jit: bool,
+    use_wasmtime: bool,
+    wasmtime_path: str | None,
+) -> dict[str, dict[str, Path]]:
+    """Materialize all module variants used by the timing loop.
+
+    Returns ``{module_name: {kind: path}}``. ``kind`` is one of
+    ``wasm``, ``wamr_cwasm``, ``wasmtime_cwasm``.
+    """
+    modules: dict[str, dict[str, Path]] = {}
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    # --- noop.wasm: reuse the committed 36-byte fixture ----------------
+    src_noop = repo / "tests/coldstart/noop.wasm"
+    if not src_noop.exists():
+        raise RuntimeError(f"missing committed noop fixture at {src_noop}")
+    noop_wasm = workdir / "noop.wasm"
+    shutil.copy2(src_noop, noop_wasm)
+
+    # --- noop.cwasm via the *target* wamrc ----------------------------
+    target_wamrc = target_wt / "zig-out/bin/wamrc"
+    noop_cwasm = workdir / "wamr" / "noop.cwasm"
+    noop_cwasm.parent.mkdir(parents=True, exist_ok=True)
+    print("[harness] AOT-compiling noop.cwasm via target wamrc", file=sys.stderr)
+    run(
+        [str(target_wamrc), "compile", str(noop_wasm), "-o", str(noop_cwasm)],
+        cwd=workdir,
+        env=target_env,
+    )
+
+    entry: dict[str, Path] = {"wasm": noop_wasm, "wamr_cwasm": noop_cwasm}
+
+    # --- noop.cwasm via wasmtime (if requested) -----------------------
+    if use_wasmtime and wasmtime_path is not None:
+        wt_cwasm = workdir / "wasmtime" / "noop.cwasm"
+        wt_cwasm.parent.mkdir(parents=True, exist_ok=True)
+        print("[harness] AOT-compiling noop.cwasm via wasmtime", file=sys.stderr)
+        run(
+            [wasmtime_path, "compile", "-o", str(wt_cwasm), str(noop_wasm)],
+            cwd=workdir,
+        )
+        entry["wasmtime_cwasm"] = wt_cwasm
+
+    modules[NOOP_MODULE] = entry
+
+    # --- add100 (optional, behind --include-jit) ----------------------
+    if include_jit:
+        ws = find_wasm_tools()
+        if ws is None:
+            print(
+                "[harness] --include-jit requested but `wasm-tools` is not on "
+                "PATH; skipping add100 module",
+                file=sys.stderr,
+            )
+        else:
+            wat = workdir / "add100.wat"
+            wat.write_text(synthesize_add100_wat())
+            wasm = workdir / "add100.wasm"
+            print("[harness] synthesizing add100.wasm", file=sys.stderr)
+            run([ws, "parse", str(wat), "-o", str(wasm)], cwd=workdir)
+
+            cwasm = workdir / "wamr" / "add100.cwasm"
+            run(
+                [str(target_wamrc), "compile", str(wasm), "-o", str(cwasm)],
+                cwd=workdir,
+                env=target_env,
+            )
+
+            jit_entry: dict[str, Path] = {"wasm": wasm, "wamr_cwasm": cwasm}
+            if use_wasmtime and wasmtime_path is not None:
+                wt_cwasm = workdir / "wasmtime" / "add100.cwasm"
+                run(
+                    [wasmtime_path, "compile", "-o", str(wt_cwasm), str(wasm)],
+                    cwd=workdir,
+                )
+                jit_entry["wasmtime_cwasm"] = wt_cwasm
+            modules[ADD100_MODULE] = jit_entry
+
+    return modules
+
+
+# ---------------------------------------------------------------------------
+# Timing loop + statistics.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Sample:
+    engine: str
+    module: str
+    variant: str  # "wasm" or "cwasm"
+    elapsed_ns: int
+
+
+@dataclass
+class Summary:
+    engine: str
+    module: str
+    variant: str
+    samples: int
+    median_ns: int
+    min_ns: int
+    max_ns: int
+    p95_ns: int
+    stdev_ns: int
+    raw_ns: list[int] = field(default_factory=list)
+
+
+def time_invocation(cmd: list[str]) -> int:
+    """Spawn ``cmd`` once and return wall-clock ns. Raises on non-zero exit."""
+    start = time.perf_counter_ns()
+    proc = subprocess.run(cmd, capture_output=True, check=False)
+    elapsed = time.perf_counter_ns() - start
+    if proc.returncode != 0:
+        sys.stderr.write(
+            f"[harness] cold-start invocation failed (exit "
+            f"{proc.returncode}): {' '.join(cmd)}\n"
+        )
+        if proc.stdout:
+            sys.stderr.write(proc.stdout.decode("utf-8", "replace"))
+        if proc.stderr:
+            sys.stderr.write(proc.stderr.decode("utf-8", "replace"))
+        sys.stderr.flush()
+        raise RuntimeError(f"cold-start invocation returned {proc.returncode}")
+    return elapsed
+
+
+def time_engine_module(
+    label: str,
+    cmd: list[str],
+    samples: int,
+    warmup: int,
+    engine: str,
+    module: str,
+    variant: str,
+) -> Summary:
+    """Run ``cmd`` ``samples + warmup`` times, summarize discarding warmups."""
+    print(
+        f"[harness] timing {label} ({engine}/{module}/{variant}) "
+        f"warmup={warmup} samples={samples}",
+        file=sys.stderr,
+    )
+    raw: list[int] = []
+    total = samples + warmup
+    for i in range(total):
+        elapsed = time_invocation(cmd)
+        if i >= warmup:
+            raw.append(elapsed)
+    raw_sorted = sorted(raw)
+    median_ns = int(statistics.median(raw_sorted))
+    p95_idx = max(0, int(round(0.95 * (len(raw_sorted) - 1))))
+    p95_ns = int(raw_sorted[p95_idx])
+    stdev_ns = int(statistics.stdev(raw_sorted)) if len(raw_sorted) > 1 else 0
+    return Summary(
+        engine=engine,
+        module=module,
+        variant=variant,
+        samples=len(raw),
+        median_ns=median_ns,
+        min_ns=int(raw_sorted[0]),
+        max_ns=int(raw_sorted[-1]),
+        p95_ns=p95_ns,
+        stdev_ns=stdev_ns,
+        raw_ns=raw,
+    )
+
+
+def collect_summaries(
+    *,
+    target_wamr: Path,
+    baseline_wamr: Path,
+    wasmtime_path: str | None,
+    modules: dict[str, dict[str, Path]],
+    samples: int,
+    warmup: int,
+) -> list[Summary]:
+    out: list[Summary] = []
+    for module_name, paths in modules.items():
+        wasm = paths["wasm"]
+        wamr_cwasm = paths["wamr_cwasm"]
+
+        # wamr-target: cwasm + wasm
+        out.append(
+            time_engine_module(
+                f"{target_wamr} run {wamr_cwasm.name}",
+                [str(target_wamr), "run", str(wamr_cwasm)],
+                samples, warmup, ENGINE_TARGET, module_name, "cwasm",
+            )
+        )
+        out.append(
+            time_engine_module(
+                f"{target_wamr} run {wasm.name}",
+                [str(target_wamr), "run", str(wasm)],
+                samples, warmup, ENGINE_TARGET, module_name, "wasm",
+            )
+        )
+
+        # wamr-baseline: cwasm + wasm. The baseline build's wamr binary
+        # is paired with the *baseline* wamrc when AOT-compiling, since
+        # cwasm format is engine-version specific. Compile a dedicated
+        # baseline cwasm next to the baseline wamr.
+        baseline_cwasm = baseline_wamr.parent.parent / "_coldstart" / f"{module_name}.cwasm"
+        baseline_cwasm.parent.mkdir(parents=True, exist_ok=True)
+        baseline_wamrc = baseline_wamr.parent / "wamrc"
+        if not baseline_cwasm.exists():
+            print(
+                f"[harness] AOT-compiling {module_name}.cwasm via baseline wamrc",
+                file=sys.stderr,
+            )
+            run(
+                [str(baseline_wamrc), "compile", str(wasm), "-o", str(baseline_cwasm)],
+                cwd=baseline_wamr.parent,
+            )
+        out.append(
+            time_engine_module(
+                f"{baseline_wamr} run {baseline_cwasm.name}",
+                [str(baseline_wamr), "run", str(baseline_cwasm)],
+                samples, warmup, ENGINE_BASELINE, module_name, "cwasm",
+            )
+        )
+        out.append(
+            time_engine_module(
+                f"{baseline_wamr} run {wasm.name}",
+                [str(baseline_wamr), "run", str(wasm)],
+                samples, warmup, ENGINE_BASELINE, module_name, "wasm",
+            )
+        )
+
+        if wasmtime_path is not None and "wasmtime_cwasm" in paths:
+            wt_cwasm = paths["wasmtime_cwasm"]
+            out.append(
+                time_engine_module(
+                    f"{wasmtime_path} {wt_cwasm.name}",
+                    [
+                        wasmtime_path,
+                        "run",
+                        "--allow-precompiled",
+                        str(wt_cwasm),
+                    ],
+                    samples, warmup, ENGINE_WASMTIME_AOT, module_name, "cwasm",
+                )
+            )
+            out.append(
+                time_engine_module(
+                    f"{wasmtime_path} {wasm.name}",
+                    [wasmtime_path, "run", str(wasm)],
+                    samples, warmup, ENGINE_WASMTIME_JIT, module_name, "wasm",
+                )
+            )
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Rendering + regression detection.
+# ---------------------------------------------------------------------------
+
+
+def fmt_ms(ns: int | float | None) -> str:
+    if ns is None:
+        return "—"
+    return f"{ns / 1_000_000:.3f}"
+
+
+def lookup(
+    summaries: list[Summary],
+    engine: str,
+    module: str,
+    variant: str,
+) -> Summary | None:
+    for s in summaries:
+        if s.engine == engine and s.module == module and s.variant == variant:
+            return s
+    return None
+
+
+def render_table(
+    baseline_ref: str,
+    target_ref: str,
+    summaries: list[Summary],
+    wasmtime_path: str | None,
+) -> str:
+    """Markdown table grouped by (module, variant)."""
+    modules_seen: list[str] = []
+    for s in summaries:
+        if s.module not in modules_seen:
+            modules_seen.append(s.module)
+
+    engines: list[tuple[str, str]] = [
+        (ENGINE_TARGET, f"target (`{target_ref}`)"),
+        (ENGINE_BASELINE, f"baseline (`{baseline_ref}`)"),
+    ]
+    if wasmtime_path is not None:
+        engines.append((ENGINE_WASMTIME_AOT, "wasmtime (precompiled)"))
+        engines.append((ENGINE_WASMTIME_JIT, "wasmtime (JIT)"))
+
+    lines: list[str] = ["### Cold-start CLI comparison (median ms)", ""]
+    lines.append(
+        "| Module | Variant | Engine | Median | Min | Max | p95 | σ | Δ vs baseline |"
+    )
+    lines.append("|---|---|---|---:|---:|---:|---:|---:|---:|")
+
+    for module in modules_seen:
+        for variant in ("cwasm", "wasm"):
+            base = lookup(summaries, ENGINE_BASELINE, module, variant)
+            for engine_id, engine_label in engines:
+                s = lookup(summaries, engine_id, module, variant)
+                if s is None:
+                    continue
+                if engine_id == ENGINE_BASELINE or base is None:
+                    delta = "—"
+                else:
+                    ratio = s.median_ns / base.median_ns
+                    pct = (ratio - 1.0) * 100.0
+                    sign = "+" if pct >= 0 else ""
+                    delta = f"{sign}{pct:.1f}% (×{ratio:.2f})"
+                lines.append(
+                    f"| `{module}` | `{variant}` | {engine_label} | "
+                    f"{fmt_ms(s.median_ns)} | {fmt_ms(s.min_ns)} | "
+                    f"{fmt_ms(s.max_ns)} | {fmt_ms(s.p95_ns)} | "
+                    f"{fmt_ms(s.stdev_ns)} | {delta} |"
+                )
+    return "\n".join(lines)
+
+
+@dataclass
+class Regression:
+    module: str
+    variant: str
+    target_median_ns: int
+    baseline_median_ns: int
+    ratio: float
+    threshold: float
+    kind: str  # "ratio" or "budget"
+
+
+def find_regressions(
+    summaries: list[Summary],
+    *,
+    regression_ratio: float,
+    budget_ms: float | None,
+) -> list[Regression]:
+    regressions: list[Regression] = []
+    modules: list[str] = []
+    for s in summaries:
+        if s.module not in modules:
+            modules.append(s.module)
+
+    for module in modules:
+        for variant in ("cwasm", "wasm"):
+            t = lookup(summaries, ENGINE_TARGET, module, variant)
+            b = lookup(summaries, ENGINE_BASELINE, module, variant)
+            if t is None or b is None:
+                continue
+            ratio = t.median_ns / b.median_ns
+            if ratio > regression_ratio:
+                regressions.append(
+                    Regression(
+                        module=module,
+                        variant=variant,
+                        target_median_ns=t.median_ns,
+                        baseline_median_ns=b.median_ns,
+                        ratio=ratio,
+                        threshold=regression_ratio,
+                        kind="ratio",
+                    )
+                )
+            if budget_ms is not None and t.median_ns > budget_ms * 1_000_000:
+                regressions.append(
+                    Regression(
+                        module=module,
+                        variant=variant,
+                        target_median_ns=t.median_ns,
+                        baseline_median_ns=b.median_ns,
+                        ratio=t.median_ns / (budget_ms * 1_000_000),
+                        threshold=budget_ms,
+                        kind="budget",
+                    )
+                )
+    return regressions
+
+
+def write_json(
+    path: Path,
+    *,
+    samples: int,
+    warmup: int,
+    baseline_ref: str,
+    target_ref: str,
+    summaries: list[Summary],
+    regressions: list[Regression],
+    regression_ratio: float,
+    budget_ms: float | None,
+) -> None:
+    payload = {
+        "samples": samples,
+        "warmup": warmup,
+        "baseline_ref": baseline_ref,
+        "target_ref": target_ref,
+        "regression_ratio": regression_ratio,
+        "budget_ms": budget_ms,
+        "results": [
+            {
+                "engine": s.engine,
+                "module": s.module,
+                "variant": s.variant,
+                "samples": s.samples,
+                "median_ns": s.median_ns,
+                "min_ns": s.min_ns,
+                "max_ns": s.max_ns,
+                "p95_ns": s.p95_ns,
+                "stdev_ns": s.stdev_ns,
+                "raw_ns": s.raw_ns,
+            }
+            for s in summaries
+        ],
+        "regressions": [
+            {
+                "module": r.module,
+                "variant": r.variant,
+                "target_median_ns": r.target_median_ns,
+                "baseline_median_ns": r.baseline_median_ns,
+                "ratio": r.ratio,
+                "threshold": r.threshold,
+                "kind": r.kind,
+            }
+            for r in regressions
+        ],
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint.
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--baseline", default="origin/main", help="git ref for the baseline")
+    p.add_argument("--target", default="HEAD", help="git ref for the target")
+    p.add_argument("--samples", type=int, default=30, help="timed invocations per (engine, module, variant)")
+    p.add_argument("--warmup", type=int, default=3, help="warmup invocations per (engine, module, variant) discarded before timing")
+    p.add_argument("--wasmtime", action="store_true", help="include wasmtime columns")
+    p.add_argument("--wasmtime-path", default=None, help="wasmtime executable to use with --wasmtime (default: PATH lookup)")
+    p.add_argument("--include-jit", action="store_true", help="also run a synthesized add100 module to surface JIT-startup cost")
+    p.add_argument("--budget-ms", type=float, default=None, help="optional absolute backstop: fail if any wamr-target median exceeds this")
+    p.add_argument("--regression-ratio", type=float, default=1.5, help="fail if any wamr target_median / baseline_median exceeds this ratio (default 1.5)")
+    p.add_argument("--json", dest="json_path", type=Path, default=None, help="write machine-readable results to this file")
+    p.add_argument("--out", type=Path, default=None, help="if given, write the markdown table here as well")
+    p.add_argument("--emit", choices=["markdown", "github"], default="markdown", help="`github` also appends to $GITHUB_STEP_SUMMARY when present")
+    p.add_argument("--repo", type=Path, default=Path(__file__).resolve().parents[1], help="path to wamr repo (default: parent of scripts/)")
+    args = p.parse_args()
+
+    if args.samples <= 0:
+        raise ValueError("--samples must be positive")
+    if args.warmup < 0:
+        raise ValueError("--warmup must be non-negative")
+    if args.regression_ratio <= 0:
+        raise ValueError("--regression-ratio must be positive")
+    if args.budget_ms is not None and args.budget_ms <= 0:
+        raise ValueError("--budget-ms must be positive")
+
+    repo = args.repo.resolve()
+
+    wasmtime_path: str | None = None
+    if args.wasmtime:
+        wasmtime_path = find_wasmtime(args.wasmtime_path)
+        if wasmtime_path is None:
+            print(
+                "[harness] --wasmtime requested but no wasmtime binary "
+                "found; continuing without wasmtime rows",
+                file=sys.stderr,
+            )
+
+    tmp_root = Path("/work") if Path("/work").is_dir() else None
+    with tempfile.TemporaryDirectory(prefix="bench-coldstart-", dir=tmp_root) as tmp:
+        root = Path(tmp)
+        try:
+            wt_t = make_worktree(repo, args.target, root, "target")
+            wt_b = make_worktree(repo, args.baseline, root, "baseline")
+
+            target_env = build_worktree(wt_t)
+            build_worktree(wt_b)
+
+            modules = prepare_modules(
+                repo,
+                wt_t,
+                target_env,
+                root / "modules",
+                include_jit=args.include_jit,
+                use_wasmtime=args.wasmtime,
+                wasmtime_path=wasmtime_path,
+            )
+
+            summaries = collect_summaries(
+                target_wamr=wt_t / "zig-out/bin/wamr",
+                baseline_wamr=wt_b / "zig-out/bin/wamr",
+                wasmtime_path=wasmtime_path,
+                modules=modules,
+                samples=args.samples,
+                warmup=args.warmup,
+            )
+        finally:
+            run(["git", "worktree", "prune"], cwd=repo, check=False)
+
+    table = render_table(args.baseline, args.target, summaries, wasmtime_path)
+    print(table)
+
+    regressions = find_regressions(
+        summaries,
+        regression_ratio=args.regression_ratio,
+        budget_ms=args.budget_ms,
+    )
+
+    if regressions:
+        print("", file=sys.stderr)
+        print("[harness] regressions detected:", file=sys.stderr)
+        for r in regressions:
+            if r.kind == "ratio":
+                print(
+                    f"  - {r.module}/{r.variant}: "
+                    f"{fmt_ms(r.target_median_ns)} ms vs baseline "
+                    f"{fmt_ms(r.baseline_median_ns)} ms "
+                    f"(×{r.ratio:.2f} > {r.threshold:.2f})",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"  - {r.module}/{r.variant}: "
+                    f"{fmt_ms(r.target_median_ns)} ms exceeds budget "
+                    f"{r.threshold:.2f} ms (×{r.ratio:.2f})",
+                    file=sys.stderr,
+                )
+
+    if args.out:
+        args.out.write_text(table + "\n")
+
+    if args.emit == "github":
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write(table + "\n")
+
+    if args.json_path is not None:
+        write_json(
+            args.json_path,
+            samples=args.samples,
+            warmup=args.warmup,
+            baseline_ref=args.baseline,
+            target_ref=args.target,
+            summaries=summaries,
+            regressions=regressions,
+            regression_ratio=args.regression_ratio,
+            budget_ms=args.budget_ms,
+        )
+
+    return 1 if regressions else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #394.

Adds `scripts/bench_coldstart.py` and `.github/workflows/coldstart-aarch64.yml` to guard WAMR's ~50× CLI cold-start advantage over Wasmtime.

## Harness (`scripts/bench_coldstart.py`)

Mirrors the established two-worktree pattern from `scripts/bench_coremark.py` / `scripts/bench_simd.py`: build target + baseline in throwaway worktrees with isolated Zig caches (`unset ZIG_LOCAL_CACHE_DIR; ZIG_GLOBAL_CACHE_DIR=<wt>/.zig-global-cache`), time `subprocess.run` invocations of each engine's CLI against:

1. `noop.wasm` — reuses the committed 36-byte fixture at `tests/coldstart/noop.wasm` (already present from #395).
2. `noop.cwasm` — produced by the **target** `wamrc` for the target build, and the **baseline** `wamrc` for the baseline build (cwasm format is engine-version specific).
3. *(optional `--include-jit`)* `add100.wasm` — synthesized at runtime via `wasm-tools parse` from a generated WAT (100 helper i32.add functions plus an exported `_start`).

For each `(engine, module, variant)` it spawns `--samples` invocations (default 30), discards the first `--warmup` (default 3), and reports median/min/max/p95/σ measured with `time.perf_counter_ns()`.

CLI:
```
bench_coldstart.py [--baseline REF] [--target REF]
                   [--samples N] [--warmup N]
                   [--wasmtime] [--wasmtime-path PATH]
                   [--include-jit]
                   [--budget-ms FLOAT]
                   [--regression-ratio FLOAT]   # default 1.5
                   [--json OUT.json] [--out OUT.md]
                   [--emit {markdown,github}] [--repo PATH]
```

Exit 1 if any wamr `(module, variant)` has `target_median / baseline_median > regression_ratio`, or (when `--budget-ms` is set) if `target_median > budget_ms`. Always prints the table before exiting.

## CI workflow (`.github/workflows/coldstart-aarch64.yml`)

Mirrors `coremark-aarch64.yml`:

- `runs-on: [self-hosted, Linux, ARM64]` — hosted x86 noise easily exceeds the ~1 ms wamr signal.
- `concurrency: coldstart-aarch64, cancel-in-progress: true`.
- `pull_request` paths: `src/main.zig`, `src/runtime/**`, `src/component/**`, `src/wasi/**`, `src/compiler/**`, `build.zig{,.zon}`, `tests/coldstart/**`, the script itself, the workflow file. `workflow_dispatch` with `baseline`/`target`/`samples`/`warmup`/`regression_ratio` inputs.
- Steps: checkout (fetch-depth 0), `mlugg/setup-zig` 0.16.0, `./.github/actions/zig-cache`, resolve refs, run harness with `continue-on-error: true` (`--samples 50 --warmup 5 --regression-ratio 1.5`), upload `coldstart-table.md` + `coldstart.json` artifacts (90d retention), **sticky** PR comment keyed on `<!-- coldstart-aarch64 -->` marker (find existing → `updateComment`, else `createComment`), final `Fail on cold-start regression` step.

## Verification

Both required acceptance scenarios verified on this AArch64 D16pds_v6 VM:

**No-op PR (baseline harness vs `f52b0570`, --samples 10 --warmup 2 --wasmtime):**

| Module | Variant | Engine | Median (ms) | Δ vs baseline |
|---|---|---|---:|---:|
| noop | cwasm | target HEAD | 0.767 | +1.2% (×1.01) |
| noop | cwasm | baseline f52b0570 | 0.758 | — |
| noop | cwasm | wasmtime (precompiled) | 42.060 | ×55.50 |
| noop | wasm | target HEAD | 0.780 | -3.7% (×0.96) |
| noop | wasm | baseline f52b0570 | 0.810 | — |
| noop | wasm | wasmtime (JIT) | 45.982 | ×56.75 |

→ exit 0. wamr `noop.cwasm` median **0.767 ms**, comfortably inside the documented `[0.6, 1.2]` ms band, and Wasmtime is the expected ~55× slower.

**Synthetic regression (5 ms `nanosleep` injected at top of `pub fn main`, --samples 20 --warmup 2):**

| Module | Variant | Engine | Median (ms) | Δ vs baseline |
|---|---|---|---:|---:|
| noop | cwasm | target (synthetic) | 5.847 | +691.2% (×7.91) |
| noop | cwasm | baseline main | 0.739 | — |
| noop | wasm | target (synthetic) | 5.882 | +668.9% (×7.69) |
| noop | wasm | baseline main | 0.765 | — |

→ exit 1. The ×7.91 and ×7.69 ratios are well above the 1.5× threshold; CI would fail on this PR.

The issue's `std.Thread.sleep(.{ .ms = 5 })` example targets an older Zig API; on Zig 0.16 we use `std.posix.system.nanosleep` instead. Both produce the same 5 ms guest-side stall.

## Acceptance criteria

- [x] `scripts/bench_coldstart.py --target HEAD` runs and prints the table.
- [x] `--baseline <ref> --target HEAD` builds two isolated worktrees and reports both columns plus Δ%.
- [x] `--wasmtime` adds wasmtime columns (precompiled + JIT) when `wasmtime` is on `PATH`.
- [x] `coldstart-aarch64.yml` triggers on PRs and posts a sticky comment.
- [x] Verified locally that CI would fail on a synthetic 5 ms-sleep regression PR.
- [x] No-op PRs are unaffected (paths filter doesn't fire on docs-only changes).
- [x] On the issue's reference range, `wamr-cwasm` median 0.767 ms ∈ `[0.6 ms, 1.2 ms]`. Documented in the workflow preamble.

## Out of scope

Nightly cron variant + tracking issue, branch-protection required check + `coldstart-skip.yml` companion, component-model cold-start, RSS measurement — all deferred to follow-up issues per scoping in the plan.

## Notes

- Reuses the 36-byte `tests/coldstart/noop.wasm` fixture from #395; no new committed binary.
- The script and the in-process budget test (`src/tests/coldstart_test.zig`) are complementary: subprocess timing measures the user-visible total, the in-process test isolates the WAMR-attributable slice. Together they give early signal on different categories of regression.
- `subprocess.run(..., capture_output=True, check=False)` is used for timed invocations to avoid pipe-buffer flush variance; the `run()` helper for build/setup commands surfaces stdout+stderr verbatim on failure (per the pattern in `bench_coremark.py`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>