### PR TITLE
ci(copilot-setup): bump wabt pin to v3.0.0-dev.6

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Configure Zig caches
         uses: ./.github/actions/zig-cache
 
-      - name: Install cataggar/wabt v3.0.0-dev.5 (component CLI)
+      - name: Install cataggar/wabt v3.0.0-dev.6 (component CLI)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -59,7 +59,7 @@ jobs:
           # at 60/hr on Azure-hosted runners that share IPs across
           # tenants.
           pipx install ghr-bin==0.1.6
-          ghr install cataggar/wabt@v3.0.0-dev.5
+          ghr install cataggar/wabt@v3.0.0-dev.6
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/wabt" version
 

--- a/build.zig
+++ b/build.zig
@@ -632,7 +632,7 @@ pub fn build(b: *std.Build) void {
 /// Neither is reachable from `zig build` or `zig build test`.
 ///
 /// Pinned versions:
-///   * `cataggar/wabt` ≥ v3.0.0-dev.5 on PATH (provides `component embed`,
+///   * `cataggar/wabt` ≥ v3.0.0-dev.6 on PATH (provides `component embed`,
 ///     `component new`, `component compose`, `module validate`).
 ///     The wasi-preview1 → component adapter is embedded in `wabt` and
 ///     auto-attached by `wabt component new`; no external adapter fetch.

--- a/examples/components/README.md
+++ b/examples/components/README.md
@@ -55,7 +55,7 @@ zig-out/component-examples/
 | Tool                                  | Version    | Notes                                                    |
 |---------------------------------------|-----------:|----------------------------------------------------------|
 | Zig                                   | 0.16.x     | Toolchain already required by the rest of the repo.       |
-| `wabt` (cataggar/wabt)                | v3.0.0-dev.5 | Provides `component embed/new`, `module validate`, `component compose`. The wasi-preview1 → component adapter is bundled inside `wabt` and auto-attached by `wabt component new`. |
+| `wabt` (cataggar/wabt)                | v3.0.0-dev.6 | Provides `component embed/new`, `module validate`, `component compose`. The wasi-preview1 → component adapter is bundled inside `wabt` and auto-attached by `wabt component new`. |
 | Rust toolchain (`cargo`, `rustup`)    | recent stable | Mixed example only.                                  |
 | `wasm32-wasip1` Rust target           | —          | `rustup target add wasm32-wasip1`. Mixed example only.    |
 

--- a/examples/components/mixed-zig-rust-calc/README.md
+++ b/examples/components/mixed-zig-rust-calc/README.md
@@ -63,7 +63,7 @@ That step produces `zig-out/component-examples/mixed-zig-rust-calc.composed.wasm
 ## Prerequisites
 
 - Zig 0.16.x (already required for the rest of the repo).
-- `wabt` (cataggar/wabt v3.0.0-dev.5+) on `PATH`. The wasi-preview1
+- `wabt` (cataggar/wabt v3.0.0-dev.6+) on `PATH`. The wasi-preview1
   → component adapter is bundled inside `wabt` and auto-attached
   by `wabt component new` — no external adapter download required.
 - A Rust toolchain with the `wasm32-wasip1` target installed:


### PR DESCRIPTION
Bumps the `cataggar/wabt` pin from `v3.0.0-dev.5` to `v3.0.0-dev.6` (published 2026-05-12T23:24Z, 32 release assets).

## What's new in v3.0.0-dev.6

* [cataggar/wabt#181](https://github.com/cataggar/wabt/pull/181) — explicit `own<descriptor>` in `preopens.get-directories` (fixes the cross-runtime regression that broke wasmtime validation on dev.5 release artifacts).
* [cataggar/wabt#184](https://github.com/cataggar/wabt/pull/184) — encoder auto-wraps bare resource refs with `own<>` in value-type positions; closes the underlying gap that caused #181. Tracked workaround revert at [cataggar/wabt#189](https://github.com/cataggar/wabt/issues/189).
* [cataggar/wabt#185](https://github.com/cataggar/wabt/pull/185) — CLI: positional `help` subcommand, drops `-h`/`--help` on subcommands. Mirrors cataggar/wamr#459.
* [cataggar/wabt#187](https://github.com/cataggar/wabt/pull/187) — `fd_fdstat` refinements (user-fd lift via `wasi:filesystem/types.descriptor.get-flags` + `get-type`, terminal detection via `wasi:cli/terminal-{input,output}`).
* [cataggar/wabt#183](https://github.com/cataggar/wabt/pull/183) — docs retargeting.

## Files changed

* `build.zig` — pinned-version comment.
* `.github/workflows/copilot-setup-steps.yml` — `ghr install cataggar/wabt@v3.0.0-dev.6`.
* `examples/components/README.md` + `examples/components/mixed-zig-rust-calc/README.md` — version table.

No code changes.

## Verification

Locally against `cataggar/wamr@048dd3f5` (main), using the freshly-built wabt commit that v3.0.0-dev.6 was cut from:

| fixture | `wamr` | `wasmtime -S cli-exit-with-code` |
|---|---|---|
| `zig-hello.component` | 0 | 0 |
| `zig-exit.component` | 7 | 7 |
| `zig-calculator-cmd.composed` | 0 | 0 |
| `mixed-zig-rust-calc.composed` | 0 | 0 |

Stdout text byte-identical across all four (`expectStdOutEqual` assertions in `build.zig` pass via `zig build component-examples-run`). Full `zig build test` clean.