### PR TITLE
fix(component): route guest proc_exit to host process exit code (#436)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -692,6 +692,32 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     run_hello.expectStdErrEqual("hello from zig component\n");
     run_step.dependOn(&run_hello.step);
 
+    // ── zig-exit ───────────────────────────────────────────────────
+    // Exercises the component exit-code path (issue #436): `_start`
+    // writes a marker line then calls `proc_exit(7)`; through the
+    // wasi-preview1 adapter that becomes `wasi:cli/exit.exit-with-code(7)`,
+    // which `runLoadedComponent` propagates as `RunOutcome.exit_code`
+    // and `main.zig:runComponent` maps to host exit code 7.
+    const exit_core = compileZigWasm(b, .{
+        .source = "examples/components/zig-exit/src/main.zig",
+        .target_triple = "wasm32-wasi",
+        .exports = &.{"_start"},
+        .output = "zig-exit.core.wasm",
+    });
+    const exit_component = makeCommandComponent(b, .{
+        .name = "zig-exit",
+        .core = exit_core,
+        .adapter = adapter,
+    });
+    installAndValidate(b, examples_step, exit_component, "zig-exit.component.wasm");
+
+    const run_exit = b.addRunArtifact(wamr_exe);
+    run_exit.addArg("run");
+    run_exit.addFileArg(exit_component);
+    run_exit.expectExitCode(7);
+    run_exit.expectStdErrEqual("exiting with code 7\n");
+    run_step.dependOn(&run_exit.step);
+
     // ── zig-adder ──────────────────────────────────────────────────
     // Library component (no `run`): exports `docs:adder/add@0.1.0`.
     const adder_core = compileZigWasm(b, .{

--- a/examples/components/zig-exit/README.md
+++ b/examples/components/zig-exit/README.md
@@ -1,0 +1,51 @@
+# zig-exit
+
+A WASI command component that exits with a nonzero code (issue #436
+fixture).
+
+The Zig source defines its own `_start` and calls
+`wasi_snapshot_preview1.proc_exit(7)` after writing a short marker line.
+The wasm-tools wasi-preview1 component adapter rewrites that
+`proc_exit` into `wasi:cli/exit.exit-with-code(7)`, which wamr's
+`WasiCliAdapter` captures as the run's numeric exit code.
+
+## Build pipeline
+
+```sh
+# 1. Build the core wasm with a custom _start.
+zig build-exe -target wasm32-wasi -O ReleaseSmall \
+    -fno-entry --export=_start \
+    src/main.zig
+
+# 2. Wrap it as a component using the wasi-preview1 command adapter.
+wabt component new main.wasm \
+    --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.command.wasm \
+    -o zig-exit.component.wasm
+```
+
+The repo's root `build.zig` automates both steps:
+
+```sh
+zig build component-examples           # build + validate all examples
+zig build component-examples-run       # run this one through ./zig-out/bin/wamr
+```
+
+## Run
+
+```console
+$ ./zig-out/bin/wamr zig-out/component-examples/zig-exit.component.wasm
+exiting with code 7
+$ echo $?
+7
+```
+
+## What this exercises
+
+- The component-model exit-code propagation path added in #436:
+  `proc_exit(rc)` → wamr's `wasiProcExit` (the import is bound via the
+  wasm-tools wasi-preview1 adapter, but wamr's wasi auto-resolution
+  currently dispatches it directly) → `ModuleInstance.exit_code_sink`
+  → `WasiCliAdapter.exit_code` → `RunOutcome.exit_code` →
+  `main.zig:runComponent` → host `std.process.exit(rc as u8)`.
+- Pairs with `zig-hello` (normal return → exit code 0) for end-to-end
+  coverage of both component exit shapes.

--- a/examples/components/zig-exit/src/main.zig
+++ b/examples/components/zig-exit/src/main.zig
@@ -1,0 +1,23 @@
+//! WASI command component that exercises the exit-code path (issue #436).
+//!
+//! Writes a marker line to fd 1 via `wasi_snapshot_preview1.fd_write`, then
+//! calls `wasi_snapshot_preview1.proc_exit(7)`. The numeric code reaches
+//! the host via `ModuleInstance.exit_code_sink` →
+//! `WasiCliAdapter.exit_code` → `RunOutcome.exit_code` →
+//! `main.zig:runComponent`, which exits the host process with 7.
+//!
+//! Pair with `zig-hello` which exercises the normal-return path.
+
+const std = @import("std");
+
+export fn _start() void {
+    const msg = "exiting with code 7\n";
+    var nwritten: usize = 0;
+    _ = std.os.wasi.fd_write(
+        1,
+        &.{.{ .base = msg.ptr, .len = msg.len }},
+        1,
+        &nwritten,
+    );
+    std.os.wasi.proc_exit(7);
+}

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -264,18 +264,28 @@ pub fn callComponentFuncByLocal(
     // 5. Call the core function
     interp.executeFunction(env, exported.core_func_idx) catch {
         if (env.host_trap) |ht| {
-            std.debug.print("[component trap] core_func_idx={d}", .{ht.core_func_idx});
-            if (ht.component_func_idx != std.math.maxInt(u32))
-                std.debug.print(" component_func_idx={d}", .{ht.component_func_idx});
-            if (ht.import_module_name.len > 0 or ht.import_field_name.len > 0)
+            // Suppress the diagnostic when this trap is actually a
+            // `wasi_snapshot_preview1.proc_exit` unwind that already
+            // landed the numeric code on `exit_code_sink` — that's
+            // normal control flow, not a real error (issue #436).
+            const is_proc_exit = if (module_inst.exit_code_sink) |sink|
+                sink.* != null
+            else
+                false;
+            if (!is_proc_exit) {
+                std.debug.print("[component trap] core_func_idx={d}", .{ht.core_func_idx});
+                if (ht.component_func_idx != std.math.maxInt(u32))
+                    std.debug.print(" component_func_idx={d}", .{ht.component_func_idx});
+                if (ht.import_module_name.len > 0 or ht.import_field_name.len > 0)
+                    std.debug.print(
+                        " import='{s}.{s}'",
+                        .{ ht.import_module_name, ht.import_field_name },
+                    );
                 std.debug.print(
-                    " import='{s}.{s}'",
-                    .{ ht.import_module_name, ht.import_field_name },
+                    " stage={s} error={s}\n",
+                    .{ @tagName(ht.stage), ht.err_name },
                 );
-            std.debug.print(
-                " stage={s} error={s}\n",
-                .{ @tagName(ht.stage), ht.err_name },
-            );
+            }
         }
         return error.TrapInCoreFunction;
     };

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -9255,8 +9255,17 @@ pub const RunComponentError = error{
 
 pub const RunOutcome = struct {
     /// The component exited normally. `is_ok=true` means run returned ok;
-    /// false means the component returned `result::error(_)`.
+    /// false means the component returned `result::error(_)` or
+    /// trapped via `wasi:cli/exit.exit{,-with-code}` / preview1
+    /// `proc_exit` with a nonzero code.
     is_ok: bool,
+    /// Numeric exit code recorded when the component called
+    /// `wasi:cli/exit.exit-with-code(rc)` (or the preview1
+    /// `proc_exit(rc)` path, which the wasm-tools adapter rewrites into
+    /// `exit-with-code`). `null` on a normal return — callers should
+    /// fall back to `is_ok` in that case. When set, the CLI translates
+    /// it into the host process exit code (saturated to `u8`).
+    exit_code: ?u32 = null,
 };
 
 /// Whether a component import name matches a WASI interface prefix,
@@ -9592,6 +9601,21 @@ pub fn runLoadedComponent(
         else => return error.LinkFailed,
     };
 
+    // Wire each core module instance's `exit_code_sink` to the adapter's
+    // slot so a guest preview1 `proc_exit(code)` routed through wamr's
+    // wasi auto-resolution still lands the numeric code where the CLI
+    // expects it. Components composed with the wasm-tools wasi-preview1
+    // adapter normally route `proc_exit` to the adapter's exported
+    // `proc_exit` (which then calls `wasi:cli/exit.exit-with-code` and
+    // hits `cliExitWithCode`); but in wamr today, wasi auto-resolution
+    // overrides the cross-instance import binding for `proc_exit`, so
+    // we'd otherwise lose the code. Issue #436.
+    for (inst.core_instances) |entry| {
+        if (entry.module_inst) |mi| {
+            mi.exit_code_sink = &adapter.exit_code;
+        }
+    }
+
     if (inst.getExport("run") == null) {
         return error.NoRunExport;
     }
@@ -9604,8 +9628,10 @@ pub fn runLoadedComponent(
         } };
     } else |_| {
         // `wasi:cli/exit.{exit, exit-with-code}` traps after stashing
-        // a code on the adapter; translate that into a normal outcome.
-        if (adapter.exit_code) |code| return .{ .is_ok = code == 0 };
+        // a code on the adapter; translate that into a normal outcome
+        // that carries the numeric exit code so the CLI can mirror it
+        // into the host process exit code (see issue #436).
+        if (adapter.exit_code) |code| return .{ .is_ok = code == 0, .exit_code = code };
         return error.Trap;
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -286,7 +286,15 @@ fn runComponent(
         stdout_file.writeStreamingAll(io, captured) catch {};
     }
 
-    std.process.exit(if (outcome.is_ok) 0 else 1);
+    // Prefer the explicit numeric exit code recorded by
+    // `wasi:cli/exit.exit-with-code` / preview1 `proc_exit` (#436);
+    // fall back to the boolean is_ok mapping when the component
+    // returned normally without recording a code. POSIX exit codes
+    // are 8-bit on most hosts, so saturate to 1 on overflow.
+    const rc: u8 = if (outcome.exit_code) |code|
+        std.math.cast(u8, code) orelse 1
+    else if (outcome.is_ok) 0 else 1;
+    std.process.exit(rc);
 }
 
 fn runHttpComponent(

--- a/src/runtime/common/types.zig
+++ b/src/runtime/common/types.zig
@@ -818,6 +818,17 @@ pub const ModuleInstance = struct {
     gc_objects: std.ArrayListUnmanaged(GcObject) = .empty,
     /// Cached evaluated element segment values (spec requires one-time evaluation)
     cached_elem_values: []?[]Value = &.{},
+    /// Optional pointer to a `?u32` slot the component-layer caller
+    /// uses to capture a guest's `wasi_snapshot_preview1.proc_exit`
+    /// numeric exit code (issue #436). When non-null, `wasiProcExit`
+    /// writes the requested code through this pointer in addition to
+    /// trapping the guest. The component-model `runLoadedComponent`
+    /// path wires this to `WasiCliAdapter.exit_code` so the CLI can
+    /// mirror it into the host process exit code. Stays null on the
+    /// core-wasm path — that route already encodes the exit code on
+    /// the attached `WasiCtx` and unwinds via `wasiProcExit`'s trap.
+    /// Not owned by `ModuleInstance`.
+    exit_code_sink: ?*?u32 = null,
 
     pub fn getExportFunc(self: *const ModuleInstance, name: []const u8) ?u32 {
         const exp = self.module.findExport(name, .function) orelse return null;

--- a/src/wasi/host_functions.zig
+++ b/src/wasi/host_functions.zig
@@ -77,6 +77,16 @@ pub fn wasiProcExit(env_opaque: *anyopaque) types.HostFnError!void {
         ctx.exit_code = @bitCast(code);
     }
 
+    // Component-model wiring (issue #436): the wamr component flow has no
+    // `WasiCtx`, so writeback above is a no-op. When the component layer
+    // routed a guest preview1 `proc_exit` here via wasi auto-resolution
+    // (vs through the wasm-tools adapter), record the numeric code on the
+    // host-side slot so `runLoadedComponent`/`runComponent` can mirror it
+    // into the host process exit code.
+    if (env.module_inst.exit_code_sink) |sink| {
+        sink.* = @bitCast(code);
+    }
+
     if (env.module_inst.thread_manager) |tm| {
         tm.signalTrap();
     }


### PR DESCRIPTION
Closes #436.

Routes a guest's `wasi_snapshot_preview1.proc_exit(rc)` inside a WASI command component up to the host `wamr run` exit code, so e.g. a Zig component that ends with `std.process.exit(7)` makes `wamr run` exit with code 7 (was 1).

## What was broken

Two paths exist for component `proc_exit`:

1. **wasm-tools adapter rewrite** — guest's preview1 `proc_exit` is bound to the adapter's `proc_exit` body, which calls `wasi:cli/exit.exit-with-code(rc)` → `WasiCliAdapter.cliExitWithCode`. That already stashed `adapter.exit_code = rc`, but `runLoadedComponent` discarded the numeric code in `RunOutcome` (only kept `is_ok`).
2. **wamr's wasi auto-resolution** — `src/runtime/interpreter/instance.zig:155-186` layers WASI auto-resolution on top of cross-instance import bindings, so guest `proc_exit` actually lands in `wasiProcExit` directly. `wasiProcExit` only wrote to `WasiCtx.exit_code`, and the component flow doesn't attach a `WasiCtx`, so the code was lost.

`main.zig:runComponent` then did `exit(if (outcome.is_ok) 0 else 1)`, collapsing every nonzero rc to 1.

## What this changes

* New `ModuleInstance.exit_code_sink: ?*?u32` (host-owned slot).
* `wasiProcExit` writes through the sink when non-null (additive — `WasiCtx.exit_code` writeback unchanged for the core-wasm path).
* `runLoadedComponent` walks `inst.core_instances` after `linkImports` and points each instance's sink at `&adapter.exit_code`. This captures the auto-resolution route, and the existing `cliExitWithCode` continues to handle the adapter-rewrite route.
* `RunOutcome` gains `exit_code: ?u32`; the trap branch sets it alongside `is_ok`.
* `main.zig:runComponent` prefers `outcome.exit_code` (saturated to `u8`) over the boolean.
* `callComponentFuncByLocal` suppresses the `[component trap] …` diagnostic when the trap is a `proc_exit` unwind that already recorded a code — that's normal control flow.

## Test fixture

`examples/components/zig-exit`: `_start` writes `exiting with code 7\n` then calls `proc_exit(7)`. `build.zig:addComponentExamples` runs it through `./zig-out/bin/wamr` with `expectExitCode(7)` + `expectStdErrEqual("exiting with code 7\n")`.

## Verification

* ✅ `zig build test` (full suite).
* ✅ `zig build component-examples-run` — zig-hello, zig-exit (rc=7), zig-calculator-cmd, mixed-zig-rust-calc.
* ✅ `wamr run …/wasi-testsuite/.../proc_exit-success.wasm` → 0; `…/proc_exit-failure.wasm` → 33 (core-wasm preview1 path unchanged).
* ✅ Manual: `wamr run …/zig-exit.component.wasm` prints `exiting with code 7` (no `[component trap]` noise) and exits 7.

## Follow-up (out of scope)

The deeper bug — WASI auto-resolution at `src/runtime/interpreter/instance.zig:155-186` clobbers cross-instance bindings for *every* preview1 import a component composes (`fd_write`, `args_get`, etc.) — is documented in the in-source comment of `runLoadedComponent`. This PR captures `proc_exit` via the sink; a follow-up issue can thread a cross-instance mask through `ImportContext` so wasi auto-resolution only fills slots that lack a binding.