### PR TITLE
ci: component-examples + cross-runtime parity jobs (#457)

### DIFF
--- a/.github/actions/install-wasi-sdk-wabt/action.yml
+++ b/.github/actions/install-wasi-sdk-wabt/action.yml
@@ -93,26 +93,5 @@ runs:
 
         echo "::notice::wasi-sdk-25 installed on Windows"
 
-    - name: Install wabt via ghr (Ubuntu, macOS)
-      if: ${{ startsWith(inputs.os, 'ubuntu') || startsWith(inputs.os, 'macos') }}
-      shell: bash
-      run: |
-        set -euo pipefail
-        # ghr-bin downloads sha256-verified GitHub release archives and
-        # links the chosen binary into ~/.local/bin. Pin both versions.
-        pipx install ghr-bin==0.1.6
-        ghr install cataggar/wabt@v3.0.0-dev.4
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        "$HOME/.local/bin/wabt" version
-        echo "::notice::cataggar/wabt v3.0.0-dev.4 installed on ${{ inputs.os }}"
-
-    - name: Install wabt via ghr (Windows)
-      if: ${{ startsWith(inputs.os, 'windows') }}
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = "Stop"
-        pipx install ghr-bin==0.1.6
-        ghr install cataggar/wabt@v3.0.0-dev.4
-        Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.local\bin"
-        & "$env:USERPROFILE\.local\bin\wabt.exe" version
-        Write-Host "::notice::cataggar/wabt v3.0.0-dev.4 installed on Windows"
+    - name: Install wabt via ghr
+      uses: ./.github/actions/wabt-install

--- a/.github/actions/wabt-install/action.yml
+++ b/.github/actions/wabt-install/action.yml
@@ -1,0 +1,55 @@
+name: 'Install cataggar/wabt CLI'
+description: |
+  Installs `wabt` from a pinned cataggar/wabt release into ~/.local/bin (and
+  prepends it to GITHUB_PATH) using `ghr install`. Forwards `GH_TOKEN` so the
+  GitHub API calls `ghr` makes use the workflow's authenticated 5000/hr quota
+  instead of the unauthenticated 60/hr-per-IP limit observed flaking on
+  Azure-hosted runners that share IPs across tenants.
+
+  Used by `.github/workflows/copilot-setup-steps.yml` and the
+  `component-examples` / `component-examples-wasmtime` jobs in
+  `.github/workflows/ci.yml`. The `install-wasi-sdk-wabt` composite also
+  delegates here for its wabt half so the pin lives in one place.
+
+inputs:
+  version:
+    description: |
+      cataggar/wabt release tag (e.g. v3.0.0-dev.6). Bump the default here to
+      roll the pinned version across every caller.
+    required: false
+    default: 'v3.0.0-dev.6'
+
+runs:
+  using: composite
+  steps:
+    - name: Install wabt via ghr (Linux + macOS)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        WABT_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        # ghr-bin is a tiny PyPI wrapper that downloads sha256-verified
+        # GitHub release archives and links the chosen binary into
+        # ~/.local/bin. pipx is preinstalled on ubuntu-latest; pip is
+        # blocked by PEP 668. Pin both ghr-bin and the wabt release.
+        pipx install ghr-bin==0.1.6
+        ghr install "cataggar/wabt@${WABT_VERSION}"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        "$HOME/.local/bin/wabt" version
+        echo "::notice::cataggar/wabt ${WABT_VERSION} installed"
+
+    - name: Install wabt via ghr (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+        WABT_VERSION: ${{ inputs.version }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        pipx install ghr-bin==0.1.6
+        ghr install "cataggar/wabt@$env:WABT_VERSION"
+        Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.local\bin"
+        & "$env:USERPROFILE\.local\bin\wabt.exe" version
+        Write-Host "::notice::cataggar/wabt $env:WABT_VERSION installed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Install wasmtime
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v36.0.9
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v44.0.1
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
 
       - name: Build for wasm32-wasi
@@ -157,16 +157,77 @@ jobs:
       - name: Run wasi-testsuite conformance suite
         run: zig build wasi-testsuite
 
-  # Summary job matching the required status check name for branch protection
+  component-examples:
+    name: Build & Test (component-examples)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
+
+      - name: Install cataggar/wabt (component CLI)
+        uses: ./.github/actions/wabt-install
+
+      - name: Install Rust wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
+
+      - name: Build and run component-examples (wamr golden)
+        run: zig build install component-examples component-examples-run
+
+  component-examples-wasmtime:
+    name: Build & Test (component-examples-wasmtime)
+    runs-on: ubuntu-22.04
+    # Non-blocking until the first green run + any flake handling lands.
+    # ci-summary intentionally leaves this out of its needs[] failure-gate.
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
+
+      - name: Install cataggar/wabt (component CLI)
+        uses: ./.github/actions/wabt-install
+
+      - name: Install Rust wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
+
+      - name: Install wasmtime v44.0.1
+        run: |
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v44.0.1
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+
+      - name: Build and run component-examples (wasmtime parity)
+        run: zig build install component-examples component-examples-run-wasmtime
+
+  # Summary job matching the required status check name for branch protection.
+  # `component-examples-wasmtime` is intentionally NOT in the blocking set
+  # while the cross-runtime parity check beds in (cataggar/wamr#457).
   ci-summary:
     name: Build & Test
     runs-on: ubuntu-22.04
-    needs: [build-and-test, wasi-test, wasi-testsuite]
+    needs: [build-and-test, wasi-test, wasi-testsuite, component-examples]
     if: always()
     steps:
       - name: Check results
         run: |
-          if [ "${{ needs.build-and-test.result }}" != "success" ] || [ "${{ needs.wasi-test.result }}" != "success" ] || [ "${{ needs.wasi-testsuite.result }}" != "success" ]; then
+          if [ "${{ needs.build-and-test.result }}" != "success" ] || [ "${{ needs.wasi-test.result }}" != "success" ] || [ "${{ needs.wasi-testsuite.result }}" != "success" ] || [ "${{ needs.component-examples.result }}" != "success" ]; then
             echo "::error::One or more CI jobs failed"
             exit 1
           fi

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,24 +44,8 @@ jobs:
       - name: Configure Zig caches
         uses: ./.github/actions/zig-cache
 
-      - name: Install cataggar/wabt v3.0.0-dev.6 (component CLI)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # ghr-bin is a tiny PyPI wrapper that downloads sha256-verified
-          # GitHub release archives and links the chosen binary into
-          # ~/.local/bin. pipx is preinstalled on ubuntu-latest; pip is
-          # blocked by PEP 668. Pin both ghr-bin and the wabt release.
-          # GH_TOKEN is forwarded so `ghr` uses the workflow's
-          # authenticated quota (5000/hr) instead of the runner IP's
-          # unauthenticated 60/hr GitHub API limit — observed flaking
-          # at 60/hr on Azure-hosted runners that share IPs across
-          # tenants.
-          pipx install ghr-bin==0.1.6
-          ghr install cataggar/wabt@v3.0.0-dev.6
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/wabt" version
+      - name: Install cataggar/wabt (component CLI)
+        uses: ./.github/actions/wabt-install
 
       - name: Cache Zig global cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/build.zig
+++ b/build.zig
@@ -626,10 +626,13 @@ pub fn build(b: *std.Build) void {
 }
 
 /// Wires up the Component-Model example pipeline (sources under
-/// `examples/components/`). Two opt-in steps are exposed:
-///   * `zig build component-examples`     — build + validate all four
-///   * `zig build component-examples-run` — runs `zig-hello` through `wamr`
-/// Neither is reachable from `zig build` or `zig build test`.
+/// `examples/components/`). Three opt-in steps are exposed:
+///   * `zig build component-examples`               — build + validate all four
+///   * `zig build component-examples-run`           — run them through `./zig-out/bin/wamr`
+///   * `zig build component-examples-run-wasmtime`  — run them through
+///                                                    `wasmtime run -S cli-exit-with-code`
+///                                                    (cross-runtime parity gate; wasmtime v44+).
+/// None are reachable from `zig build` or `zig build test`.
 ///
 /// Pinned versions:
 ///   * `cataggar/wabt` ≥ v3.0.0-dev.6 on PATH (provides `component embed`,
@@ -644,8 +647,20 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     );
     const run_step = b.step(
         "component-examples-run",
-        "Run the runnable component examples (zig-hello) through ./zig-out/bin/wamr",
+        "Run the runnable component examples through ./zig-out/bin/wamr",
     );
+    // Cross-runtime parity step (cataggar/wamr#457): the same four
+    // fixtures + assertions, but run under `wasmtime run -S
+    // cli-exit-with-code` (v44+ required for the `@unstable`
+    // `wasi:cli/exit.exit-with-code` feature gate the wabt-bundled
+    // adapter lowers `proc_exit` through). Opt-in — failure mode
+    // when `wasmtime` is missing from PATH is a clear systemcommand
+    // error.
+    const run_step_wasmtime = b.step(
+        "component-examples-run-wasmtime",
+        "Run the runnable component examples through `wasmtime run -S cli-exit-with-code` for cross-runtime parity validation",
+    );
+    const runs: ComponentRunSteps = .{ .wamr = run_step, .wasmtime = run_step_wasmtime };
 
     // ── zig-hello ──────────────────────────────────────────────────
     // Pure-Zig WASI command: `_start` writes a greeting via fd_write.
@@ -661,18 +676,11 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     });
     installAndValidate(b, examples_step, hello, "zig-hello.component.wasm");
 
