### PR TITLE
main: drop std.process.exit; return u8 exit code from main (#450)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -24,34 +24,41 @@ fn parseSubcommand(s: []const u8) ?Subcommand {
     return null;
 }
 
-pub fn main(init: std.process.Init) !void {
+/// Returns the host process exit code. Returning (rather than calling
+/// `std.process.exit`) lets the Zig 0.16 startup runtime run its own
+/// teardown — most importantly the `DebugAllocator` leak hook on
+/// `init.gpa` in Debug builds (#449, #450). Exit-code policy:
+///   * 0 — successful guest run / `help` / `version`
+///   * `outcome.exit_code` / `ctx.exit_code` — guest-requested
+///     (preview1 `proc_exit`, `wasi:cli/exit.exit-with-code`)
+///   * 1 — runtime failure (trap, load/instantiate fail, host-side OOM
+///     during guest setup, etc.)
+///   * 2 — CLI / arg-parsing / usage error
+pub fn main(init: std.process.Init) !u8 {
     const allocator = init.gpa;
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     if (args.len < 2) {
         std.debug.print("error: missing subcommand — try `wamr help`\n", .{});
-        std.process.exit(1);
+        return 2;
     }
 
     const subcmd = parseSubcommand(args[1]) orelse {
         std.debug.print("error: unknown subcommand '{s}' — try `wamr help`\n", .{args[1]});
-        std.process.exit(1);
+        return 2;
     };
 
-    switch (subcmd) {
-        .version => {
+    return switch (subcmd) {
+        .version => blk: {
             writeStdout(init.io, "wamr " ++ wamr.version.string ++ "\n");
-            return;
+            break :blk 0;
         },
-        .help => {
-            runHelp(init.io, args[2..]);
-            return;
-        },
+        .help => runHelp(init.io, args[2..]),
         .run => try runRun(init, allocator, args[2..]),
-    }
+    };
 }
 
-fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []const []const u8) !void {
+fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []const []const u8) !u8 {
     var wasm_path: ?[]const u8 = null;
     var wasm_args: std.ArrayListUnmanaged([]const u8) = .empty;
     defer wasm_args.deinit(allocator);
@@ -68,22 +75,21 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
         const arg = run_args[i];
         if (!past_options and arg.len > 0 and arg[0] == '-') {
             if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-                runHelp(init.io, &.{"run"});
-                return;
+                return runHelp(init.io, &.{"run"});
             } else if (std.mem.startsWith(u8, arg, "--stack-size=")) {
                 stack_size = std.fmt.parseInt(u32, arg["--stack-size=".len..], 10) catch {
                     std.debug.print("error: invalid --stack-size value\n", .{});
-                    std.process.exit(1);
+                    return 2;
                 };
             } else if (std.mem.startsWith(u8, arg, "--listen=")) {
                 if (listen_address != null) {
                     std.debug.print("error: --listen specified more than once; only one listening socket preopen is supported\n", .{});
-                    std.process.exit(1);
+                    return 2;
                 }
                 const spec = arg["--listen=".len..];
                 listen_address = parseListenAddress(spec) catch {
                     std.debug.print("error: invalid --listen address '{s}'\n", .{spec});
-                    std.process.exit(1);
+                    return 2;
                 };
             } else if (std.mem.startsWith(u8, arg, "--heap-size=")) {
                 // Reserved for future WASI heap allocation
@@ -92,34 +98,34 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                     i += 1;
                     if (i >= run_args.len) {
                         std.debug.print("error: --env requires KEY=VALUE\n", .{});
-                        std.process.exit(1);
+                        return 2;
                     }
                     break :blk run_args[i];
                 } else arg["--env=".len..];
                 if (std.mem.indexOfScalar(u8, spec, '=') == null) {
                     std.debug.print("error: --env value '{s}' is missing '='\n", .{spec});
-                    std.process.exit(1);
+                    return 2;
                 }
-                env_flags.append(allocator, spec) catch std.process.exit(1);
+                try env_flags.append(allocator, spec);
             } else if (std.mem.eql(u8, arg, "--map-dir") or std.mem.startsWith(u8, arg, "--map-dir=")) {
                 const spec = if (std.mem.eql(u8, arg, "--map-dir")) blk: {
                     i += 1;
                     if (i >= run_args.len) {
                         std.debug.print("error: --map-dir requires HOST::GUEST\n", .{});
-                        std.process.exit(1);
+                        return 2;
                     }
                     break :blk run_args[i];
                 } else arg["--map-dir=".len..];
                 const md = parseMapDir(spec) catch {
                     std.debug.print("error: --map-dir value '{s}' must be 'HOST::GUEST'\n", .{spec});
-                    std.process.exit(1);
+                    return 2;
                 };
-                map_dirs.append(allocator, md) catch std.process.exit(1);
+                try map_dirs.append(allocator, md);
             } else if (std.mem.eql(u8, arg, "--")) {
                 past_options = true;
             } else {
                 std.debug.print("error: unknown option '{s}' — try `wamr help run`\n", .{arg});
-                std.process.exit(1);
+                return 2;
             }
         } else if (wasm_path == null) {
             wasm_path = arg;
@@ -131,7 +137,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
 
     const path = wasm_path orelse {
         std.debug.print("error: missing wasm/cwasm file — usage: wamr run <file> [args...]\n", .{});
-        std.process.exit(1);
+        return 2;
     };
 
     const io = init.io;
@@ -145,10 +151,9 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     if (wasm_data.len >= 4 and std.mem.readInt(u32, wasm_data[0..4], .little) == wamr.types.aot_magic) {
         if (listen_address != null) {
             std.debug.print("Error: --listen is not supported for AOT modules; rerun without --aot\n", .{});
-            std.process.exit(1);
+            return 2;
         }
-        runAot(wasm_data, allocator);
-        return;
+        return runAot(wasm_data, allocator);
     }
 
     // Distinguish core wasm from a component by the version word
@@ -173,25 +178,17 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                 }
             }
             if (listen_address) |addr| {
-                runHttpComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, addr);
-                return;
+                return runHttpComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, addr);
             }
