### PR TITLE
perf(codegen): pin vmctx in a callee-saved register (#465)

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -33,15 +33,21 @@ const RegMap = struct {
     // X15 is reserved as `tmp2` for multi-operand sequences (e.g., bounds
     // check needs vmctx + zext_addr + mem_size live simultaneously).
     //
-    // X19–X28 are AAPCS64 callee-saved and appended after the caller-saved
-    // block. They survive calls (no save around BL), trading one extra
-    // STR/LDR pair per function per reg that the body allocates.
+    // X19 is reserved as the pinned `vmctx` register for the entire
+    // function body (issue #465). The prologue copies x0 (AAPCS64 arg0
+    // = vmctx) into x19 once, and every site that previously reloaded
+    // vmctx from `[fp + 16]` reads x19 directly. Because x19 is AAPCS64
+    // callee-saved, calls (to wasm helpers, trap helpers, host
+    // functions) preserve it without a save/restore at the call site.
+    //
+    // X20–X28 are AAPCS64 callee-saved and appended after the caller-
+    // saved block. They survive calls (no save around BL), trading one
+    // extra STR/LDR pair per function per reg that the body allocates.
     pub const caller_saved_count: usize = 15;
     pub const scratch_regs = [_]emit.Reg{
         .x0,  .x1,  .x2,  .x3,  .x4,  .x5,  .x6,  .x7,
         .x8,  .x9,  .x10, .x11, .x12, .x13, .x14,
-        // Callee-saved:
-        .x19,
+        // Callee-saved (x19 is pinned to vmctx, not allocatable):
         .x20, .x21, .x22, .x23, .x24, .x25, .x26, .x27,
         .x28,
     };
@@ -76,6 +82,12 @@ const RegMap = struct {
             .entries = std.AutoHashMap(ir.VReg, Location).init(allocator),
             .spill_base = spill_base,
             .spill_capacity = spill_capacity,
+            // x19 is permanently pinned to vmctx (issue #465). Mark it
+            // as used in `used_callee_mask` (bit 0) so the prologue STR
+            // / epilogue LDR for x19 is never NOP-patched. The prologue
+            // STR happens BEFORE we clobber x19 with x0, so the
+            // caller's x19 is correctly preserved across our frame.
+            .used_callee_mask = 1,
         };
     }
 
@@ -94,13 +106,17 @@ const RegMap = struct {
                 switch (a) {
                     .reg => |r| {
                         // `r` is the aarch64 register NUMBER (0..14 or
-                        // 19..28). Find its index in `scratch_regs` to
-                        // update `reg_used` / `used_callee_mask`.
+                        // 20..28; x19 is excluded — pinned to vmctx).
+                        // Find its index in `scratch_regs` to update
+                        // `reg_used` / `used_callee_mask`. After
+                        // skipping x15..x18 (4 non-allocatable) plus
+                        // x19 (pinned), reg_num N >= 20 maps to
+                        // scratch_regs index N - 5.
                         const reg_num: u32 = @intCast(r);
-                        const idx: usize = if (reg_num <= 14) reg_num else reg_num - 4;
+                        const idx: usize = if (reg_num <= 14) reg_num else reg_num - 5;
                         self.reg_used[idx] = true;
                         if (idx >= caller_saved_count) {
-                            self.used_callee_mask |= (@as(u16, 1) << @intCast(idx - caller_saved_count));
+                            self.used_callee_mask |= (@as(u16, 1) << @intCast(idx - caller_saved_count + 1));
                         }
                         const loc = Location{ .reg = scratch_regs[idx] };
                         try self.entries.put(vreg, loc);
@@ -126,7 +142,11 @@ const RegMap = struct {
             if (!self.reg_used[i]) {
                 self.reg_used[i] = true;
                 if (i >= caller_saved_count) {
-                    self.used_callee_mask |= (@as(u16, 1) << @intCast(i - caller_saved_count));
+                    // scratch_regs callee-saved tail starts at x20 (x19
+                    // is pinned to vmctx). callee_saved_regs (used for
+                    // prologue STR/LDR) still starts at x19 at bit 0,
+                    // so x20 occupies bit 1.
+                    self.used_callee_mask |= (@as(u16, 1) << @intCast(i - caller_saved_count + 1));
                 }
                 const loc = Location{ .reg = r };
                 try self.entries.put(vreg, loc);
@@ -1342,6 +1362,15 @@ pub fn compileFunctionImpl(
     try code.emitPrologue(frame_size);
     try emitCalleeSaveStoreTracked(&code, &fctx);
 
+    // Pin vmctx (AAPCS64 arg0 = x0) in callee-saved x19 for the whole
+    // function body (issue #465). The preceding callee-save STR has
+    // already preserved the caller's x19, and `RegMap.init` forces
+    // x19's bit in `used_callee_mask` so the STR is not NOP-patched.
+    // Every former `ldr Xd, [fp + vmctx_slot_offset/8]` is replaced by
+    // a `mov Xd, x19` (or a `mov x0, x19` when staging arg0 for a
+    // helper / cross-function call).
+    try code.movRegReg(.x19, .x0);
+
     // Spill VMContext (x0) and wasm params (x1..x7) to their frame slots.
     try emitEntrySpill(&code, func.*, local_layout.offsets, fctx.local_types, hrp_save_off, frame_size, allocator);
 
@@ -1886,8 +1915,11 @@ fn emitEntrySpill(
     frame_size: u32,
     allocator: std.mem.Allocator,
 ) !void {
-    // VMContext → [fp + 16]
-    try code.strImm(.x0, .fp, vmctx_slot_offset / 8);
+    // VMContext (x0) is pinned in x19 by `compileFunctionImpl`'s
+    // prologue (issue #465); no spill to `[fp + 16]` is needed. The
+    // slot itself is retained in the frame layout (locals still start
+    // at `[fp + 24]`) to avoid rippling the offset math through HRP,
+    // RegMap.spill_base, and v128 local-slot computations.
 
     var abi = try buildEntryAbiPlan(allocator, func, local_types);
     defer abi.deinit();
@@ -5584,14 +5616,15 @@ fn emitCall(
         if (cl.extra_results > 0) (if (cl.tail) HrpSource.forwarded else HrpSource.caller_scratch) else null,
     );
 
-    // Load VMContext into x0 (was saved above if previously live).
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    // Load VMContext into x0 (pinned in x19, issue #465).
+    try code.movRegReg(.x0, .x19);
 
     if (cl.tail) {
         // For imports the target lives in a vmctx slot; load it into
-        // tmp0 BEFORE tearing down the frame (vmctx reads need FP).
-        // tmp0 (x16) is a caller-save register not touched by the
-        // epilogue, so it survives to the `br` below.
+        // tmp0 BEFORE tearing down the frame (the callee-save restore
+        // below will overwrite x19 with the caller's value, and x0 is
+        // also live with vmctx). tmp0 (x16) is a caller-save register
+        // not touched by the epilogue, so it survives to the `br` below.
         if (is_import) {
             try code.ldrImm(RegMap.tmp0, .x0, vmctx_host_functions_slot);
             const fn_slot: u12 = @intCast(cl.func_idx);
@@ -5709,7 +5742,7 @@ fn emitMemAddrImpl(
         }
 
         // Step 3: load VmCtx.memory_size (at +8, scaled-by-8 offset = 1).
-        try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
+        try code.movRegReg(RegMap.tmp0, .x19);
         try code.ldrImm(RegMap.tmp0, RegMap.tmp0, 1);
 
         // Step 4: cmp end, mem_size; B.LS over_trap.
@@ -5718,7 +5751,7 @@ fn emitMemAddrImpl(
         try code.bCond(.ls, 0); // placeholder
 
         // Trap path.
-        try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+        try code.movRegReg(.x0, .x19);
         try code.ldrImm(RegMap.tmp0, .x0, vmctx_trap_oob_fn_slot);
         try code.blr(RegMap.tmp0);
         try code.brk(0);
@@ -5736,7 +5769,7 @@ fn emitMemAddrImpl(
     }
 
     // Step 5: load mem_base into tmp0.
-    try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(RegMap.tmp0, .x19);
     try code.ldrImm(RegMap.tmp0, RegMap.tmp0, 0);
 
     // Step 6: tmp0 = mem_base + zext(wasm_addr).
@@ -5824,7 +5857,7 @@ fn emitGlobalGet(
     const byte_offset = try globalByteOffset(fctx, idx);
     if (ty == .v128) {
         const vt = try v128_cache.defineFresh(code, v128_map, dest, null);
-        try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
+        try code.movRegReg(RegMap.tmp0, .x19);
         try code.ldrImm(RegMap.tmp0, RegMap.tmp0, vmctx_globals_slot);
         try addGlobalByteOffset(code, RegMap.tmp0, byte_offset, RegMap.tmp1);
         try code.ldrQ(vt, RegMap.tmp0);
@@ -5832,7 +5865,7 @@ fn emitGlobalGet(
     }
 
     // tmp0 = vmctx; tmp0 = globals_base
-    try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(RegMap.tmp0, .x19);
     try code.ldrImm(RegMap.tmp0, RegMap.tmp0, vmctx_globals_slot);
 
     const info = try destBegin(reg_map, dest, RegMap.tmp1);
@@ -5862,7 +5895,7 @@ fn emitGlobalSet(
     const byte_offset = try globalByteOffset(fctx, gs.idx);
     if (ty == .v128) {
         const vt = try v128_cache.ensure(code, v128_map, gs.val, null);
-        try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
+        try code.movRegReg(RegMap.tmp0, .x19);
         try code.ldrImm(RegMap.tmp0, RegMap.tmp0, vmctx_globals_slot);
         try addGlobalByteOffset(code, RegMap.tmp0, byte_offset, RegMap.tmp1);
         try code.strQ(vt, RegMap.tmp0);
@@ -5871,7 +5904,7 @@ fn emitGlobalSet(
 
     const val_r = try useInto(code, reg_map, gs.val, RegMap.tmp1);
     // tmp0 = vmctx; tmp0 = globals_base
-    try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(RegMap.tmp0, .x19);
     try code.ldrImm(RegMap.tmp0, RegMap.tmp0, vmctx_globals_slot);
     // Scalar/reference globals use 8-byte slots. i32/f32 consumers read the
     // low 32 bits, matching the pre-v128 layout and preserving old behaviour.
@@ -5894,7 +5927,7 @@ fn emitMemorySize(
     // Load vmctx into tmp0 first, then allocate dest (dest's scratch is
     // tmp1, so even if dest spills we don't alias tmp0 until after the
     // vmctx load).
-    try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(RegMap.tmp0, .x19);
     const info = try destBegin(reg_map, dest, RegMap.tmp1);
     try code.ldrImm32(info.reg, RegMap.tmp0, vmctx_mem_pages_slot_w);
     try destCommit(code, reg_map, info);
@@ -5948,7 +5981,7 @@ fn emitMemoryCopy(
 /// Uses `RegMap.tmp0` internally if `dest` == vmctx register (it won't,
 /// since `dest` is always a scratch caller like tmp0/tmp1 at call sites).
 fn loadTableInfoAddr(code: *emit.CodeBuffer, dest: emit.Reg, table_idx: u32) !void {
-    try code.ldrImm(dest, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(dest, .x19);
     try code.ldrImm(dest, dest, vmctx_tables_info_slot);
     const off: u32 = table_idx * table_info_stride;
     if (off != 0) {
@@ -6023,7 +6056,7 @@ fn emitTableSet(
     try code.movImm32(.x1, @intCast(ts.table_idx));
     try stageArgFromSaved(code, reg_map, fctx, .x2, ts.idx, 0);
     try stageArgFromSaved(code, reg_map, fctx, .x3, ts.val, 0);
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.ldrImm(RegMap.tmp0, .x0, vmctx_table_set_fn_slot);
     try code.blr(RegMap.tmp0);
 
@@ -6177,7 +6210,7 @@ fn emitTableGrow(
     try stageArgFromSaved(code, reg_map, fctx, .x1, tg.init, 0);
     try stageArgFromSaved(code, reg_map, fctx, .x2, tg.delta, 0);
     try code.movImm32(.x3, @intCast(tg.table_idx));
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.ldrImm(RegMap.tmp0, .x0, vmctx_table_grow_fn_slot);
     try code.blr(RegMap.tmp0);
 
@@ -6206,7 +6239,7 @@ fn emitRefFunc(
     reg_map: *RegMap,
 ) !void {
     const dest = inst.dest orelse return;
-    try code.ldrImm(RegMap.tmp0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(RegMap.tmp0, .x19);
     try code.ldrImm(RegMap.tmp0, RegMap.tmp0, vmctx_funcptrs_slot);
     const info = try destBegin(reg_map, dest, RegMap.tmp1);
     const slot: u12 = @intCast(func_idx);
@@ -6293,7 +6326,7 @@ fn emitCallIndirect(
     try code.ldrImm32(RegMap.tmp1, RegMap.tmp1, 0); // tmp1 = actual_sig
 
     // Load expected_sig from vmctx.sig_table_ptr[type_idx].
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.ldrImm(.x0, .x0, vmctx_sig_table_slot);
     try code.ldrImm32(RegMap.tmp0, .x0, @intCast(ci.type_idx)); // scale 4
 
@@ -6331,14 +6364,14 @@ fn emitCallIndirect(
         if (ci.extra_results > 0) (if (ci.tail) HrpSource.forwarded else HrpSource.caller_scratch) else null,
     );
     if (ci.tail) {
-        try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+        try code.movRegReg(.x0, .x19);
         try emitCalleeSaveRestoreTracked(code, fctx);
         try code.emitEpilogueNoRet(fctx.frame_size);
         try code.br(RegMap.tmp0);
         return;
     }
 
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.blr(RegMap.tmp0);
     if (abi.stack_size > 0) try emitSpAdjust(code, abi.stack_size, .add);
 
@@ -6390,7 +6423,7 @@ fn emitCallRef(
     const cbz_site = code.len();
     try code.cbz64(RegMap.tmp0, 0); // patched below
     // trap: load vmctx, load fn, blr (noreturn)
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.ldrImm(RegMap.tmp1, .x0, vmctx_trap_unreachable_fn_slot);
     try code.blr(RegMap.tmp1);
     // CBZ shares the b.cond imm19 encoding at bits [23:5], so the same
@@ -6412,14 +6445,14 @@ fn emitCallRef(
         if (cr.extra_results > 0) (if (cr.tail) HrpSource.forwarded else HrpSource.caller_scratch) else null,
     );
     if (cr.tail) {
-        try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+        try code.movRegReg(.x0, .x19);
         try emitCalleeSaveRestoreTracked(code, fctx);
         try code.emitEpilogueNoRet(fctx.frame_size);
         try code.br(RegMap.tmp0);
         return;
     }
 
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.blr(RegMap.tmp0);
     if (abi.stack_size > 0) try emitSpAdjust(code, abi.stack_size, .add);
 
@@ -6561,7 +6594,7 @@ fn emitVmctxHelperCall(
     _ = &arg_regs;
 
     // x0 = vmctx; tmp0 = vmctx.<fn_slot>; BLR tmp0.
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.ldrImm(RegMap.tmp0, .x0, fn_slot);
     try code.blr(RegMap.tmp0);
 
@@ -6645,7 +6678,7 @@ fn emitTableInit(
     try code.movImm64(.x2, packed_st);
 
     // x0 = vmctx; tmp0 = vmctx.table_init_fn; BLR tmp0.
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.ldrImm(RegMap.tmp0, .x0, vmctx_table_init_fn_slot);
     try code.blr(RegMap.tmp0);
 
@@ -6672,7 +6705,7 @@ fn emitElemDrop(
     try saveCallerSaveForCall(code, reg_map, fctx, &used_snapshot, &.{});
 
     try code.movImm32(.x1, @bitCast(seg_idx));
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.ldrImm(RegMap.tmp0, .x0, vmctx_elem_drop_fn_slot);
     try code.blr(RegMap.tmp0);
 
@@ -6705,7 +6738,7 @@ fn patchBCondHere(code: *emit.CodeBuffer, patch_off: usize) void {
 /// Clobbers x0, tmp0, LR — but this path is noreturn, so callers do not
 /// care what survives it.
 fn emitTrapHelperCall(code: *emit.CodeBuffer, slot: u12) !void {
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.ldrImm(RegMap.tmp0, .x0, slot);
     try code.blr(RegMap.tmp0);
     try code.brk(0);
@@ -7090,7 +7123,7 @@ fn emitAtomicNotify(
     // x2 = count
     try stageArgFromSaved(code, reg_map, fctx, .x2, an.count, 0);
     // x0 = vmctx, tmp0 = helper, BLR.
-    try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+    try code.movRegReg(.x0, .x19);
     try code.ldrImm(RegMap.tmp0, .x0, vmctx_futex_notify_fn_slot);
     try code.blr(RegMap.tmp0);
 
@@ -7150,7 +7183,7 @@ fn emitAtomicWait(
         try code.movRegReg(.x4, .x3);
         try code.lsrImm(.x4, .x4, 32);
         try code.uxtw(.x3, .x3);
-        try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+        try code.movRegReg(.x0, .x19);
         try code.ldrImm(RegMap.tmp0, .x0, vmctx_futex_wait32_fn_slot);
     } else {
         // wait64: expected is i64 → exp_lo (x2) / exp_hi (x3).
@@ -7163,7 +7196,7 @@ fn emitAtomicWait(
         try code.movRegReg(.x5, .x4);
         try code.lsrImm(.x5, .x5, 32);
         try code.uxtw(.x4, .x4);
-        try code.ldrImm(.x0, .fp, vmctx_slot_offset / 8);
+        try code.movRegReg(.x0, .x19);
         try code.ldrImm(RegMap.tmp0, .x0, vmctx_futex_wait64_fn_slot);
     }
 
@@ -7438,12 +7471,13 @@ pub fn compileModuleWithOptions(
 /// Allocatable aarch64 GPRs, in stable index order used by clobber masks.
 ///
 /// Indices 0..14 map to x0..x14 (AAPCS64 caller-saved; x15 is reserved as
-/// a non-allocatable scratch `RegMap.tmp2`). Indices 15..24 map to
-/// x19..x28 (callee-saved). x16/x17 are `RegMap.tmp0/tmp1`, x18 is the
-/// platform register, x29/x30 are FP/LR, and x31 is SP — all excluded.
+/// a non-allocatable scratch `RegMap.tmp2`). Indices 15..23 map to
+/// x20..x28 (callee-saved). x16/x17 are `RegMap.tmp0/tmp1`, x18 is the
+/// platform register, x19 is pinned to `vmctx` for the function body
+/// (issue #465), x29/x30 are FP/LR, and x31 is SP — all excluded.
 pub const aarch64_alloc_regs = [_]regalloc.PhysReg{
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
-    19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+    20, 21, 22, 23, 24, 25, 26, 27, 28,
 };
 
 /// Indices into `aarch64_alloc_regs` of AAPCS64 caller-saved registers
@@ -7454,10 +7488,11 @@ pub const aarch64_caller_saved_indices = [_]u8{
 };
 
 /// Indices into `aarch64_alloc_regs` of AAPCS64 callee-saved registers
-/// (x19..x28). Preferred for live ranges that span a call, since they
-/// survive without save/restore.
+/// (x20..x28). Preferred for live ranges that span a call, since they
+/// survive without save/restore. x19 is excluded — it is permanently
+/// pinned to `vmctx` for the whole function body (issue #465).
 pub const aarch64_callee_saved_indices = [_]u8{
-    15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+    15, 16, 17, 18, 19, 20, 21, 22, 23,
 };
 
 /// Bitmask over `aarch64_alloc_regs` of registers destroyed by any
@@ -7653,8 +7688,8 @@ fn addCallArgScalarHints(
 
 /// Emit a single `Hint` for `vreg` targeting AAPCS64 register `xN` if
 /// `xN` is allocatable in `aarch64_alloc_regs`. x0..x14 are; x15..x18
-/// and the callee-saved x19..x28 are (callee-saved are reachable but
-/// not used for ABI-fixed call-arg slots).
+/// and x19 (pinned to vmctx, issue #465) are not. The callee-saved
+/// x20..x28 are reachable but not used for ABI-fixed call-arg slots.
 fn appendArgRegHint(
     list: *std.ArrayList(regalloc.Hint),
     allocator: std.mem.Allocator,
@@ -11762,8 +11797,10 @@ test "compile: br_if with two blocks" {
 
 // ── Phase 1b: VMContext ABI + locals tests ───────────────────────────────────
 
-test "compile: entry spills vmctx to [fp+16]" {
-    // Function with no params, no locals: prologue must still spill x0 → [fp+16].
+test "compile: entry pins vmctx in x19 (issue #465)" {
+    // Function with no params, no locals: prologue must copy x0 → x19
+    // after the 10 callee-save STRs (vmctx is pinned in x19 for the
+    // whole function body).
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -11773,12 +11810,12 @@ test "compile: entry spills vmctx to [fp+16]" {
     try func.getBlock(bid).append(.{ .op = .{ .ret = v0 } });
     const code = try compileFunctionWithOptions(&func, allocator, .{ .enable_peephole = false });
     defer allocator.free(code);
-    // Layout: prologue (STP + ADD fp,sp,0), then 10 callee-save STRs for
-    // x19..x28 (40 bytes), then STR x0 → [fp+16].
-    //   opcode 0xF9000000 | (imm12=2 << 10) | (rn=29 << 5) | rt=0
-    //   = 0xF9000000 | 0x800 | 0x3A0 | 0 = 0xF9000BA0
-    const str_word = std.mem.readInt(u32, code[48..][0..4], .little);
-    try std.testing.expectEqual(@as(u32, 0xF9000BA0), str_word);
+    // Layout: prologue (STP + ADD fp,sp,0 = 8 bytes), then 10 callee-save
+    // STRs for x19..x28 (40 bytes), then MOV x19, x0 (= ORR x19, xzr, x0).
+    //   encoding: 0xAA000000 | (rm=0 << 16) | (rn=31 << 5) | rd=19
+    //   = 0xAA000000 | 0x3E0 | 0x13 = 0xAA0003F3
+    const mov_word = std.mem.readInt(u32, code[48..][0..4], .little);
+    try std.testing.expectEqual(@as(u32, 0xAA0003F3), mov_word);
 }
 
 test "compile: param spill — STR x1 into first local slot" {
@@ -12706,10 +12743,11 @@ test "collectClobberPoints: positions are monotonic across blocks" {
 
 test "aarch64RegSet: sane layout for a tiny function" {
     const rs = aarch64RegSet(0);
-    // 25 allocatable GPRs, 15 caller-saved + 10 callee-saved.
-    try std.testing.expectEqual(@as(usize, 25), rs.alloc_regs.len);
+    // 24 allocatable GPRs, 15 caller-saved + 9 callee-saved (x19 is
+    // pinned to vmctx per issue #465 and not in the allocator pool).
+    try std.testing.expectEqual(@as(usize, 24), rs.alloc_regs.len);
     try std.testing.expectEqual(@as(usize, 15), rs.caller_saved_indices.len);
-    try std.testing.expectEqual(@as(usize, 10), rs.callee_saved_indices.len);
+    try std.testing.expectEqual(@as(usize, 9), rs.callee_saved_indices.len);
     // Spill stride grows upward (away from fp).
     try std.testing.expect(rs.spill_stride > 0);
     // Spills live above the locals area (saved fp/lr + vmctx + locals = 24 bytes min).

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1224,7 +1224,7 @@ fn compileInst(
         },
         .elem_drop => {},
         .table_size => {
-            try code.movRegMem(.r10, .rbp, vmctx_offset);
+            try code.movRegReg(.r10, .rbx);
             try code.movRegMemNoRex(.rax, .r10, vmctx_func_table_len_field);
             try stack.push(code, .rax);
         },
@@ -1244,7 +1244,7 @@ fn compileInst(
             try stack.push(code, .rax);
         },
         .ref_func => |fidx| {
-            try code.movRegMem(.r10, .rbp, vmctx_offset);
+            try code.movRegReg(.r10, .rbx);
             try code.movRegMem(.r10, .r10, vmctx_funcptrs_field);
             try code.movRegMem(.rax, .r10, @as(i32, @intCast(fidx * 8)));
             try stack.push(code, .rax);
@@ -1486,22 +1486,29 @@ const GlobalCallPatch = struct {
 const regalloc = @import("../../ir/regalloc.zig");
 const analysis = @import("../../ir/analysis.zig");
 
-/// x86-64 allocatable GPR set: rdx(2), rbx(3), rsi(6), rdi(7), r8(8), r9(9),
-/// r12(12), r13(13), r14(14), r15(15). Order matches the legacy mask layout,
-/// so `caller_saved_indices` / `callee_saved_indices` are stable indices
+/// x86-64 allocatable GPR set: rdx(2), rsi(6), rdi(7), r8(8), r9(9),
+/// r12(12), r13(13), r14(14), r15(15). `rbx`(3) is permanently pinned to
+/// `vmctx` for the function body (issue #465) and excluded from the
+/// allocator pool; the prologue copies `param_regs[0]` (rdi/rcx) into
+/// rbx once, and every site that previously reloaded vmctx from
+/// `[rbp - 8]` reads rbx directly.
+///
+/// `caller_saved_indices` / `callee_saved_indices` are stable indices
 /// into `alloc_regs` and match the bit positions used in clobber masks below.
-const x86_64_alloc_regs = [_]regalloc.PhysReg{ 2, 3, 6, 7, 8, 9, 12, 13, 14, 15 };
+const x86_64_alloc_regs = [_]regalloc.PhysReg{ 2, 6, 7, 8, 9, 12, 13, 14, 15 };
 
 /// Indices into `x86_64_alloc_regs` of callee-saved registers (same on
-/// Win64 and SysV): rbx(idx 1), r12..r15 (idx 6..9).
-const x86_64_callee_saved_indices = [_]u8{ 1, 6, 7, 8, 9 };
+/// Win64 and SysV): r12..r15 (idx 5..8). rbx is excluded — it is the
+/// pinned vmctx register and saved/restored unconditionally by the
+/// prologue/epilogue rather than by the allocator.
+const x86_64_callee_saved_indices = [_]u8{ 5, 6, 7, 8 };
 
 /// Indices into `x86_64_alloc_regs` of caller-saved registers, by ABI.
 /// On Win64: rdx, r8, r9. On SysV: add rsi, rdi.
 const x86_64_caller_saved_indices = if (builtin.os.tag == .windows)
-    [_]u8{ 0, 4, 5 }
+    [_]u8{ 0, 3, 4 }
 else
-    [_]u8{ 0, 2, 3, 4, 5 };
+    [_]u8{ 0, 1, 2, 3, 4 };
 
 /// Bitmask over `x86_64_alloc_regs` indices of caller-saved registers
 /// clobbered by a normal call / host runtime call (memory.grow, table.set,
@@ -1526,8 +1533,8 @@ fn x86_64_alloc_idx(reg: emit.Reg) ?u8 {
 /// registers (rcx on SysV, rcx on Win64 since param_regs[0]=rcx is
 /// non-allocatable) are null.
 ///
-/// SysV: rdi(idx 3), rsi(idx 2), rdx(idx 0), rcx(null), r8(idx 4), r9(idx 5)
-/// Win64: rcx(null), rdx(idx 0), r8(idx 4), r9(idx 5)
+/// SysV: rdi(idx 2), rsi(idx 1), rdx(idx 0), rcx(null), r8(idx 3), r9(idx 4)
+/// Win64: rcx(null), rdx(idx 0), r8(idx 3), r9(idx 4)
 const param_reg_hint_idx: [param_regs.len]?u8 = blk: {
     var t: [param_regs.len]?u8 = undefined;
     for (param_regs, 0..) |r, i| t[i] = x86_64_alloc_idx(r);
@@ -1837,6 +1844,12 @@ fn compileFunctionRAWithGlobalOffsets(
     var used_caller_saved: [caller_saved_alloc.len]bool = .{false} ** caller_saved_alloc.len;
     // Track which callee-saved registers are used (for prologue/epilogue preservation).
     var used_callee_saved: [callee_saved_alloc.len]bool = .{false} ** callee_saved_alloc.len;
+    // rbx is permanently pinned to vmctx for the function body (issue
+    // #465). It's at index 0 of `callee_saved_alloc` on both Win64 and
+    // SysV, so always mark it used: the prologue must `push rbx` (to
+    // preserve the caller's value) before the prologue copies vmctx
+    // (`param_regs[0]`) into it.
+    used_callee_saved[0] = true;
     {
         var it = alloc_result.assignments.iterator();
         while (it.next()) |entry| {
@@ -1894,10 +1907,13 @@ fn compileFunctionRAWithGlobalOffsets(
     const frame_size: u32 = if (callee_save_count % 2 == 0) aligned else aligned | 8;
     try code.emitPrologue(frame_size);
 
-    // Save memory base (VMContext) from first ABI register to [rbp - 8]
-    // The runtime passes the linear memory base pointer as a hidden first parameter.
+    // VMContext is pinned in rbx for the whole function body (issue
+    // #465). The slot at `[rbp - 8]` remains structurally reserved
+    // (locals start at `[rbp - 16]`) but is no longer initialized —
+    // every reload site reads `rbx` directly. The `push rbx` below
+    // (always emitted because `used_callee_saved[0]` is forced true)
+    // preserves the caller's rbx before we overwrite it.
     const vmctx_reg = param_regs[0]; // rcx on Win64, rdi on SysV
-    try code.movMemReg(.rbp, vmctx_offset, vmctx_reg);
 
     // Spill wasm parameters from ABI registers to stack frame slots.
     // Wasm params are shifted by 1 because the first ABI register is the VMContext.
@@ -1950,10 +1966,20 @@ fn compileFunctionRAWithGlobalOffsets(
     }
 
     // Save callee-saved registers used by this function.
-    // Win64: rsi, rdi, r12, r13. SysV: r12, r13.
+    // rbx is always pushed (pinned vmctx, issue #465). Win64: rsi, rdi,
+    // r12..r15 if used. SysV: r12..r15 if used.
     for (callee_saved_alloc, 0..) |reg, i| {
         if (used_callee_saved[i]) try code.pushReg(reg);
     }
+
+    // Capture vmctx into rbx (pinned for the whole function body).
+    // `vmctx_reg` (param_regs[0] = rdi on SysV / rcx on Win64) still
+    // holds the runtime-supplied VmCtx*: param_regs[0] is never
+    // overwritten by the param-spill loop above (which copies
+    // param_regs[1..]) nor by the zero-locals / HRP setup (both use
+    // rax). Doing the move AFTER `push rbx` preserves the caller's
+    // rbx in the slot reserved by the push.
+    try code.movRegReg(.rbx, vmctx_reg);
 
     var block_offsets = std.AutoHashMap(ir.BlockId, usize).init(allocator);
     defer block_offsets.deinit();
@@ -2054,7 +2080,7 @@ fn emitStaticBulkMemBoundsCheck(
     addr: ir.VReg,
     len: u8,
 ) !void {
-    try code.movRegMem(.r10, .rbp, vmctx_offset);
+    try code.movRegReg(.r10, .rbx);
     try loadWasmU32Addr(code, alloc_result, addr, .rax);
     try emitMemBoundsCheck(code, len);
 }
@@ -2121,7 +2147,7 @@ fn emitSmallMemoryCopy(
     try emitStaticBulkMemBoundsCheck(code, alloc_result, src, len);
     if (len == 0) return;
 
-    try code.movRegMem(.r10, .rbp, vmctx_offset);
+    try code.movRegReg(.r10, .rbx);
     try loadWasmU32Addr(code, alloc_result, dst, .rax);
     try code.movRegMem(.r10, .r10, vmctx_membase_field);
     try code.addRegReg(.rax, .r10);
@@ -2149,7 +2175,7 @@ fn emitSmallMemoryFill(
     try emitStaticBulkMemBoundsCheck(code, alloc_result, dst, len);
     if (len == 0) return;
 
-    try code.movRegMem(.r10, .rbp, vmctx_offset);
+    try code.movRegReg(.r10, .rbx);
     try loadWasmU32Addr(code, alloc_result, dst, .rax);
     try code.movRegMem(.r10, .r10, vmctx_membase_field);
     try code.addRegReg(.rax, .r10);
@@ -2701,7 +2727,7 @@ fn compileInstRA(
                 // is in caller_saved_alloc, so it may hold an arg vreg that
                 // emitCallRegArgMoves must consume. Loading vmctx earlier would
                 // clobber that vreg.
-                try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+                try code.movRegReg(param_regs[0], .rbx);
                 if (has_hrp) {
                     const hrp_save_off: i32 = -@as(i32, @intCast((local_count + 2) * 8));
                     const hrp_dst = param_regs[1 + n_args];
@@ -2729,7 +2755,7 @@ fn compileInstRA(
                 // rdi is in caller_saved_alloc and may hold an arg vreg that
                 // emitCallRegArgMoves below consumes. We load vmctx → rdi
                 // only after all arg setup is complete.
-                try code.movRegMem(.r10, .rbp, vmctx_offset);
+                try code.movRegReg(.r10, .rbx);
                 try code.movRegMem(.r10, .r10, vmctx_host_functions_field);
                 if (cl.func_idx > 0) {
                     try code.addRegImm32(.r10, @intCast(@as(u32, cl.func_idx) * 8));
@@ -2743,7 +2769,7 @@ fn compileInstRA(
                     try code.movMemReg(.rsp, @intCast(shadow + j * 8), arg_reg);
                 }
                 try emitCallRegArgMoves(code, alloc_result, cl.args, max_reg_args);
-                try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+                try code.movRegReg(param_regs[0], .rbx);
                 if (has_hrp) {
                     if (hrp_in_reg) {
                         const hrp_dst = param_regs[1 + n_args];
@@ -2769,7 +2795,7 @@ fn compileInstRA(
                 // on SysV) is in caller_saved_alloc, so an arg vreg may be live in
                 // rdi at the call (e.g. arg 2 of a 3-arg call). Loading vmctx into
                 // rdi before emitCallRegArgMoves would clobber that vreg.
-                try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+                try code.movRegReg(param_regs[0], .rbx);
                 if (has_hrp) {
                     if (hrp_in_reg) {
                         const hrp_dst = param_regs[1 + n_args];
@@ -2822,7 +2848,7 @@ fn compileInstRA(
             // Load vmctx into r10. For table 0 we use the fast path that
             // reads vmctx.func_table_ptr/len directly. For higher-numbered
             // tables we go through vmctx.tables_info_ptr[table_idx].
-            try code.movRegMem(.r10, .rbp, vmctx_offset);
+            try code.movRegReg(.r10, .rbx);
 
             if (ci.table_idx == 0) {
                 // cmp eax, dword ptr [r10 + func_table_len]
@@ -2913,7 +2939,7 @@ fn compileInstRA(
             // Load vmctx into param_regs[0] AFTER arg setup: rdi (param_regs[0] on
             // SysV) is in caller_saved_alloc, so it may hold an arg vreg consumed
             // by emitCallRegArgMoves. Loading vmctx earlier would clobber it.
-            try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+            try code.movRegReg(param_regs[0], .rbx);
             if (has_hrp) {
                 if (hrp_in_reg) {
                     const hrp_dst = param_regs[1 + n_args];
@@ -2970,7 +2996,7 @@ fn compileInstRA(
 
             // Null check: if r11 == 0, trap via trap_unreachable_fn.
             // Load vmctx into r10 first so the trap call has it handy.
-            try code.movRegMem(.r10, .rbp, vmctx_offset);
+            try code.movRegReg(.r10, .rbx);
             // test r11, r11  → 0x4D 0x85 0xDB
             try code.emitSlice(&.{ 0x4D, 0x85, 0xDB });
             // jne over_trap (rel8). Trap block is 3 + 7 + 2 = 12 bytes.
@@ -3007,7 +3033,7 @@ fn compileInstRA(
             // Load vmctx into param_regs[0] AFTER arg setup: rdi (param_regs[0] on
             // SysV) is in caller_saved_alloc, so it may hold an arg vreg consumed
             // by emitCallRegArgMoves. Loading vmctx earlier would clobber it.
-            try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+            try code.movRegReg(param_regs[0], .rbx);
             if (has_hrp) {
                 if (hrp_in_reg) {
                     const hrp_dst = param_regs[1 + n_args];
@@ -3073,7 +3099,7 @@ fn compileInstRA(
             // Bounds check is inserted between vmctx load and mem_base load so
             // the check can read VmCtx.memory_size while r10 still holds the
             // VmCtx pointer.
-            try code.movRegMem(.r10, .rbp, vmctx_offset); // load VmCtx*
+            try code.movRegReg(.r10, .rbx); // load VmCtx*
             const base_reg = try useVReg(code, alloc_result, ld.base, .rax);
             if (base_reg != .rax) try code.movRegReg(.rax, base_reg);
             try code.zeroExtend32(.rax); // wasm addresses are i32
@@ -3118,7 +3144,7 @@ fn compileInstRA(
             // Bounds check is inserted between vmctx load and mem_base load so
             // the check can read VmCtx.memory_size while r10 still holds the
             // VmCtx pointer.
-            try code.movRegMem(.r10, .rbp, vmctx_offset); // load VmCtx*
+            try code.movRegReg(.r10, .rbx); // load VmCtx*
             // Compute final address in rax (not allocatable — safe to clobber).
             const base_reg = try useVReg(code, alloc_result, st.base, .rax);
             if (base_reg != .rax) try code.movRegReg(.rax, base_reg);
@@ -3159,7 +3185,7 @@ fn compileInstRA(
             try code.zeroExtend32(param_regs[2]);
             try code.zeroExtend32(param_regs[3]);
             // Load vmctx + helper fn pointer (uses rax + param_regs[0]).
-            try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+            try code.movRegReg(param_regs[0], .rbx);
             try code.movRegMem(.rax, param_regs[0], vmctx_mem_copy_fn_field);
 
             const shadow: u32 = if (comptime builtin.os.tag == .windows) 32 else 0;
@@ -3176,7 +3202,7 @@ fn compileInstRA(
             // REP STOSB: rdi=dst, al=val, rcx=len
             //
             // Bounds check semantics (wasm spec): trap if dst + len > mem_size.
-            try code.movRegMem(.r10, .rbp, vmctx_offset); // load VmCtx*
+            try code.movRegReg(.r10, .rbx); // load VmCtx*
             const len_reg = try useVReg(code, alloc_result, mf.len, .rcx);
             if (len_reg != .rcx) try code.movRegReg(.rcx, len_reg);
             try code.zeroExtend32(.rcx); // wasm lengths are u32
@@ -3200,7 +3226,7 @@ fn compileInstRA(
             const dest = inst.dest orelse return;
             const dr = destReg(alloc_result, dest);
             // Read current page count from VmCtx
-            try code.movRegMem(.r10, .rbp, vmctx_offset);
+            try code.movRegReg(.r10, .rbx);
             try code.movRegMemNoRex(dr, .r10, vmctx_mem_pages_field);
             // 32-bit load already zero-extends
             try writeDef(code, alloc_result, dest, dr);
@@ -3219,7 +3245,7 @@ fn compileInstRA(
             try code.zeroExtend32(arg_pages);
 
             // Load vmctx into param_regs[0].
-            try code.movRegMem(arg_vmctx, .rbp, vmctx_offset);
+            try code.movRegReg(arg_vmctx, .rbx);
             // Load grow helper pointer into rax.
             try code.movRegMem(.rax, arg_vmctx, vmctx_mem_grow_fn_field);
 
@@ -3283,7 +3309,7 @@ fn compileInstRA(
             try code.movRegImm64(arg_packed_st_reg, packed_st);
 
             // vmctx into param_regs[0]; helper ptr into rax.
-            try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+            try code.movRegReg(param_regs[0], .rbx);
             try code.movRegMem(.rax, param_regs[0], vmctx_table_init_fn_field);
 
             const shadow: u32 = if (comptime builtin.os.tag == .windows) 32 else 0;
@@ -3297,7 +3323,7 @@ fn compileInstRA(
             //   Win64: rcx=vmctx, rdx=seg_idx
             //   SysV:  rdi=vmctx, rsi=seg_idx
             try code.movRegImm32(param_regs[1], @bitCast(seg_idx));
-            try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+            try code.movRegReg(param_regs[0], .rbx);
             try code.movRegMem(.rax, param_regs[0], vmctx_elem_drop_fn_field);
 
             const shadow: u32 = if (comptime builtin.os.tag == .windows) 32 else 0;
@@ -3312,7 +3338,7 @@ fn compileInstRA(
             const dest = inst.dest orelse return;
             const dr = destReg(alloc_result, dest);
             // r10 = vmctx.tables_info_ptr; read len (u32) from slot [table_idx].
-            try code.movRegMem(.r10, .rbp, vmctx_offset);
+            try code.movRegReg(.r10, .rbx);
             try code.movRegMem(.r10, .r10, vmctx_tables_info_field);
             const len_off: i32 = @as(i32, @intCast(table_idx)) * table_info_stride + table_info_len_off;
             try code.movRegMemNoRex(dr, .r10, len_off);
@@ -3327,7 +3353,7 @@ fn compileInstRA(
             try code.zeroExtend32(.rax);
 
             // r10 = vmctx.tables_info_ptr.
-            try code.movRegMem(.r10, .rbp, vmctx_offset);
+            try code.movRegReg(.r10, .rbx);
             try code.movRegMem(.r10, .r10, vmctx_tables_info_field);
 
             // cmp eax, [r10 + table_idx*16 + 8]   (table len, u32)
@@ -3374,7 +3400,7 @@ fn compileInstRA(
                 try code.movRegReg(.rdx, .rax);
                 try code.movRegImm32(.rsi, @bitCast(ts.table_idx));
             }
-            try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+            try code.movRegReg(param_regs[0], .rbx);
             try code.movRegMem(.rax, param_regs[0], vmctx_table_set_fn_field);
             const shadow: u32 = if (comptime builtin.os.tag == .windows) 32 else 0;
             const stack_adjust: u32 = (shadow + 15) & ~@as(u32, 15);
@@ -3385,7 +3411,7 @@ fn compileInstRA(
         .ref_func => |fidx| {
             const dest = inst.dest orelse return;
             // Load funcptrs array, then [funcptrs + fidx*8].
-            try code.movRegMem(.r10, .rbp, vmctx_offset);
+            try code.movRegReg(.r10, .rbx);
             try code.movRegMem(.r10, .r10, vmctx_funcptrs_field);
             const dr = destReg(alloc_result, dest);
             try code.movRegMem(dr, .r10, @as(i32, @intCast(fidx * 8)));
@@ -3417,7 +3443,7 @@ fn compileInstRA(
             }
 
             // Load vmctx into param_regs[0] and grow fn ptr into rax.
-            try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+            try code.movRegReg(param_regs[0], .rbx);
             try code.movRegMem(.rax, param_regs[0], vmctx_table_grow_fn_field);
 
             const shadow: u32 = if (comptime builtin.os.tag == .windows) 32 else 0;
@@ -3713,14 +3739,14 @@ fn compileInstRA(
             const dest = inst.dest orelse return;
             const dr = destReg(alloc_result, dest);
             // Load globals_base from VmCtx, then load global value
-            try code.movRegMem(.r10, .rbp, vmctx_offset); // VmCtx*
+            try code.movRegReg(.r10, .rbx); // VmCtx*
             try code.movRegMem(.r10, .r10, vmctx_globals_field); // globals_base
             try code.movRegMem(dr, .r10, try globalByteOffset(global_offsets, idx)); // global[idx]
             try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
         .global_set => |gs| {
             const val_reg = try useVReg(code, alloc_result, gs.val, .rax);
-            try code.movRegMem(.r10, .rbp, vmctx_offset); // VmCtx*
+            try code.movRegReg(.r10, .rbx); // VmCtx*
             try code.movRegMem(.r10, .r10, vmctx_globals_field); // globals_base
             try code.movMemReg(.r10, try globalByteOffset(global_offsets, gs.idx), val_reg); // global[idx] = val
         },
@@ -4447,7 +4473,7 @@ fn compileInstRA(
                 try code.movRegReg(.rdx, .rax); // count
                 try code.movRegReg(.rsi, .rcx); // addr
             }
-            try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+            try code.movRegReg(param_regs[0], .rbx);
             try code.movRegMem(.rax, param_regs[0], vmctx_futex_notify_fn_field);
             const shadow: u32 = if (comptime builtin.os.tag == .windows) 32 else 0;
             const stack_adjust: u32 = (shadow + 15) & ~@as(u32, 15);
@@ -4474,7 +4500,7 @@ fn compileInstRA(
             if (timeout_reg != .rcx) try code.movRegReg(.rcx, timeout_reg);
 
             // Set up ABI args and call the appropriate helper
-            try code.movRegMem(param_regs[0], .rbp, vmctx_offset);
+            try code.movRegReg(param_regs[0], .rbx);
 
             if (aw.size == 4) {
                 if (comptime builtin.os.tag == .windows) {
@@ -4946,6 +4972,47 @@ test "compileFunctionRA: iconst_32 + ret" {
 
     try std.testing.expect(code.len > 5);
     try std.testing.expectEqual(@as(u8, 0xC3), code[code.len - 1]);
+}
+
+test "compileFunctionRA: prologue pins vmctx in rbx (issue #465)" {
+    // Every function's prologue must (a) `push rbx` (preserve the
+    // caller's rbx, since x86-64 callee-saved discipline requires it)
+    // and (b) `mov rbx, param_regs[0]` (capture vmctx). The two
+    // instructions must appear together in the prologue.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v0 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // `push rbx` = 0x53 (single byte, low-8 register, no REX prefix).
+    const push_rbx: u8 = 0x53;
+    // `mov rbx, param_regs[0]`:
+    //   SysV:  rdi → rbx → REX.W 0x48, MOV opcode 0x89, ModR/M 0xFB
+    //          (mod=11, reg=rdi=7, r/m=rbx=3) = 48 89 FB.
+    //   Win64: rcx → rbx → REX.W 0x48, opcode 0x89, ModR/M 0xCB
+    //          (mod=11, reg=rcx=1, r/m=rbx=3) = 48 89 CB.
+    const mov_rbx: [3]u8 = if (builtin.os.tag == .windows)
+        .{ 0x48, 0x89, 0xCB }
+    else
+        .{ 0x48, 0x89, 0xFB };
+
+    const idx_mov = std.mem.indexOf(u8, code, &mov_rbx) orelse
+        return error.TestExpectedMovRbxFromParam0;
+    // The `push rbx` byte must appear earlier in the prologue.
+    const prologue = code[0..idx_mov];
+    const idx_push = std.mem.indexOfScalar(u8, prologue, push_rbx) orelse
+        return error.TestExpectedPushRbxBeforeMov;
+    try std.testing.expect(idx_push < idx_mov);
 }
 
 test "compileFunctionRA: add two constants" {
@@ -6011,12 +6078,17 @@ test "emitCallRegArgMoves: regression — arg[1] source equals arg[0] target (co
     }
 }
 
-test "compileModule: regression #406 — vmctx → rdi load deferred past arg moves at call (SysV)" {
+test "compileModule: regression #406 — vmctx → rdi setup deferred past arg moves at call (SysV)" {
     // Issue #406: when an arg vreg is bound to rdi at a call site, the
-    // call-site `mov rdi, [rbp-vmctx_offset]` must be emitted AFTER
+    // call-site vmctx setup into rdi must be emitted AFTER
     // emitCallRegArgMoves. The buggy order clobbered the arg vreg with
     // vmctx before the parallel-move algorithm read it; the parallel move
     // then propagated vmctx into the wrong arg register.
+    //
+    // With the pinned-vmctx change (issue #465) the setup is now
+    // `mov rdi, rbx` (rbx holds vmctx for the whole function body)
+    // rather than `mov rdi, [rbp - 8]`, but the ordering invariant
+    // still applies.
     //
     // On Win64 rdi/rsi are not parameter registers, so the bug is
     // SysV-specific.
@@ -6069,19 +6141,19 @@ test "compileModule: regression #406 — vmctx → rdi load deferred past arg mo
     const idx_call = std.mem.lastIndexOfScalar(u8, caller_code, 0xE8) orelse
         return error.TestExpectedCallEmitted;
 
-    // The vmctx → rdi load is `mov rdi, [rbp-8]` encoded as the disp32 form
-    // movRegMem always emits: REX.W (0x48), opcode 0x8B, ModR/M=0xBD
-    // (mod=10, reg=rdi=7, r/m=rbp=5), disp32 = 0xFFFFFFF8.
-    const vmctx_load: [7]u8 = .{ 0x48, 0x8B, 0xBD, 0xF8, 0xFF, 0xFF, 0xFF };
-    const idx_vmctx = std.mem.lastIndexOf(u8, caller_code[0..idx_call], &vmctx_load) orelse
-        return error.TestExpectedVmctxLoadBeforeCall;
+    // The vmctx → rdi setup is now `mov rdi, rbx`. Encoding:
+    //   REX.W (0x48), opcode 0x89 (MOV r/m64, r64), ModR/M = 0xDF
+    //   (mod=11 reg-reg, reg=rbx=3, r/m=rdi=7).
+    const vmctx_setup: [3]u8 = .{ 0x48, 0x89, 0xDF };
+    const idx_vmctx = std.mem.lastIndexOf(u8, caller_code[0..idx_call], &vmctx_setup) orelse
+        return error.TestExpectedVmctxSetupBeforeCall;
 
-    // After the fix, the vmctx load is the LAST emit before HRP setup +
+    // After the fix, the vmctx setup is the LAST emit before HRP setup +
     // CALL. Crucially, no `mov dst, rdi` (reading rdi as source via
     // REX.W 0x89 with ModR/M reg-field = 7, mod = 11) may appear between
-    // vmctx_load and the CALL — such a move would propagate vmctx (not
+    // vmctx_setup and the CALL — such a move would propagate vmctx (not
     // the original arg vreg) into the destination register.
-    const tail = caller_code[idx_vmctx + vmctx_load.len .. idx_call];
+    const tail = caller_code[idx_vmctx + vmctx_setup.len .. idx_call];
     var i: usize = 0;
     while (i + 2 < tail.len) : (i += 1) {
         // REX.W only (0x48): mov reg64, reg64 with both reg and r/m in
@@ -6093,7 +6165,7 @@ test "compileModule: regression #406 — vmctx → rdi load deferred past arg mo
             const mod = (modrm >> 6) & 0x3;
             const reg_field = (modrm >> 3) & 0x7;
             if (mod == 0b11 and reg_field == 7) {
-                // Found `mov ?, rdi` between vmctx load and CALL — bug shape.
+                // Found `mov ?, rdi` between vmctx setup and CALL — bug shape.
                 return error.TestVmctxLoadClobbersArgVreg;
             }
         }


### PR DESCRIPTION
Closes #465. Tracking: #393.

## What

Reserve a callee-saved GPR per architecture as the pinned `VmCtx*` for the whole function body, eliminating dozens of redundant fp/rbp-relative reloads in hot wasm functions:

| Arch    | Pinned reg | Replaces                |
| ------- | ---------- | ----------------------- |
| aarch64 | x19        | `ldr Xn, [fp + 16]`     |
| x86_64  | rbx        | `mov Rn, [rbp - 8]`     |

Both registers are AAPCS64 / SysV+Win64 callee-saved, so calls (host helpers, trap helpers, cross-function wasm calls) preserve them without a save/restore at the call site.

## Disassembly proof

`core_state_transition` (28 % of CoreMark) — every former `ldr x16, [x29, #16]` is now `mov x16, x19`:

```
   c4:  mov  x16, x19          ; was: ldr x16, [x29, #16]
   c8:  ldr  x16, [x16, #8]    ; vmctx.memory_size for bounds check
   d4:  mov  x0,  x19          ; was: ldr x0,  [x29, #16]
   d8:  ldr  x16, [x0, #80]    ; vmctx.trap_oob_fn
   e4:  mov  x16, x19          ; was: ldr x16, [x29, #16]
   e8:  ldr  x16, [x16]        ; vmctx.memory_base
```

7+ memory loads → register moves per hot loop iteration on the issue's exact pattern.

## Measured impact (aarch64 D16pds_v6, native)

| Workload                | Baseline   | Pinned vmctx | Δ        |
| ----------------------- | ---------- | ------------ | -------- |
| `coremark_wasi.wasm`    | 8132 i/s   | 8500 i/s     | **+4.4 %** |
| `coremark_wasi_nofp`    | 8461 i/s   | 9166 i/s     | **+8.3 %** |

x86_64 numbers from this aarch64 host go through QEMU TCG (a slow emulator with non-representative perf characteristics) — real x86_64 CI will be the authoritative answer.

## Mechanics (recap of commit body)

### aarch64

- Drop `x19` from `RegMap.scratch_regs`, `aarch64_alloc_regs`, `aarch64_callee_saved_indices`.
- `RegMap.init` forces `used_callee_mask` bit 0 so `STR x19` is never NOP-patched in the prologue.
- Prologue emits `mov x19, x0` after the callee-save STRs.
- Drop the dead `str x0, [fp + 16]` in `emitEntrySpill` (the slot itself is retained so locals/HRP don't shift).
- Rewrite 26 reload sites: `ldrImm(reg, .fp, vmctx_slot_offset / 8)` → `movRegReg(reg, .x19)`.

### x86_64

- Drop `rbx` (phys 3) from `x86_64_alloc_regs` and renumber `x86_64_callee_saved_indices`.
- Force `used_callee_saved[0] = true` so the prologue always emits `push rbx` first (and matching `pop rbx` last in every epilogue: `.ret`, `.ret_multi`, `.br_table`, both `.br_if` branches).
- Drop the dead `mov [rbp - 8], vmctx_reg` store.
- Emit `mov rbx, param_regs[0]` immediately after the push loop (param_regs[0] is never overwritten by param spills / zero-locals / HRP setup).
- Rewrite 30 reload sites: `movRegMem(reg, .rbp, vmctx_offset)` → `movRegReg(reg, .rbx)`.

## Tests

- aarch64 entry-prologue test updated to assert `ORR x19, xzr, x0` (= `0xAA0003F3`) appears at the same offset where `STR X0, [FP, #16]` used to live.
- New x86_64 `compileFunctionRA` test asserts `push rbx` (0x53) earlier than `mov rbx, param_regs[0]` (SysV: `48 89 FB` / Win64: `48 89 CB`).
- Issue #406 regression test (vmctx-into-rdi clobber order) retargeted to look for `mov rdi, rbx` (`48 89 DF`) instead of the former 7-byte memory load. Ordering invariant (vmctx setup must follow arg moves) is preserved.

## Acceptance criteria

1. `zig build test` — ✅ green on aarch64 native (1437/1437); x86_64 cross-compile + qemu also 1437/1437 (two pre-existing flake leaks in `wasi.thread_manager` integration test reproduce on baseline; cold-start budget test flakes under qemu).
2. `zig build coremark-aot` — ✅ aarch64: +4.4 % and +8.3 %. x86_64 deferred to CI.
3. `zig build spec-tests-aot` — pass rate unchanged (both baseline and this branch abort at `linking.json` line 592 — pre-existing unrelated bug).
4. New regression test in the aarch64 codegen asserts the pinned-vmctx prologue invariant; an analogous test exists for x86_64.

## Risk: register pressure

This drops the allocatable GPR pool from 10 → 9 on x86_64 and 25 → 24 on aarch64. aarch64 has plenty of headroom; x86_64 is more sensitive (per the existing `regalloc.zig` tuning note in the codebase about a 15→14 reg change costing −7.86 %). If CI on real x86_64 hardware shows a perf regression beyond the gate, a follow-up to gate pinning on functions that actually touch `vmctx` (almost all of them do) is straightforward.