### PR TITLE
wasi: phase 5b follow-up bundle (#420)

### DIFF
--- a/src/wasi/host_functions.zig
+++ b/src/wasi/host_functions.zig
@@ -1128,12 +1128,35 @@ fn doWrite(ctx: *wasi.WasiCtx, entry_ptr: *wasi.FdEntry, data: []const u8) !usiz
             if ((entry_ptr.rights_base & wasi.RIGHTS_FD_WRITE) == 0) return error.BadFd;
             const host_fd = entry_ptr.host_fd orelse return error.BadFd;
             const file = std.Io.File{ .handle = host_fd, .flags = .{ .nonblocking = false } };
-            var buf: [4096]u8 = undefined;
-            var w = file.writer(ctx.io, &buf);
-            w.seekTo(entry_ptr.pos) catch return error.IoError;
-            w.interface.writeAll(data) catch return error.IoError;
-            w.flush() catch return error.IoError;
-            entry_ptr.pos += data.len;
+            const append = (entry_ptr.fdflags & wasi.FDFLAGS_APPEND) != 0;
+            if (append) {
+                // O_APPEND requires streaming write() on the host: std.Io's
+                // positional writer would issue pwrite, which on Linux
+                // still respects O_APPEND but the std side tracks an
+                // independent cursor that drifts from the kernel offset.
+                // Use writeStreamingAll (calls write(2)) so the kernel
+                // append + offset advancement stay in sync, then read the
+                // post-write offset back to update entry.pos.
+                file.writeStreamingAll(ctx.io, data) catch return error.IoError;
+                if (builtin.os.tag == .linux) {
+                    const linux = std.os.linux;
+                    const rc = linux.lseek(host_fd, 0, std.posix.SEEK.CUR);
+                    if (linux.errno(rc) == .SUCCESS) {
+                        entry_ptr.pos = @intCast(rc);
+                    } else {
+                        entry_ptr.pos += data.len;
+                    }
+                } else {
+                    entry_ptr.pos += data.len;
+                }
+            } else {
+                var buf: [4096]u8 = undefined;
+                var w = file.writer(ctx.io, &buf);
+                w.seekTo(entry_ptr.pos) catch return error.IoError;
+                w.interface.writeAll(data) catch return error.IoError;
+                w.flush() catch return error.IoError;
+                entry_ptr.pos += data.len;
+            }
             return data.len;
         },
         else => return error.BadFd,
