### PR TITLE
perf(regalloc): loop-depth-weighted spill cost in linear-scan

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -1416,8 +1416,15 @@ fn computeLiveRangesScheduled(
     var last_use_pos = std.AutoHashMap(ir.VReg, u32).init(allocator);
     defer last_use_pos.deinit();
 
+    // Per-order-position flat-index span (mirrors the same array used
+    // by `analysis.computeLiveRangesWithOrder`). One extra slot acts as
+    // a sentinel so `block_starts[i+1]` is always a valid exclusive end.
+    const block_starts = try allocator.alloc(u32, block_order.len + 1);
+    defer allocator.free(block_starts);
+
     var global_idx: u32 = 0;
-    for (block_order) |bid| {
+    for (block_order, 0..) |bid, oi| {
+        block_starts[oi] = global_idx;
         if (liveness.getPtr(bid)) |bl| {
             var lit = bl.live_in.iterator();
             while (lit.next()) |entry| {
@@ -1451,6 +1458,13 @@ fn computeLiveRangesScheduled(
             }
         }
     }
+    block_starts[block_order.len] = global_idx;
+
+    // Per-block loop-nest depth. Kept as a separate helper so the
+    // scheduler-aware path here and the canonical `computeLiveRanges`
+    // path share the exact same eviction-priority signal.
+    const loop_depth_by_block: []u8 = try analysis.loopDepthByBlockForFunc(func, allocator);
+    defer allocator.free(loop_depth_by_block);
 
     var ranges: std.ArrayList(analysis.LiveRange) = .empty;
     errdefer ranges.deinit(allocator);
@@ -1459,11 +1473,20 @@ fn computeLiveRangesScheduled(
         const vreg = entry.key_ptr.*;
         const start = entry.value_ptr.*;
         const end = last_use_pos.get(vreg) orelse start;
+        const final_end = @max(start, end);
+        const depth = analysis.maxLoopDepthOverSpan(
+            start,
+            final_end,
+            block_order,
+            block_starts,
+            loop_depth_by_block,
+        );
         try ranges.append(allocator, .{
             .vreg = vreg,
             .start = start,
-            .end = @max(start, end),
+            .end = final_end,
             .type = def_type.get(vreg) orelse .i32,
+            .max_loop_depth = depth,
         });
     }
 

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -466,11 +466,24 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
 }
 
 /// A live range interval for a VReg.
+///
+/// `max_loop_depth` is the loop-nest depth of the hottest block the range
+/// overlaps. The register allocator uses it to bias eviction toward the
+/// coldest active interval — a long-living, loop-invariant value carrying
+/// `max_loop_depth = N` is preferred over a short-lived noise vreg at
+/// depth `0` when the spill cost would otherwise be paid once per
+/// iteration. See `computeLoopDepthByBlock` for how the value is derived.
 pub const LiveRange = struct {
     vreg: ir.VReg,
     start: u32, // global instruction index of definition
     end: u32, // global instruction index of last use
     type: ir.IrType,
+    /// Maximum loop-nest depth of any block the range overlaps. `0` means
+    /// the range is never inside a loop (cheap to spill). Higher values
+    /// indicate hotter code — every iteration of the enclosing loop pays
+    /// the load/store cost of a spill, so the allocator should prefer to
+    /// evict ranges with smaller `max_loop_depth`.
+    max_loop_depth: u8 = 0,
 };
 
 /// Compute live ranges for all VRegs in a function.
@@ -520,8 +533,16 @@ pub fn computeLiveRangesWithOrder(
     };
     defer if (owns_order) allocator.free(effective_order);
 
+    // Per-order-position flat-index span: block at order position `i`
+    // covers [block_starts[i], block_starts[i+1]). Used after the main
+    // pass to annotate each live range with the max loop-nest depth of
+    // any block it overlaps.
+    const block_starts = try allocator.alloc(u32, effective_order.len + 1);
+    defer allocator.free(block_starts);
+
     var global_idx: u32 = 0;
-    for (effective_order) |bid| {
+    for (effective_order, 0..) |bid, oi| {
+        block_starts[oi] = global_idx;
         const block = func.blocks.items[bid];
 
         // VRegs in live_in are used before defined in this block — extend their range
@@ -558,6 +579,16 @@ pub fn computeLiveRangesWithOrder(
             }
         }
     }
+    block_starts[effective_order.len] = global_idx;
+
+    // Per-block loop-nest depth, computed once and reused for every
+    // range. On functions without back-edges this stays all-zeros and
+    // the eviction heuristic degrades to the pre-change "longest end"
+    // rule. Failures here are propagated rather than silently masked —
+    // dominator/loop computation is bounded by CFG size and very rarely
+    // OOMs in practice.
+    const loop_depth_by_block: []u8 = try computeLoopDepthByBlockForFunc(func, allocator);
+    defer allocator.free(loop_depth_by_block);
 
     // Build sorted live ranges
     var ranges: std.ArrayList(LiveRange) = .empty;
@@ -566,11 +597,20 @@ pub fn computeLiveRangesWithOrder(
         const vreg = entry.key_ptr.*;
         const start = entry.value_ptr.*;
         const end = last_use_pos.get(vreg) orelse start;
+        const final_end = @max(start, end);
+        const depth = maxLoopDepthOverSpan(
+            start,
+            final_end,
+            effective_order,
+            block_starts,
+            loop_depth_by_block,
+        );
         try ranges.append(allocator, .{
             .vreg = vreg,
             .start = start,
-            .end = @max(start, end),
+            .end = final_end,
             .type = def_type.get(vreg) orelse .i32,
+            .max_loop_depth = depth,
         });
     }
 
@@ -582,6 +622,68 @@ pub fn computeLiveRangesWithOrder(
     }.lessThan);
 
     return try ranges.toOwnedSlice(allocator);
+}
+
+/// Build the dominator tree and loop forest for `func` and return the
+/// per-block loop-nest depth (slice of length `func.blocks.items.len`).
+/// All zeros if the function has no natural loops or no blocks.
+///
+/// Exposed under both names so the aarch64 scheduler-aware live-range
+/// path can call into the same helper as `computeLiveRangesWithOrder`,
+/// keeping the eviction-priority signal byte-identical between
+/// backends.
+pub fn loopDepthByBlockForFunc(
+    func: *const ir.IrFunction,
+    allocator: std.mem.Allocator,
+) ![]u8 {
+    return computeLoopDepthByBlockForFunc(func, allocator);
+}
+
+fn computeLoopDepthByBlockForFunc(
+    func: *const ir.IrFunction,
+    allocator: std.mem.Allocator,
+) ![]u8 {
+    const nblocks = func.blocks.items.len;
+    if (nblocks == 0) return try allocator.alloc(u8, 0);
+
+    var dom = try computeDominators(func, allocator);
+    defer dom.deinit();
+    var forest = try computeLoops(func, &dom, allocator);
+    defer forest.deinit();
+    return try computeLoopDepthByBlock(func, &forest, allocator);
+}
+
+/// Walk the blocks whose flat-index spans overlap `[start, end]` and
+/// return the largest `depth_by_block` value encountered. `block_starts`
+/// is the sentinel-terminated array produced by
+/// `computeLiveRangesWithOrder`. Falls back to depth 0 if the range
+/// spans no recognized block (defensive — shouldn't happen for ranges
+/// produced by this pass).
+///
+/// Exposed publicly so the aarch64 scheduler-aware live-range builder
+/// can reuse the same overlap-walk logic.
+pub fn maxLoopDepthOverSpan(
+    start: u32,
+    end: u32,
+    block_order: []const ir.BlockId,
+    block_starts: []const u32,
+    depth_by_block: []const u8,
+) u8 {
+    if (block_order.len == 0) return 0;
+    var max_depth: u8 = 0;
+    for (block_order, 0..) |bid, oi| {
+        const blk_begin = block_starts[oi];
+        const blk_end = block_starts[oi + 1]; // exclusive
+        // Range is [start, end] inclusive; block is [blk_begin, blk_end).
+        // No overlap if blk_end <= start or blk_begin > end.
+        if (blk_end <= start) continue;
+        if (blk_begin > end) break; // block_starts is monotonic; rest are later
+        if (bid < depth_by_block.len) {
+            const d = depth_by_block[bid];
+            if (d > max_depth) max_depth = d;
+        }
+    }
+    return max_depth;
 }
 
 fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u32) void {
@@ -1401,6 +1503,33 @@ pub fn computeLoops(
     };
 }
 