-    // The hello component is the only example that runs end-to-end on
-    // wamr today; wire it into `component-examples-run`. The wabt
-    // adapter lowers `fd_write(1, …)` through
+    // The wabt-bundled adapter lowers `fd_write(1, …)` through
     // `wasi:io/streams.blocking-write-and-flush` against
-    // `wasi:cli/stdout.get-stdout`, which wamr's
-    // `WasiCliAdapter` flushes to the host's actual stdout.
-    const run_hello = b.addRunArtifact(wamr_exe);
-    run_hello.addArg("run");
-    run_hello.addFileArg(hello);
-    run_hello.expectExitCode(0);
-    run_hello.expectStdOutEqual("hello from zig component\n");
-    run_step.dependOn(&run_hello.step);
+    // `wasi:cli/stdout.get-stdout`, which both runtimes flush to
+    // the host's actual stdout.
+    wireComponentRun(b, runs, wamr_exe, hello, "hello from zig component\n", 0);
 
     // ── zig-exit ───────────────────────────────────────────────────
     // Exercises the component exit-code path (issue #436): `_start`
@@ -693,12 +701,7 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     });
     installAndValidate(b, examples_step, exit_component, "zig-exit.component.wasm");
 
-    const run_exit = b.addRunArtifact(wamr_exe);
-    run_exit.addArg("run");
-    run_exit.addFileArg(exit_component);
-    run_exit.expectExitCode(7);
-    run_exit.expectStdOutEqual("exiting with code 7\n");
-    run_step.dependOn(&run_exit.step);
+    wireComponentRun(b, runs, wamr_exe, exit_component, "exiting with code 7\n", 7);
 
     // ── zig-adder ──────────────────────────────────────────────────
     // Library component (no `run`): exports `docs:adder/add@0.1.0`.
