### PR TITLE
feat(wasi): sock_accept, sock_recv, sock_send + socket preopens

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -395,6 +395,47 @@ pub fn build(b: *std.Build) void {
         test_step.dependOn(&run_coldstart_tests.step);
     }
 
+    // ── WASI sockets (#437) end-to-end ────────────────────────────────
+    // Compiles a tiny `wasm32-wasi` echo server that calls preview1
+    // `sock_accept`/`sock_recv`/`sock_send` against an embedder-provided
+    // socket preopen at fd 3, then spawns `wamr run --listen=127.0.0.1:<port>`
+    // and round-trips a single payload from a host client.
+    //
+    // Linux-only — host sockets and the `--listen` CLI plumbing return
+    // ENOSYS / NotSupported on other targets. Uses a fixed high port to
+    // avoid teaching the CLI an out-of-band port-discovery channel.
+    if (target.result.os.tag == .linux) {
+        const echo_wasm = compileZigWasm(b, .{
+            .source = "tests/wasi-sock/echo_server.zig",
+            .target_triple = "wasm32-wasi",
+            .exports = &.{"_start"},
+            .output = "echo_server.wasm",
+        });
+
+        const driver_module = b.createModule(.{
+            .root_source_file = b.path("tests/wasi-sock/driver.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        const driver_exe = b.addExecutable(.{
+            .name = "wasi-sock-driver",
+            .root_module = driver_module,
+        });
+
+        const run_sock = b.addRunArtifact(driver_exe);
+        run_sock.addFileArg(exe.getEmittedBin());
+        run_sock.addFileArg(echo_wasm);
+        run_sock.addArg("43657");
+        run_sock.expectExitCode(0);
+
+        const sock_step = b.step(
+            "test-wasi-sock",
+            "Run the WASI sockets end-to-end echo test (#437; Linux only)",
+        );
+        sock_step.dependOn(&run_sock.step);
+        test_step.dependOn(&run_sock.step);
+    }
+
     // ── Benchmark ─────────────────────────────────────────────────────
     const bench_module = b.createModule(.{
         .root_source_file = b.path("src/compiler/bench_codegen.zig"),

--- a/src/main.zig
+++ b/src/main.zig
@@ -76,6 +76,10 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                     std.process.exit(1);
                 };
             } else if (std.mem.startsWith(u8, arg, "--listen=")) {
+                if (listen_address != null) {
+                    std.debug.print("error: --listen specified more than once; only one listening socket preopen is supported\n", .{});
+                    std.process.exit(1);
+                }
                 const spec = arg["--listen=".len..];
                 listen_address = parseListenAddress(spec) catch {
                     std.debug.print("error: invalid --listen address '{s}'\n", .{spec});
@@ -140,7 +144,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     // Detect file type by magic bytes: AOT (\0aot) vs Wasm (\0asm)
     if (wasm_data.len >= 4 and std.mem.readInt(u32, wasm_data[0..4], .little) == wamr.types.aot_magic) {
         if (listen_address != null) {
-            std.debug.print("Error: --listen is only supported for WASI HTTP components\n", .{});
+            std.debug.print("Error: --listen is not supported for AOT modules; rerun without --aot\n", .{});
             std.process.exit(1);
         }
         runAot(wasm_data, allocator);
@@ -177,13 +181,17 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
         }
     }
 
-    if (listen_address != null) {
-        std.debug.print("Error: --listen is only supported for WASI HTTP components\n", .{});
-        std.process.exit(1);
+    if (listen_address) |addr| {
+        // Core wasm path: --listen registers a TCP listening socket as a
+        // socket preopen (kind = .socket, fd ≥ 3) for the guest's WASI
+        // preview1 sock_accept. The component-model path above already
+        // handled --listen for HTTP servers.
+        runWasm(wasm_data, stack_size, path, &wasm_args, env_flags.items, map_dirs.items, addr, allocator, io);
+        return;
     }
 
     // Wasm module (core)
-    runWasm(wasm_data, stack_size, path, &wasm_args, env_flags.items, map_dirs.items, allocator, io);
+    runWasm(wasm_data, stack_size, path, &wasm_args, env_flags.items, map_dirs.items, null, allocator, io);
 }
 
 fn parseMapDir(spec: []const u8) !MapDir {
@@ -379,6 +387,7 @@ fn runWasm(
     wasm_args: *std.ArrayListUnmanaged([]const u8),
     env_flags: []const []const u8,
     map_dirs: []const MapDir,
+    listen_address: ?std.Io.net.IpAddress,
     allocator: std.mem.Allocator,
     io: std.Io,
 ) void {
@@ -434,6 +443,17 @@ fn runWasm(
         };
     }
 
+    if (listen_address) |addr| {
+        const listen_fd = openListenSocket(addr) catch |err| {
+            std.debug.print("Error: --listen bind failed: {}\n", .{err});
+            std.process.exit(1);
+        };
+        _ = ctx.addPreopenSocket(listen_fd) catch |err| {
+            std.debug.print("Error: cannot register --listen socket preopen: {}\n", .{err});
+            std.process.exit(1);
+        };
+    }
+
     env.wasi_ctx = @ptrCast(ctx);
 
     if (param_count >= 2) {
@@ -448,6 +468,67 @@ fn runWasm(
     };
 
     if (ctx.exit_code) |code| std.process.exit(@intCast(code));
+}
+
+/// Bind a TCP socket to `addr` and put it in the listen state. Used by the
+/// core wasm `--listen=` flow to register the listener as a socket
+/// preopen (fd ≥ 3) for the guest's WASI preview1 sock_accept. Backlog
+/// matches `SOMAXCONN` on modern Linux (128 is the historical floor).
+///
+/// Implemented with raw `std.os.linux` syscalls because the cross-platform
+/// `std.posix.{socket,bind,listen,close}` wrappers were removed in Zig 0.16.0.
+/// `--listen` is therefore Linux-only on the core-wasm path; the CLI
+/// front-end rejects it elsewhere.
+fn openListenSocket(addr: std.Io.net.IpAddress) !std.posix.fd_t {
+    if (comptime builtin.os.tag != .linux) return error.UnsupportedPlatform;
+    const linux = std.os.linux;
+
+    const family: u32 = switch (addr) {
+        .ip4 => linux.AF.INET,
+        .ip6 => linux.AF.INET6,
+    };
+    const sock_type: u32 = linux.SOCK.STREAM | linux.SOCK.CLOEXEC;
+    const sock_rc = linux.socket(family, sock_type, linux.IPPROTO.TCP);
+    if (linux.errno(sock_rc) != .SUCCESS) return error.SocketFailed;
+    const fd: std.posix.fd_t = @intCast(@as(isize, @bitCast(sock_rc)));
+    errdefer _ = linux.close(fd);
+
+    // SO_REUSEADDR: lets the host re-bind quickly after a restart while
+    // a previous accepted client lingers in TIME_WAIT.
+    const one: c_int = 1;
+    const so_rc = linux.setsockopt(
+        fd,
+        linux.SOL.SOCKET,
+        linux.SO.REUSEADDR,
+        @ptrCast(&one),
+        @sizeOf(c_int),
+    );
+    if (linux.errno(so_rc) != .SUCCESS) return error.SetSockOptFailed;
+
+    switch (addr) {
+        .ip4 => |v4| {
+            const sa = linux.sockaddr.in{
+                .port = std.mem.nativeToBig(u16, v4.port),
+                .addr = @bitCast(v4.bytes),
+            };
+            const b = linux.bind(fd, @ptrCast(&sa), @sizeOf(@TypeOf(sa)));
+            if (linux.errno(b) != .SUCCESS) return error.BindFailed;
+        },
+        .ip6 => |v6| {
+            const sa = linux.sockaddr.in6{
+                .port = std.mem.nativeToBig(u16, v6.port),
+                .flowinfo = v6.flow,
+                .addr = v6.bytes,
+                .scope_id = v6.interface.index,
+            };
+            const b = linux.bind(fd, @ptrCast(&sa), @sizeOf(@TypeOf(sa)));
+            if (linux.errno(b) != .SUCCESS) return error.BindFailed;
+        },
+    }
+
+    const lr = linux.listen(fd, 128);
+    if (linux.errno(lr) != .SUCCESS) return error.ListenFailed;
+    return fd;
 }
 
 fn writeStdout(io: std.Io, text: []const u8) void {
@@ -473,7 +554,10 @@ const run_usage =
     \\Options:
     \\  --stack-size=<bytes>     Stack size for the interpreter (default: 65536)
     \\  --heap-size=<bytes>      Reserved (currently ignored)
-    \\  --listen=<ip:port>       Serve a WASI HTTP component on a TCP address
+    \\  --listen=<ip:port>       For components: serve WASI HTTP on the address.
+    \\                           For core wasm: bind a TCP listening socket and
+    \\                           expose it to the guest as the next preopen fd
+    \\                           (≥ 3) for `sock_accept` (single use only).
     \\  --env KEY=VALUE          Set a WASI environment variable (repeatable)
     \\  --map-dir HOST::GUEST    Pre-open `HOST` host directory as `GUEST`
     \\                           inside the guest WASI sandbox (repeatable)

--- a/src/wasi/host_functions.zig
+++ b/src/wasi/host_functions.zig
@@ -978,6 +978,95 @@ pub fn wasiSockShutdown(env_opaque: *anyopaque) types.HostFnError!void {
     env.pushI32(ctxSockShutdownCore(ctx, fd, sdflags)) catch return error.StackOverflow;
 }
 
+/// `wasi_snapshot_preview1.sock_accept` — accept an incoming connection on a
+/// listening socket fd. Signature:
+/// `(fd: i32, fdflags: i32, ro_fd_ptr: i32) -> errno: i32`. On success the
+/// new guest fd is written to `ro_fd_ptr` and `ESUCCESS` is returned.
+pub fn wasiSockAccept(env_opaque: *anyopaque) types.HostFnError!void {
+    const env: *ExecEnv = @ptrCast(@alignCast(env_opaque));
+    const ro_fd_ptr: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+    const fdflags = env.popI32() catch return error.StackUnderflow;
+    const fd = env.popI32() catch return error.StackUnderflow;
+
+    const ctx = getCtx(env) orelse {
+        env.pushI32(wasi_core.WASI_ENOSYS) catch return error.StackOverflow;
+        return;
+    };
+    const mem = getMemory(env) orelse {
+        env.pushI32(wasi_core.WASI_EINVAL) catch return error.StackOverflow;
+        return;
+    };
+
+    env.pushI32(ctxSockAcceptCore(ctx, mem, fd, fdflags, ro_fd_ptr)) catch return error.StackOverflow;
+}
+
+/// `wasi_snapshot_preview1.sock_recv` — receive a message from a connected
+/// socket. Signature: `(fd, ri_data_ptr, ri_data_len, ri_flags, ro_datalen_ptr,
+/// ro_flags_ptr) -> errno`. `ri_data_ptr` is a guest pointer to an `iovec`
+/// array and `ri_data_len` is its element count. `ro_datalen_ptr` receives
+/// the number of bytes read; `ro_flags_ptr` receives a roflags bitset
+/// (currently always 0 — `MSG_TRUNC` propagation is a follow-up).
+pub fn wasiSockRecv(env_opaque: *anyopaque) types.HostFnError!void {
+    const env: *ExecEnv = @ptrCast(@alignCast(env_opaque));
+    const ro_flags_ptr: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+    const ro_datalen_ptr: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+    const ri_flags = env.popI32() catch return error.StackUnderflow;
+    const ri_data_len: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+    const ri_data_ptr: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+    const fd = env.popI32() catch return error.StackUnderflow;
+
+    const ctx = getCtx(env) orelse {
+        env.pushI32(wasi_core.WASI_ENOSYS) catch return error.StackOverflow;
+        return;
+    };
+    const mem = getMemory(env) orelse {
+        env.pushI32(wasi_core.WASI_EINVAL) catch return error.StackOverflow;
+        return;
+    };
+
+    env.pushI32(ctxSockRecvCore(
+        ctx,
+        mem,
+        fd,
+        ri_data_ptr,
+        ri_data_len,
+        ri_flags,
+        ro_datalen_ptr,
+        ro_flags_ptr,
+    )) catch return error.StackOverflow;
+}
+
+/// `wasi_snapshot_preview1.sock_send` — send a message on a connected socket.
+/// Signature: `(fd, si_data_ptr, si_data_len, si_flags, so_datalen_ptr) -> errno`.
+/// `si_flags` is reserved and must be 0.
+pub fn wasiSockSend(env_opaque: *anyopaque) types.HostFnError!void {
+    const env: *ExecEnv = @ptrCast(@alignCast(env_opaque));
+    const so_datalen_ptr: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+    const si_flags = env.popI32() catch return error.StackUnderflow;
+    const si_data_len: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+    const si_data_ptr: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+    const fd = env.popI32() catch return error.StackUnderflow;
+
+    const ctx = getCtx(env) orelse {
+        env.pushI32(wasi_core.WASI_ENOSYS) catch return error.StackOverflow;
+        return;
+    };
+    const mem = getMemory(env) orelse {
+        env.pushI32(wasi_core.WASI_EINVAL) catch return error.StackOverflow;
+        return;
+    };
+
+    env.pushI32(ctxSockSendCore(
+        ctx,
+        mem,
+        fd,
+        si_data_ptr,
+        si_data_len,
+        si_flags,
+        so_datalen_ptr,
+    )) catch return error.StackOverflow;
+}
+
 // ── ctx-aware core implementations ────────────────────────────────────
 
 /// Layout for `args_get` / `environ_get`: write `argv_ptrs` (one i32 pointer
@@ -2356,6 +2445,24 @@ fn mapLinuxErrno(rc: usize) i32 {
         .NAMETOOLONG => @intCast(@intFromEnum(wasi.Errno.nametoolong)),
         .XDEV => @intCast(@intFromEnum(wasi.Errno.xdev)),
         .MLINK => @intCast(@intFromEnum(wasi.Errno.mlink)),
+        // Socket-relevant errnos for sock_accept / sock_recv / sock_send.
+        .AGAIN => @intCast(@intFromEnum(wasi.Errno.again)),
+        .INTR => @intCast(@intFromEnum(wasi.Errno.intr)),
+        .CONNABORTED => @intCast(@intFromEnum(wasi.Errno.connaborted)),
+        .CONNRESET => @intCast(@intFromEnum(wasi.Errno.connreset)),
+        .CONNREFUSED => @intCast(@intFromEnum(wasi.Errno.connrefused)),
+        .NOTCONN => @intCast(@intFromEnum(wasi.Errno.notconn)),
+        .NOTSOCK => @intCast(@intFromEnum(wasi.Errno.notsock)),
+        .PIPE => @intCast(@intFromEnum(wasi.Errno.pipe)),
+        .NOBUFS => @intCast(@intFromEnum(wasi.Errno.nobufs)),
+        .NOMEM => @intCast(@intFromEnum(wasi.Errno.nomem)),
+        .MFILE => @intCast(@intFromEnum(wasi.Errno.mfile)),
+        .NFILE => @intCast(@intFromEnum(wasi.Errno.nfile)),
+        .MSGSIZE => @intCast(@intFromEnum(wasi.Errno.msgsize)),
+        .HOSTUNREACH => @intCast(@intFromEnum(wasi.Errno.hostunreach)),
+        .NETUNREACH => @intCast(@intFromEnum(wasi.Errno.netunreach)),
+        .NETDOWN => @intCast(@intFromEnum(wasi.Errno.netdown)),
+        .FAULT => @intCast(@intFromEnum(wasi.Errno.fault)),
         else => wasi_core.WASI_EINVAL,
     };
 }
@@ -2815,6 +2922,253 @@ fn ctxSockShutdownCore(ctx: *wasi.WasiCtx, fd: i32, sdflags: i32) i32 {
     }
 }
 
+// ── sock_accept / sock_recv / sock_send (#437) ────────────────────────
+
+/// Max number of iovecs accepted in a single sock_recv/sock_send call.
+/// wasi-libc / wasmtime cap stack-allocated iovec arrays at small bounds;
+/// 16 mirrors common practice and avoids unbounded allocations from the
+/// guest. Guests that pass more than this many iovecs will see only the
+/// first 16 processed (the rest are silently dropped, matching the
+/// effective behavior of a short read/write at the iovec boundary).
+const SOCK_IOV_MAX: u32 = 16;
+
+/// Read an `iovec` array (`{u32 buf_ptr, u32 buf_len}` slots) out of guest
+/// memory and project it into a flat slice of host `posix.iovec_const`
+/// suitable for `sendmsg(2)`. Returns the number of iovecs successfully
+/// translated (clipped at `out.len` / `SOCK_IOV_MAX`) or a negative WASI
+/// errno on out-of-bounds access.
+fn readSendIovecs(
+    mem: []const u8,
+    iovs_ptr: u32,
+    iovs_len: u32,
+    out: []std.posix.iovec_const,
+) i32 {
+    var n: u32 = 0;
+    const limit = @min(iovs_len, @as(u32, @intCast(out.len)));
+    while (n < limit) : (n += 1) {
+        const slot = iovs_ptr + n * 8;
+        const buf_ptr = wasi_core.memReadU32(mem, slot) orelse return wasi_core.WASI_EINVAL;
+        const buf_len = wasi_core.memReadU32(mem, slot + 4) orelse return wasi_core.WASI_EINVAL;
+        if (@as(u64, buf_ptr) + buf_len > mem.len) return wasi_core.WASI_EINVAL;
+        out[n] = .{
+            .base = @constCast(mem.ptr) + buf_ptr,
+            .len = buf_len,
+        };
+    }
+    return @intCast(n);
+}
+
+/// Mirror of `readSendIovecs` for `recvmsg(2)`. Writes a mutable
+/// `posix.iovec` slice pointing into guest memory.
+fn readRecvIovecs(
+    mem: []u8,
+    iovs_ptr: u32,
+    iovs_len: u32,
+    out: []std.posix.iovec,
+) i32 {
+    var n: u32 = 0;
+    const limit = @min(iovs_len, @as(u32, @intCast(out.len)));
+    while (n < limit) : (n += 1) {
+        const slot = iovs_ptr + n * 8;
+        const buf_ptr = wasi_core.memReadU32(mem, slot) orelse return wasi_core.WASI_EINVAL;
+        const buf_len = wasi_core.memReadU32(mem, slot + 4) orelse return wasi_core.WASI_EINVAL;
+        if (@as(u64, buf_ptr) + buf_len > mem.len) return wasi_core.WASI_EINVAL;
+        out[n] = .{
+            .base = mem.ptr + buf_ptr,
+            .len = buf_len,
+        };
+    }
+    return @intCast(n);
+}
+
+/// Accept an incoming connection on a listening socket fd. Returns
+/// `ESUCCESS` and writes the new guest fd to `ro_fd_ptr`, or a WASI errno
+/// on failure. `fdflags` may carry `FDFLAGS_NONBLOCK` — any other bit is
+/// rejected with `EINVAL`. The accepted fd is installed as a `.socket`
+/// `FdEntry` with `SOCKET_BASE_RIGHTS`.
+fn ctxSockAcceptCore(
+    ctx: *wasi.WasiCtx,
+    mem: []u8,
+    fd: i32,
+    fdflags: i32,
+    ro_fd_ptr: u32,
+) i32 {
+    if (comptime builtin.os.tag == .windows) return wasi_core.WASI_ENOSYS;
+
+    if (fdflags < 0) return wasi_core.WASI_EINVAL;
+    const u_fdflags: u32 = @intCast(fdflags);
+    // Only FDFLAGS_NONBLOCK is meaningful on a freshly-accepted fd.
+    // APPEND / DSYNC / RSYNC / SYNC have no socket semantics.
+    if ((u_fdflags & ~@as(u32, wasi.FDFLAGS_NONBLOCK)) != 0) return wasi_core.WASI_EINVAL;
+
+    if (fd < 0) return wasi_core.WASI_EBADF;
+    const u_fd: u32 = @intCast(fd);
+    const entry = ctx.fd_table.get(u_fd) orelse return wasi_core.WASI_EBADF;
+
+    if (entry.kind != .socket) return @intCast(@intFromEnum(wasi.Errno.notsock));
+    if ((entry.rights_base & wasi.RIGHTS_SOCK_ACCEPT) == 0) {
+        return @intCast(@intFromEnum(wasi.Errno.notcapable));
+    }
+
+    const host_listen_fd = entry.host_fd orelse return wasi_core.WASI_EBADF;
+
+    if (comptime builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        var accept_flags: u32 = linux.SOCK.CLOEXEC;
+        if ((u_fdflags & wasi.FDFLAGS_NONBLOCK) != 0) accept_flags |= linux.SOCK.NONBLOCK;
+        const rc = linux.accept4(host_listen_fd, null, null, accept_flags);
+        const wasi_err = mapLinuxErrno(rc);
+        if (wasi_err != wasi_core.WASI_ESUCCESS) return wasi_err;
+        const new_host_fd: std.posix.fd_t = @intCast(@as(isize, @bitCast(rc)));
+
+        const new_guest_fd = ctx.fd_table.allocateFd();
+        ctx.fd_table.insert(new_guest_fd, .{
+            .kind = .socket,
+            .host_fd = new_host_fd,
+            .rights_base = wasi.SOCKET_BASE_RIGHTS,
+            .rights_inheriting = wasi.SOCKET_BASE_RIGHTS,
+            .fdflags = @intCast(u_fdflags & wasi.FDFLAGS_NONBLOCK),
+        }) catch {
+            _ = linux.close(new_host_fd);
+            return wasi_core.WASI_EINVAL;
+        };
+        if (!wasi_core.memWriteU32(mem, ro_fd_ptr, new_guest_fd)) {
+            _ = ctx.fd_close(new_guest_fd);
+            return wasi_core.WASI_EINVAL;
+        }
+        return wasi_core.WASI_ESUCCESS;
+    } else {
+        return wasi_core.WASI_ENOSYS;
+    }
+}
+
+/// Receive a message on a connected socket. Builds an `iovec` array from
+/// guest memory (capped at `SOCK_IOV_MAX`), maps the wasi `ri_flags`
+/// bitset onto `MSG_*`, and runs `recvmsg(2)`. Writes the byte count to
+/// `ro_datalen_ptr` and a (currently always 0) roflags bitset to
+/// `ro_flags_ptr`.
+fn ctxSockRecvCore(
+    ctx: *wasi.WasiCtx,
+    mem: []u8,
+    fd: i32,
+    ri_data_ptr: u32,
+    ri_data_len: u32,
+    ri_flags: i32,
+    ro_datalen_ptr: u32,
+    ro_flags_ptr: u32,
+) i32 {
+    if (comptime builtin.os.tag == .windows) return wasi_core.WASI_ENOSYS;
+
+    if (ri_flags < 0) return wasi_core.WASI_EINVAL;
+    const u_riflags: u32 = @intCast(ri_flags);
+    if ((u_riflags & ~@as(u32, wasi.RIFLAGS_ALL)) != 0) return wasi_core.WASI_EINVAL;
+
+    if (fd < 0) return wasi_core.WASI_EBADF;
+    const u_fd: u32 = @intCast(fd);
+    const entry = ctx.fd_table.get(u_fd) orelse return wasi_core.WASI_EBADF;
+
+    if (entry.kind != .socket) return @intCast(@intFromEnum(wasi.Errno.notsock));
+    if ((entry.rights_base & wasi.RIGHTS_FD_READ) == 0) {
+        return @intCast(@intFromEnum(wasi.Errno.notcapable));
+    }
+    const host_fd = entry.host_fd orelse return wasi_core.WASI_EBADF;
+
+    if (comptime builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        var iovs: [SOCK_IOV_MAX]std.posix.iovec = undefined;
+        const n_or_err = readRecvIovecs(mem, ri_data_ptr, ri_data_len, &iovs);
+        if (n_or_err < 0) return n_or_err;
+        const n: u32 = @intCast(n_or_err);
+        if (n == 0) {
+            if (!wasi_core.memWriteU32(mem, ro_datalen_ptr, 0)) return wasi_core.WASI_EINVAL;
+            if (!wasi_core.memWriteU32(mem, ro_flags_ptr, 0)) return wasi_core.WASI_EINVAL;
+            return wasi_core.WASI_ESUCCESS;
+        }
+
+        var msg_flags: u32 = 0;
+        if ((u_riflags & wasi.RIFLAGS_RECV_PEEK) != 0) msg_flags |= linux.MSG.PEEK;
+        if ((u_riflags & wasi.RIFLAGS_RECV_WAITALL) != 0) msg_flags |= linux.MSG.WAITALL;
+
+        var mh: linux.msghdr = .{
+            .name = null,
+            .namelen = 0,
+            .iov = @ptrCast(&iovs[0]),
+            .iovlen = n,
+            .control = null,
+            .controllen = 0,
+            .flags = 0,
+        };
+        const rc = linux.recvmsg(host_fd, &mh, msg_flags);
+        const wasi_err = mapLinuxErrno(rc);
+        if (wasi_err != wasi_core.WASI_ESUCCESS) return wasi_err;
+        const got: u32 = @intCast(@as(isize, @bitCast(rc)));
+        if (!wasi_core.memWriteU32(mem, ro_datalen_ptr, got)) return wasi_core.WASI_EINVAL;
+        // roflags: we don't propagate MSG_TRUNC yet (follow-up).
+        if (!wasi_core.memWriteU32(mem, ro_flags_ptr, 0)) return wasi_core.WASI_EINVAL;
+        return wasi_core.WASI_ESUCCESS;
+    } else {
+        return wasi_core.WASI_ENOSYS;
+    }
+}
+
+/// Send a message on a connected socket. `si_flags` is reserved (must be
+/// 0). Builds an `iovec_const` array from guest memory (capped at
+/// `SOCK_IOV_MAX`) and runs `sendmsg(2)` with `MSG_NOSIGNAL` so a
+/// terminated peer surfaces as `EPIPE` instead of `SIGPIPE` on the host.
+fn ctxSockSendCore(
+    ctx: *wasi.WasiCtx,
+    mem: []u8,
+    fd: i32,
+    si_data_ptr: u32,
+    si_data_len: u32,
+    si_flags: i32,
+    so_datalen_ptr: u32,
+) i32 {
+    if (comptime builtin.os.tag == .windows) return wasi_core.WASI_ENOSYS;
+
+    if (si_flags != 0) return wasi_core.WASI_EINVAL;
+
+    if (fd < 0) return wasi_core.WASI_EBADF;
+    const u_fd: u32 = @intCast(fd);
+    const entry = ctx.fd_table.get(u_fd) orelse return wasi_core.WASI_EBADF;
+
+    if (entry.kind != .socket) return @intCast(@intFromEnum(wasi.Errno.notsock));
+    if ((entry.rights_base & wasi.RIGHTS_FD_WRITE) == 0) {
+        return @intCast(@intFromEnum(wasi.Errno.notcapable));
+    }
+    const host_fd = entry.host_fd orelse return wasi_core.WASI_EBADF;
+
+    if (comptime builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        var iovs: [SOCK_IOV_MAX]std.posix.iovec_const = undefined;
+        const n_or_err = readSendIovecs(mem, si_data_ptr, si_data_len, &iovs);
+        if (n_or_err < 0) return n_or_err;
+        const n: u32 = @intCast(n_or_err);
+        if (n == 0) {
+            if (!wasi_core.memWriteU32(mem, so_datalen_ptr, 0)) return wasi_core.WASI_EINVAL;
+            return wasi_core.WASI_ESUCCESS;
+        }
+
+        const mh: linux.msghdr_const = .{
+            .name = null,
+            .namelen = 0,
+            .iov = @ptrCast(&iovs[0]),
+            .iovlen = n,
+            .control = null,
+            .controllen = 0,
+            .flags = 0,
+        };
+        const rc = linux.sendmsg(host_fd, &mh, linux.MSG.NOSIGNAL);
+        const wasi_err = mapLinuxErrno(rc);
+        if (wasi_err != wasi_core.WASI_ESUCCESS) return wasi_err;
+        const sent: u32 = @intCast(@as(isize, @bitCast(rc)));
+        if (!wasi_core.memWriteU32(mem, so_datalen_ptr, sent)) return wasi_core.WASI_EINVAL;
+        return wasi_core.WASI_ESUCCESS;
+    } else {
+        return wasi_core.WASI_ENOSYS;
+    }
+}
+
 // ── Import resolution ─────────────────────────────────────────────────
 
 /// Resolve WASI host functions for a module's imports.
@@ -2892,6 +3246,9 @@ fn resolveWasiFunction(name: []const u8) ?types.HostFn {
         .{ "path_readlink", &wasiPathReadlink },
         .{ "poll_oneoff", &wasiPollOneoff },
         .{ "sock_shutdown", &wasiSockShutdown },
+        .{ "sock_accept", &wasiSockAccept },
+        .{ "sock_recv", &wasiSockRecv },
+        .{ "sock_send", &wasiSockSend },
         .{ "clock_res_get", &wasiClockResGet },
         .{ "sched_yield", &wasiSchedYield },
         .{ "proc_raise", &wasiProcRaise },
@@ -3024,21 +3381,22 @@ test "resolveWasiFunction: unknown returns null" {
 
 test "resolveWasiFunction: all 44 functions resolve" {
     const names = [_][]const u8{
-        "proc_exit",          "thread-spawn",         "fd_write",
-        "fd_read",            "fd_pread",             "fd_pwrite",
-        "fd_readdir",         "fd_seek",              "fd_close",
-        "fd_renumber",        "fd_fdstat_get",        "fd_fdstat_set_flags",
-        "fd_fdstat_set_rights", "fd_filestat_get",    "fd_filestat_set_size",
-        "fd_filestat_set_times", "fd_advise",         "fd_allocate",
-        "fd_datasync",        "fd_sync",              "fd_tell",
-        "fd_prestat_get",     "fd_prestat_dir_name",  "clock_time_get",
-        "environ_sizes_get",  "environ_get",          "args_sizes_get",
-        "args_get",           "random_get",           "path_open",
-        "path_filestat_get",  "path_filestat_set_times", "path_create_directory",
-        "path_remove_directory", "path_unlink_file",  "path_link",
-        "path_rename",        "path_symlink",         "path_readlink",
-        "poll_oneoff",        "sock_shutdown",        "clock_res_get",
-        "sched_yield",        "proc_raise",
+        "proc_exit",             "thread-spawn",            "fd_write",
+        "fd_read",               "fd_pread",                "fd_pwrite",
+        "fd_readdir",            "fd_seek",                 "fd_close",
+        "fd_renumber",           "fd_fdstat_get",           "fd_fdstat_set_flags",
+        "fd_fdstat_set_rights",  "fd_filestat_get",         "fd_filestat_set_size",
+        "fd_filestat_set_times", "fd_advise",               "fd_allocate",
+        "fd_datasync",           "fd_sync",                 "fd_tell",
+        "fd_prestat_get",        "fd_prestat_dir_name",     "clock_time_get",
+        "environ_sizes_get",     "environ_get",             "args_sizes_get",
+        "args_get",              "random_get",              "path_open",
+        "path_filestat_get",     "path_filestat_set_times", "path_create_directory",
+        "path_remove_directory", "path_unlink_file",        "path_link",
+        "path_rename",           "path_symlink",            "path_readlink",
+        "poll_oneoff",           "sock_shutdown",           "clock_res_get",
+        "sock_accept",           "sock_recv",               "sock_send",
+        "sched_yield",           "proc_raise",
     };
     for (names) |name| {
         const result = resolveWasiFunction(name);
@@ -4863,7 +5221,7 @@ test "ctxSockShutdownCore: socket without RIGHTS_SOCK_SHUTDOWN → ENOTCAPABLE" 
     defer ctx.deinit();
     try ctx.fd_table.insert(102, .{
         .kind = .socket,
-        .host_fd = 0,
+        .host_fd = null,
         .rights_base = 0,
         .rights_inheriting = 0,
     });
@@ -4872,4 +5230,304 @@ test "ctxSockShutdownCore: socket without RIGHTS_SOCK_SHUTDOWN → ENOTCAPABLE" 
         expected,
         ctxSockShutdownCore(ctx, 102, @as(i32, wasi.SDFLAGS_RD)),
     );
+}
+
+// ── sock_accept / sock_recv / sock_send tests (#437) ───────────────────
+
+// Helper: install a `.socket` FdEntry with the given rights mask. Uses
+// host_fd = null so classification paths can be exercised without any
+// real kernel socket — the syscall path is reached only after passing
+// all rights/kind checks, and these tests target the negative paths
+// before the syscall ever fires. A null host_fd also keeps `WasiCtx.deinit`
+// from attempting to close a fake fd, which the std I/O path treats as
+// a use-after-free panic.
+fn insertSocketEntry(ctx: *wasi.WasiCtx, fd: u32, rights_base: u64) !void {
+    try ctx.fd_table.insert(fd, .{
+        .kind = .socket,
+        .host_fd = null,
+        .rights_base = rights_base,
+        .rights_inheriting = rights_base,
+    });
+}
+
+test "ctxSockAcceptCore: bad fd → EBADF" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    var mem: [16]u8 = @splat(0);
+    try std.testing.expectEqual(
+        wasi_core.WASI_EBADF,
+        ctxSockAcceptCore(ctx, &mem, -1, 0, 0),
+    );
+    try std.testing.expectEqual(
+        wasi_core.WASI_EBADF,
+        ctxSockAcceptCore(ctx, &mem, 99, 0, 0),
+    );
+}
+
+test "ctxSockAcceptCore: stdout fd → ENOTSOCK" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    var mem: [16]u8 = @splat(0);
+    const expected: i32 = @intCast(@intFromEnum(wasi.Errno.notsock));
+    try std.testing.expectEqual(expected, ctxSockAcceptCore(ctx, &mem, 1, 0, 0));
+}
+
+test "ctxSockAcceptCore: socket without RIGHTS_SOCK_ACCEPT → ENOTCAPABLE" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try insertSocketEntry(ctx, 102, 0);
+    var mem: [16]u8 = @splat(0);
+    const expected: i32 = @intCast(@intFromEnum(wasi.Errno.notcapable));
+    try std.testing.expectEqual(expected, ctxSockAcceptCore(ctx, &mem, 102, 0, 0));
+}
+
+test "ctxSockAcceptCore: reserved fdflags bit → EINVAL" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try insertSocketEntry(ctx, 102, wasi.SOCKET_LISTEN_RIGHTS);
+    var mem: [16]u8 = @splat(0);
+    // FDFLAGS_APPEND has no socket semantics; reject.
+    try std.testing.expectEqual(
+        wasi_core.WASI_EINVAL,
+        ctxSockAcceptCore(ctx, &mem, 102, @as(i32, wasi.FDFLAGS_APPEND), 0),
+    );
+}
+
+test "ctxSockRecvCore: bad fd → EBADF" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    var mem: [64]u8 = @splat(0);
+    try std.testing.expectEqual(
+        wasi_core.WASI_EBADF,
+        ctxSockRecvCore(ctx, &mem, -1, 0, 0, 0, 0, 0),
+    );
+    try std.testing.expectEqual(
+        wasi_core.WASI_EBADF,
+        ctxSockRecvCore(ctx, &mem, 99, 0, 0, 0, 0, 0),
+    );
+}
+
+test "ctxSockRecvCore: stdout fd → ENOTSOCK" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    var mem: [64]u8 = @splat(0);
+    const expected: i32 = @intCast(@intFromEnum(wasi.Errno.notsock));
+    try std.testing.expectEqual(expected, ctxSockRecvCore(ctx, &mem, 1, 0, 0, 0, 0, 0));
+}
+
+test "ctxSockRecvCore: socket without RIGHTS_FD_READ → ENOTCAPABLE" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    // Listener has SOCKET_LISTEN_RIGHTS which omits FD_READ on purpose.
+    try insertSocketEntry(ctx, 102, wasi.SOCKET_LISTEN_RIGHTS);
+    var mem: [64]u8 = @splat(0);
+    const expected: i32 = @intCast(@intFromEnum(wasi.Errno.notcapable));
+    try std.testing.expectEqual(expected, ctxSockRecvCore(ctx, &mem, 102, 0, 0, 0, 0, 0));
+}
+
+test "ctxSockRecvCore: reserved ri_flags bit → EINVAL" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try insertSocketEntry(ctx, 102, wasi.SOCKET_BASE_RIGHTS);
+    var mem: [64]u8 = @splat(0);
+    // 0x10 is outside RIFLAGS_RECV_PEEK | RIFLAGS_RECV_WAITALL.
+    try std.testing.expectEqual(
+        wasi_core.WASI_EINVAL,
+        ctxSockRecvCore(ctx, &mem, 102, 0, 0, 0x10, 0, 0),
+    );
+}
+
+test "ctxSockSendCore: bad fd → EBADF" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    var mem: [64]u8 = @splat(0);
+    try std.testing.expectEqual(
+        wasi_core.WASI_EBADF,
+        ctxSockSendCore(ctx, &mem, -1, 0, 0, 0, 0),
+    );
+    try std.testing.expectEqual(
+        wasi_core.WASI_EBADF,
+        ctxSockSendCore(ctx, &mem, 99, 0, 0, 0, 0),
+    );
+}
+
+test "ctxSockSendCore: stdout fd → ENOTSOCK" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    var mem: [64]u8 = @splat(0);
+    const expected: i32 = @intCast(@intFromEnum(wasi.Errno.notsock));
+    try std.testing.expectEqual(expected, ctxSockSendCore(ctx, &mem, 1, 0, 0, 0, 0));
+}
+
+test "ctxSockSendCore: socket without RIGHTS_FD_WRITE → ENOTCAPABLE" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try insertSocketEntry(ctx, 102, wasi.SOCKET_LISTEN_RIGHTS);
+    var mem: [64]u8 = @splat(0);
+    const expected: i32 = @intCast(@intFromEnum(wasi.Errno.notcapable));
+    try std.testing.expectEqual(expected, ctxSockSendCore(ctx, &mem, 102, 0, 0, 0, 0));
+}
+
+test "ctxSockSendCore: si_flags != 0 → EINVAL" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try insertSocketEntry(ctx, 102, wasi.SOCKET_BASE_RIGHTS);
+    var mem: [64]u8 = @splat(0);
+    try std.testing.expectEqual(
+        wasi_core.WASI_EINVAL,
+        ctxSockSendCore(ctx, &mem, 102, 0, 0, 1, 0),
+    );
+}
+
+// ── socketpair round-trip (Linux only) ─────────────────────────────────
+// Exercise the full syscall path of sock_recv / sock_send against a
+// kernel-backed connected socket pair. The pair member we install as a
+// .socket FdEntry is owned by WasiCtx and closed in deinit; the
+// non-installed peer is closed manually.
+
+test "ctxSockSendCore + ctxSockRecvCore: UNIX socketpair round-trip" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const linux = std.os.linux;
+
+    var pair: [2]std.posix.fd_t = .{ -1, -1 };
+    {
+        const rc = linux.socketpair(linux.AF.UNIX, linux.SOCK.STREAM, 0, &pair);
+        try std.testing.expectEqual(linux.E.SUCCESS, linux.errno(rc));
+    }
+    // Peer (pair[1]) stays host-side; pair[0] becomes the guest socket.
+    defer _ = linux.close(pair[1]);
+
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+
+    const guest_fd: u32 = 200;
+    try ctx.fd_table.insert(guest_fd, .{
+        .kind = .socket,
+        .host_fd = pair[0],
+        .rights_base = wasi.SOCKET_BASE_RIGHTS,
+        .rights_inheriting = wasi.SOCKET_BASE_RIGHTS,
+    });
+
+    // Simulated guest linear memory:
+    //   [0..8)   iovec slot 0: { buf_ptr=16, buf_len=5 }
+    //   [8..12)  so_datalen_ptr / ro_datalen_ptr scratch
+    //   [12..16) ro_flags_ptr scratch
+    //   [16..21) payload bytes
+    var mem: [128]u8 = @splat(0);
+    std.mem.writeInt(u32, mem[0..4], 16, .little);
+    std.mem.writeInt(u32, mem[4..8], 5, .little);
+    @memcpy(mem[16..21], "hello");
+
+    // send "hello"
+    const send_rc = ctxSockSendCore(ctx, &mem, @intCast(guest_fd), 0, 1, 0, 8);
+    try std.testing.expectEqual(wasi_core.WASI_ESUCCESS, send_rc);
+    const sent = std.mem.readInt(u32, mem[8..12], .little);
+    try std.testing.expectEqual(@as(u32, 5), sent);
+
+    // Read on the peer to verify the bytes left the host fd.
+    var peer_buf: [16]u8 = undefined;
+    const got_rc = linux.read(pair[1], peer_buf[0..], 16);
+    try std.testing.expectEqual(linux.E.SUCCESS, linux.errno(got_rc));
+    const got: usize = @intCast(@as(isize, @bitCast(got_rc)));
+    try std.testing.expectEqualSlices(u8, "hello", peer_buf[0..got]);
+
+    // Now send back from the peer and recv on the guest side.
+    const write_rc = linux.write(pair[1], "world", 5);
+    try std.testing.expectEqual(linux.E.SUCCESS, linux.errno(write_rc));
+
+    // Reuse the iovec at mem[0..8] pointing at mem[32..37].
+    @memset(mem[16..], 0);
+    std.mem.writeInt(u32, mem[0..4], 32, .little);
+    std.mem.writeInt(u32, mem[4..8], 5, .little);
+    const recv_rc = ctxSockRecvCore(ctx, &mem, @intCast(guest_fd), 0, 1, 0, 8, 12);
+    try std.testing.expectEqual(wasi_core.WASI_ESUCCESS, recv_rc);
+    const recvd = std.mem.readInt(u32, mem[8..12], .little);
+    try std.testing.expectEqual(@as(u32, 5), recvd);
+    try std.testing.expectEqualSlices(u8, "world", mem[32..37]);
+}
+
+test "ctxSockAcceptCore: TCP listener accepts a host-side connection" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const linux = std.os.linux;
+
+    // Bind a listener on 127.0.0.1:0 (ephemeral port).
+    const lfd_rc = linux.socket(linux.AF.INET, linux.SOCK.STREAM | linux.SOCK.CLOEXEC, linux.IPPROTO.TCP);
+    try std.testing.expectEqual(linux.E.SUCCESS, linux.errno(lfd_rc));
+    const listen_fd: std.posix.fd_t = @intCast(@as(isize, @bitCast(lfd_rc)));
+    defer _ = linux.close(listen_fd);
+    var sa: linux.sockaddr.in = .{
+        .port = 0,
+        .addr = @bitCast([4]u8{ 127, 0, 0, 1 }),
+    };
+    {
+        const rc = linux.bind(listen_fd, @ptrCast(&sa), @sizeOf(@TypeOf(sa)));
+        try std.testing.expectEqual(linux.E.SUCCESS, linux.errno(rc));
+    }
+    {
+        const rc = linux.listen(listen_fd, 1);
+        try std.testing.expectEqual(linux.E.SUCCESS, linux.errno(rc));
+    }
+
+    // Read back the kernel-assigned port via getsockname.
+    var bound: linux.sockaddr.in = undefined;
+    var bound_len: linux.socklen_t = @sizeOf(@TypeOf(bound));
+    {
+        const rc = linux.getsockname(listen_fd, @ptrCast(&bound), &bound_len);
+        try std.testing.expectEqual(linux.E.SUCCESS, linux.errno(rc));
+    }
+
+    // Spawn a client thread that connects, exchanges nothing, and closes.
+    const ConnectArg = struct { port: u16 };
+    const arg: ConnectArg = .{ .port = std.mem.bigToNative(u16, bound.port) };
+    const Connector = struct {
+        fn run(a: ConnectArg) void {
+            const l = std.os.linux;
+            const c_rc = l.socket(l.AF.INET, l.SOCK.STREAM | l.SOCK.CLOEXEC, l.IPPROTO.TCP);
+            if (l.errno(c_rc) != .SUCCESS) return;
+            const cfd: std.posix.fd_t = @intCast(@as(isize, @bitCast(c_rc)));
+            defer _ = l.close(cfd);
+            const dst: l.sockaddr.in = .{
+                .port = std.mem.nativeToBig(u16, a.port),
+                .addr = @bitCast([4]u8{ 127, 0, 0, 1 }),
+            };
+            _ = l.connect(cfd, @ptrCast(&dst), @sizeOf(@TypeOf(dst)));
+        }
+    };
+    var thread = try std.Thread.spawn(.{}, Connector.run, .{arg});
+    defer thread.join();
+
+    // Wire the listener as a socket preopen and accept once.
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    const guest_listen_fd: u32 = 200;
+    try ctx.fd_table.insert(guest_listen_fd, .{
+        .kind = .socket,
+        .host_fd = listen_fd,
+        .rights_base = wasi.SOCKET_LISTEN_RIGHTS,
+        .rights_inheriting = wasi.SOCKET_BASE_RIGHTS,
+    });
+
+    var mem: [16]u8 = @splat(0);
+    const rc = ctxSockAcceptCore(ctx, &mem, @intCast(guest_listen_fd), 0, 0);
+    try std.testing.expectEqual(wasi_core.WASI_ESUCCESS, rc);
+    const new_guest_fd = std.mem.readInt(u32, mem[0..4], .little);
+    try std.testing.expect(new_guest_fd >= 3);
+    const entry = ctx.fd_table.get(new_guest_fd) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(wasi.FdEntry.FdKind.socket, entry.kind);
+    // listen_fd is owned by the test; rewire its FdEntry to drop ownership
+    // before deinit closes a fd the deferred linux.close also closes.
+    var lis = ctx.fd_table.entries.getPtr(guest_listen_fd).?;
+    lis.host_fd = null;
 }