+/// Compute per-block loop-nest depth: for each block `b`, the number of
+/// natural loops (from `forest`) that contain `b`. Outer loops contribute
+/// to the depth of every block they cover, so a block inside two nested
+/// loops gets depth 2. Unreachable blocks and blocks outside any loop
+/// have depth 0.
+///
+/// Saturates at `std.math.maxInt(u8)` — pathological CFGs with hundreds
+/// of nesting levels would otherwise wrap.
+///
+/// Caller owns the returned slice (length `func.blocks.items.len`).
+pub fn computeLoopDepthByBlock(
+    func: *const ir.IrFunction,
+    forest: *const LoopForest,
+    allocator: std.mem.Allocator,
+) ![]u8 {
+    const nblocks = func.blocks.items.len;
+    const depths = try allocator.alloc(u8, nblocks);
+    @memset(depths, 0);
+    for (forest.loops) |loop| {
+        for (loop.blocks) |bid| {
+            if (bid >= nblocks) continue;
+            depths[bid] = std.math.add(u8, depths[bid], 1) catch std.math.maxInt(u8);
+        }
+    }
+    return depths;
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 test "buildSuccessors: linear block" {
@@ -1964,4 +2093,104 @@ test "computeLoops: irreducible-ish (no back-edge without dominator) produces no
     try std.testing.expectEqual(@as(usize, 1), lf.loops.len);
     try std.testing.expectEqual(b0, lf.loops[0].header);
     try std.testing.expectEqual(@as(usize, 3), lf.loops[0].blocks.len);
+}
+
+// ── Loop-depth annotation on live ranges (issue #382) ──────────────────
+
+test "computeLoopDepthByBlock: nested loop yields depth 2 in body" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    // outer header → inner header → body → inner header → outer header.
+    const b0 = try func.newBlock();
+    const h_o = try func.newBlock();
+    const h_i = try func.newBlock();
+    const body = try func.newBlock();
+    const exit_i = try func.newBlock();
+    const exit_o = try func.newBlock();
+    const c_o = func.newVReg();
+    const c_i = func.newVReg();
+    const c_e = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .br = h_o } });
+    try func.getBlock(h_o).append(.{ .op = .{ .iconst_32 = 1 }, .dest = c_o });
+    try func.getBlock(h_o).append(.{ .op = .{ .br_if = .{ .cond = c_o, .then_block = h_i, .else_block = exit_o } } });
+    try func.getBlock(h_i).append(.{ .op = .{ .iconst_32 = 1 }, .dest = c_i });
+    try func.getBlock(h_i).append(.{ .op = .{ .br_if = .{ .cond = c_i, .then_block = body, .else_block = exit_i } } });
+    try func.getBlock(body).append(.{ .op = .{ .br = h_i } });
+    try func.getBlock(exit_i).append(.{ .op = .{ .iconst_32 = 1 }, .dest = c_e });
+    try func.getBlock(exit_i).append(.{ .op = .{ .br_if = .{ .cond = c_e, .then_block = h_o, .else_block = exit_o } } });
+    try func.getBlock(exit_o).append(.{ .op = .{ .ret = null } });
+
+    var dom = try computeDominators(&func, allocator);
+    defer dom.deinit();
+    var forest = try computeLoops(&func, &dom, allocator);
+    defer forest.deinit();
+    const depths = try computeLoopDepthByBlock(&func, &forest, allocator);
+    defer allocator.free(depths);
+
+    try std.testing.expectEqual(@as(u8, 0), depths[b0]);
+    try std.testing.expectEqual(@as(u8, 1), depths[h_o]);
+    try std.testing.expectEqual(@as(u8, 2), depths[h_i]);
+    try std.testing.expectEqual(@as(u8, 2), depths[body]);
+    try std.testing.expectEqual(@as(u8, 1), depths[exit_i]);
+    try std.testing.expectEqual(@as(u8, 0), depths[exit_o]);
+}
+
+test "computeLiveRanges: max_loop_depth annotated for loop body vreg" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    // Single-block self-loop: vreg defined inside the loop must end up
+    // with depth 1. A vreg defined before the loop and dead after it
+    // would not get depth — we only need to confirm the inside-loop
+    // case here.
+    const b0 = try func.newBlock();
+    const b_hdr = try func.newBlock();
+    const b_exit = try func.newBlock();
+    const v_cond = func.newVReg();
+    const v_loop = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .br = b_hdr } });
+    try func.getBlock(b_hdr).append(.{ .op = .{ .iconst_32 = 7 }, .dest = v_loop });
+    try func.getBlock(b_hdr).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_cond });
+    try func.getBlock(b_hdr).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b_hdr, .else_block = b_exit } } });
+    try func.getBlock(b_exit).append(.{ .op = .{ .ret = null } });
+
+    const ranges = try computeLiveRanges(&func, allocator);
+    defer allocator.free(ranges);
+
+    // Find vreg defined inside the loop. The header is at depth 1 in
+    // its own natural loop.
+    var seen = false;
+    for (ranges) |r| {
+        if (r.vreg == v_loop) {
+            try std.testing.expectEqual(@as(u8, 1), r.max_loop_depth);
+            seen = true;
+        }
+    }
+    try std.testing.expect(seen);
+}
+
+test "computeLiveRanges: max_loop_depth is 0 for ranges outside any loop" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const block0 = func.getBlock(b0);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try block0.append(.{ .op = .{ .iconst_32 = 10 }, .dest = v0 });
+    try block0.append(.{ .op = .{ .iconst_32 = 20 }, .dest = v1 });
+    try block0.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v2 });
+    try block0.append(.{ .op = .{ .ret = v2 } });
+
+    const ranges = try computeLiveRanges(&func, allocator);
+    defer allocator.free(ranges);
+
+    for (ranges) |r| {
+        try std.testing.expectEqual(@as(u8, 0), r.max_loop_depth);
+    }
 }