@@ -754,17 +757,11 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
 
     // Run the composed Zig calculator command. The wabt-bundled
     // wasi-preview1 adapter lowers `fd_write(1, …)` through
-    // `wasi:io/streams.blocking-write-and-flush`, which wamr's
-    // `WasiCliAdapter` flushes to the host's actual stdout. Issue
-    // #355 wired the alias chain + sub-component instantiation
-    // that this composed command needs to reach its `wasi:cli/run`
-    // export.
-    const run_calc = b.addRunArtifact(wamr_exe);
-    run_calc.addArg("run");
-    run_calc.addFileArg(calc_final);
-    run_calc.expectExitCode(0);
-    run_calc.expectStdOutEqual("40 + 2 = 42\n100 + 200 = 300\n");
-    run_step.dependOn(&run_calc.step);
+    // `wasi:io/streams.blocking-write-and-flush`, which both runtimes
+    // flush to the host's actual stdout. Issue #355 wired the alias
+    // chain + sub-component instantiation that this composed command
+    // needs to reach its `wasi:cli/run` export.
+    wireComponentRun(b, runs, wamr_exe, calc_final, "40 + 2 = 42\n100 + 200 = 300\n", 0);
 
     // ── mixed-zig-rust-calc (Zig adder + Rust command, composed) ───
     // Rust command builds via cargo on `wasm32-wasip1`; we then run the
@@ -810,14 +807,50 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     // Run the composed Rust-command + Zig-adder. Same alias-walking
     // path as `zig-calculator-cmd` (issue #355); produces the same
     // two-line output. With the wabt-bundled adapter (#453) wamr +
