### PR TITLE
perf(passes): wire forwardRedundantLoads + deadStoreElimination into x86_64 pipeline (#384, #390)

### DIFF
--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -5622,6 +5622,8 @@ const x86_64_default_passes: []const PassFn = &.{
     &inductionVariableSimplification,
     &hoistLoopInvariantCode,
     &unrollSmallFixedLoops,
+    &@import("forward_redundant_loads.zig").forwardRedundantLoads,
+    &deadStoreElimination,
     &deadCodeElimination,
     &deadLocalSetElimination,
     &hoistLoopBoundsChecks,


### PR DESCRIPTION
## What

Add `forwardRedundantLoads` and `deadStoreElimination` to `x86_64_default_passes` in `src/compiler/ir/passes.zig`.

```diff
     &unrollSmallFixedLoops,
+    &@import("forward_redundant_loads.zig").forwardRedundantLoads,
+    &deadStoreElimination,
     &deadCodeElimination,
```

## Why

Tracked as suggested follow-up **#1** of the #393 audit:
https://github.com/cataggar/wamr/issues/393#issuecomment-4423326059

> Wire `forwardRedundantLoads` and `deadStoreElimination` into `x86_64_default_passes` — two one-line additions in `passes.zig` would let #384 / #390 actually run on x86_64.

When the two passes landed in PRs #412 (issue #384) and #416 (issue #390), they were added to `default_passes` (used for aarch64) but never to `x86_64_default_passes`. The audit confirmed via `grep` that they were entirely absent from the x86_64 pipeline, so two presumed perf wins for x86_64 CoreMark have been merged-as-dead-code since.

Placement mirrors the aarch64 `default_passes` ordering — after `unrollSmallFixedLoops` and before `deadCodeElimination` — so the pipeline shape is identical across architectures for the production `enable_iv_simplify` + `enable_loop_unroll` path that CoreMark exercises.

## Scope

- Touches only `x86_64_default_passes`.
- The `_no_iv` / `_no_unroll` / `_no_iv_no_unroll` variants are unreachable in production (`grep` for `enable_iv_simplify = false` / `enable_loop_unroll = false` returns nothing), so they are not touched. This keeps x86_64 symmetric with aarch64, where only the main `default_passes` carries the pair.
- No new tests: both passes already have unit tests under `src/compiler/ir/` from PRs #412 and #416. This PR is a wiring change; its correctness is exercised by the existing `zig build test` (1422 + helpers, all green) and the CoreMark AOT CI.

## CoreMark AOT (aarch64, local, 3 runs each)

| Ref | Mean iter/s | Min | Max |
|---|---:|---:|---:|
| `origin/main` baseline | 8568.7 | 8558.3 | 8583.7 |
| `HEAD` target          | 8586.9 | 8566.2 | 8600.3 |
| **Δ**                  | **+0.21%** |   |   |

aarch64 is within noise as expected — these passes already ran there. The interesting measurement is **x86_64**, produced by the `coremark-x86_64` workflow on this PR. A measurable positive delta there would be the first real perf gain landed against #393 since the audit.

## Risks / fall-back

- If x86_64 still doesn't move, that's diagnostic: CoreMark's x86_64 hot path doesn't carry the redundant-load / dead-store patterns these passes target. Next pivots would be follow-up #5 (investigate #385 x86_64 −2.45% regression) or #2 (wire `forwardRedundantLoadsDominator`).
- Independent of stuck PRs #440 (spill cost) and #443 (block reorder); does not touch regalloc or block layout.

Refs: #393, #384, #390