--- a/src/wasi/wasi.zig
+++ b/src/wasi/wasi.zig
@@ -218,6 +218,21 @@ pub const EVENT_SIZE: usize = 32;
 pub const SDFLAGS_RD: u16 = 0x0001;
 pub const SDFLAGS_WR: u16 = 0x0002;
 
+// ── sock_recv riflags ───────────────────────────────────────────────────
+// Witx `riflags` is a bitset. Only the two below are defined; any other
+// bit must be rejected with `EINVAL`. `WAITALL` maps to `MSG_WAITALL`,
+// `PEEK` to `MSG_PEEK`.
+pub const RIFLAGS_RECV_PEEK: u16 = 0x0001;
+pub const RIFLAGS_RECV_WAITALL: u16 = 0x0002;
+pub const RIFLAGS_ALL: u16 = RIFLAGS_RECV_PEEK | RIFLAGS_RECV_WAITALL;
+
+// ── sock_recv roflags ───────────────────────────────────────────────────
+// Currently only `DATA_TRUNCATED` is defined (set when the host kernel
+// reports `MSG_TRUNC`). wamr's `sock_recv` does not surface this yet —
+// the bit is defined for forward compatibility and for the guest-side
+// header layout.
+pub const ROFLAGS_RECV_DATA_TRUNCATED: u16 = 0x0001;
+
 // ── WASI rights (bitset, u64) — only the bits we currently consult ──────
 // Full taxonomy in the preview1 spec; extend on demand.
 
