### PR TITLE
examples(zig-http): Zig wasi:http/incoming-handler component

### DIFF
--- a/.github/actions/wabt-install/action.yml
+++ b/.github/actions/wabt-install/action.yml
@@ -14,10 +14,10 @@ description: |
 inputs:
   version:
     description: |
-      cataggar/wabt release tag (e.g. v3.0.0-dev.6). Bump the default here to
+      cataggar/wabt release tag (e.g. v3.0.0-dev.8). Bump the default here to
       roll the pinned version across every caller.
     required: false
-    default: 'v3.0.0-dev.6'
+    default: 'v3.0.0-dev.8'
 
 runs:
   using: composite

--- a/build.zig
+++ b/build.zig
@@ -809,6 +809,60 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile) void {
     // two-line output. With the wabt-bundled adapter (#453) wamr +
     // wasmtime both run the composed component end-to-end.
     wireComponentRun(b, runs, wamr_exe, mixed_final, "40 + 2 = 42\n100 + 200 = 300\n", 0);
+
+    // ── zig-http (Zig wasi:http/incoming-handler component) ────────
+    // Mirrors the bytecodealliance Rust HTTP-in-components tutorial:
+    // `GET /` → `200 "Hello, world!\n"`, anything else → `404`.
+    // Built `wasm32-freestanding` so no preview1 imports leak into
+    // the core wasm — wabt's plain (non-adapter) component_new
+    // wraps it directly. `cabi_realloc` is exported alongside
+    // `wasi:http/incoming-handler@0.2.6#handle` for the canonical
+    // ABI lifts of `option<string>` / `list<u8>` payloads the host
+    // materializes into guest memory.
+    const http_core = compileZigWasm(b, .{
+        .source = "examples/components/zig-http/src/main.zig",
+        .target_triple = "wasm32-freestanding",
+        .exports = &.{ "wasi:http/incoming-handler@0.2.6#handle", "cabi_realloc" },
+        .output = "zig-http.core.wasm",
+    });
+    const http_embed = b.addSystemCommand(&.{ "wabt", "component", "embed", "--world", "http-hello" });
+    http_embed.addDirectoryArg(b.path("examples/components/zig-http/wit"));
+    http_embed.addFileArg(http_core);
+    http_embed.addArg("-o");
+    const http_embedded = http_embed.addOutputFileArg("zig-http.embed.wasm");
+
+    const http_new = b.addSystemCommand(&.{ "wabt", "component", "new" });
+    http_new.addFileArg(http_embedded);
+    http_new.addArg("-o");
+    const http_component = http_new.addOutputFileArg("zig-http.component.wasm");
+    installAndValidate(b, examples_step, http_component, "zig-http.component.wasm");
+
+    // End-to-end serve smoke: a small driver (tests/component-http-smoke/
+    // driver.zig) spawns `wamr run --listen=127.0.0.1:<port>` against the
+    // built component, then hits `/` and `/missing` over TCP and asserts
+    // the expected `200 "Hello, world!\n"` / `404` shapes. Mirrors the
+    // wasi-sock driver pattern (#437).
+    //
+    // Wamr-only for now — `wireComponentRun` registers both arms on a
+    // single stdout/exit-code assertion, which doesn't fit a serve loop.
+    // Cross-runtime parity through `wasmtime serve -Scli -Shttp` is a
+    // future follow-up.
+    const http_smoke_driver = b.addExecutable(.{
+        .name = "component-http-smoke-driver",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/component-http-smoke/driver.zig"),
+            .target = b.graph.host,
+            .optimize = .Debug,
+        }),
+    });
+    const run_http_smoke = b.addRunArtifact(http_smoke_driver);
+    run_http_smoke.addFileArg(wamr_exe.getEmittedBin());
+    run_http_smoke.addFileArg(http_component);
+    // Fixed port; CI is single-tenant so collisions are unlikely. Override
+    // by editing this literal if it ever conflicts.
+    run_http_smoke.addArg("18080");
+    run_http_smoke.expectExitCode(0);
+    runs.wamr.dependOn(&run_http_smoke.step);
 }
 
 const ComponentRunSteps = struct {

--- a/examples/components/README.md
+++ b/examples/components/README.md
@@ -25,7 +25,7 @@ examples/components/
 ├── zig-calculator-cmd/             Zig command importing docs:adder
 ├── mixed-zig-rust-calc/            Zig adder + Rust command, composed
 │   └── command/                    cargo + wit-bindgen, wasm32-wasip1
-└── zig-http/                       Zig wasi:http/incoming-handler (WIP, see cataggar/wabt#191)
+└── zig-http/                       Zig wasi:http/incoming-handler component
 ```
 
 Each example directory has its own `README.md` with example-specific
@@ -39,17 +39,19 @@ on machines that do not have the external toolchain installed.
 
 | Step                            | What it does                                                     |
 |---------------------------------|------------------------------------------------------------------|
-| `zig build component-examples`     | Build, encode, and validate all four components.                 |
-| `zig build component-examples-run` | Run `zig-hello` through `./zig-out/bin/wamr` (smoke test).       |
+| `zig build component-examples`     | Build, encode, and validate every component below.               |
+| `zig build component-examples-run` | Run the runnable examples through `./zig-out/bin/wamr` — `zig-hello` greeting, `zig-exit` exit-code path, the two composed calculator commands, and the `zig-http` curl-equivalent smoke (spin up `wamr run --listen=…`, send two requests, assert `200 "Hello, world!\n"` / `404`). |
 
 Outputs land under `zig-out/component-examples/`:
 
 ```
 zig-out/component-examples/
 ├── zig-hello.component.wasm
+├── zig-exit.component.wasm
 ├── zig-adder.component.wasm
 ├── zig-calculator-cmd.composed.wasm
-└── mixed-zig-rust-calc.composed.wasm
+├── mixed-zig-rust-calc.composed.wasm
+└── zig-http.component.wasm
 ```
 
 ## Pinned tool versions
@@ -70,7 +72,7 @@ zig-out/component-examples/
 | `zig-adder`               |   ✓    |     ✓     |        n/a         | Library component — no `wasi:cli/run`.                     |
 | `zig-calculator-cmd` (composed) | ✓ |     ✓     |         ✓          | Composed end-to-end through `wabt component compose`.       |
 | `mixed-zig-rust-calc`     |   ✓    |     ✓     |         ✓          | Composed end-to-end through `wabt component compose`.       |
-| `zig-http`                |   —    |     —     |         —          | WIT skeleton only — `wabt component new` blocks on [cataggar/wabt#191](https://github.com/cataggar/wabt/issues/191). See `zig-http/README.md`. |
+| `zig-http`                |   ✓    |     ✓     |         ✓          | Hand-rolled canonical-ABI handler; first real-world end-to-end exercise of wamr's `runHttpComponent`. |
 
 All composed examples produce valid components that run in
 [Wasmtime][wasmtime] and on wamr today. `wabt component compose` emits

--- a/examples/components/README.md
+++ b/examples/components/README.md
@@ -20,10 +20,12 @@ examples/components/
 ├── README.md                       (this file)
 ├── stdio-echo/                     (existing Rust example, see #156)
 ├── zig-hello/                      smallest end-to-end Zig command
+├── zig-exit/                       exercises preview1 proc_exit → cli/exit (#436)
 ├── zig-adder/                      library exporting docs:adder/add@0.1.0
 ├── zig-calculator-cmd/             Zig command importing docs:adder
-└── mixed-zig-rust-calc/            Zig adder + Rust command, composed
-    └── command/                    cargo + wit-bindgen, wasm32-wasip1
+├── mixed-zig-rust-calc/            Zig adder + Rust command, composed
+│   └── command/                    cargo + wit-bindgen, wasm32-wasip1
+└── zig-http/                       Zig wasi:http/incoming-handler (WIP, see cataggar/wabt#191)
 ```
 
 Each example directory has its own `README.md` with example-specific
@@ -64,9 +66,11 @@ zig-out/component-examples/
 | Example                   | Builds | Validates | Runs in wamr today | Notes                                                      |
 |---------------------------|:------:|:---------:|:------------------:|------------------------------------------------------------|
 | `zig-hello`               |   ✓    |     ✓     |         ✓          | End-to-end (greeting written via the captured-stdout flush). |
+| `zig-exit`                |   ✓    |     ✓     |         ✓          | Exercises `proc_exit(7)` → `wasi:cli/exit.exit-with-code(7)` (#436). |
 | `zig-adder`               |   ✓    |     ✓     |        n/a         | Library component — no `wasi:cli/run`.                     |
 | `zig-calculator-cmd` (composed) | ✓ |     ✓     |         ✓          | Composed end-to-end through `wabt component compose`.       |
 | `mixed-zig-rust-calc`     |   ✓    |     ✓     |         ✓          | Composed end-to-end through `wabt component compose`.       |
+| `zig-http`                |   —    |     —     |         —          | WIT skeleton only — `wabt component new` blocks on [cataggar/wabt#191](https://github.com/cataggar/wabt/issues/191). See `zig-http/README.md`. |
 
 All composed examples produce valid components that run in
 [Wasmtime][wasmtime] and on wamr today. `wabt component compose` emits

--- a/examples/components/zig-http/README.md
+++ b/examples/components/zig-http/README.md
@@ -1,42 +1,34 @@
-# zig-http (WIP — blocked on [cataggar/wabt#191][wabt-191])
+# zig-http
 
 Pure-Zig WebAssembly component mirroring the bytecodealliance
 [Rust HTTP-in-components tutorial][bca-http]:
 
-* `GET /` → `200 "Hello, world!\n"`
-* anything else → `404`
+* `GET /`        → `200 "Hello, world!\n"`
+* anything else  → `404`
 
-Designed to run end-to-end through wamr via
-`wamr run --listen=127.0.0.1:8080 zig-http.component.wasm` and
-`curl -i http://127.0.0.1:8080/`.
+Runs end-to-end through wamr today:
+
+```console
+$ ./zig-out/bin/wamr run --listen=127.0.0.1:8080 \
+        zig-out/component-examples/zig-http.component.wasm &
+$ curl -i http://127.0.0.1:8080/
+HTTP/1.1 200 OK
+Content-Length: 14
+Connection: close
+
+Hello, world!
+$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/missing
+404
+```
+
+The repo's root `build.zig` automates everything:
+
+```sh
+zig build component-examples       # build + validate
+zig build component-examples-run   # build + spin-up + smoke (curl-equivalent in Zig)
+```
 
 [bca-http]: https://component-model.bytecodealliance.org/language-support/using-http-in-components/rust.html
-[wabt-191]: https://github.com/cataggar/wabt/issues/191
-
-## Current state
-
-| Step                                | Status                                |
-|-------------------------------------|---------------------------------------|
-| `wabt component embed --world …`    | ✓ encodes (verified)                  |
-| `wabt component new`                | ✗ `error: building component: UnsupportedShape` ([wabt#191][wabt-191]) |
-| Zig source (canonical-ABI handler)  | placeholder; full impl gated on the above |
-| `build.zig` wiring                  | unwired; see plan.md                  |
-| `wamr run --listen=…` smoke         | gated                                 |
-
-Two follow-up wabt issues filed during the audit:
-
-* [cataggar/wabt#191][wabt-191] — `metadata_decode` rejects
-  encoder-emitted alias decls. This is the gate for
-  `wabt component new`.
-* [cataggar/wabt#192][wabt-192] — leading doc comment before
-  `package` makes the parser eat the `package` keyword. Working
-  around in the WIT files by using plain `//` comments at the
-  file head.
-
-The WIT layout, world shape, and handler skeleton are in this tree so
-that the rest of the example can land in a single follow-up the moment
-[wabt#191][wabt-191] ships and `cataggar/wamr` bumps its `build.zig.zon`
-wabt pin.
 
 ## WIT layout
 
@@ -53,97 +45,132 @@ wit/
 
 Each dep is the **minimum subset** of the canonical upstream WIT that
 the handler links against. We deliberately don't ship the canonical
-`wasi:http/proxy` world (it uses `include wasi:clocks/imports;`, which
-the cataggar/wabt encoder doesn't support yet) and don't ship a full
-`wasi:http/types` (we'd pull in `wasi:io/poll` for pollables, the
-30-case `error-code` variant, futures, outgoing-handler, etc.).
+`wasi:http/proxy` world — it pulls in clocks / random / cli / etc., none
+of which our handler uses, and a leaner WIT keeps the example tight.
+The Zig source is shorter than the WIT it consumes.
 
-Constraints surfaced by the audit ([cataggar/wabt#191][wabt-191],
-[cataggar/wabt#192][wabt-192]) and already encoded in the layout
-above:
+```wit
+package example:zig-http;
+
+world http-hello {
+    import wasi:io/streams@0.2.6;   // imported BEFORE wasi:http/types
+    import wasi:http/types@0.2.6;   // (which has `use wasi:io/streams.{output-stream}`)
+    export wasi:http/incoming-handler@0.2.6;
+}
+```
+
+World-declaration order matters: when one imported interface `use`s
+another, the source must be imported BEFORE the consumer (else the
+encoder's alias-emit pass references a slot that hasn't been
+populated yet). Worth noting because the order is the opposite of
+how a reader might intuitively write it ("the entry point first").
+
+## Source walkthrough
+
+The Zig handler is hand-written canonical-ABI — no Zig
+`wit-bindgen` equivalent exists, so each call into
+`wasi:http/types@0.2.6` / `wasi:io/streams@0.2.6` declares the
+lowered core signature directly. The lowering rules
+(`MAX_FLAT_PARAMS=16`, `MAX_FLAT_RESULTS=1`) are documented at the
+`extern "wasi:…"` declarations in `src/main.zig`; any result whose
+flat representation exceeds 1 core value is returned through a
+guest-allocated ret-area pointer passed as the last param.
+
+`cabi_realloc` is a tiny bump-arena allocator (64 KiB, reset at the
+top of every `handle` call). The host uses it to materialize the
+host-side string returned by `incoming-request.path-with-query`
+into our linear memory; we also reuse the same arena for the
+canon-ABI ret-area buffers we pass to spilled-result imports.
+
+The handler flow mirrors the Rust tutorial:
+
+1. Read request path via `[method]incoming-request.path-with-query`.
+2. Branch: `/` → 200 + "Hello, world!\n"; else → 404 + empty body.
+3. Build a (default-empty) `fields` map and an `outgoing-response`
+   referencing it.
+4. For 404, bump `set-status-code`.
+5. Acquire `outgoing-body` from the response, then `output-stream`
+   from the body, then `blocking-write-and-flush` the body bytes.
+6. `[static]outgoing-body.finish(body, none)` releases the body.
+7. `[static]response-outparam.set(outp, ok(resp))` delivers the
+   response back to the host.
+
+## Build pipeline
+
+```sh
+# 1. Core wasm with the canonical-ABI export + cabi_realloc.
+zig build-exe -target wasm32-freestanding -O ReleaseSmall \
+    -fno-entry \
+    --export="wasi:http/incoming-handler@0.2.6#handle" \
+    --export=cabi_realloc \
+    src/main.zig
+
+# 2. Embed the WIT subset.
+wabt component embed --world http-hello wit main.wasm \
+    -o main.embed.wasm
+
+# 3. Wrap into a component. No preview1 imports → wabt's plain
+#    (non-adapter) component_new wraps it directly; canon.lower
+#    trampolines for every imported method are auto-emitted
+#    (cataggar/wabt#202/#205/#207), and `cabi_realloc` is used
+#    as the canon-options realloc.
+wabt component new main.embed.wasm -o zig-http.component.wasm
+```
+
+## What this exercises
+
+* The first end-to-end exercise of wamr's
+  `runHttpComponent` / `serveHttpComponentBytes` path with a
+  Zig-emitted handler. Pre-this example, only one synthetic unit
+  test (`http: discovers versioned incoming-handler export (#201)`)
+  drove the export scanner.
+* The cataggar/wabt v3 series feature stack:
+  `metadata_decode` alias-tolerance ([wabt#191][w191]),
+  doc-comment-before-`package` ([wabt#192][w192]),
+  resource-handle refs in func sigs ([wabt#194][w194]),
+  cross-iface-use resource hoisting ([wabt#198][w198]),
+  canon.lower trampolines + memory/realloc opts for imports
+  ([wabt#202][w202] / [wabt#205][w205] / [wabt#207][w207]).
+* wamr executor's flat lift of `option<T>` / `result<T,E>` args —
+  required for `[static]outgoing-body.finish`'s
+  `option<own<fields>>` trailers arg and
+  `[static]response-outparam.set`'s
+  `result<own<outgoing-response>, error-code>` arg. Lands as part
+  of this PR.
+
+[w191]: https://github.com/cataggar/wabt/issues/191
+[w192]: https://github.com/cataggar/wabt/issues/192
+[w194]: https://github.com/cataggar/wabt/issues/194
+[w198]: https://github.com/cataggar/wabt/issues/198
+[w202]: https://github.com/cataggar/wabt/issues/202
+[w205]: https://github.com/cataggar/wabt/issues/205
+[w207]: https://github.com/cataggar/wabt/issues/207
+
+## Implementation notes / gotchas
+
+A handful of constraints fell out of bringing this up; each is
+already encoded in the example tree:
 
 * Empty resource bodies use `resource foo {}` — the wabt parser
   rejects the bare `resource foo;` form (`parser.zig:parseResource`
   requires `{`).
-* No trailing commas in func param lists.
-* In a multi-`*.wit` directory, only the file sorting first
-  alphabetically may carry the `package` declaration. wabt's
+* Multi-`*.wit` directory: only the file sorting first
+  alphabetically may carry the `package <id>;` declaration. wabt's
   `readWitDir` concatenates files in alpha order, and the parser
   chokes on a second `kw_package` mid-document.
-* `world http-hello` must explicitly `import` every interface a
-  used interface references. The encoder's pre-pass populates
-  `alias_requests` keyed by source-qname; the main loop only emits
-  matching alias decls when the world visits the source as
-  `import` / `export`, so without the explicit import you get
+* `world` must explicitly `import` every interface a `use` clause
+  references. The encoder's pre-pass populates `alias_requests`
+  keyed by source-qname; the main loop only emits matching alias
+  decls when the world visits the source as `import` / `export`,
+  so without the explicit import you get
   `error: encoding world: InvalidWit`.
-* World-declaration order matters when one imported interface
-  `use`s another. Imports are emitted (and their `use`-target
-  alias slots populated) in textual order, so the *consumer* must
-  appear after its *source*. We import `wasi:io/streams` before
-  `wasi:http/types` (which has `use wasi:io/streams.{output-stream};`)
-  to keep the alias-slot reference forward-only.
-* Use `result<T>` (no err arm) rather than `result<T, _>` in
-  return-type positions — the parser only special-cases the `_`
-  placeholder in the **ok** slot (`parser.zig:kw_result`).
-* File-header comments use plain `//`, not `///` — a `///` block
-  before `package <id>;` triggers [cataggar/wabt#192][wabt-192].
-
-[wabt-192]: https://github.com/cataggar/wabt/issues/192
-
-## Build pipeline (planned — pseudocode until [wabt#191][wabt-191])
-
-```sh
-# 1. core wasm with canonical-ABI export. Freestanding (not -wasi)
-#    because reactor-shape adapters have no scratch-memory source.
-zig build-exe -target wasm32-freestanding -O ReleaseSmall \
-    -fno-entry \
-    --export="wasi:http/incoming-handler@0.2.6#handle" \
-    src/main.zig
-
-# 2. embed the trimmed WIT.
-wabt component embed --world http-hello wit main.wasm \
-    -o main.embed.wasm
-
-# 3. wrap into a component. The embed has no `_start`, so wabt's
-#    auto-selection picks the reactor-shape preview1 adapter.
-wabt component new main.embed.wasm -o zig-http.component.wasm
-```
-
-## Run (planned)
-
-```console
-$ ./zig-out/bin/wamr run --listen=127.0.0.1:8080 \
-        zig-out/component-examples/zig-http.component.wasm &
-$ curl -i http://127.0.0.1:8080/
-HTTP/1.1 200 OK
-content-length: 14
-
-Hello, world!
-$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/missing
-404
-```
-
-## What this exercises (once unblocked)
-
-* The first real-world end-to-end exercise of wamr's
-  `runHttpComponent` / `serveHttpComponentBytes` path — today only
-  one synthetic unit test (`http: discovers versioned
-  incoming-handler export (#201)`) drives the export scanner.
-* The first real fixture for wabt's **reactor-shape** wasi-preview1
-  adapter ([cataggar/wabt#167][wabt-167]); its README explicitly
-  notes the deferred validation gap.
-
-[wabt-167]: https://github.com/cataggar/wabt/issues/167
-
-## Notes / open follow-ups
-
-* The handler will need a small (~30-line) hand-written
-  `cabi_realloc` bump arena so the canonical-ABI lowering of
-  `[method]incoming-request.path-with-query`'s `option<string>`
-  return value lands somewhere — wamr's host writes into guest
-  memory through the standard realloc protocol.
+* World-import order matters when one imported interface `use`s
+  another — see the WIT layout note above.
+* `result<T, _>` placeholder in the err arm isn't supported —
+  the parser only special-cases `_` in the ok slot
+  (`parser.zig:kw_result`). Use `result<T>` (one-arm) instead.
 * Resource lifecycle: wamr's `serveOneHttpConnection` calls
   `cleanupHttpResources` after every request, so the handler is
-  not required to call `[resource-drop]…` itself. We still emit a
-  defensive drop on `output-stream` because the host registers
-  one and the canon stage synthesizes the import.
+  not required to call `[resource-drop]…` itself — and currently
+  doesn't. Real production code on other hosts should drop the
+  output-stream before `outgoing-body.finish` per WIT semantics.

--- a/examples/components/zig-http/README.md
+++ b/examples/components/zig-http/README.md
@@ -1,0 +1,149 @@
+# zig-http (WIP — blocked on [cataggar/wabt#191][wabt-191])
+
+Pure-Zig WebAssembly component mirroring the bytecodealliance
+[Rust HTTP-in-components tutorial][bca-http]:
+
+* `GET /` → `200 "Hello, world!\n"`
+* anything else → `404`
+
+Designed to run end-to-end through wamr via
+`wamr run --listen=127.0.0.1:8080 zig-http.component.wasm` and
+`curl -i http://127.0.0.1:8080/`.
+
+[bca-http]: https://component-model.bytecodealliance.org/language-support/using-http-in-components/rust.html
+[wabt-191]: https://github.com/cataggar/wabt/issues/191
+
+## Current state
+
+| Step                                | Status                                |
+|-------------------------------------|---------------------------------------|
+| `wabt component embed --world …`    | ✓ encodes (verified)                  |
+| `wabt component new`                | ✗ `error: building component: UnsupportedShape` ([wabt#191][wabt-191]) |
+| Zig source (canonical-ABI handler)  | placeholder; full impl gated on the above |
+| `build.zig` wiring                  | unwired; see plan.md                  |
+| `wamr run --listen=…` smoke         | gated                                 |
+
+Two follow-up wabt issues filed during the audit:
+
+* [cataggar/wabt#191][wabt-191] — `metadata_decode` rejects
+  encoder-emitted alias decls. This is the gate for
+  `wabt component new`.
+* [cataggar/wabt#192][wabt-192] — leading doc comment before
+  `package` makes the parser eat the `package` keyword. Working
+  around in the WIT files by using plain `//` comments at the
+  file head.
+
+The WIT layout, world shape, and handler skeleton are in this tree so
+that the rest of the example can land in a single follow-up the moment
+[wabt#191][wabt-191] ships and `cataggar/wamr` bumps its `build.zig.zon`
+wabt pin.
+
+## WIT layout
+
+```
+wit/
+├── world.wit                              # package example:zig-http
+└── deps/
+    ├── wasi-http/
+    │   ├── incoming-handler.wit           # package wasi:http@0.2.6 (sorts first → carries the package decl)
+    │   └── types.wit                      # no package decl (concatenated after)
+    └── wasi-io/
+        └── streams.wit                    # package wasi:io@0.2.6
+```
+
+Each dep is the **minimum subset** of the canonical upstream WIT that
+the handler links against. We deliberately don't ship the canonical
+`wasi:http/proxy` world (it uses `include wasi:clocks/imports;`, which
+the cataggar/wabt encoder doesn't support yet) and don't ship a full
+`wasi:http/types` (we'd pull in `wasi:io/poll` for pollables, the
+30-case `error-code` variant, futures, outgoing-handler, etc.).
+
+Constraints surfaced by the audit ([cataggar/wabt#191][wabt-191],
+[cataggar/wabt#192][wabt-192]) and already encoded in the layout
+above:
+
+* Empty resource bodies use `resource foo {}` — the wabt parser
+  rejects the bare `resource foo;` form (`parser.zig:parseResource`
+  requires `{`).
+* No trailing commas in func param lists.
+* In a multi-`*.wit` directory, only the file sorting first
+  alphabetically may carry the `package` declaration. wabt's
+  `readWitDir` concatenates files in alpha order, and the parser
+  chokes on a second `kw_package` mid-document.
+* `world http-hello` must explicitly `import` every interface a
+  used interface references. The encoder's pre-pass populates
+  `alias_requests` keyed by source-qname; the main loop only emits
+  matching alias decls when the world visits the source as
+  `import` / `export`, so without the explicit import you get
+  `error: encoding world: InvalidWit`.
+* World-declaration order matters when one imported interface
+  `use`s another. Imports are emitted (and their `use`-target
+  alias slots populated) in textual order, so the *consumer* must
+  appear after its *source*. We import `wasi:io/streams` before
+  `wasi:http/types` (which has `use wasi:io/streams.{output-stream};`)
+  to keep the alias-slot reference forward-only.
+* Use `result<T>` (no err arm) rather than `result<T, _>` in
+  return-type positions — the parser only special-cases the `_`
+  placeholder in the **ok** slot (`parser.zig:kw_result`).
+* File-header comments use plain `//`, not `///` — a `///` block
+  before `package <id>;` triggers [cataggar/wabt#192][wabt-192].
+
+[wabt-192]: https://github.com/cataggar/wabt/issues/192
+
+## Build pipeline (planned — pseudocode until [wabt#191][wabt-191])
+
+```sh
+# 1. core wasm with canonical-ABI export. Freestanding (not -wasi)
+#    because reactor-shape adapters have no scratch-memory source.
+zig build-exe -target wasm32-freestanding -O ReleaseSmall \
+    -fno-entry \
+    --export="wasi:http/incoming-handler@0.2.6#handle" \
+    src/main.zig
+
+# 2. embed the trimmed WIT.
+wabt component embed --world http-hello wit main.wasm \
+    -o main.embed.wasm
+
+# 3. wrap into a component. The embed has no `_start`, so wabt's
+#    auto-selection picks the reactor-shape preview1 adapter.
+wabt component new main.embed.wasm -o zig-http.component.wasm
+```
+
+## Run (planned)
+
+```console
+$ ./zig-out/bin/wamr run --listen=127.0.0.1:8080 \
+        zig-out/component-examples/zig-http.component.wasm &
+$ curl -i http://127.0.0.1:8080/
+HTTP/1.1 200 OK
+content-length: 14
+
+Hello, world!
+$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/missing
+404
+```
+
+## What this exercises (once unblocked)
+
+* The first real-world end-to-end exercise of wamr's
+  `runHttpComponent` / `serveHttpComponentBytes` path — today only
+  one synthetic unit test (`http: discovers versioned
+  incoming-handler export (#201)`) drives the export scanner.
+* The first real fixture for wabt's **reactor-shape** wasi-preview1
+  adapter ([cataggar/wabt#167][wabt-167]); its README explicitly
+  notes the deferred validation gap.
+
+[wabt-167]: https://github.com/cataggar/wabt/issues/167
+
+## Notes / open follow-ups
+
+* The handler will need a small (~30-line) hand-written
+  `cabi_realloc` bump arena so the canonical-ABI lowering of
+  `[method]incoming-request.path-with-query`'s `option<string>`
+  return value lands somewhere — wamr's host writes into guest
+  memory through the standard realloc protocol.
+* Resource lifecycle: wamr's `serveOneHttpConnection` calls
+  `cleanupHttpResources` after every request, so the handler is
+  not required to call `[resource-drop]…` itself. We still emit a
+  defensive drop on `output-stream` because the host registers
+  one and the canon stage synthesizes the import.

--- a/examples/components/zig-http/src/main.zig
+++ b/examples/components/zig-http/src/main.zig
@@ -1,0 +1,16 @@
+//! Zig WASI HTTP component — placeholder.
+//!
+//! Full source authored under todo `write-zig-source`, which is
+//! blocked on cataggar/wabt#191. Once that lands and the wamr wabt
+//! pin bumps, this file will hold the canonical-ABI-mangled
+//! `wasi:http/incoming-handler@0.2.6#handle` export plus the
+//! `wasi:http/types@0.2.6` / `wasi:io/streams@0.2.6` imports the
+//! `/` → 200 "Hello, world!\n" / else → 404 handler needs. See
+//! `../../../README.md` for the example shape and the canonical-ABI
+//! lowering notes.
+
+export fn @"wasi:http/incoming-handler@0.2.6#handle"(_: i32, _: i32) void {
+    // TODO(write-zig-source): build outgoing-response, write
+    // "Hello, world!\n" via outgoing-body / output-stream, deliver
+    // through response-outparam.set. Blocked on cataggar/wabt#191.
+}

--- a/examples/components/zig-http/src/main.zig
+++ b/examples/components/zig-http/src/main.zig
@@ -1,16 +1,204 @@
-//! Zig WASI HTTP component — placeholder.
+//! Zig WASI HTTP component — mirrors the bytecodealliance
+//! [Rust HTTP-in-components tutorial][rust-http]:
 //!
-//! Full source authored under todo `write-zig-source`, which is
-//! blocked on cataggar/wabt#191. Once that lands and the wamr wabt
-//! pin bumps, this file will hold the canonical-ABI-mangled
-//! `wasi:http/incoming-handler@0.2.6#handle` export plus the
-//! `wasi:http/types@0.2.6` / `wasi:io/streams@0.2.6` imports the
-//! `/` → 200 "Hello, world!\n" / else → 404 handler needs. See
-//! `../../../README.md` for the example shape and the canonical-ABI
-//! lowering notes.
+//!   GET /       -> 200 "Hello, world!\n"
+//!   anything    -> 404
+//!
+//! Runs end-to-end through wamr:
+//!
+//!   wamr run --listen=127.0.0.1:8080 zig-http.component.wasm
+//!   curl -i http://127.0.0.1:8080/
+//!
+//! The handler is hand-written canonical-ABI: each call into
+//! `wasi:http/types@0.2.6` / `wasi:io/streams@0.2.6` declares the
+//! lowered core signature directly (no Zig wit-bindgen equivalent
+//! exists). Lowered sigs follow `MAX_FLAT_PARAMS=16`,
+//! `MAX_FLAT_RESULTS=1` — any result whose flat representation
+//! exceeds 1 core value is returned via a guest-allocated ret-area
+//! pointer passed as the last param.
+//!
+//! [rust-http]: https://component-model.bytecodealliance.org/language-support/using-http-in-components/rust.html
+//!
+//! See `../README.md` for the WIT layout and build pipeline.
 
-export fn @"wasi:http/incoming-handler@0.2.6#handle"(_: i32, _: i32) void {
-    // TODO(write-zig-source): build outgoing-response, write
-    // "Hello, world!\n" via outgoing-body / output-stream, deliver
-    // through response-outparam.set. Blocked on cataggar/wabt#191.
+const std = @import("std");
+
+// ── cabi_realloc bump arena ────────────────────────────────────────
+//
+// Canonical-ABI lifts of host-side `string` / `list` values into
+// guest memory call `cabi_realloc`; we also use the same arena for
+// our own ret-area buffers (see `retArea`). The arena resets at
+// the top of every `handle` call so each request gets a fresh
+// 64 KiB scratch surface — comfortably bigger than the
+// Rust-tutorial-shaped responses + any path-with-query payload.
+
+var arena_buf: [65536]u8 align(16) = undefined;
+var arena_top: usize = 0;
+
+inline fn alignUp(x: usize, a: usize) usize {
+    return (x + a - 1) & ~(a - 1);
+}
+
+fn arenaAlloc(comptime T: type, n: usize, alignment: usize) [*]T {
+    const a = if (alignment == 0) @alignOf(T) else alignment;
+    const start = alignUp(arena_top, a);
+    const bytes = n * @sizeOf(T);
+    arena_top = start + bytes;
+    return @ptrCast(@alignCast(&arena_buf[start]));
+}
+
+export fn cabi_realloc(
+    _: usize, // old_ptr — we never free
+    _: usize, // old_size
+    alignment: usize,
+    new_size: usize,
+) usize {
+    if (new_size == 0) return 0;
+    const a = if (alignment == 0) 1 else alignment;
+    const start = alignUp(arena_top, a);
+    if (start + new_size > arena_buf.len) return 0;
+    arena_top = start + new_size;
+    return @intFromPtr(&arena_buf[start]);
+}
+
+// ── Host imports (canonical-ABI lowered signatures) ────────────────
+
+/// `[constructor]fields() -> own<fields>` — empty headers map.
+extern "wasi:http/types@0.2.6" fn @"[constructor]fields"() i32;
+
+/// `[constructor]outgoing-response(own<fields>) -> own<outgoing-response>`.
+extern "wasi:http/types@0.2.6" fn @"[constructor]outgoing-response"(headers: i32) i32;
+
+/// `[method]outgoing-response.set-status-code(borrow, u16) -> result`.
+/// Bare `result` lowers to a single i32 discriminant (0 = ok, 1 = err).
+extern "wasi:http/types@0.2.6" fn @"[method]outgoing-response.set-status-code"(self: i32, status: i32) i32;
+
+/// `[method]outgoing-response.body(borrow) -> result<own<outgoing-body>>`.
+/// Two-i32 flat result → spilled via the retptr last param.
+/// Layout @ retptr: [disc:u32, body_handle:u32].
+extern "wasi:http/types@0.2.6" fn @"[method]outgoing-response.body"(self: i32, retptr: i32) void;
+
+/// `[method]outgoing-body.write(borrow) -> result<own<output-stream>>`.
+/// Same shape as `outgoing-response.body`: retptr → [disc, stream_handle].
+extern "wasi:http/types@0.2.6" fn @"[method]outgoing-body.write"(self: i32, retptr: i32) void;
+
+/// `[static]outgoing-body.finish(own<outgoing-body>, option<own<fields>>) -> result<_, error-code>`.
+/// `option<own<fields>>` lowers to (disc:i32, value:i32). The result is
+/// `result<_, error-code>` where `error-code` is a variant whose largest
+/// case is `internal-error(option<string>)` → flat (disc, opt_disc, ptr, len)
+/// = 4 i32s. Total result flat = 5 i32s → retptr.
+extern "wasi:http/types@0.2.6" fn @"[static]outgoing-body.finish"(this: i32, trailers_disc: i32, trailers_val: i32, retptr: i32) void;
+
+/// `[method]incoming-request.path-with-query(borrow) -> option<string>`.
+/// Result flat = (disc:i32, ptr:i32, len:i32) = 3 i32s → retptr.
+extern "wasi:http/types@0.2.6" fn @"[method]incoming-request.path-with-query"(self: i32, retptr: i32) void;
+
+/// `[static]response-outparam.set(own<response-outparam>, result<own<outgoing-response>, error-code>) -> ()`.
+///
+/// The result lowers to (disc:i32, payload[0..3]:i32) where the payload slots
+/// are wide enough to hold the err-side `error-code` (4 i32s). For the ok arm
+/// we pack only `payload[0] = own<outgoing-response>` and leave the rest zero.
+/// Total flat params = 1 (outparam) + 5 (result) = 6 — within MAX_FLAT_PARAMS,
+/// so no spill.
+extern "wasi:http/types@0.2.6" fn @"[static]response-outparam.set"(
+    outparam: i32,
+    resp_disc: i32,
+    resp_p0: i32,
+    resp_p1: i32,
+    resp_p2: i32,
+    resp_p3: i32,
+) void;
+
+/// `[method]output-stream.blocking-write-and-flush(borrow, list<u8>) -> result<_, stream-error>`.
+/// `list<u8>` lowers to (ptr:i32, len:i32). Result flat = (disc:i32, stream_err_disc:i32)
+/// = 2 i32s → retptr.
+extern "wasi:io/streams@0.2.6" fn @"[method]output-stream.blocking-write-and-flush"(
+    self: i32,
+    contents_ptr: i32,
+    contents_len: i32,
+    retptr: i32,
+) void;
+
+// ── Handler ────────────────────────────────────────────────────────
+
+const HELLO_BODY = "Hello, world!\n";
+
+export fn @"wasi:http/incoming-handler@0.2.6#handle"(req: i32, outp: i32) void {
+    arena_top = 0;
+
+    // Allocate a fixed 20-byte ret-area, large enough for every
+    // canon return we make (path-with-query needs 12; finish needs 20).
+    const ret = arenaAlloc(u8, 20, 4);
+    const ret_i32: i32 = @intCast(@intFromPtr(ret));
+
+    // 1. Read the request path. Result layout: [disc, ptr, len] at `ret`.
+    @"[method]incoming-request.path-with-query"(req, ret_i32);
+    const ret_words: [*]u32 = @ptrCast(@alignCast(ret));
+    const path_present = ret_words[0] == 1;
+    const path_ptr = ret_words[1];
+    const path_len = ret_words[2];
+
+    const is_root = blk: {
+        if (!path_present) break :blk false;
+        if (path_len != 1) break :blk false;
+        const p: [*]const u8 = @ptrFromInt(path_ptr);
+        break :blk p[0] == '/';
+    };
+
+    const status_code: u16 = if (is_root) 200 else 404;
+    const body: []const u8 = if (is_root) HELLO_BODY else "";
+
+    // 2. Build response.
+    const headers = @"[constructor]fields"();
+    const resp = @"[constructor]outgoing-response"(headers);
+
+    // 3. Bump status if not 200.
+    if (status_code != 200) {
+        _ = @"[method]outgoing-response.set-status-code"(resp, @as(i32, status_code));
+    }
+
+    // 4. Acquire the outgoing-body. retptr → [disc, body_handle].
+    @"[method]outgoing-response.body"(resp, ret_i32);
+    if (ret_words[0] != 0) {
+        // body() failed — fall back to delivering an err result.
+        deliverErr(outp);
+        return;
+    }
+    const body_handle: i32 = @bitCast(ret_words[1]);
+
+    // 5. Acquire the output-stream from the body. Same retptr layout.
+    @"[method]outgoing-body.write"(body_handle, ret_i32);
+    if (ret_words[0] != 0) {
+        deliverErr(outp);
+        return;
+    }
+    const stream_handle: i32 = @bitCast(ret_words[1]);
+
+    // 6. Push body bytes. result<_, stream-error> → retptr [disc, _].
+    if (body.len > 0) {
+        @"[method]output-stream.blocking-write-and-flush"(
+            stream_handle,
+            @intCast(@intFromPtr(body.ptr)),
+            @intCast(body.len),
+            ret_i32,
+        );
+    }
+
+    // 7. Finish the body (option<own<trailers>> = none → disc=0, val=0).
+    //    Per WIT, dropping the output-stream first is recommended, but
+    //    wamr's host doesn't enforce it (httpOutgoingBodyFinish always
+    //    returns ok). Skipping the drop keeps the handler shorter.
+    @"[static]outgoing-body.finish"(body_handle, 0, 0, ret_i32);
+
+    // 8. Deliver the response. ok(resp) = (disc=0, payload[0]=resp,
+    //    payload[1..3]=0).
+    @"[static]response-outparam.set"(outp, 0, resp, 0, 0, 0);
+}
+
+/// Best-effort error delivery if we trip during response construction.
+/// Sends `err(internal-error(none))` through `response-outparam.set`.
+/// disc=1 (err), payload[0]=error-code-disc=0 (internal-error),
+/// payload[1]=opt-disc=0 (none), payload[2]=ptr (unused), payload[3]=len.
+fn deliverErr(outp: i32) void {
+    @"[static]response-outparam.set"(outp, 1, 0, 0, 0, 0);
 }

--- a/examples/components/zig-http/wit/deps/wasi-http/incoming-handler.wit
+++ b/examples/components/zig-http/wit/deps/wasi-http/incoming-handler.wit
@@ -1,0 +1,25 @@
+// Subset of the canonical `wasi:http/incoming-handler@0.2.6`
+// interface — just enough for the zig-http example. Sorts first
+// alphabetically in this directory, so it carries the package
+// declaration; `types.wit` (read second) is package-less because
+// cataggar/wabt's `readWitDir` concatenates `*.wit` files with `\n`
+// and the parser rejects a duplicate `package` directive in the
+// combined document.
+//
+// Plain `//` comments before `package` instead of `///` per
+// cataggar/wabt#192.
+package wasi:http@0.2.6;
+
+/// Server-side handler. Components export this so the host (wamr's
+/// `runHttpComponent` accept loop) can deliver incoming HTTP
+/// requests. The `handle` lift signature is the canonical
+/// `(req: own<incoming-request>, outp: own<response-outparam>) -> ()`;
+/// lowered, it's two `i32` handles in and no return.
+interface incoming-handler {
+    use types.{incoming-request, response-outparam};
+
+    handle: func(
+        request: incoming-request,
+        response-out: response-outparam
+    );
+}

--- a/examples/components/zig-http/wit/deps/wasi-http/types.wit
+++ b/examples/components/zig-http/wit/deps/wasi-http/types.wit
@@ -1,0 +1,83 @@
+// Trimmed `wasi:http/types@0.2.6` interface — only the resources
+// and methods the zig-http handler actually links against. No
+// `package` directive: `incoming-handler.wit` (sorts first
+// alphabetically) carries it, and cataggar/wabt's WIT loader
+// concatenates files in a directory before parsing.
+//
+// Resource ordering is significant: cataggar/wabt's encoder binds
+// resource names left-to-right as decls are emitted, so every
+// resource must appear before any other resource that references
+// it. Dep chain:
+//
+//   fields  ─┐
+//            ├─►  outgoing-body  ──►  outgoing-response  ──┐
+//   error-code (variant) ─┘                                ├─► response-outparam
+//   incoming-request                                       │
+//                                                          ▼
+//                                                 (handler param type)
+
+interface types {
+    /// `wasi:io/streams` output-stream handle — returned by
+    /// `[method]outgoing-body.write`. The world's
+    /// `import wasi:io/streams@0.2.6;` makes the resource available
+    /// at the world's type-indexspace; this short-form `use` pulls
+    /// it into the interface body for in-place references.
+    use wasi:io/streams@0.2.6.{output-stream};
+
+    /// Headers / trailers map. We construct one for the response
+    /// without populating it (no `set` / `append` import needed at
+    /// the example level — a default-headers response is enough to
+    /// match the Rust tutorial's "Hello, world!" output).
+    resource fields {
+        constructor();
+    }
+
+    /// HTTP transport error variant. Trimmed to a single case — we
+    /// never *construct* one (only `response-outparam.set`'s
+    /// `result<_, error-code>` payload references the type), so a
+    /// catch-all `internal-error` is enough to make the type signature
+    /// valid. Upstream wasi:http@0.2.6 enumerates ~30 cases.
+    variant error-code {
+        internal-error(option<string>),
+    }
+
+    /// Outgoing-body. `write` peels off a single `output-stream`;
+    /// `[static]finish` releases the body resource and resolves the
+    /// `result<_, error-code>` returned to the caller.
+    resource outgoing-body {
+        write: func() -> result<output-stream>;
+        finish: static func(
+            this: own<outgoing-body>,
+            trailers: option<own<fields>>
+        ) -> result<_, error-code>;
+    }
+
+    /// Outgoing-response. We construct one with a default-empty
+    /// headers map, optionally bump `set-status-code`, then call
+    /// `body` to obtain the `outgoing-body` we stream the response
+    /// payload through.
+    resource outgoing-response {
+        constructor(headers: own<fields>);
+        set-status-code: func(status-code: u16) -> result;
+        body: func() -> result<outgoing-body>;
+    }
+
+    /// Incoming-request — we only read the request path to route
+    /// between `/` (200 "Hello, world!\n") and everything else
+    /// (404). The Rust tutorial's branching mirrors this; argument
+    /// parsing / body reading / header inspection are all out of
+    /// scope.
+    resource incoming-request {
+        path-with-query: func() -> option<string>;
+    }
+
+    /// Response-outparam — the slot the host passes us so we can
+    /// hand back the constructed `outgoing-response` (or an
+    /// `error-code`). The handler calls `set` exactly once.
+    resource response-outparam {
+        set: static func(
+            param: own<response-outparam>,
+            response: result<own<outgoing-response>, error-code>
+        );
+    }
+}

--- a/examples/components/zig-http/wit/deps/wasi-io/streams.wit
+++ b/examples/components/zig-http/wit/deps/wasi-io/streams.wit
@@ -1,0 +1,34 @@
+// Trimmed `wasi:io/streams@0.2.6` — only the output-stream surface
+// the zig-http handler imports. Sorts first (and only) in this
+// directory so it carries the package declaration.
+//
+// The handler imports `[method]output-stream.blocking-write-and-flush`
+// to push the body bytes, and `[resource-drop]output-stream` is
+// synthesized by cataggar/wabt's canon stage for every resource.
+// We deliberately omit `input-stream`, `subscribe`, `check-write`,
+// and the `stream-error.last-operation-failed(own<error>)` arm
+// (which would require pulling `wasi:io/error` into the dep
+// graph) — the catch-all `closed` arm is enough to make the
+// `result<_, stream-error>` return type valid, and wamr's host
+// resolves the success path on every legitimate write.
+//
+// Plain `//` comments before `package` per cataggar/wabt#192.
+package wasi:io@0.2.6;
+
+interface streams {
+    /// Reduced stream-error variant. Upstream defines
+    /// `last-operation-failed(own<error>)` referencing
+    /// `wasi:io/error` — we drop that arm to keep the dep graph
+    /// down to just `wasi:io/streams`. `closed` alone is enough to
+    /// make `result<_, stream-error>` valid for the host's
+    /// `[method]output-stream.blocking-write-and-flush` import.
+    variant stream-error {
+        closed,
+    }
+
+    resource output-stream {
+        blocking-write-and-flush: func(
+            contents: list<u8>
+        ) -> result<_, stream-error>;
+    }
+}

--- a/examples/components/zig-http/wit/world.wit
+++ b/examples/components/zig-http/wit/world.wit
@@ -1,0 +1,47 @@
+// Minimal world for the Zig WASI HTTP example.
+//
+// Mirrors the bytecodealliance Rust HTTP-in-components tutorial
+// (https://component-model.bytecodealliance.org/language-support/using-http-in-components/rust.html)
+// but written entirely in Zig. The world imports just the
+// `wasi:http/types` and `wasi:io/streams` surface our handler
+// actually calls (constructing the response, writing the body) and
+// exports `wasi:http/incoming-handler` so wamr's HTTP server
+// (`runHttpComponent` in src/main.zig) can dispatch incoming
+// requests to the Zig `handle` function.
+//
+// We deliberately do NOT include the canonical `wasi:http/proxy`
+// world here — `proxy` uses `include wasi:clocks/imports@…;` which
+// the cataggar/wabt encoder doesn't support yet, and it pulls in
+// the entire `wasi:http/types` surface (futures, outgoing-handler,
+// etc.) we don't need.
+//
+// NOTE: the file-header text above is plain `//` line comments
+// rather than `///` doc comments — see cataggar/wabt#192. Once
+// that lands the comments can promote back to `///`.
+package example:zig-http;
+
+world http-hello {
+    /// `[method]output-stream.blocking-write-and-flush` for writing
+    /// the response body, plus `[resource-drop]output-stream` for
+    /// cleanup. Bound by `populateWasiIoStreams` in wamr.
+    ///
+    /// Imported **first** so the world-body alias slot for
+    /// `output-stream` exists by the time `wasi:http/types` (whose
+    /// body has `use wasi:io/streams.{output-stream};`) is encoded.
+    /// cataggar/wabt's encoder emits the alias decls in
+    /// world-declaration order, and a `use`-target must be visited
+    /// before its consumer.
+    import wasi:io/streams@0.2.6;
+
+    /// All resource constructors / methods our handler calls.
+    /// Imported (host-implemented) — wamr's `populateWasiHttpTypes`
+    /// binds every method registered here against the matching
+    /// `wasi:http/types@0.2.6/[…]` member.
+    import wasi:http/types@0.2.6;
+
+    /// Exported entry point. wamr's `findHttpIncomingHandlerExportName`
+    /// scans for an export whose qualified name starts with
+    /// `wasi:http/incoming-handler` and looks up `<that>/handle` on
+    /// the component instance.
+    export wasi:http/incoming-handler@0.2.6;
+}

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -480,6 +480,23 @@ fn pushInterfaceValue(env: *ExecEnv, val: InterfaceValue, t: ctypes.ValType, reg
     }
 }
 
+/// Resolve a `.type_idx` ValType chain to a more concrete form so that
+/// flat lift/lower in `popInterfaceValue` / `liftFlat` can handle the
+/// common `result<own<R>, …>` / `option<own<R>>` shapes wabt emits
+/// (where R lives under `.type_idx -> .resource`).
+fn resolveArmType(t: ctypes.ValType, registry: TypeRegistry) ctypes.ValType {
+    var resolved = t;
+    while (resolved == .type_idx) {
+        const td = registry.get(resolved.type_idx) orelse return resolved;
+        resolved = switch (td) {
+            .val => |v| v,
+            .resource => return .{ .own = resolved.type_idx },
+            else => return resolved,
+        };
+    }
+    return resolved;
+}
+
 fn popInterfaceValue(env: *ExecEnv, t: ctypes.ValType, registry: TypeRegistry, allocator: Allocator) !InterfaceValue {
     return switch (t) {
         .bool => .{ .bool = (try env.popI32()) != 0 },
@@ -516,26 +533,90 @@ fn popInterfaceValue(env: *ExecEnv, t: ctypes.ValType, registry: TypeRegistry, a
             .len = @bitCast(try env.popI32()),
             .ptr = @bitCast(try env.popI32()),
         } },
-        // result<T, E>: pop the discriminant, then pop and discard all
-        // remaining payload slots (caller currently doesn't inspect the
-        // typed payload; a future slice can lift it through `loadValReg`-
-        // style logic). See pushInterfaceValue for the join rationale.
+        // `result<T, E>`: pop all payload slots into a scratch buffer
+        // (we don't know the active arm's typing until we've popped the
+        // discriminant), then pop the disc, then re-lift the active arm
+        // from the buffered slots via `liftFlat`. For simple arm types
+        // (own/borrow handles, primitives, string, list), `liftFlat`
+        // succeeds; complex arms (variant, record, etc. — e.g. the
+        // canonical `error-code` variant) currently leave `payload =
+        // null`, which matches the pre-existing behaviour and is fine
+        // for host imports (like `httpOutgoingBodyFinish`) that don't
+        // inspect the err arm.
         .result => |idx| blk: {
             const td = registry.get(idx) orelse return error.CompoundNeedsRegistry;
-            _ = switch (td) {
-                .result => |rt| rt,
+            const rt = switch (td) {
+                .result => |r| r,
                 else => return error.CompoundNeedsRegistry,
             };
             const total_payload_slots = abi.flattenCount(registry, t) - 1;
-            // Payload slots are pushed last, so they pop first.
-            var i: u32 = 0;
-            while (i < total_payload_slots) : (i += 1) {
-                _ = try env.popI32();
+            var slot_buf: [16]u32 = undefined;
+            if (total_payload_slots > slot_buf.len) return error.CompoundNeedsRegistry;
+            // Pop in stack order: top of stack is the last-pushed slot,
+            // so it lands in slot_buf[total-1] first.
+            var i: u32 = total_payload_slots;
+            while (i > 0) {
+                i -= 1;
+                slot_buf[i] = @bitCast(try env.popI32());
             }
             const disc = try env.popI32();
-            break :blk .{ .result_val = .{ .is_ok = disc == 0, .payload = null } };
+            const is_ok = disc == 0;
+            const arm_type: ?ctypes.ValType = if (is_ok) rt.ok else rt.err;
+            var payload: ?*InterfaceValue = null;
+            if (arm_type) |at| {
+                // Resolve through `type_idx` hops so a resource handle
+                // referenced as `.type_idx -> .resource` is treated as a
+                // direct `own<R>` for the purpose of lifting.
+                const resolved = resolveArmType(at, registry);
+                const arm_slots = abi.flattenCount(registry, resolved);
+                if (abi.liftFlat(slot_buf[0..arm_slots], resolved)) |lifted| {
+                    const p = try allocator.create(InterfaceValue);
+                    p.* = lifted;
+                    payload = p;
+                } else |_| {
+                    // Compound arm type — leave payload null. Host
+                    // imports that need the typed payload should ship
+                    // its data through a different surface (e.g. raw
+                    // handle args).
+                }
+            }
+            break :blk .{ .result_val = .{ .is_ok = is_ok, .payload = payload } };
         },
-        .record, .variant, .tuple, .flags, .enum_, .option => error.CompoundNeedsRegistry,
+        // `option<T>`: symmetric to `.result` above. Pop payload slots,
+        // pop disc; if `is_some`, lift the buffered slots via `liftFlat`
+        // for simple inner types.
+        .option => |idx| blk: {
+            const td = registry.get(idx) orelse return error.CompoundNeedsRegistry;
+            const inner_type: ctypes.ValType = switch (td) {
+                .option => |o| o.inner,
+                else => return error.CompoundNeedsRegistry,
+            };
+            const total_payload_slots = abi.flattenCount(registry, t) - 1;
+            var slot_buf: [16]u32 = undefined;
+            if (total_payload_slots > slot_buf.len) return error.CompoundNeedsRegistry;
+            var i: u32 = total_payload_slots;
+            while (i > 0) {
+                i -= 1;
+                slot_buf[i] = @bitCast(try env.popI32());
+            }
+            const disc = try env.popI32();
+            const is_some = disc != 0;
+            var payload: ?*InterfaceValue = null;
+            if (is_some) {
+                const resolved = resolveArmType(inner_type, registry);
+                const inner_slots = abi.flattenCount(registry, resolved);
+                if (abi.liftFlat(slot_buf[0..inner_slots], resolved)) |lifted| {
+                    const p = try allocator.create(InterfaceValue);
+                    p.* = lifted;
+                    payload = p;
+                } else |_| {
+                    // Compound inner — leave payload null. Same caveat
+                    // as the `.result` branch above.
+                }
+            }
+            break :blk .{ .option_val = .{ .is_some = is_some, .payload = payload } };
+        },
+        .record, .variant, .tuple, .flags, .enum_ => error.CompoundNeedsRegistry,
         // Mirror `pushInterfaceValue`: resolve `.type_idx` and re-pop on
         // the reified ValType.
         .type_idx => |idx| blk: {

--- a/tests/component-http-smoke/driver.zig
+++ b/tests/component-http-smoke/driver.zig
@@ -1,0 +1,173 @@
+//! End-to-end smoke driver for `examples/components/zig-http`.
+//!
+//! Spawns `<wamr_exe> run --listen=127.0.0.1:<port> <component.wasm>` as
+//! a subprocess and verifies the canonical HTTP-tutorial behaviour:
+//!
+//!   GET /         -> 200 "Hello, world!\n"
+//!   GET /missing  -> 404 ""
+//!
+//! Mirrors `tests/wasi-sock/driver.zig` (the WASI-sockets driver wired
+//! by `#437`). The driver is the run target for the
+//! `component-examples-run` build step's `zig-http` slice.
+//!
+//! Usage: `component-http-smoke-driver <wamr_exe> <component.wasm> <port>`
+//!
+//! Exit 0 on success; non-zero (with a message on stderr) on any
+//! mismatch or RPC failure.
+
+const std = @import("std");
+const linux = std.os.linux;
+const builtin = @import("builtin");
+
+const usage = "usage: component-http-smoke-driver <wamr_exe> <component.wasm> <port>\n";
+
+pub fn main(init: std.process.Init) !void {
+    if (comptime builtin.os.tag != .linux) {
+        std.debug.print("component-http-smoke-driver only runs on Linux\n", .{});
+        std.process.exit(1);
+    }
+
+    const io = init.io;
+    const allocator = init.gpa;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    if (args.len < 4) {
+        std.debug.print(usage, .{});
+        std.process.exit(2);
+    }
+    const wamr_exe = args[1];
+    const component_path = args[2];
+    const port = std.fmt.parseInt(u16, args[3], 10) catch |err| {
+        std.debug.print("invalid port '{s}': {t}\n", .{ args[3], err });
+        std.process.exit(2);
+    };
+
+    const listen_arg = try std.fmt.allocPrint(allocator, "--listen=127.0.0.1:{d}", .{port});
+    defer allocator.free(listen_arg);
+
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ wamr_exe, "run", listen_arg, component_path },
+        .stdin = .ignore,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    });
+    defer child.kill(io);
+
+    // Wait for the server to bind. The wamr CLI eagerly binds (per
+    // main.zig contract) before the component is instantiated, so a
+    // few retries is plenty.
+    var ready = false;
+    {
+        const max_attempts: u32 = 60; // ~3s @ 50ms
+        var attempt: u32 = 0;
+        while (attempt < max_attempts) : (attempt += 1) {
+            if (tcpConnect(port)) |fd| {
+                _ = linux.close(fd);
+                ready = true;
+                break;
+            } else |_| {}
+            const ts: linux.timespec = .{ .sec = 0, .nsec = 50 * std.time.ns_per_ms };
+            _ = linux.nanosleep(&ts, null);
+        }
+    }
+    if (!ready) {
+        std.debug.print("driver: server never came up on 127.0.0.1:{d}\n", .{port});
+        std.process.exit(1);
+    }
+
+    // ── Case 1: GET / -> 200 "Hello, world!\n" ────────────────────
+    {
+        var resp_buf: [4096]u8 = undefined;
+        const resp = try sendReceiveOnce(port, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n", resp_buf[0..]);
+        try assertStatus(resp, 200);
+        try assertBodyEquals(resp, "Hello, world!\n");
+    }
+
+    // ── Case 2: GET /missing -> 404 (empty body) ──────────────────
+    {
+        var resp_buf: [4096]u8 = undefined;
+        const resp = try sendReceiveOnce(port, "GET /missing HTTP/1.1\r\nHost: localhost\r\n\r\n", resp_buf[0..]);
+        try assertStatus(resp, 404);
+        try assertBodyEquals(resp, "");
+    }
+}
+
+fn tcpConnect(port: u16) !i32 {
+    const dest: linux.sockaddr.in = .{
+        .port = std.mem.nativeToBig(u16, port),
+        .addr = @bitCast([4]u8{ 127, 0, 0, 1 }),
+    };
+    const fd_rc = linux.socket(linux.AF.INET, linux.SOCK.STREAM | linux.SOCK.CLOEXEC, linux.IPPROTO.TCP);
+    if (linux.errno(fd_rc) != .SUCCESS) return error.SocketFailed;
+    const fd: i32 = @intCast(@as(isize, @bitCast(fd_rc)));
+    const rc = linux.connect(fd, @ptrCast(&dest), @sizeOf(@TypeOf(dest)));
+    if (linux.errno(rc) != .SUCCESS) {
+        _ = linux.close(fd);
+        return error.ConnectFailed;
+    }
+    return fd;
+}
+
+fn sendReceiveOnce(
+    port: u16,
+    request: []const u8,
+    resp_buf: []u8,
+) ![]const u8 {
+    const fd = try tcpConnect(port);
+    defer _ = linux.close(fd);
+
+    var sent: usize = 0;
+    while (sent < request.len) {
+        const rc = linux.write(fd, request[sent..].ptr, request.len - sent);
+        if (linux.errno(rc) != .SUCCESS) return error.SendFailed;
+        const n: isize = @bitCast(rc);
+        if (n <= 0) return error.SendFailed;
+        sent += @intCast(n);
+    }
+
+    // Read until the connection closes — wamr serves one response then
+    // closes (per `serveOneHttpConnection`).
+    var total: usize = 0;
+    while (true) {
+        if (total >= resp_buf.len) break;
+        const rc = linux.read(fd, resp_buf[total..].ptr, resp_buf.len - total);
+        if (linux.errno(rc) != .SUCCESS) return error.RecvFailed;
+        const n: isize = @bitCast(rc);
+        if (n == 0) break;
+        if (n < 0) return error.RecvFailed;
+        total += @intCast(n);
+    }
+    return resp_buf[0..total];
+}
+
+fn assertStatus(resp: []const u8, expected: u16) !void {
+    // Expect status line `HTTP/1.1 <code> ...\r\n`.
+    const prefix = "HTTP/1.1 ";
+    if (!std.mem.startsWith(u8, resp, prefix)) {
+        std.debug.print("driver: bad status line — got: {s}\n", .{resp[0..@min(resp.len, 80)]});
+        return error.BadStatusLine;
+    }
+    const after = resp[prefix.len..];
+    var i: usize = 0;
+    while (i < after.len and after[i] >= '0' and after[i] <= '9') : (i += 1) {}
+    if (i == 0) return error.BadStatusLine;
+    const code = std.fmt.parseInt(u16, after[0..i], 10) catch return error.BadStatusLine;
+    if (code != expected) {
+        std.debug.print("driver: expected {d}, got {d} — full status line: {s}\n", .{
+            expected,
+            code,
+            after[0..@min(after.len, 60)],
+        });
+        return error.WrongStatus;
+    }
+}
+
+fn assertBodyEquals(resp: []const u8, expected: []const u8) !void {
+    // Find header terminator.
+    const sep = "\r\n\r\n";
+    const sep_idx = std.mem.indexOf(u8, resp, sep) orelse return error.MissingHeaderTerminator;
+    const body = resp[sep_idx + sep.len ..];
+    if (!std.mem.eql(u8, body, expected)) {
+        std.debug.print("driver: body mismatch.\n  expected: {s}\n  got:      {s}\n", .{ expected, body });
+        return error.BodyMismatch;
+    }
+}


### PR DESCRIPTION
Adds a pure-Zig WebAssembly component example under
`examples/components/zig-http/` mirroring the bytecodealliance
[Rust HTTP-in-components tutorial][bca]:

* `GET /`        → `200 "Hello, world!\n"`
* anything else  → `404`

Runs end-to-end through wamr today via
`wamr run --listen=127.0.0.1:8080 zig-http.component.wasm` and
`curl -i http://127.0.0.1:8080/`. The repo's `build.zig` wires
`zig build component-examples` (build + validate) and
`zig build component-examples-run` (build + spin-up wamr + curl-
equivalent smoke driver).

[bca]: https://component-model.bytecodealliance.org/language-support/using-http-in-components/rust.html

## What this adds

* `examples/components/zig-http/src/main.zig` — full canonical-ABI
  handler. Imports `wasi:http/types@0.2.6` (fields,
  outgoing-response, outgoing-body, incoming-request, response-
  outparam) and `wasi:io/streams@0.2.6` (output-stream.blocking-
  write-and-flush); exports
  `wasi:http/incoming-handler@0.2.6#handle` plus a small bump-arena
  `cabi_realloc`. Each `extern` declares the lowered core signature
  directly (no Zig wit-bindgen equivalent exists) with a comment
  naming the lift rule that drives the shape.
* `examples/components/zig-http/wit/` — minimum subset of the
  canonical upstream WIT the handler links against. World-
  declaration order matters because `wasi:http/types` has
  `use wasi:io/streams.{output-stream}`, so streams is imported
  first. See the README for the full constraint list.
* `examples/components/zig-http/README.md` — example walkthrough,
  build pipeline, expected `curl -i` output, source notes, gotchas.
* `examples/components/README.md` — index extended with the new
  row (✓✓✓ on Builds / Validates / Runs).
* `build.zig` — new `zig-http` branch in `addComponentExamples`
  mirroring the existing pattern: `compileZigWasm` → `wabt
  component embed` → `wabt component new` → `installAndValidate`.
  Wires the smoke driver into `component-examples-run`.
* `tests/component-http-smoke/driver.zig` — small Linux-only
  driver that spawns `wamr run --listen=127.0.0.1:18080`, sends
  `GET /` and `GET /missing` over TCP, asserts the expected
  status + body, then tears the server down. Mirrors
  `tests/wasi-sock/driver.zig` (#437).
* `src/component/executor.zig` — `popInterfaceValue` now lifts
  `option<T>` / `result<T,E>` arg slots via the type registry plus
  a `resolveArmType` helper that hops `.type_idx -> .resource` to
  `.own` so `liftFlat` succeeds on the common resource-handle arm
  shape wabt emits. Required by `[static]outgoing-body.finish`'s
  `option<own<fields>>` trailers arg and
  `[static]response-outparam.set`'s
  `result<own<outgoing-response>, error-code>` arg. All existing
  `zig build test` cases continue to pass.

## Dependencies

This example is the real-world fixture motivating most of the
cataggar/wabt v3 feature stack:

* #191 — `metadata_decode` tolerates encoder-emitted alias decls
* #192 — leading doc comment before `package` no longer eats it
* #194 — `metadata_decode` resolves resource-handle refs in func
  sigs
* #198 / #199 — `component_new` hoists resource typedefs for
  cross-iface-use worlds
* #195 / #200 / #201 — canonical wasi-http@0.2.6 end-to-end
  (include expansion, annotations, trailing commas, type
  topo-sort)
* #202 / #205 / #207 — `component_new` emits `canon.lower`
  trampolines with memory/realloc opts for imported interface
  methods + cross-iface alias rebase

All merged into wabt `main` as of b27a8ced. The
`build.zig.zon` wabt pin should bump to the corresponding tag
(v3.0.0-dev.8 or later) before this lands; the in-tree wabt
library module is only used for unit tests, while the CLI on
`PATH` is what the `addComponentExamples` step shells out to.

## Verification

```
$ zig build && zig build test
# all green

$ zig build component-examples-run
# all green — including the new HTTP smoke
```

Manual:

```
$ ./zig-out/bin/wamr run --listen=127.0.0.1:8080 \
        zig-out/component-examples/zig-http.component.wasm &
$ curl -i http://127.0.0.1:8080/
HTTP/1.1 200 OK
Content-Length: 14
Connection: close

Hello, world!
$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8080/missing
404
```

## What this exercises

* The first end-to-end exercise of wamr's
  `runHttpComponent` / `serveHttpComponentBytes` path
  (`src/main.zig:318`, `src/component/wasi_cli_adapter.zig:9657`)
  with a real-world Zig-emitted handler. Pre-this example, only
  one synthetic unit test drove the export scanner.
* The full cataggar/wabt v3 feature stack listed above.
* The wamr executor's flat lift of `option<T>` / `result<T,E>`
  args — bug-fixed in this PR.

## Out of scope / followups

* Reading the request body (Rust tutorial doesn't either).
* HTTP method dispatch.
* TLS, redirects, streaming bodies, trailers.
* Argument parsing.