--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -182,18 +182,42 @@ pub fn allocateFromRangesWithHints(
                 .end = range.end,
                 .reg_idx = reg_idx,
                 .type = range.type,
+                .max_loop_depth = range.max_loop_depth,
             });
         } else {
             // No safe free register — try to evict an active interval
-            // whose register IS safe for this range.
+            // whose register IS safe for this range. Eviction order:
+            //
+            //   1. Prefer the active interval with the **smallest**
+            //      `max_loop_depth` (the coldest candidate — its spill
+            //      pays at most a few loads outside any loop).
+            //   2. Tie-break by **largest end** (Poletto–Sarkar's
+            //      original "longest remaining" rule, which retires the
+            //      shorter ranges first).
+            //
+            // We also require the candidate's `max_loop_depth` to be no
+            // larger than the new range's: spilling something that's
+            // hotter than the value we're trying to keep just shifts
+            // the per-iteration load/store penalty around rather than
+            // removing it. If no such candidate exists we fall back to
+            // spilling the incoming range itself (this is the same
+            // fallback the previous heuristic used when no longer-end
+            // active was safe).
             var best_evict: ?usize = null;
             for (active.items, 0..) |ai, idx| {
-                if (ai.end > range.end and
-                    regSafeForRange(ai.reg_idx, range.start, range.end, clobbers))
-                {
-                    if (best_evict == null or ai.end > active.items[best_evict.?].end) {
+                if (ai.end <= range.end) continue;
+                if (!regSafeForRange(ai.reg_idx, range.start, range.end, clobbers)) continue;
+                if (ai.max_loop_depth > range.max_loop_depth) continue;
+                if (best_evict) |bi| {
+                    const cur = active.items[bi];
+                    // Lower loop depth wins; tie → larger end wins.
+                    if (ai.max_loop_depth < cur.max_loop_depth or
+                        (ai.max_loop_depth == cur.max_loop_depth and ai.end > cur.end))
+                    {
                         best_evict = idx;
                     }
+                } else {
+                    best_evict = idx;
                 }
             }
 
@@ -208,6 +232,7 @@ pub fn allocateFromRangesWithHints(
                     .end = range.end,
                     .reg_idx = stolen_reg,
                     .type = range.type,
+                    .max_loop_depth = range.max_loop_depth,
                 });
             } else {
                 // No safe eviction candidate — spill the new interval
@@ -249,6 +274,12 @@ const ActiveInterval = struct {
     end: u32,
     reg_idx: u8,
     type: ir.IrType,
+    /// Max loop-nest depth of the originating live range. The eviction
+    /// heuristic prefers to spill the active interval with the smallest
+    /// `max_loop_depth` (i.e. the coldest), which keeps loop-invariant
+    /// pointers in registers across iterations on hot wasm loops like
+    /// CoreMark's `core_state_transition`.
+    max_loop_depth: u8,
 };
 
 /// Remove intervals from `active` whose end position is <= `pos`.
@@ -676,4 +707,110 @@ test "allocateFromRangesWithHints: empty hint list behaves like allocateFromRang
 
     try std.testing.expectEqual(result_a.get(0).?, result_b.get(0).?);
     try std.testing.expectEqual(result_a.get(1).?, result_b.get(1).?);
+}
+
+// ── Loop-depth-weighted eviction (issue #382) ───────────────────────────
+
+test "allocateFromRanges: cold vreg evicted over hot vreg under pressure" {
+    // Two-register pool with one free-reg conflict. Both candidates are
+    // longer than the incoming range, so the old end-only heuristic
+    // would pick whichever has the larger `.end`. Here we set the
+    // *cold* candidate to have the larger end and the *hot* candidate
+    // (max_loop_depth > 0) to have the smaller end. The new heuristic
+    // must still evict the cold one because it is at depth 0.
+    const allocator = std.testing.allocator;
+    const two_reg_set: RegSet = .{
+        .alloc_regs = &.{ 7, 8 },
+        .callee_saved_indices = &.{},
+        .caller_saved_indices = &.{ 0, 1 },
+        .spill_base = 64,
+        .spill_stride = 8,
+    };
+    // vreg 0: cold (depth 0), end=100 → would be the legacy eviction
+    // pick because it has the largest end.
+    // vreg 1: hot (depth 2), end=60 → legacy heuristic would *keep* it
+    // (smaller end) but it's already what we want; flipped end values
+    // below ensure we're really testing the depth signal, not a happy
+    // accident.
+    // vreg 2: incoming, start=2, end=10 → forces eviction because both
+    // registers are taken at this point.
+    const ranges = [_]analysis.LiveRange{
+        .{ .vreg = 0, .start = 0, .end = 100, .type = .i64, .max_loop_depth = 0 },
+        .{ .vreg = 1, .start = 1, .end = 60, .type = .i64, .max_loop_depth = 2 },
+        .{ .vreg = 2, .start = 2, .end = 10, .type = .i64, .max_loop_depth = 0 },
+    };
+
+    var result = try allocateFromRanges(allocator, two_reg_set, &.{}, &ranges);
+    defer result.deinit();
+
+    // The hot vreg (1) must remain in a register; the cold vreg (0)
+    // must have been spilled.
+    try std.testing.expect(result.get(1).? == .reg);
+    try std.testing.expect(result.get(0).? == .stack);
+    // And vreg 2 (the one that triggered eviction) must have taken
+    // vreg 0's slot.
+    try std.testing.expect(result.get(2).? == .reg);
+    try std.testing.expectEqual(@as(u32, 1), result.spill_count);
+}
+
+test "allocateFromRanges: tie on loop depth falls back to longest end" {
+    // When all active intervals share the same loop depth, the
+    // heuristic must reproduce the original Poletto–Sarkar rule
+    // (evict the longest-remaining).
+    const allocator = std.testing.allocator;
+    const two_reg_set: RegSet = .{
+        .alloc_regs = &.{ 7, 8 },
+        .callee_saved_indices = &.{},
+        .caller_saved_indices = &.{ 0, 1 },
+        .spill_base = 64,
+        .spill_stride = 8,
+    };
+    const ranges = [_]analysis.LiveRange{
+        .{ .vreg = 0, .start = 0, .end = 50, .type = .i64, .max_loop_depth = 1 },
+        .{ .vreg = 1, .start = 1, .end = 100, .type = .i64, .max_loop_depth = 1 },
+        .{ .vreg = 2, .start = 2, .end = 10, .type = .i64, .max_loop_depth = 1 },
+    };
+
+    var result = try allocateFromRanges(allocator, two_reg_set, &.{}, &ranges);
+    defer result.deinit();
+
+    // Both candidates share depth 1; the longer one (vreg 1, end=100)
+    // must be evicted, matching the pre-change behavior.
+    try std.testing.expect(result.get(0).? == .reg);
+    try std.testing.expect(result.get(1).? == .stack);
+    try std.testing.expect(result.get(2).? == .reg);
+    try std.testing.expectEqual(@as(u32, 1), result.spill_count);
+}
+
+test "allocateFromRanges: hotter incoming range spills itself instead of evicting cold" {
+    // The incoming range is *hotter* than every active interval, but
+    // the predicate `ai.max_loop_depth <= range.max_loop_depth`
+    // permits evicting equally-cold candidates. To verify the
+    // safeguard against the opposite direction we set up an incoming
+    // range that is *colder* than every active and confirm no
+    // eviction happens — the new range falls back to a stack slot.
+    const allocator = std.testing.allocator;
+    const two_reg_set: RegSet = .{
+        .alloc_regs = &.{ 7, 8 },
+        .callee_saved_indices = &.{},
+        .caller_saved_indices = &.{ 0, 1 },
+        .spill_base = 64,
+        .spill_stride = 8,
+    };
+    const ranges = [_]analysis.LiveRange{
+        .{ .vreg = 0, .start = 0, .end = 100, .type = .i64, .max_loop_depth = 3 },
+        .{ .vreg = 1, .start = 1, .end = 80, .type = .i64, .max_loop_depth = 2 },
+        // Incoming range at depth 0 — colder than both actives. With
+        // the new rule we should keep both hot actives and spill the
+        // newcomer.
+        .{ .vreg = 2, .start = 2, .end = 50, .type = .i64, .max_loop_depth = 0 },
+    };
+
+    var result = try allocateFromRanges(allocator, two_reg_set, &.{}, &ranges);
+    defer result.deinit();
+
+    try std.testing.expect(result.get(0).? == .reg);
+    try std.testing.expect(result.get(1).? == .reg);
+    try std.testing.expect(result.get(2).? == .stack);
+    try std.testing.expectEqual(@as(u32, 1), result.spill_count);
 }

--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -186,35 +186,50 @@ pub fn allocateFromRangesWithHints(
             });
         } else {
             // No safe free register — try to evict an active interval
-            // whose register IS safe for this range. Eviction order:
+            // whose register IS safe for this range. Eviction strategy
+            // depends on whether the new range is itself inside a
+            // genuinely hot inner loop (`max_loop_depth >= HOT_LOOP_THRESHOLD`):
             //
-            //   1. Prefer the active interval with the **smallest**
-            //      `max_loop_depth` (the coldest candidate — its spill
-            //      pays at most a few loads outside any loop).
-            //   2. Tie-break by **largest end** (Poletto–Sarkar's
-            //      original "longest remaining" rule, which retires the
-            //      shorter ranges first).
+            //   * **Hot newcomer** (depth ≥ HOT_LOOP_THRESHOLD): the
+            //     value we're trying to keep pays an iteration-level
+            //     load/store per spill, so prefer evicting the
+            //     **coldest** safe candidate (smallest
+            //     `max_loop_depth`); tie-break by largest end. Also
+            //     refuse to spill any candidate hotter than the
+            //     newcomer — doing so just shifts iteration-paid spill
+            //     cost rather than removing it.
             //
-            // We also require the candidate's `max_loop_depth` to be no
-            // larger than the new range's: spilling something that's
-            // hotter than the value we're trying to keep just shifts
-            // the per-iteration load/store penalty around rather than
-            // removing it. If no such candidate exists we fall back to
-            // spilling the incoming range itself (this is the same
-            // fallback the previous heuristic used when no longer-end
-            // active was safe).
+            //   * **Shallow newcomer** (depth < HOT_LOOP_THRESHOLD):
+            //     fall back to the original Poletto–Sarkar "largest
+            //     end" rule. The depth-aware defense above was
+            //     measurably worse on tight register files (notably
+            //     x86_64 with 15 alloc regs vs aarch64's 16) because
+            //     it forced spills of short-lived shallow newcomers
+            //     to protect actives that don't actually pay
+            //     iteration-paid spill cost. See PR #440 supervisor
+            //     note on issue #393.
+            //
+            // If no safe eviction candidate exists in either branch
+            // we fall through to spilling the incoming range itself.
+            const HOT_LOOP_THRESHOLD: u8 = 2;
+            const range_in_hot_loop = range.max_loop_depth >= HOT_LOOP_THRESHOLD;
             var best_evict: ?usize = null;
             for (active.items, 0..) |ai, idx| {
                 if (ai.end <= range.end) continue;
                 if (!regSafeForRange(ai.reg_idx, range.start, range.end, clobbers)) continue;
-                if (ai.max_loop_depth > range.max_loop_depth) continue;
+                if (range_in_hot_loop and ai.max_loop_depth > range.max_loop_depth) continue;
                 if (best_evict) |bi| {
                     const cur = active.items[bi];
-                    // Lower loop depth wins; tie → larger end wins.
-                    if (ai.max_loop_depth < cur.max_loop_depth or
-                        (ai.max_loop_depth == cur.max_loop_depth and ai.end > cur.end))
-                    {
-                        best_evict = idx;
+                    if (range_in_hot_loop) {
+                        if (ai.max_loop_depth < cur.max_loop_depth or
+                            (ai.max_loop_depth == cur.max_loop_depth and ai.end > cur.end))
+                        {
+                            best_evict = idx;
+                        }
+                    } else {
+                        if (ai.end > cur.end) {
+                            best_evict = idx;
+                        }
                     }
                 } else {
                     best_evict = idx;
@@ -782,13 +797,16 @@ test "allocateFromRanges: tie on loop depth falls back to longest end" {
     try std.testing.expectEqual(@as(u32, 1), result.spill_count);
 }
 
-test "allocateFromRanges: hotter incoming range spills itself instead of evicting cold" {
-    // The incoming range is *hotter* than every active interval, but
-    // the predicate `ai.max_loop_depth <= range.max_loop_depth`
-    // permits evicting equally-cold candidates. To verify the
-    // safeguard against the opposite direction we set up an incoming
-    // range that is *colder* than every active and confirm no
-    // eviction happens — the new range falls back to a stack slot.
+test "allocateFromRanges: hot incoming range (depth >= 2) respects hot actives" {
+    // The incoming range is itself inside a deep inner loop (depth 2),
+    // so the hot-loop protection kicks in: refuse to evict any active
+    // hotter than the newcomer. With both actives at depth 3 and 2
+    // (both ≥ newcomer's depth 2), neither is a valid eviction
+    // candidate — the newcomer spills itself.
+    //
+    // Mirrors the supervisor-gated rule from PR #440 follow-up: the
+    // depth-aware defense only fires for genuinely deep inner-loop
+    // newcomers (`max_loop_depth >= 2`).
     const allocator = std.testing.allocator;
     const two_reg_set: RegSet = .{
         .alloc_regs = &.{ 7, 8 },
@@ -800,17 +818,61 @@ test "allocateFromRanges: hotter incoming range spills itself instead of evictin
     const ranges = [_]analysis.LiveRange{
         .{ .vreg = 0, .start = 0, .end = 100, .type = .i64, .max_loop_depth = 3 },
         .{ .vreg = 1, .start = 1, .end = 80, .type = .i64, .max_loop_depth = 2 },
-        // Incoming range at depth 0 — colder than both actives. With
-        // the new rule we should keep both hot actives and spill the
-        // newcomer.
+        // Incoming range at depth 2 — same depth as vreg 1 but strictly
+        // colder than vreg 0. The filter `ai.depth > range.depth` skips
+        // vreg 0 (hotter) but keeps vreg 1 (same depth). vreg 1 has
+        // larger end than the newcomer (80 > 50) so it's a valid
+        // candidate — wait, vreg 1's depth = newcomer's depth, so
+        // priority falls back to "largest end" within the same depth.
+        // Both eligible candidates (only vreg 1 here) keep the
+        // newcomer in a register.
+        .{ .vreg = 2, .start = 2, .end = 50, .type = .i64, .max_loop_depth = 2 },
+    };
+
+    var result = try allocateFromRanges(allocator, two_reg_set, &.{}, &ranges);
+    defer result.deinit();
+
+    // vreg 0 (depth 3) is protected from the depth-2 newcomer.
+    // vreg 1 (depth 2, end=80) is the only eligible candidate; it gets
+    // evicted to make room for the newcomer.
+    try std.testing.expect(result.get(0).? == .reg);
+    try std.testing.expect(result.get(1).? == .stack);
+    try std.testing.expect(result.get(2).? == .reg);
+    try std.testing.expectEqual(@as(u32, 1), result.spill_count);
+}
+
+test "allocateFromRanges: shallow incoming range (depth < 2) falls back to largest-end rule" {
+    // The incoming range is *not* inside a deep loop (depth 0), so the
+    // hot-loop protection is bypassed and the pre-change
+    // Poletto–Sarkar "largest remaining" rule applies. This restores
+    // the eviction behavior PR #440 originally regressed on x86_64.
+    const allocator = std.testing.allocator;
+    const two_reg_set: RegSet = .{
+        .alloc_regs = &.{ 7, 8 },
+        .callee_saved_indices = &.{},
+        .caller_saved_indices = &.{ 0, 1 },
+        .spill_base = 64,
+        .spill_stride = 8,
+    };
+    const ranges = [_]analysis.LiveRange{
+        // vreg 0 is hot (depth 3) with largest end (100). Under the
+        // shallow-newcomer rule it MUST still be evicted: x86_64
+        // CoreMark regressed precisely because shallow merge-block
+        // vregs were being spilled to protect actives like this one
+        // that don't actually pay per-iteration spill cost.
+        .{ .vreg = 0, .start = 0, .end = 100, .type = .i64, .max_loop_depth = 3 },
+        .{ .vreg = 1, .start = 1, .end = 80, .type = .i64, .max_loop_depth = 2 },
+        // Shallow incoming (depth 0) — gate triggers pre-change rule.
         .{ .vreg = 2, .start = 2, .end = 50, .type = .i64, .max_loop_depth = 0 },
     };
 
     var result = try allocateFromRanges(allocator, two_reg_set, &.{}, &ranges);
     defer result.deinit();
 
-    try std.testing.expect(result.get(0).? == .reg);
+    // Largest-end active (vreg 0, end=100) is evicted; the shallow
+    // newcomer takes its register.
+    try std.testing.expect(result.get(0).? == .stack);
     try std.testing.expect(result.get(1).? == .reg);
-    try std.testing.expect(result.get(2).? == .stack);
+    try std.testing.expect(result.get(2).? == .reg);
     try std.testing.expectEqual(@as(u32, 1), result.spill_count);
 }


### PR DESCRIPTION
Closes #382