@@ -300,6 +315,27 @@ pub const FILE_BASE_RIGHTS: u64 =
 /// `path_open`. Same as base + the file rights so opening a regular
 /// file inside still gets read/write/seek capabilities.
 pub const DIRECTORY_INHERITING_RIGHTS: u64 = DIRECTORY_BASE_RIGHTS | FILE_BASE_RIGHTS;
+
+/// Rights granted to a connected stream socket — what `sock_accept`
+/// installs on the new fd. wasi-libc expects an accepted socket to
+/// support `read`/`write`/`poll`/`shutdown`; it does not expect the
+/// child fd to be able to `accept` again.
+pub const SOCKET_BASE_RIGHTS: u64 =
+    RIGHTS_FD_READ |
+    RIGHTS_FD_WRITE |
+    RIGHTS_FD_FDSTAT_SET_FLAGS |
+    RIGHTS_POLL_FD_READWRITE |
+    RIGHTS_SOCK_SHUTDOWN;
+
+/// Rights granted to a listening socket preopen (the `--listen=` fd).
+/// It accepts new connections and is poll-able; it cannot itself be
+/// read from or written to, mirroring wasi-libc's expectation for a
+/// passive `socket(2)` + `listen(2)` fd.
+pub const SOCKET_LISTEN_RIGHTS: u64 =
+    RIGHTS_SOCK_ACCEPT |
+    RIGHTS_POLL_FD_READWRITE |
+    RIGHTS_SOCK_SHUTDOWN |
+    RIGHTS_FD_FDSTAT_SET_FLAGS;
 
 // ── WASI fstflags (bitset, u16) for `*_filestat_set_times` ──────────────
 
