### PR TITLE
feat(components): drop wasmtime adapter fetch + exit_code_sink (#453)

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Configure Zig caches
         uses: ./.github/actions/zig-cache
 
-      - name: Install cataggar/wabt v3.0.0-dev.4 (component CLI)
+      - name: Install cataggar/wabt v3.0.0-dev.5 (component CLI)
         run: |
           set -euo pipefail
           # ghr-bin is a tiny PyPI wrapper that downloads sha256-verified
@@ -52,7 +52,7 @@ jobs:
           # ~/.local/bin. pipx is preinstalled on ubuntu-latest; pip is
           # blocked by PEP 668. Pin both ghr-bin and the wabt release.
           pipx install ghr-bin==0.1.6
-          ghr install cataggar/wabt@v3.0.0-dev.4
+          ghr install cataggar/wabt@v3.0.0-dev.5
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/wabt" version
 

--- a/build.zig
+++ b/build.zig
@@ -632,28 +632,12 @@ pub fn build(b: *std.Build) void {
 /// Neither is reachable from `zig build` or `zig build test`.
 ///
 /// Pinned versions:
-///   * Wasmtime preview1 → component adapter v36.0.9 (sha256 verified)
-///   * `cataggar/wabt` ≥ v3.0.0-dev.4 on PATH (provides `component embed`,
-///     `component new`, `component compose`, `validate`)
+///   * `cataggar/wabt` ≥ v3.0.0-dev.5 on PATH (provides `component embed`,
+///     `component new`, `component compose`, `module validate`).
+///     The wasi-preview1 → component adapter is embedded in `wabt` and
+///     auto-attached by `wabt component new`; no external adapter fetch.
 ///   * `cargo` with `wasm32-wasip1` target for the mixed example
 fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
-    const adapter_url =
-        "https://github.com/bytecodealliance/wasmtime/releases/download/v36.0.9/wasi_snapshot_preview1.command.wasm";
-    const adapter_sha256 =
-        "2b0afc5edd1301716580c2df9d14b350529d770b54804def60c69807ed7600e0";
-
-    // Fetch + sha256-verify the wasi-preview1 → component adapter.
-    // sh -c "<script>" -- $1=output-path
-    const fetch_script = b.fmt(
-        "set -eu\n" ++
-            "curl --fail --silent --show-error --location --output \"$1\" \"{s}\"\n" ++
-            "echo \"{s}  $1\" | sha256sum -c -\n",
-        .{ adapter_url, adapter_sha256 },
-    );
-    const fetch_adapter = b.addSystemCommand(&.{ "sh", "-c", fetch_script, "--" });
-    fetch_adapter.setName("fetch wasi-preview1 adapter (v36.0.9)");
-    const adapter = fetch_adapter.addOutputFileArg("wasi_snapshot_preview1.command.wasm");
-
     const examples_step = b.step(
         "component-examples",
         "Build the WebAssembly Component examples in examples/components/",
@@ -674,38 +658,29 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     const hello = makeCommandComponent(b, .{
         .name = "zig-hello",
         .core = hello_core,
-        .adapter = adapter,
     });
     installAndValidate(b, examples_step, hello, "zig-hello.component.wasm");
 
     // The hello component is the only example that runs end-to-end on
-    // wamr today; wire it into `component-examples-run`. wamr's
-    // component-model CLI captures stdout via the wasi-cli adapter and
-    // currently flushes it to the host's *stderr* fd (the captured
-    // bytes go through `init.io`'s File-write dispatch which lands on
-    // fd 2 today; tracking issue separate from this PR).
-    //
-    // The `expectStdErrEqual("hello from zig component\n")` assertion
-    // is currently **disabled**: with #448's gate active, the bytes
-    // route through the wasmtime preview1 adapter, but our `wabt
-    // component {embed,new}` build pipeline emits an adapter-composed
-    // component whose stdout path silently drops the bytes (verified:
-    // even `wasmtime run` against the same component yields empty
-    // output). Restore the full assertion once #453 ships a
-    // wamr-native preview1 adapter built in-tree.
+    // wamr today; wire it into `component-examples-run`. The wabt
+    // adapter lowers `fd_write(1, …)` through
+    // `wasi:io/streams.blocking-write-and-flush` against
+    // `wasi:cli/stdout.get-stdout`, which wamr's
+    // `WasiCliAdapter` flushes to the host's actual stdout.
     const run_hello = b.addRunArtifact(wamr_exe);
     run_hello.addArg("run");
     run_hello.addFileArg(hello);
     run_hello.expectExitCode(0);
-    // run_hello.expectStdErrEqual("hello from zig component\n");  // gated on #453
+    run_hello.expectStdOutEqual("hello from zig component\n");
     run_step.dependOn(&run_hello.step);
 
     // ── zig-exit ───────────────────────────────────────────────────
     // Exercises the component exit-code path (issue #436): `_start`
-    // writes a marker line then calls `proc_exit(7)`; through the
-    // wasi-preview1 adapter that becomes `wasi:cli/exit.exit-with-code(7)`,
-    // which `runLoadedComponent` propagates as `RunOutcome.exit_code`
-    // and `main.zig:runComponent` maps to host exit code 7.
+    // writes a marker line then calls `proc_exit(7)`; through wabt's
+    // bundled wasi-preview1 → preview2 adapter that becomes
+    // `wasi:cli/exit.exit-with-code(7)`, which `runLoadedComponent`
+    // propagates as `RunOutcome.exit_code` and `main.zig:runComponent`
+    // maps to host exit code 7.
     const exit_core = compileZigWasm(b, .{
         .source = "examples/components/zig-exit/src/main.zig",
         .target_triple = "wasm32-wasi",
@@ -715,7 +690,6 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     const exit_component = makeCommandComponent(b, .{
         .name = "zig-exit",
         .core = exit_core,
-        .adapter = adapter,
     });
     installAndValidate(b, examples_step, exit_component, "zig-exit.component.wasm");
 
@@ -723,18 +697,7 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     run_exit.addArg("run");
     run_exit.addFileArg(exit_component);
     run_exit.expectExitCode(7);
-    // The `expectStdErrEqual("exiting with code 7\n")` assertion is
-    // currently **disabled**: with #448's gate active, `fd_write`
-    // routes through the wasmtime preview1 adapter rather than wamr's
-    // `wasiFdWrite` host fn, and our `wabt component {embed,new}`
-    // pipeline emits an adapter-composed component whose stdout path
-    // drops the bytes (verified: even `wasmtime run` against the
-    // produced component yields empty output). The exit-code check is
-    // preserved by the `proc_exit` cross-dispatch interception added
-    // alongside #448 in `src/runtime/interpreter/interp.zig`. Restore
-    // the full assertion once #453 ships a wamr-native preview1
-    // adapter built in-tree.
-    // run_exit.expectStdErrEqual("exiting with code 7\n");  // gated on #453
+    run_exit.expectStdOutEqual("exiting with code 7\n");
     run_step.dependOn(&run_exit.step);
 
     // ── zig-adder ──────────────────────────────────────────────────
@@ -777,8 +740,6 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
 
     const calc_new = b.addSystemCommand(&.{ "wabt", "component", "new" });
     calc_new.addFileArg(calc_embedded);
-    calc_new.addArg("--adapt");
-    calc_new.addPrefixedFileArg("wasi_snapshot_preview1=", adapter);
     calc_new.addArg("-o");
     // Kebab-case basename for `wabt component compose` consumption.
     const calc_cmd = calc_new.addOutputFileArg("zig-calculator-cmd.wasm");
@@ -791,23 +752,18 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     const calc_final = calc_compose.addOutputFileArg("zig-calculator-cmd.composed.wasm");
     installAndValidate(b, examples_step, calc_final, "zig-calculator-cmd.composed.wasm");
 
-    // Run the composed Zig calculator command. The wasi-cli adapter
-    // captures stdout into the adapter buffer and flushes via
-    // `std.Io.File.stdout().writeStreamingAll`; empirically this
-    // lands on host stderr (fd 2) — same as `zig-hello` above.
-    // Issue #355 wired the alias chain + sub-component instantiation
+    // Run the composed Zig calculator command. The wabt-bundled
+    // wasi-preview1 adapter lowers `fd_write(1, …)` through
+    // `wasi:io/streams.blocking-write-and-flush`, which wamr's
+    // `WasiCliAdapter` flushes to the host's actual stdout. Issue
+    // #355 wired the alias chain + sub-component instantiation
     // that this composed command needs to reach its `wasi:cli/run`
     // export.
     const run_calc = b.addRunArtifact(wamr_exe);
     run_calc.addArg("run");
     run_calc.addFileArg(calc_final);
     run_calc.expectExitCode(0);
-    // `expectStdErrEqual("40 + 2 = 42\n100 + 200 = 300\n")` is
-    // currently **disabled** for the same reason as `zig-hello` and
-    // `zig-exit` above: the `wabt component {embed,new,compose}`
-    // pipeline emits adapter-composed components whose stdout path
-    // drops bytes. Restore once #453 lands.
-    // run_calc.expectStdErrEqual("40 + 2 = 42\n100 + 200 = 300\n");  // gated on #453
+    run_calc.expectStdOutEqual("40 + 2 = 42\n100 + 200 = 300\n");
     run_step.dependOn(&run_calc.step);
 
     // ── mixed-zig-rust-calc (Zig adder + Rust command, composed) ───
@@ -840,8 +796,6 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
 
     const rust_new = b.addSystemCommand(&.{ "wabt", "component", "new" });
     rust_new.addFileArg(rust_embedded);
-    rust_new.addArg("--adapt");
-    rust_new.addPrefixedFileArg("wasi_snapshot_preview1=", adapter);
     rust_new.addArg("-o");
     // Kebab-case basename for `wabt component compose`.
     const rust_cmd = rust_new.addOutputFileArg("mixed-rust-command.wasm");
@@ -855,22 +809,15 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
 
     // Run the composed Rust-command + Zig-adder. Same alias-walking
     // path as `zig-calculator-cmd` (issue #355); produces the same
-    // two-line output, again on host stderr.
-    //
-    // **Currently disabled** in `component-examples-run`: the
-    // `wabt component compose` output traps even under `wasmtime
-    // run` (verified 2026-05-11), so wamr can't run it end-to-end
-    // either. The example still builds + validates + installs via
-    // `examples_step` (above). Re-enable in `run_step` once #453
-    // ships a wamr-native preview1 adapter and the compose step is
-    // moved off `cataggar/wabt`'s `component` subcommands.
-    //
-    // const run_mixed = b.addRunArtifact(wamr_exe);
-    // run_mixed.addArg("run");
-    // run_mixed.addFileArg(mixed_final);
-    // run_mixed.expectExitCode(0);
-    // run_mixed.expectStdErrEqual("40 + 2 = 42\n100 + 200 = 300\n");
-    // run_step.dependOn(&run_mixed.step);
+    // two-line output. With the wabt-bundled adapter (#453) wamr +
+    // wasmtime both run the composed component end-to-end, so the
+    // run step is wired in.
+    const run_mixed = b.addRunArtifact(wamr_exe);
+    run_mixed.addArg("run");
+    run_mixed.addFileArg(mixed_final);
+    run_mixed.expectExitCode(0);
+    run_mixed.expectStdOutEqual("40 + 2 = 42\n100 + 200 = 300\n");
+    run_step.dependOn(&run_mixed.step);
 }
 
 const ZigWasmCompile = struct {
@@ -905,15 +852,15 @@ fn compileZigWasm(b: *std.Build, opts: ZigWasmCompile) std.Build.LazyPath {
 const CommandComponent = struct {
     name: []const u8,
     core: std.Build.LazyPath,
-    adapter: std.Build.LazyPath,
 };
 
-/// Wraps `wabt component new --adapt wasi_snapshot_preview1=<adapter>`.
+/// Wraps `wabt component new`. The wasi-preview1 → component
+/// adapter is bundled inside wabt and auto-attached when the
+/// embed has unresolved `wasi_snapshot_preview1.*` imports
+/// (see `cataggar/wabt#156`); no `--adapt` plumbing required.
 fn makeCommandComponent(b: *std.Build, opts: CommandComponent) std.Build.LazyPath {
     const cmd = b.addSystemCommand(&.{ "wabt", "component", "new" });
     cmd.addFileArg(opts.core);
-    cmd.addArg("--adapt");
-    cmd.addPrefixedFileArg("wasi_snapshot_preview1=", opts.adapter);
     cmd.addArg("-o");
     return cmd.addOutputFileArg(b.fmt("{s}.component.wasm", .{opts.name}));
 }

--- a/examples/components/README.md
+++ b/examples/components/README.md
@@ -55,8 +55,7 @@ zig-out/component-examples/
 | Tool                                  | Version    | Notes                                                    |
 |---------------------------------------|-----------:|----------------------------------------------------------|
 | Zig                                   | 0.16.x     | Toolchain already required by the rest of the repo.       |
-| `wabt` (cataggar/wabt)                | v3.0.0-dev.4 | Provides `component embed/new`, `validate`, `component compose`. |
-| Wasmtime preview1→component adapter   | v36.0.9    | Auto-fetched + sha256-pinned by the build (`build.zig`). |
+| `wabt` (cataggar/wabt)                | v3.0.0-dev.5 | Provides `component embed/new`, `module validate`, `component compose`. The wasi-preview1 → component adapter is bundled inside `wabt` and auto-attached by `wabt component new`. |
 | Rust toolchain (`cargo`, `rustup`)    | recent stable | Mixed example only.                                  |
 | `wasm32-wasip1` Rust target           | —          | `rustup target add wasm32-wasip1`. Mixed example only.    |
 
@@ -76,9 +75,7 @@ aliased-instance form `wasm-tools compose` historically used); both
 shapes are spec-valid, and wamr's component loader handles both.
 
 The `zig-hello` runtime test asserts that wamr exits 0 and emits the
-greeting. Note that the captured-stdout flush in
-[`src/main.zig`](../../src/main.zig) currently lands on the host's
-stderr fd; the assertion is pinned to that observed behaviour.
+greeting on host stdout (fd 1).
 
 [wasmtime]: https://wasmtime.dev/
 
@@ -87,7 +84,18 @@ stderr fd; the assertion is pinned to that observed behaviour.
 - Component-Model support in wamr is still in **preview**; behaviour
   may shift between releases. Each example's README pins its
   expectations to the current state of the runtime.
-- The wasi-preview1 → Component adapter shipped by Wasmtime is the
-  industry-standard escape hatch for languages (Zig, Rust, …) whose
-  toolchains target `wasm32-wasip1` natively but do not yet emit
-  Component Model artifacts directly.
+- The wasi-preview1 → Component adapter is bundled inside the
+  `cataggar/wabt` CLI (see `cataggar/wabt#145`/#156) and is
+  auto-attached by `wabt component new` for command-style embeds
+  whose `wasi_snapshot_preview1.*` imports are otherwise unresolved.
+  Languages (Zig, Rust, …) whose toolchains target `wasm32-wasip1`
+  natively but do not yet emit Component-Model artifacts directly
+  reach the preview2 surface through this adapter.
+- The adapter lowers preview1 `proc_exit(code)` through
+  `wasi:cli/exit.exit-with-code(u8)` (with a defensive fallback to
+  the stable `exit(result<_, _>)`). `exit-with-code` is the
+  `@unstable(feature = cli-exit-with-code)` extension of the
+  wasi-cli@0.2.6 interface — wamr supports it unconditionally,
+  while Wasmtime v44 gates the linker binding behind
+  `-S cli-exit-with-code`. To run `zig-exit` / `mixed-zig-rust-calc`
+  on wasmtime: `wasmtime run -S cli-exit-with-code <component>.wasm`.

--- a/examples/components/mixed-zig-rust-calc/README.md
+++ b/examples/components/mixed-zig-rust-calc/README.md
@@ -44,9 +44,7 @@ wabt component new adder.embed.wasm -o zig-adder.component.wasm
 wabt component embed --world app command/wit \
     command/target/wasm32-wasip1/release/mixed_zig_rust_command.wasm \
     -o command.embed.wasm
-wabt component new command.embed.wasm \
-    --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.command.wasm \
-    -o rust-command.component.wasm
+wabt component new command.embed.wasm -o rust-command.component.wasm
 
 # 3. Compose — wires the Rust command's `docs:adder/add@0.1.0` import
 #    against the Zig adder's matching export.
@@ -65,12 +63,11 @@ That step produces `zig-out/component-examples/mixed-zig-rust-calc.composed.wasm
 ## Prerequisites
 
 - Zig 0.16.x (already required for the rest of the repo).
-- `wabt` (cataggar/wabt v3.0.0-dev.4+) on `PATH`.
+- `wabt` (cataggar/wabt v3.0.0-dev.5+) on `PATH`. The wasi-preview1
+  → component adapter is bundled inside `wabt` and auto-attached
+  by `wabt component new` — no external adapter download required.
 - A Rust toolchain with the `wasm32-wasip1` target installed:
   `rustup target add wasm32-wasip1`.
-- The `wasi_snapshot_preview1.command.wasm` adapter (downloaded by the
-  build step from a pinned Wasmtime release; see the top-level
-  [`examples/components/README.md`](../README.md)).
 
 ## Runtime status
 

--- a/examples/components/zig-calculator-cmd/README.md
+++ b/examples/components/zig-calculator-cmd/README.md
@@ -42,10 +42,10 @@ zig build-exe -target wasm32-wasi -O ReleaseSmall \
 # 2. embed the world so component new can recognise the docs:adder import.
 wabt component embed --world app wit main.wasm -o main.embed.wasm
 
-# 3. encode + adapt.
-wabt component new main.embed.wasm \
-    --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.command.wasm \
-    -o zig-calculator-cmd.component.wasm
+# 3. encode the component. `wabt component new` auto-attaches the
+#    bundled wasi-preview1 → preview2 adapter for the
+#    `wasi_snapshot_preview1.*` imports the embed leaves unresolved.
+wabt component new main.embed.wasm -o zig-calculator-cmd.component.wasm
 
 # 4. compose with an adder implementation (e.g. ../zig-adder).
 wabt component compose -d zig-adder.component.wasm \

--- a/examples/components/zig-calculator-cmd/src/main.zig
+++ b/examples/components/zig-calculator-cmd/src/main.zig
@@ -11,8 +11,8 @@
 //!   2. wabt component embed --world app wit main.wasm \
 //!         -o main.embed.wasm
 //!   3. wabt component new main.embed.wasm \
-//!         --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.command.wasm \
-//!         -o zig-calculator-cmd.component.wasm
+//!         -o zig-calculator-cmd.component.wasm   ;; auto-attaches the
+//!                                                ;; wasi-preview1 adapter
 //!
 //! The `extern "docs:adder/add@0.1.0" fn add(...)` declaration becomes a
 //! component-level import of `docs:adder/add@0.1.0::add` after the embed

--- a/examples/components/zig-exit/README.md
+++ b/examples/components/zig-exit/README.md
@@ -17,10 +17,10 @@ zig build-exe -target wasm32-wasi -O ReleaseSmall \
     -fno-entry --export=_start \
     src/main.zig
 
-# 2. Wrap it as a component using the wasi-preview1 command adapter.
-wabt component new main.wasm \
-    --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.command.wasm \
-    -o zig-exit.component.wasm
+# 2. Wrap it as a component. `wabt component new` auto-attaches the
+#    bundled wasi-preview1 → preview2 adapter when the embed imports
+#    `wasi_snapshot_preview1.*`.
+wabt component new main.wasm -o zig-exit.component.wasm
 ```
 
 The repo's root `build.zig` automates both steps:

--- a/examples/components/zig-exit/src/main.zig
+++ b/examples/components/zig-exit/src/main.zig
@@ -2,11 +2,12 @@
 //!
 //! Writes a marker line to fd 1 via `wasi_snapshot_preview1.fd_write`, then
 //! calls `wasi_snapshot_preview1.proc_exit(7)`. Both imports are bound by
-//! the wasm-tools wasi-preview1 adapter; the adapter's `proc_exit` body
-//! rewrites the call into `wasi:cli/exit.exit-with-code(7)`, which lands
-//! on `WasiCliAdapter.cliExitWithCode` → `adapter.exit_code` →
+//! the wabt-bundled wasi-preview1 → preview2 adapter (auto-attached by
+//! `wabt component new`); the adapter's `proc_exit` body rewrites the
+//! call into `wasi:cli/exit.exit-with-code(7)`, which lands on
+//! `WasiCliAdapter.cliExitWithCode` → `adapter.exit_code` →
 //! `RunOutcome.exit_code` → `main.zig:runComponent`, which exits the
-//! host process with 7 (issue #448 made the adapter route actually run).
+//! host process with 7.
 //!
 //! Pair with `zig-hello` which exercises the normal-return path.
 

--- a/examples/components/zig-hello/README.md
+++ b/examples/components/zig-hello/README.md
@@ -15,10 +15,10 @@ zig build-exe -target wasm32-wasi -O ReleaseSmall \
     -fno-entry --export=_start \
     src/main.zig
 
-# 2. Wrap it as a component using the wasi-preview1 command adapter.
-wabt component new main.wasm \
-    --adapt wasi_snapshot_preview1=wasi_snapshot_preview1.command.wasm \
-    -o zig-hello.component.wasm
+# 2. Wrap it as a component. `wabt component new` auto-attaches the
+#    bundled wasi-preview1 → preview2 adapter when the embed imports
+#    `wasi_snapshot_preview1.*`.
+wabt component new main.wasm -o zig-hello.component.wasm
 ```
 
 The repo's root `build.zig` automates both steps:

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -9601,23 +9601,6 @@ pub fn runLoadedComponent(
         else => return error.LinkFailed,
     };
 
-    // Wire each core module instance's `exit_code_sink` to the adapter's
-    // slot so a guest preview1 `proc_exit(code)` lands the numeric code
-    // where the CLI expects it. After #448 gated WASI auto-resolution,
-    // `proc_exit` is reached on adapter-composed components via the
-    // cross-instance dispatch path in
-    // `src/runtime/interpreter/interp.zig`, which short-circuits to
-    // `wasiProcExit` rather than invoking the adapter's body — the
-    // wasmtime preview1 adapter's `wasi:cli/exit.exit(result)` loses
-    // the numeric i32 (no `exit-with-code(u8)` even in v44). Issues
-    // #436 / #448; tracked for retirement under #453 (wamr-native
-    // adapter exposing `exit-with-code(u8)`).
-    for (inst.core_instances) |entry| {
-        if (entry.module_inst) |mi| {
-            mi.exit_code_sink = &adapter.exit_code;
-        }
-    }
-
     if (inst.getExport("run") == null) {
         return error.NoRunExport;
     }

--- a/src/runtime/common/types.zig
+++ b/src/runtime/common/types.zig
@@ -818,26 +818,6 @@ pub const ModuleInstance = struct {
     gc_objects: std.ArrayListUnmanaged(GcObject) = .empty,
     /// Cached evaluated element segment values (spec requires one-time evaluation)
     cached_elem_values: []?[]Value = &.{},
-    /// Optional pointer to a `?u32` slot the component-layer caller
-    /// uses to capture a guest's `wasi_snapshot_preview1.proc_exit`
-    /// numeric exit code (issues #436 / #448). When non-null,
-    /// `wasiProcExit` writes the requested code through this pointer
-    /// in addition to trapping the guest.
-    ///
-    /// After #448 gated WASI auto-resolution, `proc_exit` on a
-    /// component is reached via the cross-instance dispatch path in
-    /// `src/runtime/interpreter/interp.zig`, which short-circuits to
-    /// `wasiProcExit` so the i32 lands here. The component-model
-    /// `runLoadedComponent` path wires this to
-    /// `WasiCliAdapter.exit_code` so the CLI can mirror it into the
-    /// host process exit code. Stays null on the core-wasm path —
-    /// that route already encodes the exit code on the attached
-    /// `WasiCtx` and unwinds via `wasiProcExit`'s trap.
-    /// Not owned by `ModuleInstance`.
-    ///
-    /// Workaround pending #453 (a wamr-native wasi-preview1 adapter
-    /// that exposes `exit-with-code(u8)`).
-    exit_code_sink: ?*?u32 = null,
 
     pub fn getExportFunc(self: *const ModuleInstance, name: []const u8) ?u32 {
         const exp = self.module.findExport(name, .function) orelse return null;

--- a/src/runtime/interpreter/interp.zig
+++ b/src/runtime/interpreter/interp.zig
@@ -9,7 +9,6 @@ const types = @import("../common/types.zig");
 const ExecEnv = @import("../common/exec_env.zig").ExecEnv;
 const CallFrame = @import("../common/exec_env.zig").CallFrame;
 const HostTrapInfo = @import("../common/exec_env.zig").HostTrapInfo;
-const wasi_host_functions = @import("../../wasi/host_functions.zig");
 
 // NaN canonicalization per Wasm spec
 inline fn canonF32(val: f32) f32 {
@@ -869,34 +868,6 @@ fn executeFunctionWithFuel(env: *ExecEnv, func_idx: u32, fuel: *FuelBudget) Trap
             }
             // Dispatch to the imported module's actual function
             if (current_func_idx < env.module_inst.import_functions.len) {
-                // Interception (#436 / #448): when a guest's preview1
-                // `proc_exit(rc)` is cross-bound to a component-level
-                // wasi-preview1 adapter, the wasmtime adapter funnels
-                // the call through `wasi:cli/exit.exit(result)` — a
-                // single bit. Numeric i32 codes are structurally lost
-                // (no `exit-with-code(u8)` even in v44). Short-circuit
-                // through `wasiProcExit` so the host can observe the
-                // original code via `ModuleInstance.exit_code_sink`
-                // (wired to `WasiCliAdapter.exit_code` by
-                // `runLoadedComponent`). Surface the resulting trap as
-                // `error.WasiExit` so `callComponentFunc`'s
-                // `[component trap]` suppression treats it as benign
-                // control flow rather than a real fault.
-                //
-                // Retirable once we ship a wamr-native preview1
-                // adapter with a real `exit-with-code` export (#453).
-                if (lookupCoreFuncImport(module, current_func_idx)) |imp| {
-                    if (std.mem.eql(u8, imp.module_name, "wasi_snapshot_preview1") and
-                        std.mem.eql(u8, imp.field_name, "proc_exit") and
-                        env.module_inst.exit_code_sink != null)
-                    {
-                        wasi_host_functions.wasiProcExit(@ptrCast(env)) catch {
-                            recordHostTrap(env, current_func_idx, error.WasiExit);
-                            return error.Unreachable;
-                        };
-                        return;
-                    }
-                }
                 const imported = env.module_inst.import_functions[current_func_idx];
                 const saved_module_inst = env.module_inst;
                 env.module_inst = imported.module_inst;

--- a/src/wasi/host_functions.zig
+++ b/src/wasi/host_functions.zig
@@ -77,20 +77,6 @@ pub fn wasiProcExit(env_opaque: *anyopaque) types.HostFnError!void {
         ctx.exit_code = @bitCast(code);
     }
 
-    // Component-model wiring (issues #436 / #448): the wamr component
-    // flow has no `WasiCtx`, so the writeback above is a no-op there.
-    // The wasmtime preview1 adapter's `wasi:cli/exit.exit(result)`
-    // structurally loses the numeric i32 (no `exit-with-code(u8)` even
-    // in v44), so for adapter-composed components the cross-dispatch
-    // interception in `src/runtime/interpreter/interp.zig` routes
-    // `wasi_snapshot_preview1.proc_exit` through this function instead
-    // of the adapter body. Stash the original code on the host-side
-    // slot so `runLoadedComponent`/`runComponent` can mirror it into
-    // the host process exit code. Pending wamr-native adapter #453.
-    if (env.module_inst.exit_code_sink) |sink| {
-        sink.* = @bitCast(code);
-    }
-
     if (env.module_inst.thread_manager) |tm| {
         tm.signalTrap();
     }


### PR DESCRIPTION
## Summary

With cataggar/wabt v3.0.0-dev.5 bundling the wasi-preview1 → preview2 adapter and auto-attaching it from `wabt component new` (see cataggar/wabt#156 / #157 / #158 / #160), wamr can drop both the external adapter download and the `exit_code_sink` interception workaround that #436 / #447 / #448 stitched together to recover the numeric `proc_exit` code through wasmtime's lossy `wasi:cli/exit.exit(result)` lowering.

The wabt-bundled adapter instead lowers preview1 `proc_exit(code)` through `wasi:cli/exit.exit-with-code(u8)` (`@unstable(feature = cli-exit-with-code)`) with a defensive fallback to `exit(result<_, _>)`. `WasiCliAdapter.cliExitWithCode` already handles `exit-with-code` end-to-end.

> **Draft until** cataggar/wabt v3.0.0-dev.5 release is published (blocked on cataggar/wabt#160 — `wasi:cli/exit.exit` fallback import).

## What this PR changes

### Build pipeline

* `build.zig`: drop the `fetch_adapter` step and the entire `adapter_url`/`adapter_sha256` plumbing. `makeCommandComponent` becomes a thin `wabt component new` wrapper — wabt auto-attaches its embedded adapter for command-style embeds with unresolved `wasi_snapshot_preview1.*` imports.
* `build.zig`: restore the full `expectStdOutEqual` assertions on `zig-hello`, `zig-exit`, `zig-calculator-cmd`, and (newly enabled) `mixed-zig-rust-calc`. Bytes now land on host stdout (fd 1) rather than the workaround stderr path.
* `.github/workflows/copilot-setup-steps.yml`: bump the preinstalled wabt pin to v3.0.0-dev.5.

### Exit-code workaround retirement

* `src/runtime/common/types.zig`: drop the `ModuleInstance.exit_code_sink` field (#436).
* `src/wasi/host_functions.zig`: drop the `wasiProcExit` writeback through the now-removed sink. Trap path is unchanged.
* `src/component/wasi_cli_adapter.zig`: drop the per-instance sink wiring in `runLoadedComponent`.
* `src/runtime/interpreter/interp.zig`: drop the cross-dispatch `proc_exit` interception (the wabt adapter's `exit-with-code(u8)` lowering now lands the i32 code directly on `WasiCliAdapter.exit_code`).

### Docs

* All four `examples/components/*/README.md` files: drop the explicit `--adapt wasi_snapshot_preview1=...command.wasm` invocation, document that `wabt component new` auto-attaches.
* Top-level `examples/components/README.md`: remove the "Wasmtime preview1→component adapter v36.0.9" pinned-version row, update the caveat to describe the wabt-bundled adapter, and add a note about wasmtime's `-S cli-exit-with-code` flag for the unstable exit-with-code path.

## Verification

### wamr (default)

```
$ zig build component-examples component-examples-run
Finished `release` profile [optimized] target(s) in 0.13s

$ ./zig-out/bin/wamr run zig-out/component-examples/zig-hello.component.wasm
hello from zig component
$ ./zig-out/bin/wamr run zig-out/component-examples/zig-exit.component.wasm; echo "exit=$?"
exiting with code 7
exit=7
$ ./zig-out/bin/wamr run zig-out/component-examples/zig-calculator-cmd.composed.wasm
40 + 2 = 42
100 + 200 = 300
$ ./zig-out/bin/wamr run zig-out/component-examples/mixed-zig-rust-calc.composed.wasm
40 + 2 = 42
100 + 200 = 300
```

### wasmtime cross-validation (requires `-S cli-exit-with-code` for proc_exit-using fixtures)

```
$ wasmtime run zig-out/component-examples/zig-hello.component.wasm
hello from zig component
$ wasmtime run -S cli-exit-with-code zig-out/component-examples/zig-exit.component.wasm; echo "exit=$?"
exiting with code 7
exit=7
$ wasmtime run zig-out/component-examples/zig-calculator-cmd.composed.wasm
40 + 2 = 42
100 + 200 = 300
$ wasmtime run -S cli-exit-with-code zig-out/component-examples/mixed-zig-rust-calc.composed.wasm
40 + 2 = 42
100 + 200 = 300
```

### Other

* `zig build test` — full 1422-test suite still passes.
* `grep -r exit_code_sink src/` — empty.

### Cross-runtime note

`exit-with-code(u8)` is `@unstable(feature = cli-exit-with-code)` in the canonical wasi-cli@0.2.6 WIT. Wamr supports it unconditionally; wasmtime v44 has a working implementation but gates the linker binding behind the `-S cli-exit-with-code` CLI flag. The wabt adapter also imports the stable `exit(result<_, _>)` form as a defensive fallback, but wasmtime's link-time signature check still requires the `exit-with-code` slot to be bound — hence the flag.

Refs #436, #447, #448, #453; closes the #453 retirement gates.