-    // wasmtime both run the composed component end-to-end, so the
-    // run step is wired in.
-    const run_mixed = b.addRunArtifact(wamr_exe);
-    run_mixed.addArg("run");
-    run_mixed.addFileArg(mixed_final);
-    run_mixed.expectExitCode(0);
-    run_mixed.expectStdOutEqual("40 + 2 = 42\n100 + 200 = 300\n");
-    run_step.dependOn(&run_mixed.step);
+    // wasmtime both run the composed component end-to-end.
+    wireComponentRun(b, runs, wamr_exe, mixed_final, "40 + 2 = 42\n100 + 200 = 300\n", 0);
+}
+
+const ComponentRunSteps = struct {
+    /// Parent build-step for the wamr in-tree run.
+    wamr: *std.Build.Step,
+    /// Parent build-step for the cross-runtime parity run under
+    /// `wasmtime run -S cli-exit-with-code` (assumed on `PATH`;
+    /// wasmtime v44+ required for the `cli-exit-with-code`
+    /// `@unstable` feature gate).
+    wasmtime: *std.Build.Step,
+};
+
+/// Register one component fixture against both run parents. Wires
+/// up the wamr arm via `b.addRunArtifact(wamr_exe)` and the wasmtime
+/// arm via `b.addSystemCommand({"wasmtime", "run", "-S",
+/// "cli-exit-with-code"})`. Both arms assert the same expected
+/// stdout + exit code, so byte-equivalent output across runtimes is
+/// the parity invariant the CI cross-validation job enforces
+/// (cataggar/wamr#457).
+fn wireComponentRun(
+    b: *std.Build,
+    runs: ComponentRunSteps,
+    wamr_exe: *std.Build.Step.Compile,
+    component: std.Build.LazyPath,
+    expected_stdout: []const u8,
+    expected_exit: u8,
+) void {
+    {
+        const run = b.addRunArtifact(wamr_exe);
+        run.addArg("run");
+        run.addFileArg(component);
+        run.expectExitCode(expected_exit);
+        run.expectStdOutEqual(expected_stdout);
+        runs.wamr.dependOn(&run.step);
+    }
+    {
+        const run = b.addSystemCommand(&.{ "wasmtime", "run", "-S", "cli-exit-with-code" });
+        run.addFileArg(component);
+        run.expectExitCode(expected_exit);
+        run.expectStdOutEqual(expected_stdout);
+        runs.wasmtime.dependOn(&run.step);
+    }
 }
 
 const ZigWasmCompile = struct {


### PR DESCRIPTION
Closes cataggar/wamr#457 — last open item from the #453 retirement plan.

After #453's component-model retirement landed, the only thing exercising the full `embed → component-new → compose → run` pipeline was a manual `zig build component-examples` locally. This PR closes the gap.

## Summary of changes

### New composite action

`.github/actions/wabt-install/` — one place for the wabt install shape. Pins `cataggar/wabt@v3.0.0-dev.6` (overridable via `with: { version: ... }`), forwards `GH_TOKEN` so `ghr install` uses the workflow's authenticated 5000/hr quota, and ships parallel bash + pwsh branches for Linux/macOS/Windows runners.

Refactors:

* `.github/workflows/copilot-setup-steps.yml` — inline ghr block (L47-64) → `uses: ./.github/actions/wabt-install`.
* `.github/actions/install-wasi-sdk-wabt/action.yml` — drops its two OS-conditional ghr blocks (L96-118); delegates to the new composite. Bumps effective wabt pin v3.0.0-dev.4 → v3.0.0-dev.6 as a side-effect.

### `build.zig` — cross-runtime fixture wiring

* `ComponentRunSteps` struct + `wireComponentRun` helper register one component fixture against two parents (wamr + wasmtime) with identical `expectStdOutEqual` + `expectExitCode` assertions.
* New build step `component-examples-run-wasmtime` runs the same four fixtures under `wasmtime run -S cli-exit-with-code` (wasmtime v44+ required for the `@unstable` `wasi:cli/exit.exit-with-code` feature gate).
* The four inline `addRunArtifact(wamr_exe)` blocks in `addComponentExamples` collapse to four `wireComponentRun(...)` calls — one per fixture, both runners covered.

### `ci.yml` — two new jobs + wasmtime pin bump

* **`Build & Test (component-examples)`** — Ubuntu-22.04 job. Runs `zig build install component-examples component-examples-run`. Wired into `ci-summary.needs` as a **required** check.
* **`Build & Test (component-examples-wasmtime)`** — same shape + installs wasmtime v44.0.1, runs the wasmtime build step. Intentionally **not** in `ci-summary.needs` so the cross-runtime parity check lands as non-blocking; flip to required in a follow-up after the first green run + any flake handling.
* The existing `wasi-test` job's wasmtime pin bumps from v36.0.9 → v44.0.1 (no behaviour change — the existing `wasmtime zig-out/bin/wamr.wasm -- --version` invocation is wasmtime version-agnostic).

## Verification

Local (Azure aarch64 + wasmtime 44.0.1 + wabt v3.0.0-dev.6):

```
$ zig build install component-examples
$ zig build component-examples-run            # wamr golden
$ zig build component-examples-run-wasmtime   # wasmtime parity
```

Both steps green; all four fixtures (`zig-hello`, `zig-exit`, `zig-calculator-cmd`, `mixed-zig-rust-calc`) match the `expectStdOutEqual` + `expectExitCode` assertions on both runners.

`actionlint` + YAML parse — clean on all four edited files.