### PR TITLE
ci(copilot-setup): forward GH_TOKEN to ghr install for wabt

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -45,12 +45,19 @@ jobs:
         uses: ./.github/actions/zig-cache
 
       - name: Install cataggar/wabt v3.0.0-dev.5 (component CLI)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # ghr-bin is a tiny PyPI wrapper that downloads sha256-verified
           # GitHub release archives and links the chosen binary into
           # ~/.local/bin. pipx is preinstalled on ubuntu-latest; pip is
           # blocked by PEP 668. Pin both ghr-bin and the wabt release.
+          # GH_TOKEN is forwarded so `ghr` uses the workflow's
+          # authenticated quota (5000/hr) instead of the runner IP's
+          # unauthenticated 60/hr GitHub API limit — observed flaking
+          # at 60/hr on Azure-hosted runners that share IPs across
+          # tenants.
           pipx install ghr-bin==0.1.6
           ghr install cataggar/wabt@v3.0.0-dev.5
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Summary

The `Install cataggar/wabt v3.0.0-dev.5 (component CLI)` step in `.github/workflows/copilot-setup-steps.yml` calls `ghr install` which uses the unauthenticated GitHub API and hits the runner IP's 60/hr rate limit on shared Azure-hosted runner pools.

Observed failing on cataggar/wamr#455's CI:

```
error: GitHub API: API rate limit exceeded for 20.171.51.209.
error: hint: set GH_TOKEN for higher rate limits (5000/hr vs 60/hr)
error: release not found for cataggar/wabt@v3.0.0-dev.5
```

(The release **was** present at that timestamp — the lookup failed before reaching the release endpoint because the rate-limit check returns 403 immediately.)

## What this PR changes

Adds `env: GH_TOKEN: ${{ github.token }}` to the install step so `ghr` uses the workflow's authenticated 5000/hr quota.

No code or version changes.