### PR TITLE
fix: silence Debug-build loader/AOT leaks in wamrc and wamr run

### DIFF
--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -128,8 +128,20 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
 
     std.debug.print("Loaded {s} ({d} bytes)\n", .{ in_path, wasm_data.len });
 
-    // 2. Parse wasm module
-    const module = wamr.loader.load(wasm_data, allocator) catch |err| {
+    // 2. Parse wasm module.
+    //
+    // The loader allocates many slices on `module` (types, rec_groups,
+    // canonical_type_map, imports, functions, exports, data_segments,
+    // …) but `WasmModule` has no deinit and `wamrc` doesn't otherwise
+    // tear it down. Scope all loader allocations to an arena so they're
+    // freed in one shot at end-of-main, mirroring every other call site
+    // of `loader.load` in the repo (api/c_api.zig, api/wamr.zig,
+    // wast_runner, fuzz harnesses, runtime/interpreter/instance.zig,
+    // component/instance.zig). Eliminates the DebugAllocator leak
+    // reports that `wamrc` emits at exit when invoked from build steps.
+    var module_arena = std.heap.ArenaAllocator.init(allocator);
+    defer module_arena.deinit();
+    const module = wamr.loader.load(wasm_data, module_arena.allocator()) catch |err| {
         std.debug.print("Error parsing wasm: {}\n", .{err});
         std.process.exit(1);
     };

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -132,10 +132,11 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
     //
     // The loader allocates many slices on `module` (types, rec_groups,
     // canonical_type_map, imports, functions, exports, data_segments,
-    // …) but `WasmModule` has no deinit and `wamrc` doesn't otherwise
-    // tear it down. Scope all loader allocations to an arena so they're
-    // freed in one shot at end-of-main, mirroring every other call site
-    // of `loader.load` in the repo (api/c_api.zig, api/wamr.zig,
+    // …) but `WasmModule` has no deinit and `runCompile` doesn't
+    // otherwise tear it down before returning to `main`. Scope all
+    // loader allocations to an arena so they're freed in one shot when
+    // this function returns, mirroring every other call site of
+    // `loader.load` in the repo (api/c_api.zig, api/wamr.zig,
     // wast_runner, fuzz harnesses, runtime/interpreter/instance.zig,
     // component/instance.zig). Eliminates the DebugAllocator leak
     // reports that `wamrc` emits at exit when invoked from build steps.

--- a/src/main.zig
+++ b/src/main.zig
@@ -360,6 +360,14 @@ fn runAotReal(data: []const u8, allocator: std.mem.Allocator) void {
         std.debug.print("Error: failed to load AOT module: {}\n", .{err});
         std.process.exit(1);
     };
+    // Mirror the load/unload pairing used by every other `aot_loader.load`
+    // call site in the repo (compiler/emit_aot.zig, tests/coldstart_test.zig,
+    // tests/aot_harness.zig). Without this, `runAotReal` leaks every owned
+    // slice on `AotModule` — func_offsets, local_func_type_indices,
+    // func_types, exports, memories, data_segments, tables, imports,
+    // global_inits, elem_segments — which DebugAllocator prints to stderr
+    // on exit, even though the AOT image executes successfully.
+    defer aot_loader.unload(&aot_module, allocator);
 
     const aot_inst = aot_runtime.instantiate(&aot_module, allocator) catch |err| {
         std.debug.print("Error: failed to instantiate AOT module: {}\n", .{err});


### PR DESCRIPTION
Two Debug-build leak fixes that surface as DebugAllocator noise on exit. Both follow patterns already established elsewhere in the repo.

## 1. `wamrc`: scope loader allocations to an arena (commit 19af6bd5)

`runCompile` was the only `loader.load` caller passing a long-lived gpa
without arena-scoping or manual cleanup. Every other site in the repo
already does this (see commit message for the full list). Wrapping the
loader allocations in a function-scoped `std.heap.ArenaAllocator` frees
all owned slices on `WasmModule` (types, rec_groups, canonical_type_map,
imports, functions, exports, data_segments, …) when `runCompile`
returns.

Reproducer pre-fix (Debug):
```
$ wamrc compile noop.wasm -o noop.cwasm
…
error(DebugAllocator): memory address 0x… leaked:
    …/runtime/interpreter/loader.zig:1024:62: 0x… in canonicalizeTypeIndices
    …/runtime/interpreter/loader.zig:580:14:  0x… in parseFunctionSection
    …/runtime/interpreter/loader.zig:374:79:  0x… in parseTypeSection
    …/runtime/interpreter/loader.zig:413:42:  0x… in parseTypeSection
    …/runtime/interpreter/loader.zig:889:14:  0x… in parseExportSection
    …/runtime/interpreter/loader.zig:1115:14: 0x… in parseCodeSection
```

## 2. `wamr run <file.cwasm>`: pair `aot_loader.load` with `unload` (commit f55090b7)

`runAotReal` was missing the matching `aot_loader.unload(&aot_module, allocator)`.
Every other `aot_loader.load` caller (`compiler/emit_aot.zig`, `tests/coldstart_test.zig`,
`tests/aot_harness.zig`) pairs them. Without it, every owned slice on
`AotModule` — func_offsets, local_func_type_indices, func_types, exports,
memories, data_segments, tables, imports, global_inits, elem_segments — is
leaked when `runAotReal` returns to `main`, even though the AOT image
executes correctly.

Reproducer pre-fix (Debug):
```
$ wamr run noop.cwasm
1803668864
error(DebugAllocator): memory address 0x… leaked:
    …/runtime/aot/loader.zig: in load…
```

## Verification

- `wamrc compile noop.wasm -o noop.cwasm` — Debug, clean
- `wamr run noop.cwasm` (AOT) — Debug, clean (just '1803668864' on stdout)
- `wamr run noop.wasm` (interp) — Debug, clean (already used the wrapped `Module` with arena `deinit`)
- `zig build test` — passes locally on aarch64-darwin

## Why this isn't visible in Release CI

`DebugAllocator` is the std backing only in Debug builds; CI's coldstart
gate (and the runtime path used by end users) build with `ReleaseFast`,
which uses libc malloc and doesn't track leaks. The leaks were genuine
in all builds but only surfaced as visible noise (and as test failures
when DebugAllocator is asserted) in Debug.