### PR TITLE
cli: drop -h/--help, route help through `wamr <sub> help` (#458)

### DIFF
--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -37,19 +37,25 @@ pub fn main(init: std.process.Init) !void {
     };
 
     switch (subcmd) {
-        .version => {
-            writeStdout(init.io, "wamrc " ++ wamr.version.string ++ "\n");
-            return;
-        },
-        .help => {
-            runHelp(init.io, args[2..]);
-            return;
-        },
+        .version => try runVersion(init.io, args[2..]),
+        .help => runHelp(init.io, args[2..]),
         .compile => try runCompile(init, allocator, args[2..]),
     }
 }
 
+fn runVersion(io: std.Io, args: []const []const u8) !void {
+    if (args.len == 1 and std.mem.eql(u8, args[0], "help")) {
+        writeStdout(io, version_usage);
+        return;
+    }
+    writeStdout(io, "wamrc " ++ wamr.version.string ++ "\n");
+}
+
 fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
+    if (sub_args.len == 1 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, compile_usage);
+        return;
+    }
     var input_path: ?[]const u8 = null;
     var output_path: ?[]const u8 = null;
     var optimize = true;
@@ -63,10 +69,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const a = sub_args[i];
-        if (std.mem.eql(u8, a, "-h") or std.mem.eql(u8, a, "--help")) {
-            runHelp(init.io, &.{"compile"});
-            return;
-        } else if (std.mem.eql(u8, a, "-o") and i + 1 < sub_args.len) {
+        if (std.mem.eql(u8, a, "-o") and i + 1 < sub_args.len) {
             i += 1;
             output_path = sub_args[i];
         } else if (std.mem.eql(u8, a, "-O0")) {
@@ -96,7 +99,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         } else if (std.mem.eql(u8, a, "--aarch64-no-xreg-alloc")) {
             enable_aarch64_xreg_alloc = false;
         } else if (a.len > 0 and a[0] == '-') {
-            std.debug.print("error: unknown option '{s}' — try `wamrc help compile`\n", .{a});
+            std.debug.print("error: unknown option '{s}' — try `wamrc compile help`\n", .{a});
             std.process.exit(1);
         } else if (input_path == null) {
             input_path = a;
@@ -423,7 +426,9 @@ const top_usage =
     \\Subcommands:
     \\  compile   Compile a .wasm module to a .cwasm AOT binary
     \\  version   Print version and exit
-    \\  help      Print this help; `wamrc help <subcommand>` for details
+    \\  help      Print this help
+    \\
+    \\Run `wamrc <subcommand> help` to show help for a specific subcommand.
     \\
 ;
 
@@ -440,7 +445,6 @@ const compile_usage =
     \\  -O0                           Disable IR optimizations
     \\  --aarch64-no-scheduler        Disable AArch64 instruction scheduler
     \\  --aarch64-no-xreg-alloc       Disable AArch64 X-register allocator
-    \\  -h, --help                    Show this help
     \\
 ;
 
@@ -452,26 +456,18 @@ const version_usage =
 ;
 
 const help_usage =
-    \\Usage: wamrc help [subcommand]
+    \\Usage: wamrc help
     \\
-    \\Print top-level help, or help for a specific subcommand.
+    \\Print top-level help and exit.
     \\
 ;
 
 fn runHelp(io: std.Io, args: []const []const u8) void {
-    if (args.len == 0) {
-        writeStdout(io, top_usage);
+    if (args.len == 1 and std.mem.eql(u8, args[0], "help")) {
+        writeStdout(io, help_usage);
         return;
     }
-    const sub = parseSubcommand(args[0]) orelse {
-        std.debug.print("error: unknown subcommand '{s}' — try `wamrc help`\n", .{args[0]});
-        std.process.exit(1);
-    };
-    writeStdout(io, switch (sub) {
-        .compile => compile_usage,
-        .version => version_usage,
-        .help => help_usage,
-    });
+    writeStdout(io, top_usage);
 }
 
 /// Derive an output `.cwasm` path from the input wasm path. Strips a

--- a/src/main.zig
+++ b/src/main.zig
@@ -49,16 +49,26 @@ pub fn main(init: std.process.Init) !u8 {
     };
 
     return switch (subcmd) {
-        .version => blk: {
-            writeStdout(init.io, "wamr " ++ wamr.version.string ++ "\n");
-            break :blk 0;
-        },
+        .version => try runVersion(init.io, args[2..]),
         .help => runHelp(init.io, args[2..]),
         .run => try runRun(init, allocator, args[2..]),
     };
 }
 
+fn runVersion(io: std.Io, args: []const []const u8) !u8 {
+    if (args.len == 1 and std.mem.eql(u8, args[0], "help")) {
+        writeStdout(io, version_usage);
+        return 0;
+    }
+    writeStdout(io, "wamr " ++ wamr.version.string ++ "\n");
+    return 0;
+}
+
 fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []const []const u8) !u8 {
+    if (run_args.len == 1 and std.mem.eql(u8, run_args[0], "help")) {
+        writeStdout(init.io, run_usage);
+        return 0;
+    }
     var wasm_path: ?[]const u8 = null;
     var wasm_args: std.ArrayListUnmanaged([]const u8) = .empty;
     defer wasm_args.deinit(allocator);
@@ -74,9 +84,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     while (i < run_args.len) : (i += 1) {
         const arg = run_args[i];
         if (!past_options and arg.len > 0 and arg[0] == '-') {
-            if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-                return runHelp(init.io, &.{"run"});
-            } else if (std.mem.startsWith(u8, arg, "--stack-size=")) {
+            if (std.mem.startsWith(u8, arg, "--stack-size=")) {
                 stack_size = std.fmt.parseInt(u32, arg["--stack-size=".len..], 10) catch {
                     std.debug.print("error: invalid --stack-size value\n", .{});
                     return 2;
@@ -124,7 +132,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
             } else if (std.mem.eql(u8, arg, "--")) {
                 past_options = true;
             } else {
-                std.debug.print("error: unknown option '{s}' — try `wamr help run`\n", .{arg});
+                std.debug.print("error: unknown option '{s}' — try `wamr run help`\n", .{arg});
                 return 2;
             }
         } else if (wasm_path == null) {
@@ -581,7 +589,9 @@ const top_usage =
     \\Subcommands:
     \\  run       Run a .wasm or .cwasm file
     \\  version   Print version and exit
-    \\  help      Print this help; `wamr help <subcommand>` for details
+    \\  help      Print this help
+    \\
+    \\Run `wamr <subcommand> help` to show help for a specific subcommand.
     \\
 ;
 
@@ -598,7 +608,6 @@ const run_usage =
     \\  --env KEY=VALUE          Set a WASI environment variable (repeatable)
     \\  --map-dir HOST::GUEST    Pre-open `HOST` host directory as `GUEST`
     \\                           inside the guest WASI sandbox (repeatable)
-    \\  -h, --help               Show this help
     \\
 ;
 
@@ -610,26 +619,18 @@ const version_usage =
 ;
 
 const help_usage =
-    \\Usage: wamr help [subcommand]
+    \\Usage: wamr help
     \\
-    \\Print top-level help, or help for a specific subcommand.
+    \\Print top-level help and exit.
     \\
 ;
 
 fn runHelp(io: std.Io, args: []const []const u8) u8 {
-    if (args.len == 0) {
-        writeStdout(io, top_usage);
+    if (args.len == 1 and std.mem.eql(u8, args[0], "help")) {
+        writeStdout(io, help_usage);
         return 0;
     }
-    const sub = parseSubcommand(args[0]) orelse {
-        std.debug.print("error: unknown subcommand '{s}' — try `wamr help`\n", .{args[0]});
-        return 2;
-    };
-    writeStdout(io, switch (sub) {
-        .run => run_usage,
-        .version => version_usage,
-        .help => help_usage,
-    });
+    writeStdout(io, top_usage);
     return 0;
 }
 


### PR DESCRIPTION
Closes cataggar/wamr#458.

Mirrors the Zig CLI convention adopted by [cataggar/ghr#71](https://github.com/cataggar/ghr/pull/71). Each subcommand now recognizes a positional `help` token that prints its usage; the `-h` / `--help` flags and the `wamr help <subcommand>` pass-through are gone.

## Behaviour grid (verified locally)

### wamr

| invocation | result | exit |
|---|---|---|
| `wamr help` | top usage | 0 |
| `wamr run help` | run usage | 0 |
| `wamr version help` | version usage | 0 |
| `wamr help help` | help usage | 0 |
| `wamr help run` | top usage (extra arg ignored) | 0 |
| `wamr run --help` | `error: unknown option '--help' — try `wamr run help`` | 2 |
| `wamr run -h` | `error: unknown option '-h' — try `wamr run help`` | 2 |
| `wamr --help` | `error: unknown subcommand '--help' — try `wamr help`` | 2 |
| `wamr` | `error: missing subcommand — try `wamr help`` | 2 |

### wamrc

| invocation | result | exit |
|---|---|---|
| `wamrc help` | top usage | 0 |
| `wamrc compile help` | compile usage | 0 |
| `wamrc version help` | version usage | 0 |
| `wamrc help help` | help usage | 0 |
| `wamrc help compile` | top usage (extra arg ignored) | 0 |
| `wamrc compile --help` | `error: unknown option '--help' — try `wamrc compile help`` | 1 |
| `wamrc compile -h` | `error: unknown option '-h' — try `wamrc compile help`` | 1 |
| `wamrc --help` | `error: unknown subcommand '--help' — try `wamrc help`` | 1 |
| `wamrc` | `error: missing subcommand — try `wamrc help`` | 1 |

## Design note

The issue states that `-h` / `--help` should not be specially recognised — they fall through the generic 'unknown argument' path. In practice the existing arg loop already emits `error: unknown option 'X' — try `<bin> <sub> help`` for any unrecognised `-`-prefixed token, so `-h` / `--help` reach that path naturally. I updated the hint to point at `<sub> help` instead of `help <sub>` for the new convention.

Similarly the issue says `wamr help <sub>` should fall through 'whatever the generic unknown-argument path for help produces'. Two reasonable interpretations:

1. Ignore extras: `wamr help run` prints the top-level usage and exits 0.
2. Error: `wamr help run` errors with 'unknown extra argument' and exits 2.

I went with (1) — `runHelp` ignores any positional args other than the per-subcommand `help` shortcut (`wamr help help` → `help` usage). Happy to swap to (2) if review prefers; it's a one-line addition in `runHelp`.

## Regression

* `zig build test` — full suite passes.
* `zig build component-examples-run` — all four examples (`zig-hello`, `zig-exit`, `zig-calculator-cmd`, `mixed-zig-rust-calc`) pass with the restored `expectStdOut` assertions.

## Out of scope

`src/tests/simd_bench_runner.zig` and `src/tests/fuzz/common.zig` still accept `-h` / `--help` — they are internal dev tools, not user-facing CLI surface.

Refs cataggar/ghr#71.