### PR TITLE
perf(passes): drop IV simplify + loop unroll from x86_64 pipeline (#385, #393)

### DIFF
--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -5602,6 +5602,15 @@ pub const default_passes: []const PassFn = &.{
 
 
 /// Default optimization pipeline for x86-64.
+///
+/// Note: `inductionVariableSimplification` and `unrollSmallFixedLoops`
+/// are intentionally omitted here pending a cost-model fix for issue
+/// #385. PR #413's own table reported x86_64 −2.45% on CoreMark (vs
+/// aarch64 −0.24%), confirmed in the #393 audit
+/// (https://github.com/cataggar/wamr/issues/393#issuecomment-4423326059)
+/// as "the cost model is still picking wrong loops". The aarch64
+/// pipeline keeps both passes for now — issue #385 tracks the
+/// cost-model rework that should let x86_64 re-enable them safely.
 const x86_64_default_passes: []const PassFn = &.{
     &forwardLocalGet,
     &constantFold,
@@ -5619,9 +5628,7 @@ const x86_64_default_passes: []const PassFn = &.{
     &foldFloatUnaryIdempotents,
     &foldWrapOfExtend,
     &globalValueNumbering,
-    &inductionVariableSimplification,
     &hoistLoopInvariantCode,
-    &unrollSmallFixedLoops,
     &@import("forward_redundant_loads.zig").forwardRedundantLoads,
     &deadStoreElimination,
     &deadCodeElimination,


### PR DESCRIPTION
## What

Removes `inductionVariableSimplification` and `unrollSmallFixedLoops` from `x86_64_default_passes`. aarch64's `default_passes` is unchanged — both passes still run there.

```diff
     &globalValueNumbering,
-    &inductionVariableSimplification,
     &hoistLoopInvariantCode,
-    &unrollSmallFixedLoops,
     &@import("forward_redundant_loads.zig").forwardRedundantLoads,
```

## Why

Addresses suggested follow-up **#5** of the #393 audit:
https://github.com/cataggar/wamr/issues/393#issuecomment-4423326059

> **#385** is wired but measurably regresses x86_64 in its own PR.
> 5. Investigate the #385 x86_64 −2.45% regression before any further unroll/IV changes — the existing cost model is mis‑selecting loops on x86_64.

PR #413 (issue #385) landed both passes in every pipeline. Its own coremark table at the time reported:

| arch | Δ |
|---|---:|
| aarch64 | −0.24% (noise) |
| x86_64 | **−2.45%** |

This PR is a tactical recovery: drop the regressing passes from the x86_64 pipeline pending the cost-model rework that issue #385 should track. Aarch64 keeps both passes because there it broke even.

## Scope

- Single-arch change. `x86_64_default_passes` only. aarch64 (`default_passes`) untouched.
- The `_no_iv` / `_no_unroll` variants are unreachable in production and untouched.
- No new tests: removed passes still have unit tests under `src/compiler/ir/`; they just no longer run in the x86_64 production pipeline.

## CoreMark AOT (aarch64, local, 3 runs each)

| Ref | Mean iter/s | Min | Max |
|---|---:|---:|---:|
| `origin/main` baseline | 8557.2 | 8552.9 | 8559.4 |
| `HEAD` (this PR)       | 8554.5 | 8530.8 | 8568.6 |
| **Δ**                  | **−0.03%** |   |   |

aarch64 unchanged (no-op there, as expected — this PR doesn't touch `default_passes`). The interesting measurement is **x86_64** via the `coremark-x86_64` workflow on this PR.

## Acceptance / fallback

- If x86_64 shows a clear positive delta (say ≥ +1%): keep this change as the tactical recovery; issue #385 stays open to track the cost-model rework that would let us re-enable these passes safely on x86_64.
- If x86_64 stays within noise: the audit's hypothesis is partly wrong (the regression has been absorbed by other changes since PR #413 landed); we may still want to keep the passes disabled given they don't help, or revert this PR. Either way, the data is informative.

Refs: #393, #385