@@ -441,7 +477,7 @@ pub const WasiCtx = struct {
                 d.close(self.io);
             }
             if (entry.host_fd) |host_fd| {
-                if (entry.kind == .regular_file) {
+                if (entry.kind == .regular_file or entry.kind == .socket) {
                     const file = File{ .handle = host_fd, .flags = .{ .nonblocking = false } };
                     file.close(self.io);
                 }
@@ -493,6 +529,24 @@ pub const WasiCtx = struct {
             d.close(self.io);
         }
         return try self.addPreopen(guest_name, dir);
+    }
+
+    /// Register an already-listening host TCP socket as a socket preopen.
+    /// Allocates a fresh fd ≥ 3 and takes ownership of `host_fd` (closed
+    /// on `WasiCtx.deinit`). The preopen is *not* recorded in
+    /// `self.preopens` — preview1's `fd_prestat_*` surface only exposes
+    /// directory preopens; socket preopens are discoverable by convention
+    /// (wasi-libc walks fds 3.. and reports `ENOTDIR` for non-dir prestats
+    /// to enumerate them). Returns the assigned fd.
+    pub fn addPreopenSocket(self: *WasiCtx, host_fd: std.posix.fd_t) !u32 {
+        const fd = self.fd_table.allocateFd();
+        try self.fd_table.insert(fd, .{
+            .kind = .socket,
+            .host_fd = host_fd,
+            .rights_base = SOCKET_LISTEN_RIGHTS,
+            .rights_inheriting = SOCKET_BASE_RIGHTS,
+        });
+        return fd;
     }
 
     /// Look up a preopen by its assigned fd; returns the guest name or null.

--- a/tests/wasi-sock/driver.zig
+++ b/tests/wasi-sock/driver.zig
@@ -1,0 +1,133 @@
+//! Integration-test driver for the WASI sockets plumbing (#437).
+//!
+//! Spawns `wamr run --listen=127.0.0.1:<port> <echo.wasm>` as a subprocess
+//! and verifies that the guest's `sock_accept` / `sock_recv` / `sock_send`
+//! roundtrip a single payload back to a host client.
+//!
+//! Usage: `wasi-sock-driver <wamr_exe> <wasm_path> <port>`
+//!
+//! Exit code 0 on success; non-zero (and a message on stderr) on failure.
+//! The driver is the run target for the `test-wasi-sock` build step.
+
+const std = @import("std");
+const linux = std.os.linux;
+const builtin = @import("builtin");
+
+const message = "hello wamr sockets";
+const usage = "usage: wasi-sock-driver <wamr_exe> <wasm_path> <port>\n";
+
+pub fn main(init: std.process.Init) !void {
+    if (comptime builtin.os.tag != .linux) {
+        std.debug.print("wasi-sock-driver only runs on Linux\n", .{});
+        std.process.exit(1);
+    }
+
+    const io = init.io;
+    const allocator = init.gpa;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    if (args.len < 4) {
+        std.debug.print(usage, .{});
+        std.process.exit(2);
+    }
+    const wamr_exe = args[1];
+    const wasm_path = args[2];
+    const port = std.fmt.parseInt(u16, args[3], 10) catch |err| {
+        std.debug.print("invalid port '{s}': {t}\n", .{ args[3], err });
+        std.process.exit(2);
+    };
+
+    const listen_arg = try std.fmt.allocPrint(allocator, "--listen=127.0.0.1:{d}", .{port});
+    defer allocator.free(listen_arg);
+
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ wamr_exe, "run", listen_arg, wasm_path },
+        .stdin = .ignore,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    });
+    var child_owned = true;
+    defer if (child_owned) {
+        child.kill(io);
+    };
+
+    // Open a host-side client socket and retry connect while the guest
+    // initialises. The bind happens before fork+exec of wamr's interpreter
+    // loop (eager-bind contract documented in main.zig), so the kernel
+    // accepts the connect as soon as wamr is past arg parsing.
+    var connected_fd: i32 = -1;
+    {
+        const dest: linux.sockaddr.in = .{
+            .port = std.mem.nativeToBig(u16, port),
+            .addr = @bitCast([4]u8{ 127, 0, 0, 1 }),
+        };
+        const max_attempts: u32 = 60; // ~3s @ 50ms
+        var attempt: u32 = 0;
+        while (attempt < max_attempts) : (attempt += 1) {
+            const fd_rc = linux.socket(
+                linux.AF.INET,
+                linux.SOCK.STREAM | linux.SOCK.CLOEXEC,
+                linux.IPPROTO.TCP,
+            );
+            if (linux.errno(fd_rc) != .SUCCESS) return error.SocketFailed;
+            const fd: i32 = @intCast(@as(isize, @bitCast(fd_rc)));
+
+            const rc = linux.connect(fd, @ptrCast(&dest), @sizeOf(@TypeOf(dest)));
+            if (linux.errno(rc) == .SUCCESS) {
+                connected_fd = fd;
+                break;
+            }
+            _ = linux.close(fd);
+            const ts: linux.timespec = .{ .sec = 0, .nsec = 50 * std.time.ns_per_ms };
+            _ = linux.nanosleep(&ts, null);
+        }
+        if (connected_fd < 0) {
+            std.debug.print(
+                "driver: failed to connect to 127.0.0.1:{d} after {d} attempts\n",
+                .{ port, max_attempts },
+            );
+            return error.ConnectTimeout;
+        }
+    }
+    defer _ = linux.close(connected_fd);
+
+    {
+        const w_rc = linux.write(connected_fd, message.ptr, message.len);
+        if (linux.errno(w_rc) != .SUCCESS) return error.WriteFailed;
+        const wrote: usize = @intCast(@as(isize, @bitCast(w_rc)));
+        if (wrote != message.len) return error.ShortWrite;
+    }
+
+    var recv_buf: [128]u8 = undefined;
+    var total: usize = 0;
+    while (total < message.len) {
+        const r_rc = linux.read(
+            connected_fd,
+            recv_buf[total..].ptr,
+            recv_buf.len - total,
+        );
+        if (linux.errno(r_rc) != .SUCCESS) return error.ReadFailed;
+        const n: usize = @intCast(@as(isize, @bitCast(r_rc)));
+        if (n == 0) break; // EOF
+        total += n;
+    }
+    if (!std.mem.eql(u8, recv_buf[0..total], message)) {
+        std.debug.print(
+            "driver: echo mismatch — expected '{s}', got '{s}'\n",
+            .{ message, recv_buf[0..total] },
+        );
+        return error.MismatchedEcho;
+    }
+
+    const term = try child.wait(io);
+    child_owned = false;
+    switch (term) {
+        .exited => |code| if (code != 0) {
+            std.debug.print("driver: wamr exited with code {d}\n", .{code});
+            return error.WamrExitedNonZero;
+        },
+        else => {
+            std.debug.print("driver: wamr terminated abnormally: {any}\n", .{term});
+            return error.WamrAbnormalTerm;
+        },
+    }
+}