-            runComponent(wasm_data, allocator, io, path, wasm_args.items, env_list.items);
-            return;
+            return runComponent(wasm_data, allocator, io, path, wasm_args.items, env_list.items);
         }
     }
 
-    if (listen_address) |addr| {
-        // Core wasm path: --listen registers a TCP listening socket as a
-        // socket preopen (kind = .socket, fd ≥ 3) for the guest's WASI
-        // preview1 sock_accept. The component-model path above already
-        // handled --listen for HTTP servers.
-        runWasm(wasm_data, stack_size, path, &wasm_args, env_flags.items, map_dirs.items, addr, allocator, io);
-        return;
-    }
-
-    // Wasm module (core)
-    runWasm(wasm_data, stack_size, path, &wasm_args, env_flags.items, map_dirs.items, null, allocator, io);
+    // Wasm module (core). `--listen` registers a TCP listening socket as a
+    // socket preopen (kind = .socket, fd ≥ 3) for the guest's WASI preview1
+    // sock_accept. The component-model branch above already handled --listen
+    // for HTTP servers.
+    return runWasm(wasm_data, stack_size, path, &wasm_args, env_flags.items, map_dirs.items, listen_address, allocator, io);
 }
 
 fn parseMapDir(spec: []const u8) !MapDir {
@@ -239,21 +236,36 @@ fn runComponent(
     wasm_path: []const u8,
     wasm_args: []const []const u8,
     env_vars: []const wamr.wasi_cli_adapter.EnvVar,
-) void {
+) u8 {
     const adapter_mod = wamr.wasi_cli_adapter;
     var adapter = adapter_mod.WasiCliAdapter.init(allocator);
     defer adapter.deinit();
 
     // argv[0] = wasm path, rest = user args (matches wasmtime convention).
     var argv_buf = allocator.alloc([]const u8, 1 + wasm_args.len) catch
-        std.process.exit(1);
+        return 1;
     defer allocator.free(argv_buf);
     argv_buf[0] = wasm_path;
     for (wasm_args, 0..) |a, i| argv_buf[i + 1] = a;
     adapter.setArguments(argv_buf);
     adapter.setEnvironment(env_vars);
 
-    const outcome = adapter_mod.runComponentBytes(data, allocator, &adapter) catch |err| {
+    // The component loader has no `Component.deinit` yet (#142 Phase 1B);
+    // its allocations (and the matching `ComponentInstance` machinery, whose
+    // `inst.deinit()` would otherwise have to mirror every loader-owned
+    // slice) are gathered into an arena that we tear down here. Mirrors the
+    // AOT path's `defer aot_loader.unload(...)` (PR #449) and matches the
+    // established pattern used by every component end-to-end test in the
+    // repo (see `wasi_cli_adapter.zig` test "stdio-echo: end-to-end real
+    // wasi-p2 component" and the explicit comment at `runLoadedComponent`
+    // about "hand-rolled callers ... which pass an arena"). Without this,
+    // DebugAllocator drowns the real component-path leak signal in
+    // hundreds of loader-allocated slices on every Debug-build run.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const outcome = adapter_mod.runComponentBytes(data, arena_alloc, &adapter) catch |err| {
         switch (err) {
             error.NoRunExport => std.debug.print(
                 "Error: component does not expose a top-level `run` export. " ++
@@ -274,7 +286,7 @@ fn runComponent(
             error.Trap => std.debug.print("Error: component trapped during run\n", .{}),
             else => std.debug.print("Error: component run failed: {}\n", .{err}),
         }
-        std.process.exit(1);
+        return 1;
     };
 
     // Flush captured stdout to the host. Buffered + flush at end is the
@@ -291,10 +303,8 @@ fn runComponent(
     // fall back to the boolean is_ok mapping when the component
     // returned normally without recording a code. POSIX exit codes
     // are 8-bit on most hosts, so saturate to 1 on overflow.
-    const rc: u8 = if (outcome.exit_code) |code|
-        std.math.cast(u8, code) orelse 1
-    else if (outcome.is_ok) 0 else 1;
-    std.process.exit(rc);
+    if (outcome.exit_code) |code| return std.math.cast(u8, code) orelse 1;
+    return if (outcome.is_ok) 0 else 1;
 }
 
 fn runHttpComponent(
@@ -304,20 +314,26 @@ fn runHttpComponent(
     wasm_args: []const []const u8,
     env_vars: []const wamr.wasi_cli_adapter.EnvVar,
     listen_address: std.Io.net.IpAddress,
-) void {
+) u8 {
     const adapter_mod = wamr.wasi_cli_adapter;
     var adapter = adapter_mod.WasiCliAdapter.init(allocator);
     defer adapter.deinit();
 
     var argv_buf = allocator.alloc([]const u8, 1 + wasm_args.len) catch
-        std.process.exit(1);
+        return 1;
     defer allocator.free(argv_buf);
     argv_buf[0] = wasm_path;
     for (wasm_args, 0..) |a, i| argv_buf[i + 1] = a;
     adapter.setArguments(argv_buf);
     adapter.setEnvironment(env_vars);
 
-    adapter_mod.serveHttpComponentBytes(data, allocator, &adapter, .{
+    // See `runComponent` for the rationale behind the arena wrapper —
+    // same loader/instance allocation story applies on the HTTP path.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    adapter_mod.serveHttpComponentBytes(data, arena_alloc, &adapter, .{
         .listen_address = listen_address,
     }) catch |err| {
         switch (err) {
@@ -339,26 +355,29 @@ fn runHttpComponent(
             error.InstantiateFailed => std.debug.print("Error: failed to instantiate component\n", .{}),
             else => std.debug.print("Error: HTTP server failed: {}\n", .{err}),
         }
-        std.process.exit(1);
+        return 1;
     };
+    // `serveHttpComponentBytes` runs an accept loop that today never returns
+    // normally; this path keeps the function's u8 return well-defined.
+    return 0;
 }
 
-fn runAot(data: []const u8, allocator: std.mem.Allocator) void {
+fn runAot(data: []const u8, allocator: std.mem.Allocator) u8 {
     if (comptime aot_supported) {
-        runAotReal(data, allocator);
+        return runAotReal(data, allocator);
     } else {
         std.debug.print("Error: AOT execution not supported on this architecture\n", .{});
-        std.process.exit(1);
+        return 1;
     }
 }
 
-fn runAotReal(data: []const u8, allocator: std.mem.Allocator) void {
+fn runAotReal(data: []const u8, allocator: std.mem.Allocator) u8 {
     const aot_loader = wamr.aot_loader;
     const aot_runtime = wamr.aot_runtime;
 
     const aot_module = aot_loader.load(data, allocator) catch |err| {
         std.debug.print("Error: failed to load AOT module: {}\n", .{err});
-        std.process.exit(1);
+        return 1;
     };
     // Mirror the load/unload pairing used by every other `aot_loader.load`
     // call site in the repo (compiler/emit_aot.zig, tests/coldstart_test.zig,
@@ -371,29 +390,30 @@ fn runAotReal(data: []const u8, allocator: std.mem.Allocator) void {
 
     const aot_inst = aot_runtime.instantiate(&aot_module, allocator) catch |err| {
         std.debug.print("Error: failed to instantiate AOT module: {}\n", .{err});
-        std.process.exit(1);
+        return 1;
     };
     defer aot_runtime.destroy(aot_inst);
 
     // Map native code as executable
     aot_runtime.mapCodeExecutable(aot_inst) catch |err| {
         std.debug.print("Error: failed to map code as executable: {}\n", .{err});
-        std.process.exit(1);
+        return 1;
     };
 
     // Find _start or main export
     const func_idx = aot_runtime.findExportFunc(aot_inst, "_start") orelse
         aot_runtime.findExportFunc(aot_inst, "main") orelse {
         std.debug.print("Error: no _start or main function exported in AOT module\n", .{});
-        std.process.exit(1);
+        return 1;
     };
 
     // Execute
     const result = aot_runtime.callFunc(aot_inst, func_idx, i32) catch |err| {
         std.debug.print("Error: AOT execution failed: {}\n", .{err});
-        std.process.exit(1);
+        return 1;
     };
     std.debug.print("{d}\n", .{result});
+    return 0;
 }
 
 fn runWasm(
@@ -406,26 +426,26 @@ fn runWasm(
     listen_address: ?std.Io.net.IpAddress,
     allocator: std.mem.Allocator,
     io: std.Io,
-) void {
+) u8 {
     var runtime = wamr.wamr.Runtime.init(allocator);
     defer runtime.deinit();
 
     var module = runtime.loadModule(wasm_data) catch |err| {
         std.debug.print("Error: failed to load module: {}\n", .{err});
-        std.process.exit(1);
+        return 1;
     };
     defer module.deinit();
 
     var instance = module.instantiate() catch |err| {
         std.debug.print("Error: failed to instantiate: {}\n", .{err});
-        std.process.exit(1);
+        return 1;
     };
     defer instance.deinit();
 
     const start_func = module.findExport("_start", .function) orelse
         module.findExport("main", .function) orelse {
         std.debug.print("Error: no _start or main function exported\n", .{});
-        std.process.exit(1);
+        return 1;
     };
 
     const func_type = module.inner.getFuncType(start_func.index);
@@ -433,19 +453,19 @@ fn runWasm(
 
     var env = wamr.exec_env.ExecEnv.create(instance.inner, stack_size, allocator) catch |err| {
         std.debug.print("Error: failed to create execution environment: {}\n", .{err});
-        std.process.exit(1);
+        return 1;
     };
     defer env.destroy();
 
     // Build argv for WASI: [wasm_path, wasm_args...]
     var argv_list: std.ArrayListUnmanaged([]const u8) = .empty;
     defer argv_list.deinit(allocator);
-    argv_list.append(allocator, wasm_path) catch std.process.exit(1);
-    for (wasm_args.items) |a| argv_list.append(allocator, a) catch std.process.exit(1);
+    argv_list.append(allocator, wasm_path) catch return 1;
+    for (wasm_args.items) |a| argv_list.append(allocator, a) catch return 1;
 
     var ctx = wamr.WasiCtx.init(allocator, io) catch |err| {
         std.debug.print("Error: failed to create WASI context: {}\n", .{err});
-        std.process.exit(1);
+        return 1;
     };
     defer ctx.deinit();
 
@@ -455,18 +475,18 @@ fn runWasm(
     for (map_dirs) |md| {
         _ = ctx.openMappedDir(md.host_path, md.guest_name) catch |err| {
             std.debug.print("Error: cannot pre-open '{s}' as '{s}': {}\n", .{ md.host_path, md.guest_name, err });
-            std.process.exit(1);
+            return 1;
         };
     }
 
     if (listen_address) |addr| {
         const listen_fd = openListenSocket(addr) catch |err| {
             std.debug.print("Error: --listen bind failed: {}\n", .{err});
-            std.process.exit(1);
+            return 1;
         };
         _ = ctx.addPreopenSocket(listen_fd) catch |err| {
             std.debug.print("Error: cannot register --listen socket preopen: {}\n", .{err});
-            std.process.exit(1);
+            return 1;
         };
     }
 
@@ -478,12 +498,13 @@ fn runWasm(
     }
 
     wamr.interp.executeFunction(env, start_func.index) catch |err| {
-        if (ctx.exit_code) |code| std.process.exit(@intCast(code));
+        if (ctx.exit_code) |code| return @intCast(code);
         std.debug.print("Error: execution trapped: {}\n", .{err});
-        std.process.exit(1);
+        return 1;
     };
 
-    if (ctx.exit_code) |code| std.process.exit(@intCast(code));
+    if (ctx.exit_code) |code| return @intCast(code);
+    return 0;
 }
 
 /// Bind a TCP socket to `addr` and put it in the listen state. Used by the
@@ -595,20 +616,21 @@ const help_usage =
     \\
 ;
 
-fn runHelp(io: std.Io, args: []const []const u8) void {
+fn runHelp(io: std.Io, args: []const []const u8) u8 {
     if (args.len == 0) {
         writeStdout(io, top_usage);
-        return;
+        return 0;
     }
     const sub = parseSubcommand(args[0]) orelse {
         std.debug.print("error: unknown subcommand '{s}' — try `wamr help`\n", .{args[0]});
-        std.process.exit(1);
+        return 2;
     };
     writeStdout(io, switch (sub) {
         .run => run_usage,
         .version => version_usage,
         .help => help_usage,
     });
+    return 0;
 }
 
 test "subcommand parsing" {


### PR DESCRIPTION
Closes #450.

## What

Change `pub fn main(init: std.process.Init) !void` → `!u8` and thread an exit code up through every subcommand handler (`runRun`, `runHelp`, `runComponent`, `runHttpComponent`, `runWasm`, `runAot`, `runAotReal`). Removes every `std.process.exit(...)` from `src/main.zig` so the Zig 0.16 startup runtime runs its own teardown — most importantly the `DebugAllocator` leak hook on `init.gpa` in Debug builds.

## Why

Per #450:
- `runComponent`/`runHttpComponent` previously called `std.process.exit` on every path, so `defer adapter.deinit()`, `defer allocator.free(...)` and every defer inside `runComponentBytes`/`runLoadedComponent` were skipped on every component invocation.
- `DebugAllocator` leak detection was suppressed for the component path. PR #449 surfaced AOT-path leaks because the AOT path returned normally; the equivalent diagnostics weren't available for components.
- Inconsistent with sibling subcommand success paths (`runWasm`, `runAot/runAotReal`).

PR #447 added a numeric `outcome.exit_code` (preview1 `proc_exit` / `wasi:cli/exit.exit-with-code`); the CLI saturated it to `u8` and fed it to `std.process.exit`. With `main` now returning `u8`, that same code flows back through the runtime and the leak hook still fires.

## Exit-code policy

| Class                              | Code |
| ---------------------------------- | ---- |
| Successful guest run / help / version | 0 |
| Guest-requested (`proc_exit`, `exit-with-code`) | `code` (saturated to u8) |
| Runtime failure (trap, load/instantiate fail, host-side OOM during guest setup) | 1 |
| CLI / arg-parsing / usage error    | 2 |

The optional follow-up the issue mentioned ("arg-parsing `std.process.exit(1)` calls in `main` itself and `runRun` … happy to fold them in if a reviewer prefers") is folded in here. Every `std.process.exit(...)` in `src/main.zig` is gone.

## Component-path leak fix

Once teardown actually runs, `DebugAllocator` immediately surfaces hundreds of loader-allocated `CanonOpt`/component slices (the loader has no `Component.deinit` yet — #142 Phase 1B). Per the existing convention — every component end-to-end test in the repo uses an arena, and `runLoadedComponent`'s comment explicitly anticipates _"hand-rolled callers like `runComponentBytes` (which pass an arena)"_ — wrap the loader+instance allocator inside `runComponent`/`runHttpComponent` in an `ArenaAllocator` torn down on return. Mirrors PR #449's `defer aot_loader.unload(...)` approach for the AOT path. The `WasiCliAdapter` keeps using `init.gpa` so DebugAllocator still covers adapter leaks.

## Verification

- `zig build test` — 458/458 tests pass
- `zig build component-examples-run` — `zig-hello`, `zig-exit` (`expectExitCode(7)`), `zig-calculator-cmd`, `mixed-zig-rust-calc` all pass; previously all four failed with hundreds of `error(DebugAllocator): memory address … leaked` lines on stderr that the build assertions caught
- `zig build wasi-testsuite` — 72/72 pass
- `zig build test-wasi-sock` — passes
- CLI-error smoke: `wamr` → exit 2, `wamr foo` → exit 2, `wamr run` → exit 2, `wamr run --bogus` → exit 2, `wamr help`/`wamr version` → exit 0
- `zig-exit` Debug-build smoke: prints `exiting with code 7`, exits 7, no leak diagnostics on stderr — the deliverable the issue promised

No `expectExitCode(1)` or `expectExitCode(2)` assertions exist anywhere in `build.zig`/`tests/`; the existing pins on 0 and 7 are preserved.

## Files

- `src/main.zig` — only file changed (+103 / −81)