### PR TITLE
wasi: implement sock_shutdown (#420 phase 8) — closes the wasi-testsuite

### DIFF
--- a/src/wasi/host_functions.zig
+++ b/src/wasi/host_functions.zig
@@ -930,6 +930,21 @@ pub fn wasiFdTell(env_opaque: *anyopaque) types.HostFnError!void {
     env.pushI32(ctxFdTellCore(ctx, mem, fd, offset_ptr)) catch return error.StackOverflow;
 }
 
+/// `wasi_snapshot_preview1.sock_shutdown` — shut down one or both halves of
+/// a socket. Signature: (fd: i32, sdflags: i32) -> i32
+pub fn wasiSockShutdown(env_opaque: *anyopaque) types.HostFnError!void {
+    const env: *ExecEnv = @ptrCast(@alignCast(env_opaque));
+    const sdflags = env.popI32() catch return error.StackUnderflow;
+    const fd = env.popI32() catch return error.StackUnderflow;
+
+    const ctx = getCtx(env) orelse {
+        env.pushI32(wasi_core.WASI_ENOSYS) catch return error.StackOverflow;
+        return;
+    };
+
+    env.pushI32(ctxSockShutdownCore(ctx, fd, sdflags)) catch return error.StackOverflow;
+}
+
 // ── ctx-aware core implementations ────────────────────────────────────
 
 /// Layout for `args_get` / `environ_get`: write `argv_ptrs` (one i32 pointer
@@ -2719,6 +2734,54 @@ fn ctxPollOneoffCore(
     return wasi_core.WASI_ESUCCESS;
 }
 
+// ── sock_shutdown (#420 phase 8) ───────────────────────────────────────
+
+/// Shut down one or both halves of a socket. The two wasi-testsuite cases
+/// are negative-path (bad fd, non-socket fd) so this implementation is
+/// classification-heavy; the real `shutdown(2)` call only fires for the
+/// `entry.kind == .socket` path with a valid `host_fd`.
+fn ctxSockShutdownCore(ctx: *wasi.WasiCtx, fd: i32, sdflags: i32) i32 {
+    if (comptime builtin.os.tag == .windows) return wasi_core.WASI_ENOSYS;
+
+    if (sdflags < 0) return wasi_core.WASI_EINVAL;
+    const u_flags: u32 = @intCast(sdflags);
+    if (u_flags == 0) return wasi_core.WASI_EINVAL;
+    const all_bits: u32 = wasi.SDFLAGS_RD | wasi.SDFLAGS_WR;
+    if ((u_flags & ~all_bits) != 0) return wasi_core.WASI_EINVAL;
+
+    if (fd < 0) return wasi_core.WASI_EBADF;
+    const u_fd: u32 = @intCast(fd);
+    const entry = ctx.fd_table.get(u_fd) orelse return wasi_core.WASI_EBADF;
+
+    if (entry.kind != .socket) {
+        return @intCast(@intFromEnum(wasi.Errno.notsock));
+    }
+
+    if ((entry.rights_base & wasi.RIGHTS_SOCK_SHUTDOWN) == 0) {
+        return @intCast(@intFromEnum(wasi.Errno.notcapable));
+    }
+
+    const host_fd = entry.host_fd orelse return wasi_core.WASI_EBADF;
+
+    const rd = (u_flags & wasi.SDFLAGS_RD) != 0;
+    const wr = (u_flags & wasi.SDFLAGS_WR) != 0;
+    const posix_how: i32 = if (rd and wr)
+        2 // SHUT_RDWR
+    else if (wr)
+        1 // SHUT_WR
+    else
+        0; // SHUT_RD
+
+    if (comptime builtin.os.tag == .linux) {
+        const rc = std.os.linux.shutdown(host_fd, posix_how);
+        return mapLinuxErrno(rc);
+    } else {
+        const rc = std.c.shutdown(host_fd, posix_how);
+        if (rc == 0) return wasi_core.WASI_ESUCCESS;
+        return wasi_core.WASI_EINVAL;
+    }
+}
+
 // ── Import resolution ─────────────────────────────────────────────────
 
 /// Resolve WASI host functions for a module's imports.
@@ -2795,6 +2858,7 @@ fn resolveWasiFunction(name: []const u8) ?types.HostFn {
         .{ "path_symlink", &wasiPathSymlink },
         .{ "path_readlink", &wasiPathReadlink },
         .{ "poll_oneoff", &wasiPollOneoff },
+        .{ "sock_shutdown", &wasiSockShutdown },
     };
 
     inline for (map) |entry| {
@@ -2922,7 +2986,7 @@ test "resolveWasiFunction: unknown returns null" {
     try std.testing.expect(result == null);
 }
 
-test "resolveWasiFunction: all 40 functions resolve" {
+test "resolveWasiFunction: all 41 functions resolve" {
     const names = [_][]const u8{
         "proc_exit",          "thread-spawn",         "fd_write",
         "fd_read",            "fd_pread",             "fd_pwrite",
@@ -2937,7 +3001,7 @@ test "resolveWasiFunction: all 40 functions resolve" {
         "path_filestat_get",  "path_filestat_set_times", "path_create_directory",
         "path_remove_directory", "path_unlink_file",  "path_link",
         "path_rename",        "path_symlink",         "path_readlink",
-        "poll_oneoff",
+        "poll_oneoff",        "sock_shutdown",
     };
     for (names) |name| {
         const result = resolveWasiFunction(name);
@@ -4679,5 +4743,96 @@ test "ctxPollOneoffCore: rights deficit → notcapable event" {
     try std.testing.expectEqual(
         @intFromEnum(wasi.Errno.notcapable),
         pollTestEventErrno(&mem, 64, 0),
+    );
+}
+
+// ── sock_shutdown tests (#420 phase 8) ──────────────────────────────
+
+test "ctxSockShutdownCore: sdflags == 0 → EINVAL" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try std.testing.expectEqual(wasi_core.WASI_EINVAL, ctxSockShutdownCore(ctx, 3, 0));
+}
+
+test "ctxSockShutdownCore: invalid bit in sdflags → EINVAL" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    // 0x10 is outside SDFLAGS_RD|SDFLAGS_WR.
+    try std.testing.expectEqual(wasi_core.WASI_EINVAL, ctxSockShutdownCore(ctx, 3, 0x10));
+    // Combination of valid + invalid bits is still EINVAL.
+    try std.testing.expectEqual(
+        wasi_core.WASI_EINVAL,
+        ctxSockShutdownCore(ctx, 3, @as(i32, wasi.SDFLAGS_RD) | 0x10),
+    );
+}
+
+test "ctxSockShutdownCore: bad fd → EBADF" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    // Negative fd.
+    try std.testing.expectEqual(
+        wasi_core.WASI_EBADF,
+        ctxSockShutdownCore(ctx, -1, @as(i32, wasi.SDFLAGS_RD)),
+    );
+    // Out-of-range fd (no entry).
+    try std.testing.expectEqual(
+        wasi_core.WASI_EBADF,
+        ctxSockShutdownCore(ctx, 99, @as(i32, wasi.SDFLAGS_RD)),
+    );
+}
+
+test "ctxSockShutdownCore: stdout fd → ENOTSOCK" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    // Stdout (fd 1) is registered as a `.stdout` kind by WasiCtx.init.
+    const expected: i32 = @intCast(@intFromEnum(wasi.Errno.notsock));
+    try std.testing.expectEqual(
+        expected,
+        ctxSockShutdownCore(ctx, 1, @as(i32, wasi.SDFLAGS_RD)),
+    );
+}
+
+test "ctxSockShutdownCore: regular_file fd → ENOTSOCK" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try ctx.fd_table.insert(100, .{ .kind = .regular_file });
+    const expected: i32 = @intCast(@intFromEnum(wasi.Errno.notsock));
+    try std.testing.expectEqual(
+        expected,
+        ctxSockShutdownCore(ctx, 100, @as(i32, wasi.SDFLAGS_RD) | @as(i32, wasi.SDFLAGS_WR)),
+    );
+}
+
+test "ctxSockShutdownCore: directory fd → ENOTSOCK" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try ctx.fd_table.insert(101, .{ .kind = .directory });
+    const expected: i32 = @intCast(@intFromEnum(wasi.Errno.notsock));
+    try std.testing.expectEqual(
+        expected,
+        ctxSockShutdownCore(ctx, 101, @as(i32, wasi.SDFLAGS_WR)),
+    );
+}
+
+test "ctxSockShutdownCore: socket without RIGHTS_SOCK_SHUTDOWN → ENOTCAPABLE" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try ctx.fd_table.insert(102, .{
+        .kind = .socket,
+        .host_fd = 0,
+        .rights_base = 0,
+        .rights_inheriting = 0,
+    });
+    const expected: i32 = @intCast(@intFromEnum(wasi.Errno.notcapable));
+    try std.testing.expectEqual(
+        expected,
+        ctxSockShutdownCore(ctx, 102, @as(i32, wasi.SDFLAGS_RD)),
     );
 }