--- a/tests/wasi-sock/echo_server.zig
+++ b/tests/wasi-sock/echo_server.zig
@@ -1,0 +1,55 @@
+//! WASI preview1 echo server fixture for the `--listen` integration test.
+//!
+//! Compiled to `wasm32-wasi`. Assumes the embedder has installed a TCP
+//! listening socket as fd 3 (the only preopen in this layout). Accepts a
+//! single connection, echoes a single recv buffer back to the peer, then
+//! `proc_exit(0)`.
+//!
+//! Calls the preview1 host functions directly via `@extern`, bypassing
+//! wasi-libc. This keeps the fixture small and lets it exercise the new
+//! `sock_accept` / `sock_recv` / `sock_send` host functions without
+//! pulling in wasi-libc's socket emulation.
+
+const Iovec = extern struct { buf: [*]u8, len: u32 };
+const ConstIovec = extern struct { buf: [*]const u8, len: u32 };
+
+extern "wasi_snapshot_preview1" fn sock_accept(fd: i32, fdflags: i32, ro_fd: *i32) i32;
+extern "wasi_snapshot_preview1" fn sock_recv(
+    fd: i32,
+    ri_data: *const Iovec,
+    ri_data_len: u32,
+    ri_flags: i32,
+    ro_datalen: *u32,
+    ro_flags: *u32,
+) i32;
+extern "wasi_snapshot_preview1" fn sock_send(
+    fd: i32,
+    si_data: *const ConstIovec,
+    si_data_len: u32,
+    si_flags: i32,
+    so_datalen: *u32,
+) i32;
+extern "wasi_snapshot_preview1" fn fd_close(fd: i32) i32;
+extern "wasi_snapshot_preview1" fn proc_exit(code: u32) noreturn;
+
+const LISTEN_FD: i32 = 3;
+
+export fn _start() void {
+    var client_fd: i32 = 0;
+    if (sock_accept(LISTEN_FD, 0, &client_fd) != 0) proc_exit(11);
+
+    var buf: [256]u8 = undefined;
+    const iov = Iovec{ .buf = &buf, .len = buf.len };
+    var datalen: u32 = 0;
+    var roflags: u32 = 0;
+    if (sock_recv(client_fd, &iov, 1, 0, &datalen, &roflags) != 0) proc_exit(12);
+    if (datalen == 0) proc_exit(13);
+
+    const civ = ConstIovec{ .buf = &buf, .len = datalen };
+    var sent: u32 = 0;
+    if (sock_send(client_fd, &civ, 1, 0, &sent) != 0) proc_exit(14);
+    if (sent != datalen) proc_exit(15);
+
+    _ = fd_close(client_fd);
+    proc_exit(0);
+}