@@ -1184,8 +1207,10 @@ fn ctxFdSeekCore(
     if (fd < 0) return wasi_core.WASI_EBADF;
     const u_fd: u32 = @intCast(fd);
     const entry_ptr = ctx.fd_table.entries.getPtr(u_fd) orelse return wasi_core.WASI_EBADF;
-    if (entry_ptr.kind != .regular_file) {
-        return @intCast(@intFromEnum(wasi.Errno.spipe));
+    switch (entry_ptr.kind) {
+        .regular_file => {},
+        .directory => return @intCast(@intFromEnum(wasi.Errno.isdir)),
+        .stdin, .stdout, .stderr, .socket => return @intCast(@intFromEnum(wasi.Errno.spipe)),
     }
     const host_fd = entry_ptr.host_fd orelse return wasi_core.WASI_EBADF;
     const file = std.Io.File{ .handle = host_fd, .flags = .{ .nonblocking = false } };
@@ -1304,13 +1329,10 @@ fn ctxFdPwriteCore(
         .ok => |p| p,
     };
     // POSIX requires pwrite to ignore the file's append-mode (Linux's
-    // implementation in fact respects O_APPEND, contradicting POSIX).
-    // Rather than silently differ from the witx contract, refuse pwrite
-    // on append-mode fds with `notsup`. Guests that want positional
-    // writes shouldn't be opening with APPEND in the first place.
-    if ((entry_ptr.fdflags & wasi.FDFLAGS_APPEND) != 0) {
-        return @intCast(@intFromEnum(wasi.Errno.notsup));
-    }
+    // implementation in fact respects O_APPEND, contradicting POSIX). We
+    // delegate to the host's pwrite — wasi-tests' `pwrite-with-append`
+    // explicitly accepts either offset (POSIX or Linux). Crucially we
+    // don't update entry.pos here since pwrite doesn't move the cursor.
     const host_fd = entry_ptr.host_fd orelse return wasi_core.WASI_EBADF;
 
     if (builtin.os.tag != .linux) return wasi_core.WASI_ENOSYS;
@@ -1426,6 +1448,35 @@ fn ctxFdReaddirCore(
     return wasi_core.WASI_ESUCCESS;
 }
 
+/// Lexically detect whether `path` would resolve outside its dirfd's
+/// subtree once `..` and `.` segments are normalised. Returns true if
+/// the running depth ever drops below zero (i.e. a `..` pops past the
+/// dirfd). Empty segments (consecutive `/`) and `.` segments are
+/// skipped per POSIX path resolution. Trailing/leading slashes are
+/// handled naturally by treating empty components as no-ops.
+///
+/// Note: this is a *pre-flight* check before the host openat — paths
+/// that don't escape lexically still get the host's traversal which
+/// enforces existence and follows symlinks subject to dirflags. We
+/// intentionally do NOT rewrite the path: the host can resolve
+/// balanced `..`s itself, and rewriting would change the meaning of
+/// symlinked intermediate components.
+fn pathEscapesSandbox(path: []const u8) bool {
+    var depth: i32 = 0;
+    var it = std.mem.splitScalar(u8, path, '/');
+    while (it.next()) |seg| {
+        if (seg.len == 0) continue;
+        if (std.mem.eql(u8, seg, ".")) continue;
+        if (std.mem.eql(u8, seg, "..")) {
+            depth -= 1;
+            if (depth < 0) return true;
+            continue;
+        }
+        depth += 1;
+    }
+    return false;
+}
+
 /// `path_open` core: resolve `path` relative to the dirfd's host Dir,
 /// honor preview1 oflags / dirflags / fdflags, persist requested rights
 /// onto the new FdEntry, and write the new fd to `fd_ptr`.
@@ -1455,6 +1506,9 @@ fn ctxPathOpenCore(
         .err => |e| return e,
         .ok => |d| d,
     };
+    // Need the dir entry separately for rights enforcement (PATH_FILESTAT_SET_SIZE
+    // gates OFLAGS_TRUNC, etc.). pPathLookup already validated kind+host_dir.
+    const dir_entry: ?wasi.FdEntry = if (dirfd >= 0) ctx.fd_table.get(@intCast(dirfd)) else null;
     const path = readGuestPath(mem, path_ptr, path_len) orelse
         return wasi_core.WASI_EINVAL;
 
@@ -1462,6 +1516,16 @@ fn ctxPathOpenCore(
     // dir. Absolute paths escape the sandbox and are rejected with
     // notcapable.
     if (path.len > 0 and path[0] == '/') {
+        return @intCast(@intFromEnum(wasi.Errno.notcapable));
+    }
+
+    // Reject paths that lexically escape the preopen via `..`. We track
+    // depth from the dirfd: each non-empty/non-"." component pushes a
+    // level, ".." pops one. Going below zero means the path would
+    // resolve outside the sandbox even if intermediate components
+    // exist on the host. Returns NOTCAPABLE before the host openat,
+    // matching wasi-libc / wasmtime semantics.
+    if (pathEscapesSandbox(path)) {
         return @intCast(@intFromEnum(wasi.Errno.notcapable));
     }
 
@@ -1473,10 +1537,34 @@ fn ctxPathOpenCore(
 
     if (want_creat and want_dir) return wasi_core.WASI_EINVAL;
 
+    // OFLAGS_TRUNC requires PATH_FILESTAT_SET_SIZE on the dirfd. wasi-libc
+    // expects NOTCAPABLE when the right was previously dropped via
+    // fd_fdstat_set_rights.
+    if (want_trunc) {
+        if (dir_entry) |de| {
+            if ((de.rights_base & wasi.RIGHTS_PATH_FILESTAT_SET_SIZE) == 0) {
+                return @intCast(@intFromEnum(wasi.Errno.notcapable));
+            }
+        }
+    }
+
     const base = if (fs_rights_base == 0) ~@as(u64, 0) else fs_rights_base;
     const inh = if (fs_rights_inh == 0) ~@as(u64, 0) else fs_rights_inh;
     const can_read = (base & wasi.RIGHTS_FD_READ) != 0;
     const can_write = (base & wasi.RIGHTS_FD_WRITE) != 0;
+
+    // OFLAGS_DIRECTORY + a write-class right is contradictory: dirs can't
+    // be written via fd_write/fd_pwrite/etc. Return ISDIR up-front so the
+    // host openat doesn't succeed and produce a half-usable directory fd.
+    if (want_dir) {
+        const write_class = wasi.RIGHTS_FD_WRITE |
+            wasi.RIGHTS_FD_DATASYNC |
+            wasi.RIGHTS_FD_ALLOCATE |
+            wasi.RIGHTS_FD_FILESTAT_SET_SIZE;
+        if ((fs_rights_base & write_class) != 0) {
+            return @intCast(@intFromEnum(wasi.Errno.isdir));
+        }
+    }
 
     if (want_dir) {
         var new_dir = dir.openDir(ctx.io, path, .{
@@ -1488,8 +1576,8 @@ fn ctxPathOpenCore(
             .kind = .directory,
             .host_dir = new_dir,
             .fdflags = @intCast(fdflags & wasi.FDFLAGS_ALL),
-            .rights_base = base,
-            .rights_inheriting = inh,
+            .rights_base = base & wasi.DIRECTORY_BASE_RIGHTS,
+            .rights_inheriting = inh & wasi.DIRECTORY_INHERITING_RIGHTS,
         }) catch {
             new_dir.close(ctx.io);
             return wasi_core.WASI_EINVAL;
@@ -1528,8 +1616,8 @@ fn ctxPathOpenCore(
                     .kind = .directory,
                     .host_dir = nd,
                     .fdflags = @intCast(fdflags & wasi.FDFLAGS_ALL),
-                    .rights_base = base,
-                    .rights_inheriting = inh,
+                    .rights_base = base & wasi.DIRECTORY_BASE_RIGHTS,
+                    .rights_inheriting = inh & wasi.DIRECTORY_INHERITING_RIGHTS,
                 }) catch {
                     nd.close(ctx.io);
                     return wasi_core.WASI_EINVAL;
@@ -1838,6 +1926,13 @@ fn ctxPathSymlinkCore(
         return wasi_core.WASI_EINVAL;
     const new_path = readGuestPath(mem, new_path_ptr, new_path_len) orelse
         return wasi_core.WASI_EINVAL;
+    // Reject absolute symlink targets — wasi-libc / wasi-tests treat any
+    // symlink whose target leaves the preopen sandbox as a capability
+    // violation. wasmtime returns NOTCAPABLE; PERM is also accepted by
+    // wasi-tests' assert_errno helper.
+    if (old_path.len > 0 and old_path[0] == '/') {
+        return @intCast(@intFromEnum(wasi.Errno.notcapable));
+    }
     dir.symLink(ctx.io, old_path, new_path, .{}) catch |err|
         return mapStdIoErr(err);
     return wasi_core.WASI_ESUCCESS;
@@ -2072,7 +2167,11 @@ fn ctxFdAllocateCore(ctx: *wasi.WasiCtx, fd: i32, offset: i64, len: i64) i32 {
 
     const u_fd: u32 = @intCast(fd);
     const entry = ctx.fd_table.get(u_fd) orelse return wasi_core.WASI_EBADF;
-    if (entry.kind != .regular_file) return @intCast(@intFromEnum(wasi.Errno.spipe));
+    switch (entry.kind) {
+        .regular_file => {},
+        .directory => return @intCast(@intFromEnum(wasi.Errno.isdir)),
+        .stdin, .stdout, .stderr, .socket => return @intCast(@intFromEnum(wasi.Errno.spipe)),
+    }
 
     if (builtin.os.tag != .linux) return wasi_core.WASI_ENOSYS;
 
@@ -2131,6 +2230,12 @@ fn ctxFdSyncCore(ctx: *wasi.WasiCtx, fd: i32, mode: SyncMode) i32 {
 /// from the table without closing its host resource since ownership
 /// transfers to `to`. wasmtime semantics: `from == to` on an open fd
 /// is a no-op success.
+///
+/// Stdio entries are permitted in the `from` slot (the `stdio` test in
+/// wasi-testsuite renumbers stdin onto a regular file fd). They remain
+/// rejected in the `to` slot because overwriting stdio with another
+/// resource is more invasive than the test exercises and risks
+/// interfering with the host runtime's own stdio.
 fn ctxFdRenumberCore(ctx: *wasi.WasiCtx, from: i32, to: i32) i32 {
     if (from < 0 or to < 0) return wasi_core.WASI_EBADF;
     const u_from: u32 = @intCast(from);
@@ -2144,10 +2249,6 @@ fn ctxFdRenumberCore(ctx: *wasi.WasiCtx, from: i32, to: i32) i32 {
     const from_entry = ctx.fd_table.get(u_from) orelse return wasi_core.WASI_EBADF;
     const to_entry = ctx.fd_table.get(u_to) orelse return wasi_core.WASI_EBADF;
 
-    switch (from_entry.kind) {
-        .stdin, .stdout, .stderr => return wasi_core.WASI_EBADF,
-        else => {},
-    }
     switch (to_entry.kind) {
         .stdin, .stdout, .stderr => return wasi_core.WASI_EBADF,
         else => {},
@@ -2172,8 +2273,10 @@ fn ctxFdTellCore(ctx: *wasi.WasiCtx, mem: []u8, fd: i32, offset_ptr: u32) i32 {
     if (fd < 0) return wasi_core.WASI_EBADF;
     const u_fd: u32 = @intCast(fd);
     const entry = ctx.fd_table.get(u_fd) orelse return wasi_core.WASI_EBADF;
-    if (entry.kind != .regular_file) {
-        return @intCast(@intFromEnum(wasi.Errno.spipe));
+    switch (entry.kind) {
+        .regular_file => {},
+        .directory => return @intCast(@intFromEnum(wasi.Errno.isdir)),
+        .stdin, .stdout, .stderr, .socket => return @intCast(@intFromEnum(wasi.Errno.spipe)),
     }
     if (!wasi_core.memWriteU64(mem, offset_ptr, entry.pos)) return wasi_core.WASI_EINVAL;
     return wasi_core.WASI_ESUCCESS;
@@ -2585,11 +2688,14 @@ test "ctxFdPwriteCore: bad fd / negative offset / spipe / isdir / append rejecte
     const isdir: i32 = @intCast(@intFromEnum(wasi.Errno.isdir));
     try std.testing.expectEqual(isdir, ctxFdPwriteCore(ctx, &mem, 91, 0, 0, 0, 0));
 
-    // Append-mode regular file rejected with notsup, but only after the
-    // pre-checks pass (so the fdflags branch actually runs).
+    // Append-mode regular file is allowed: Linux pwrite respects O_APPEND
+    // (writes at end-of-file) and the wasi-testsuite pwrite-with-append test
+    // explicitly accepts that semantics. We don't reject the call here; just
+    // ensure it doesn't return notsup. Without an iovec/host fd this exits
+    // early with success once pre-checks pass.
     try ctx.fd_table.insert(92, .{ .kind = .regular_file, .fdflags = wasi.FDFLAGS_APPEND });
     const notsup: i32 = @intCast(@intFromEnum(wasi.Errno.notsup));
-    try std.testing.expectEqual(notsup, ctxFdPwriteCore(ctx, &mem, 92, 0, 0, 0, 0));
+    try std.testing.expect(ctxFdPwriteCore(ctx, &mem, 92, 0, 0, 0, 0) != notsup);
 }
 
 test "ctxFdReaddirCore: bad fd / notdir / inval buf" {
@@ -3694,19 +3800,23 @@ test "ctxFdRenumberCore: bad fds" {
     try std.testing.expectEqual(wasi_core.WASI_EBADF, ctxFdRenumberCore(ctx, 4, 99));
 }
 
-test "ctxFdRenumberCore: stdio in either slot returns BADF" {
+test "ctxFdRenumberCore: stdio in to slot returns BADF; from slot is allowed" {
     const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
     defer ctx.deinit();
 
     try ctx.fd_table.insert(4, .{ .kind = .regular_file });
     defer ctx.fd_table.remove(4);
 
-    // from is stdio.
-    try std.testing.expectEqual(wasi_core.WASI_EBADF, ctxFdRenumberCore(ctx, 0, 4));
-    try std.testing.expectEqual(wasi_core.WASI_EBADF, ctxFdRenumberCore(ctx, 1, 4));
-    try std.testing.expectEqual(wasi_core.WASI_EBADF, ctxFdRenumberCore(ctx, 2, 4));
+    // `from` is stdio: this is allowed (wasi-testsuite stdio test renumbers
+    // an opened scratch fd into stdout/stderr; the converse direction is also
+    // permitted). All three preopened stdio slots succeed.
+    try std.testing.expectEqual(wasi_core.WASI_ESUCCESS, ctxFdRenumberCore(ctx, 0, 4));
+    // After the renumber, fd 0 is closed and fd 4 holds what fd 0 had.
+    // Re-prime fd 4 for the next assertion.
+    ctx.fd_table.remove(4);
+    try ctx.fd_table.insert(4, .{ .kind = .regular_file });
 
-    // to is stdio.
+    // `to` is stdio: rejected to keep stdio slots stable.
     try std.testing.expectEqual(wasi_core.WASI_EBADF, ctxFdRenumberCore(ctx, 4, 0));
     try std.testing.expectEqual(wasi_core.WASI_EBADF, ctxFdRenumberCore(ctx, 4, 1));
     try std.testing.expectEqual(wasi_core.WASI_EBADF, ctxFdRenumberCore(ctx, 4, 2));

--- a/src/wasi/wasi.zig
+++ b/src/wasi/wasi.zig
@@ -143,6 +143,78 @@ pub const RIGHTS_FD_FDSTAT_SET_FLAGS: u64 = 0x0000_0000_0000_0008;
 pub const RIGHTS_FD_SYNC: u64 = 0x0000_0000_0000_0010;
 pub const RIGHTS_FD_TELL: u64 = 0x0000_0000_0000_0020;
 pub const RIGHTS_FD_WRITE: u64 = 0x0000_0000_0000_0040;
+pub const RIGHTS_FD_ADVISE: u64 = 0x0000_0000_0000_0080;
+pub const RIGHTS_FD_ALLOCATE: u64 = 0x0000_0000_0000_0100;
+pub const RIGHTS_PATH_CREATE_DIRECTORY: u64 = 0x0000_0000_0000_0200;
+pub const RIGHTS_PATH_CREATE_FILE: u64 = 0x0000_0000_0000_0400;
+pub const RIGHTS_PATH_LINK_SOURCE: u64 = 0x0000_0000_0000_0800;
+pub const RIGHTS_PATH_LINK_TARGET: u64 = 0x0000_0000_0000_1000;
+pub const RIGHTS_PATH_OPEN: u64 = 0x0000_0000_0000_2000;
+pub const RIGHTS_FD_READDIR: u64 = 0x0000_0000_0000_4000;
+pub const RIGHTS_PATH_READLINK: u64 = 0x0000_0000_0000_8000;
+pub const RIGHTS_PATH_RENAME_SOURCE: u64 = 0x0000_0000_0001_0000;
+pub const RIGHTS_PATH_RENAME_TARGET: u64 = 0x0000_0000_0002_0000;
+pub const RIGHTS_PATH_FILESTAT_GET: u64 = 0x0000_0000_0004_0000;
+pub const RIGHTS_PATH_FILESTAT_SET_SIZE: u64 = 0x0000_0000_0008_0000;
+pub const RIGHTS_PATH_FILESTAT_SET_TIMES: u64 = 0x0000_0000_0010_0000;
+pub const RIGHTS_FD_FILESTAT_GET: u64 = 0x0000_0000_0020_0000;
+pub const RIGHTS_FD_FILESTAT_SET_SIZE: u64 = 0x0000_0000_0040_0000;
+pub const RIGHTS_FD_FILESTAT_SET_TIMES: u64 = 0x0000_0000_0080_0000;
+pub const RIGHTS_PATH_SYMLINK: u64 = 0x0000_0000_0100_0000;
+pub const RIGHTS_PATH_REMOVE_DIRECTORY: u64 = 0x0000_0000_0200_0000;
+pub const RIGHTS_PATH_UNLINK_FILE: u64 = 0x0000_0000_0400_0000;
+pub const RIGHTS_POLL_FD_READWRITE: u64 = 0x0000_0000_0800_0000;
+pub const RIGHTS_SOCK_SHUTDOWN: u64 = 0x0000_0000_1000_0000;
+pub const RIGHTS_SOCK_ACCEPT: u64 = 0x0000_0000_2000_0000;
+
+/// Rights that apply to a directory file descriptor. wasi-libc and
+/// wasmtime mask `path_open` results that yield a directory against
+/// this set so e.g. `FD_READ`/`FD_WRITE`/`FD_SEEK` never appear on a
+/// dir's `fs_rights_base`.
+pub const DIRECTORY_BASE_RIGHTS: u64 =
+    RIGHTS_FD_FDSTAT_SET_FLAGS |
+    RIGHTS_FD_SYNC |
+    RIGHTS_PATH_CREATE_DIRECTORY |
+    RIGHTS_PATH_CREATE_FILE |
+    RIGHTS_PATH_LINK_SOURCE |
+    RIGHTS_PATH_LINK_TARGET |
+    RIGHTS_PATH_OPEN |
+    RIGHTS_FD_READDIR |
+    RIGHTS_PATH_READLINK |
+    RIGHTS_PATH_RENAME_SOURCE |
+    RIGHTS_PATH_RENAME_TARGET |
+    RIGHTS_PATH_FILESTAT_GET |
+    RIGHTS_PATH_FILESTAT_SET_SIZE |
+    RIGHTS_PATH_FILESTAT_SET_TIMES |
+    RIGHTS_FD_FILESTAT_GET |
+    RIGHTS_FD_FILESTAT_SET_TIMES |
+    RIGHTS_PATH_SYMLINK |
+    RIGHTS_PATH_REMOVE_DIRECTORY |
+    RIGHTS_PATH_UNLINK_FILE |
+    RIGHTS_POLL_FD_READWRITE;
+
+/// Rights that apply to a regular file descriptor (everything that's
+/// not directory-only). Used as the inheriting-rights mask for files
+/// opened beneath a directory.
+pub const FILE_BASE_RIGHTS: u64 =
+    RIGHTS_FD_DATASYNC |
+    RIGHTS_FD_READ |
+    RIGHTS_FD_SEEK |
+    RIGHTS_FD_FDSTAT_SET_FLAGS |
+    RIGHTS_FD_SYNC |
+    RIGHTS_FD_TELL |
+    RIGHTS_FD_WRITE |
+    RIGHTS_FD_ADVISE |
+    RIGHTS_FD_ALLOCATE |
+    RIGHTS_FD_FILESTAT_GET |
+    RIGHTS_FD_FILESTAT_SET_SIZE |
+    RIGHTS_FD_FILESTAT_SET_TIMES |
+    RIGHTS_POLL_FD_READWRITE;
+
+/// Rights a directory passes through to children opened beneath it via
+/// `path_open`. Same as base + the file rights so opening a regular
+/// file inside still gets read/write/seek capabilities.
+pub const DIRECTORY_INHERITING_RIGHTS: u64 = DIRECTORY_BASE_RIGHTS | FILE_BASE_RIGHTS;
 
 // ── WASI fstflags (bitset, u16) for `*_filestat_set_times` ──────────────
 
@@ -312,9 +384,16 @@ pub const WasiCtx = struct {
         const fd = self.fd_table.allocateFd();
         const owned_name = try self.allocator.dupe(u8, guest_name);
         errdefer self.allocator.free(owned_name);
+        // Preopens are directories: mask the default all-ones rights down
+        // to the directory rights set so wasi-libc / wasi-tests inheritance
+        // stays consistent (e.g. `path_open(preopen, OFLAGS_DIRECTORY,
+        // base, ...)` doesn't carry FD_WRITE/FD_SEEK that would conflict
+        // with the new fd's directory-only nature).
         try self.fd_table.insert(fd, .{
             .kind = .directory,
             .host_dir = dir,
+            .rights_base = DIRECTORY_BASE_RIGHTS,
+            .rights_inheriting = DIRECTORY_INHERITING_RIGHTS,
         });
         try self.preopens.append(self.allocator, .{ .fd = fd, .path = owned_name });
         return fd;

--- a/tests/wasi-testsuite-skip.json
+++ b/tests/wasi-testsuite-skip.json
@@ -1,19 +1,9 @@
 {
     "WASI C tests [wasm32-wasip1]": {
-        "pwrite-with-append": "fd_pwrite/path_open OFLAGS_CREAT|TRUNC|APPEND landed in #420 phases 2+5; test asserts seek tracking under O_APPEND mirrors kernel offset, which our doWrite doesn't track yet (#420 phase 5 follow-up: APPEND-mode lseek SEEK_CUR after write)",
         "sock_shutdown-invalid_fd": "sock_shutdown not implemented (#420 phase 8)",
         "sock_shutdown-not_sock": "sock_shutdown not implemented (#420 phase 8)"
     },
     "WASI Rust tests [wasm32-wasip1]": {
-        "dir_fd_op_failures": "path_create_directory/path_unlink_file landed in #420 phase 3; test also needs fd_seek directory errno fix (phase 1 follow-up)",
-        "directory_seek": "fd_readdir/path_create_directory landed in #420 phases 2-3; test also needs fd_seek directory errno fix (phase 1 follow-up)",
-        "fd_fdstat_set_rights": "fd_fdstat_set_rights landed in #420 phase 1 but per-call rights enforcement not yet implemented",
-        "interesting_paths": "path_open landed in #420 phase 5 with absolute-path rejection; test also needs path_open to reject paths whose normalized form escapes the preopen sandbox via '..' (phase 5 follow-up)",
-        "path_open_preopen": "path_open landed in #420 phase 5; test asserts that opening a preopen dir with OFLAGS_DIRECTORY + RIGHTS_FD_WRITE returns ISDIR — which requires preopen FdEntry rights to omit FD_WRITE/FD_READ (currently default all-ones). Tracked as phase 5 follow-up: tighten preopen rights mask",
-        "poll_oneoff_stdio": "poll_oneoff not implemented (#420 phase 7)",
-        "stdio": "fd_fdstat_get rights for stdio not yet matching wasi-libc expectations (#420 phase 1 follow-up)",
-        "symlink_create": "path_symlink landed in #420 phase 4; test also needs path_symlink to reject absolute target paths (phase 4 follow-up)",
-        "truncation_rights": "path_unlink_file/path_create_directory/path_remove_directory landed in #420 phase 3; test also needs fd_fdstat_set_rights per-call enforcement (phase 1 follow-up)"
+        "poll_oneoff_stdio": "poll_oneoff not implemented (#420 phase 7)"
     }
 }
-


### PR DESCRIPTION
Closes phase 5b of #420.

Eight small WASI preview1 fixes that take wasi-testsuite from **60 to 69** passing (3 remaining skipped: `poll_oneoff_stdio` + 2× `sock_shutdown`).

| # | Item | wasi-testsuite cases unblocked |
|---|------|-------------------------------|
| 1 | `fd_seek`/`fd_tell`/`fd_allocate` on directory → `ISDIR` (was `SPIPE` for everything non-file) | `dir_fd_op_failures`, `directory_seek` |
| 2 | `path_open(OFLAGS_DIRECTORY)` with any write right → `ISDIR` before host `openat` | `path_open_preopen` |
| 3 | New dir fds and preopens mask base/inheriting against `DIRECTORY_BASE_RIGHTS` / `DIRECTORY_INHERITING_RIGHTS` (no `FD_READ`/`WRITE`/`SEEK`/`TELL`/`ALLOCATE` on dirs) | `directory_seek`, `path_open_preopen` |
| 4 | `path_open(OFLAGS_TRUNC)` requires `PATH_FILESTAT_SET_SIZE` on parent | `truncation_rights` |
| 5 | `fd_renumber` permits stdio in `from` slot; `to`-stdio still rejected | `stdio` |
| 6 | `path_symlink` rejects absolute targets (`NOTCAPABLE`) | `symlink_create` |
| 7 | `doWrite` APPEND uses streaming `write(2)` (kernel honors `O_APPEND`) instead of the default positional writer that uses `pwrite` and drifts from kernel offset; `fd_pwrite` no longer rejects `APPEND` fds (Linux `pwrite` respects `O_APPEND`, test explicitly accepts that) | `pwrite-with-append` |
| 8 | `path_open` detects `..` sandbox escapes lexically; balanced traversals still pass | `interesting_paths` |

Bonus: `fd_fdstat_set_rights` already passes on main thanks to existing per-call rights gates in `doRead`/`doWrite` — only `OFLAGS_TRUNC` needed coverage.

## Verification

- `zig build test` — 1802 unit tests pass (two existing tests updated for new pwrite-APPEND and renumber-from-stdio semantics).
- `zig build wasi-testsuite` — **69 passed, 3 skipped** (poll_oneoff_stdio, sock_shutdown-invalid_fd, sock_shutdown-not_sock).
- `zig build -Dtarget=x86_64-windows-gnu -Doptimize=ReleaseSafe` — green.
- `zig build -Dtarget=aarch64-macos -Doptimize=ReleaseSafe` — green.