--- a/src/wasi/wasi.zig
+++ b/src/wasi/wasi.zig
@@ -153,6 +153,11 @@ pub const EVENT_FD_READWRITE_HANGUP: u16 = 0x0001;
 pub const SUBSCRIPTION_SIZE: usize = 48;
 pub const EVENT_SIZE: usize = 32;
 
+// ── sock_shutdown sdflags ───────────────────────────────────────────────
+// Witx encodes the direction as a bitfield; both bits set ≡ SHUT_RDWR.
+pub const SDFLAGS_RD: u16 = 0x0001;
+pub const SDFLAGS_WR: u16 = 0x0002;
+
 // ── WASI rights (bitset, u64) — only the bits we currently consult ──────
 // Full taxonomy in the preview1 spec; extend on demand.
 

--- a/tests/wasi-testsuite-skip.json
+++ b/tests/wasi-testsuite-skip.json
@@ -1,7 +1,5 @@
 {
     "WASI C tests [wasm32-wasip1]": {
-        "sock_shutdown-invalid_fd": "sock_shutdown not implemented (#420 phase 8)",
-        "sock_shutdown-not_sock": "sock_shutdown not implemented (#420 phase 8)"
     },
     "WASI Rust tests [wasm32-wasip1]": {
     }


### PR DESCRIPTION
Implements `wasi_snapshot_preview1.sock_shutdown(fd, sdflags)`. The two wasi-testsuite cases are both negative-path:

* `sock_shutdown-invalid_fd`: `shutdown(3, SHUT_RD)` → `EBADF`
* `sock_shutdown-not_sock`:   `shutdown(STDOUT_FILENO, SHUT_RD)` → `ENOTSOCK`

## Behaviour

`ctxSockShutdownCore` classification:

| Condition | Errno |
|---|---|
| `sdflags == 0` | `EINVAL` |
| `sdflags` has reserved bits | `EINVAL` |
| fd missing | `EBADF` |
| `entry.kind != .socket` | `ENOTSOCK` |
| rights deficit (`RIGHTS_SOCK_SHUTDOWN`) | `ENOTCAPABLE` |
| else | `std.os.linux.shutdown(host_fd, how)` |

WASI `sdflags` → POSIX `how` mapping:

| sdflags | POSIX how |
|---|---|
| `SDFLAGS_RD` only | `0` (SHUT_RD) |
| `SDFLAGS_WR` only | `1` (SHUT_WR) |
| both bits | `2` (SHUT_RDWR) |

Windows short-circuits with `ENOSYS` at the top of the core, consistent with the rest of the WASI surface. Non-Linux POSIX falls back to `std.c.shutdown`.

## Testing

* 7 new unit tests in `src/wasi/host_functions.zig` cover the EINVAL / EBADF / ENOTSOCK / ENOTCAPABLE paths.
* `zig build test` — **1826/1826** passing (1819 + 7 new).
* `zig build wasi-testsuite` — **72 passing, 0 skipped** ← closes the suite. Was 70/2.
* Cross-compile: `x86_64-windows-gnu -Doptimize=ReleaseSafe` ✓; `aarch64-macos -Doptimize=ReleaseSafe` ✓.

## After this PR

The wasi-testsuite is fully green for the wamr-zig runtime. Issue [#420](https://github.com/cataggar/wamr/issues/420) closes with this merge.

Future preview1 work (no remaining skip-list pressure):
* **Phase 9** — `proc_raise` / `sched_yield` / `clock_res_get` polish.
* **Phase 10** — component `proc_exit` bridge → `WasiCliAdapter.exit_code`.

Closes #420.