### PR DESCRIPTION
Closes #437. Follow-up to #420 / #434.

## What

* Implements the rest of the preview1 socket surface on Linux:
  * `sock_accept` — `accept4(SOCK_CLOEXEC | optional SOCK_NONBLOCK)`, installs the new fd as `.kind = .socket` with `SOCKET_BASE_RIGHTS`.
  * `sock_recv` — `recvmsg`. Translates `RIFLAGS_RECV_PEEK` → `MSG_PEEK`, `RIFLAGS_RECV_WAITALL` → `MSG_WAITALL`. Rejects other bits with `EINVAL`. Caps iovec count at `SOCK_IOV_MAX = 16` (TODO follow-up to chunk larger arrays).
  * `sock_send` — `sendmsg` with `MSG_NOSIGNAL`. `si_flags` must be zero per witx.
* New `WasiCtx.addPreopenSocket` helper that lands a socket at the next free guest fd with listener-only rights (`SOCKET_LISTEN_RIGHTS` = accept + poll; wasi-libc convention is that listening sockets do not carry read/write).
* CLI: `--listen=host:port` now works on the core-wasm interpreter path (was previously HTTP-component-only). Eager bind/listen at startup; duplicate `--listen` flags are rejected. `run_usage` updated.
* Three new entries in the `resolveWasiFunction` table + warning allow-list.

## Validation

* `zig build test` — **1885/1885 tests pass**, 29/29 steps. Adds 14 new tests (12 classification + socketpair roundtrip + TCP accept smoke).
* `zig build test-wasi-sock` — new end-to-end step that builds a small `wasm32-wasi` echo server (`tests/wasi-sock/echo_server.zig`) plus a native driver (`tests/wasi-sock/driver.zig`) that spawns wamr with `--listen=127.0.0.1:43657`, connects, round-trips a payload, asserts the echoed bytes match. **Passes from a clean cache.**
* `zig build wasi-testsuite` — 72/72 pass; no regression in the `sock_shutdown-*` cases.

## Out of scope

* macOS / FreeBSD parity (cores return `ENOSYS` on non-Linux, matching the existing `sock_shutdown` shape).
* `sock_recv_from` / `sock_send_to` — not in preview1.
* UDP — preview1 sockets are TCP-shaped only.
* Surfacing `MSG_TRUNC` through `ro_roflags_ptr` / per-iovec chunking past `SOCK_IOV_MAX` — flagged as TODOs.

## Notes for review

* The behaviour change in `WasiCtx.deinit` (now closes `host_fd` for `.kind = .socket` entries) required updating one pre-existing `ctxSockShutdownCore` ENOTCAPABLE test that used `host_fd = 0` (stdin) as a sentinel — it now uses `host_fd = null`, since the classification short-circuits before any syscall.
* Port `43657` is a fixed high port for the integration test. Ephemeral-port (`:0`) discovery would require an out-of-band channel that the CLI doesn't have today; I documented the trade-off in the plan and flagged it as a known small CI flake risk.
