### PR TITLE
perf(codegen): pin memory_base in a callee-saved register (#466)

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -40,16 +40,22 @@ const RegMap = struct {
     // callee-saved, calls (to wasm helpers, trap helpers, host
     // functions) preserve it without a save/restore at the call site.
     //
-    // X20–X28 are AAPCS64 callee-saved and appended after the caller-
+    // X20 is reserved as the pinned `memory_base` register (issue
+    // #466). The prologue loads `[x19 + 0]` (= VmCtx.memory_base) into
+    // x20 once, and every linear-memory access reads x20 directly
+    // instead of rematerialising the base. memory.grow and every wasm
+    // call site emit a reload `ldr x20, [x19, #0]` because either op
+    // can invalidate the cached base.
+    //
+    // X21–X28 are AAPCS64 callee-saved and appended after the caller-
     // saved block. They survive calls (no save around BL), trading one
     // extra STR/LDR pair per function per reg that the body allocates.
     pub const caller_saved_count: usize = 15;
     pub const scratch_regs = [_]emit.Reg{
         .x0,  .x1,  .x2,  .x3,  .x4,  .x5,  .x6,  .x7,
         .x8,  .x9,  .x10, .x11, .x12, .x13, .x14,
-        // Callee-saved (x19 is pinned to vmctx, not allocatable):
-        .x20, .x21, .x22, .x23, .x24, .x25, .x26, .x27,
-        .x28,
+        // Callee-saved (x19 is pinned to vmctx, x20 to memory_base; neither allocatable):
+        .x21, .x22, .x23, .x24, .x25, .x26, .x27, .x28,
     };
 
     /// Non-allocatable scratch registers usable by any handler.
@@ -82,12 +88,14 @@ const RegMap = struct {
             .entries = std.AutoHashMap(ir.VReg, Location).init(allocator),
             .spill_base = spill_base,
             .spill_capacity = spill_capacity,
-            // x19 is permanently pinned to vmctx (issue #465). Mark it
-            // as used in `used_callee_mask` (bit 0) so the prologue STR
-            // / epilogue LDR for x19 is never NOP-patched. The prologue
-            // STR happens BEFORE we clobber x19 with x0, so the
-            // caller's x19 is correctly preserved across our frame.
-            .used_callee_mask = 1,
+            // x19 (vmctx, issue #465) and x20 (memory_base, issue #466)
+            // are permanently pinned. Mark both as used in
+            // `used_callee_mask` (bits 0 and 1) so the prologue STR /
+            // epilogue LDR pair for each is never NOP-patched. The
+            // prologue STRs happen BEFORE we clobber x19/x20 with their
+            // pinned values, so each caller's value is correctly
+            // preserved across our frame.
+            .used_callee_mask = 0b11,
         };
     }
 
@@ -106,17 +114,23 @@ const RegMap = struct {
                 switch (a) {
                     .reg => |r| {
                         // `r` is the aarch64 register NUMBER (0..14 or
-                        // 20..28; x19 is excluded — pinned to vmctx).
+                        // 21..28; x19 is excluded — pinned to vmctx —
+                        // and x20 is excluded — pinned to memory_base).
                         // Find its index in `scratch_regs` to update
                         // `reg_used` / `used_callee_mask`. After
                         // skipping x15..x18 (4 non-allocatable) plus
-                        // x19 (pinned), reg_num N >= 20 maps to
-                        // scratch_regs index N - 5.
+                        // x19+x20 (pinned), reg_num N >= 21 maps to
+                        // scratch_regs index N - 6.
                         const reg_num: u32 = @intCast(r);
-                        const idx: usize = if (reg_num <= 14) reg_num else reg_num - 5;
+                        const idx: usize = if (reg_num <= 14) reg_num else reg_num - 6;
                         self.reg_used[idx] = true;
                         if (idx >= caller_saved_count) {
-                            self.used_callee_mask |= (@as(u16, 1) << @intCast(idx - caller_saved_count + 1));
+                            // scratch_regs callee-saved tail starts at
+                            // x21 (idx 15). callee_saved_regs (the array
+                            // used for prologue STR/LDR, still
+                            // [.x19..x28]) has x21 at index 2, so the
+                            // mask bit is (idx - caller_saved_count) + 2.
+                            self.used_callee_mask |= (@as(u16, 1) << @intCast(idx - caller_saved_count + 2));
                         }
                         const loc = Location{ .reg = scratch_regs[idx] };
                         try self.entries.put(vreg, loc);
@@ -142,11 +156,11 @@ const RegMap = struct {
             if (!self.reg_used[i]) {
                 self.reg_used[i] = true;
                 if (i >= caller_saved_count) {
-                    // scratch_regs callee-saved tail starts at x20 (x19
-                    // is pinned to vmctx). callee_saved_regs (used for
+                    // scratch_regs callee-saved tail starts at x21 (x19
+                    // and x20 are pinned). callee_saved_regs (used for
                     // prologue STR/LDR) still starts at x19 at bit 0,
-                    // so x20 occupies bit 1.
-                    self.used_callee_mask |= (@as(u16, 1) << @intCast(i - caller_saved_count + 1));
+                    // so x21 occupies bit 2.
+                    self.used_callee_mask |= (@as(u16, 1) << @intCast(i - caller_saved_count + 2));
                 }
                 const loc = Location{ .reg = r };
                 try self.entries.put(vreg, loc);
@@ -1370,6 +1384,15 @@ pub fn compileFunctionImpl(
     // a `mov Xd, x19` (or a `mov x0, x19` when staging arg0 for a
     // helper / cross-function call).
     try code.movRegReg(.x19, .x0);
+
+    // Pin VmCtx.memory_base in callee-saved x20 for the whole function
+    // body (issue #466). The preceding callee-save STR preserved the
+    // caller's x20, and `RegMap.init` forces x20's bit in
+    // `used_callee_mask`. Every linear-memory access reads `x20`
+    // directly instead of rematerialising via
+    // `mov tmp, x19; ldr tmp, [tmp]`. `memory.grow` and every wasm
+    // call emit `ldr x20, [x19, #0]` afterward to refresh the base.
+    try code.ldrImm(.x20, .x19, 0);
 
     // Spill VMContext (x0) and wasm params (x1..x7) to their frame slots.
     try emitEntrySpill(&code, func.*, local_layout.offsets, fctx.local_types, hrp_save_off, frame_size, allocator);
@@ -5671,6 +5694,14 @@ fn emitCall(
     }
     if (abi.stack_size > 0) try emitSpAdjust(code, abi.stack_size, .add);
 
+    // Refresh the pinned memory_base in x20 (issue #466). The callee
+    // may have invoked `memory.grow`, which reallocs the wasm linear
+    // memory and updates `[vmctx + 0]`. The callee's callee-save
+    // discipline restored *our* (pre-call) x20 in its epilogue, so the
+    // value we hold is stale; reload from the now-current
+    // `[vmctx + 0]`.
+    try code.ldrImm(.x20, .x19, 0);
+
     // Commit result (in x0 or q0) to dest's location BEFORE restoring saved regs,
     // so restoration can't clobber the result holder (dest.reg is always a
     // reg that was FREE at snapshot time — i.e. not in `used_snapshot`).
@@ -5741,9 +5772,9 @@ fn emitMemAddrImpl(
             try code.addRegReg(RegMap.tmp1, RegMap.tmp1, RegMap.tmp2);
         }
 
-        // Step 3: load VmCtx.memory_size (at +8, scaled-by-8 offset = 1).
-        try code.movRegReg(RegMap.tmp0, .x19);
-        try code.ldrImm(RegMap.tmp0, RegMap.tmp0, 1);
+        // Step 3: load VmCtx.memory_size (at +8, scaled-by-8 offset = 1)
+        // directly from the pinned vmctx in x19.
+        try code.ldrImm(RegMap.tmp0, .x19, vmctx_memsize_slot);
 
         // Step 4: cmp end, mem_size; B.LS over_trap.
         try code.cmpRegReg(RegMap.tmp1, RegMap.tmp0);
@@ -5768,14 +5799,10 @@ fn emitMemAddrImpl(
         code.patch32(over_patch, new_word);
     }
 
-    // Step 5: load mem_base into tmp0.
-    try code.movRegReg(RegMap.tmp0, .x19);
-    try code.ldrImm(RegMap.tmp0, RegMap.tmp0, 0);
+    // Step 5: ea = mem_base (pinned x20, issue #466) + zext(wasm_addr).
+    try code.addRegReg(RegMap.tmp0, .x20, RegMap.tmp2);
 
-    // Step 6: tmp0 = mem_base + zext(wasm_addr).
-    try code.addRegReg(RegMap.tmp0, RegMap.tmp0, RegMap.tmp2);
-
-    // Step 7: fold constant offset.
+    // Step 6: fold constant offset.
     if (offset != 0) {
         if (offset <= 0xFFF) {
             try code.addImm(RegMap.tmp0, RegMap.tmp0, @intCast(offset));
@@ -5954,6 +5981,10 @@ fn emitMemoryGrow(
 ) !void {
     const args = [_]ir.VReg{pages_vreg};
     try emitVmctxHelperCall(code, &args, vmctx_mem_grow_fn_slot, reg_map, fctx, inst.dest);
+    // mem_grow_fn may realloc the wasm linear memory and invalidate the
+    // pinned memory_base in x20 (issue #466). Refresh from
+    // [vmctx + 0] now so subsequent memory accesses see the new base.
+    try code.ldrImm(.x20, .x19, 0);
 }
 
 fn emitMemoryFill(
@@ -6375,6 +6406,11 @@ fn emitCallIndirect(
     try code.blr(RegMap.tmp0);
     if (abi.stack_size > 0) try emitSpAdjust(code, abi.stack_size, .add);
 
+    // Refresh pinned memory_base in x20 (issue #466) — the called
+    // function may have invoked `memory.grow`; see emitCall for
+    // rationale.
+    try code.ldrImm(.x20, .x19, 0);
+
     try emitCapturePrimaryCallResult(code, inst, reg_map, v128_map, v128_cache);
 
     for (used_snapshot, 0..) |used, i| {
@@ -6455,6 +6491,11 @@ fn emitCallRef(
     try code.movRegReg(.x0, .x19);
     try code.blr(RegMap.tmp0);
     if (abi.stack_size > 0) try emitSpAdjust(code, abi.stack_size, .add);
+
+    // Refresh pinned memory_base in x20 (issue #466) — the called
+    // function may have invoked `memory.grow`; see emitCall for
+    // rationale.
+    try code.ldrImm(.x20, .x19, 0);
 
     try emitCapturePrimaryCallResult(code, inst, reg_map, v128_map, v128_cache);
 
@@ -7471,13 +7512,14 @@ pub fn compileModuleWithOptions(
 /// Allocatable aarch64 GPRs, in stable index order used by clobber masks.
 ///
 /// Indices 0..14 map to x0..x14 (AAPCS64 caller-saved; x15 is reserved as
-/// a non-allocatable scratch `RegMap.tmp2`). Indices 15..23 map to
-/// x20..x28 (callee-saved). x16/x17 are `RegMap.tmp0/tmp1`, x18 is the
-/// platform register, x19 is pinned to `vmctx` for the function body
-/// (issue #465), x29/x30 are FP/LR, and x31 is SP — all excluded.
+/// a non-allocatable scratch `RegMap.tmp2`). Indices 15..22 map to
+/// x21..x28 (callee-saved). x16/x17 are `RegMap.tmp0/tmp1`, x18 is the
+/// platform register, x19 is pinned to `vmctx` (issue #465), x20 is
+/// pinned to `memory_base` (issue #466), x29/x30 are FP/LR, and x31 is
+/// SP — all excluded.
 pub const aarch64_alloc_regs = [_]regalloc.PhysReg{
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
-    20, 21, 22, 23, 24, 25, 26, 27, 28,
+    21, 22, 23, 24, 25, 26, 27, 28,
 };
 
 /// Indices into `aarch64_alloc_regs` of AAPCS64 caller-saved registers
@@ -7488,11 +7530,12 @@ pub const aarch64_caller_saved_indices = [_]u8{
 };
 
 /// Indices into `aarch64_alloc_regs` of AAPCS64 callee-saved registers
-/// (x20..x28). Preferred for live ranges that span a call, since they
-/// survive without save/restore. x19 is excluded — it is permanently
-/// pinned to `vmctx` for the whole function body (issue #465).
+/// (x21..x28). Preferred for live ranges that span a call, since they
+/// survive without save/restore. x19 is excluded — pinned to `vmctx`
+/// (issue #465). x20 is excluded — pinned to `memory_base` (issue
+/// #466).
 pub const aarch64_callee_saved_indices = [_]u8{
-    15, 16, 17, 18, 19, 20, 21, 22, 23,
+    15, 16, 17, 18, 19, 20, 21, 22,
 };
 
 /// Bitmask over `aarch64_alloc_regs` of registers destroyed by any
@@ -7687,9 +7730,10 @@ fn addCallArgScalarHints(
 }
 
 /// Emit a single `Hint` for `vreg` targeting AAPCS64 register `xN` if
-/// `xN` is allocatable in `aarch64_alloc_regs`. x0..x14 are; x15..x18
-/// and x19 (pinned to vmctx, issue #465) are not. The callee-saved
-/// x20..x28 are reachable but not used for ABI-fixed call-arg slots.
+/// `xN` is allocatable in `aarch64_alloc_regs`. x0..x14 are; x15..x18,
+/// x19 (pinned to vmctx, issue #465) and x20 (pinned to memory_base,
+/// issue #466) are not. The callee-saved x21..x28 are reachable but
+/// not used for ABI-fixed call-arg slots.
 fn appendArgRegHint(
     list: *std.ArrayList(regalloc.Hint),
     allocator: std.mem.Allocator,
@@ -8100,6 +8144,52 @@ test "compileFunction: memory.grow compiles" {
     const code = try compileFunction(&func, allocator);
     defer allocator.free(code);
     try std.testing.expect(code.len > 0);
+}
+
+test "compileFunction: memory.grow refreshes pinned x20 (issue #466)" {
+    // The helper call to mem_grow_fn can realloc the linear memory and
+    // invalidate x20's cached `[vmctx + 0]`. Codegen must emit a fresh
+    // LDR x20, [x19, #0] right after the grow call's BLR returns.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .memory_grow = v0 }, .dest = v1, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .ret = v1 } });
+    const code = try compileFunctionWithOptions(&func, allocator, .{ .enable_peephole = false });
+    defer allocator.free(code);
+
+    // BLR x16 (the indirect call through vmctx.mem_grow_fn) encodes as
+    //   1101011000111111000000 | Rn=10000 | 00000  → 0xD63F0200.
+    const blr_x16: u32 = 0xD63F0200;
+    var blr_off: ?usize = null;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if (w == blr_x16) {
+            blr_off = i;
+            // Don't break; we want the LAST blr — the mem_grow call
+            // happens after any earlier setup BLRs.
+        }
+    }
+    try std.testing.expect(blr_off != null);
+
+    // After the BLR, scan for LDR x20, [x19, #0]:
+    //   0xF9400000 | (imm12=0 << 10) | (Rn=19 << 5) | Rt=20 = 0xF9400274
+    const ldr_x20: u32 = 0xF9400274;
+    var saw_reload = false;
+    var j: usize = blr_off.? + 4;
+    while (j + 4 <= code.len) : (j += 4) {
+        const w = std.mem.readInt(u32, code[j..][0..4], .little);
+        if (w == ldr_x20) {
+            saw_reload = true;
+            break;
+        }
+    }
+    try std.testing.expect(saw_reload);
 }
 
 test "compileModule: records offsets" {
@@ -11797,10 +11887,11 @@ test "compile: br_if with two blocks" {
 
 // ── Phase 1b: VMContext ABI + locals tests ───────────────────────────────────
 
-test "compile: entry pins vmctx in x19 (issue #465)" {
+test "compile: entry pins vmctx in x19 and memory_base in x20 (issues #465 / #466)" {
     // Function with no params, no locals: prologue must copy x0 → x19
-    // after the 10 callee-save STRs (vmctx is pinned in x19 for the
-    // whole function body).
+    // and load `[x19 + 0]` → x20 after the 10 callee-save STRs
+    // (vmctx pinned in x19, memory_base pinned in x20 for the whole
+    // function body).
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -11811,11 +11902,17 @@ test "compile: entry pins vmctx in x19 (issue #465)" {
     const code = try compileFunctionWithOptions(&func, allocator, .{ .enable_peephole = false });
     defer allocator.free(code);
     // Layout: prologue (STP + ADD fp,sp,0 = 8 bytes), then 10 callee-save
-    // STRs for x19..x28 (40 bytes), then MOV x19, x0 (= ORR x19, xzr, x0).
-    //   encoding: 0xAA000000 | (rm=0 << 16) | (rn=31 << 5) | rd=19
+    // STRs for x19..x28 (40 bytes), then MOV x19, x0 (= ORR x19, xzr, x0),
+    // then LDR x20, [x19, #0] (memory_base pin).
+    //   MOV encoding: 0xAA000000 | (rm=0 << 16) | (rn=31 << 5) | rd=19
     //   = 0xAA000000 | 0x3E0 | 0x13 = 0xAA0003F3
     const mov_word = std.mem.readInt(u32, code[48..][0..4], .little);
     try std.testing.expectEqual(@as(u32, 0xAA0003F3), mov_word);
+    //   LDR encoding (LDR Xt, [Xn, #imm12*8]):
+    //     0xF9400000 | (imm12=0 << 10) | (rn=19 << 5) | rt=20
+    //     = 0xF9400000 | 0x260 | 0x14 = 0xF9400274
+    const ldr_word = std.mem.readInt(u32, code[52..][0..4], .little);
+    try std.testing.expectEqual(@as(u32, 0xF9400274), ldr_word);
 }
 
 test "compile: param spill — STR x1 into first local slot" {
@@ -11829,17 +11926,17 @@ test "compile: param spill — STR x1 into first local slot" {
     try func.getBlock(bid).append(.{ .op = .{ .ret = v0 } });
     const code = try compileFunctionWithOptions(&func, allocator, .{ .enable_peephole = false });
     defer allocator.free(code);
-    // Layout: STP, ADD fp,sp,0, 10× callee-save STRs (40 bytes), STR x0
-    // vmctx, STR x1 local0.
+    // Layout: STP, ADD fp,sp,0, 10× callee-save STRs (40 bytes), MOV x19, x0
+    // (#465 vmctx pin), LDR x20, [x19, #0] (#466 memory_base pin), STR x1 local0.
     //   STR x1, [fp, #24]: rt=1, rn=29, imm12=3
     //   = 0xF9000000 | (3<<10) | (29<<5) | 1 = 0xF9000FA1
-    const str_param = std.mem.readInt(u32, code[52..][0..4], .little);
+    const str_param = std.mem.readInt(u32, code[56..][0..4], .little);
     try std.testing.expectEqual(@as(u32, 0xF9000FA1), str_param);
 }
 
 test "compile: zero-init of declared local (beyond params)" {
-    // 0 params, 2 locals. After spilling x0 (vmctx), we MOVZ x16,#0 then
-    // STR x16 to both local slots.
+    // 0 params, 2 locals. After pinning vmctx + memory_base, we MOVZ x16,#0
+    // then STR x16 to both local slots.
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 2);
     defer func.deinit();
@@ -11855,14 +11952,17 @@ test "compile: zero-init of declared local (beyond params)" {
     //   [0]   STP FP, LR, [SP, #-frame_size]!
     //   [4]   MOV FP, SP
     //   [8]..[44] 10× callee-save STR (40 bytes)
-    //   [48]  STR x0 vmctx, [52] MOVZ x16, [56]/[60] STR x16 → locals.
-    const movz_word = std.mem.readInt(u32, code[52..][0..4], .little);
+    //   [48]  MOV x19, x0 (#465 vmctx pin)
+    //   [52]  LDR x20, [x19, #0] (#466 memory_base pin)
+    //   [56]  MOVZ x16, #0
+    //   [60]/[64]  STR x16 → locals
+    const movz_word = std.mem.readInt(u32, code[56..][0..4], .little);
     // MOVZ X16, #0, LSL #0 = 0xD2800000 | (0<<5) | 16 = 0xD2800010
     try std.testing.expectEqual(@as(u32, 0xD2800010), movz_word);
-    const str0 = std.mem.readInt(u32, code[56..][0..4], .little);
+    const str0 = std.mem.readInt(u32, code[60..][0..4], .little);
     // STR x16, [fp, #24]: rt=16, rn=29, imm12=3 → 0xF9000000|(3<<10)|(29<<5)|16
     try std.testing.expectEqual(@as(u32, 0xF9000FB0), str0);
-    const str1 = std.mem.readInt(u32, code[60..][0..4], .little);
+    const str1 = std.mem.readInt(u32, code[64..][0..4], .little);
     // STR x16, [fp, #32]: imm12=4 → 0xF9000000|(4<<10)|(29<<5)|16
     try std.testing.expectEqual(@as(u32, 0xF90013B0), str1);
 }
@@ -12743,11 +12843,12 @@ test "collectClobberPoints: positions are monotonic across blocks" {
 
 test "aarch64RegSet: sane layout for a tiny function" {
     const rs = aarch64RegSet(0);
-    // 24 allocatable GPRs, 15 caller-saved + 9 callee-saved (x19 is
-    // pinned to vmctx per issue #465 and not in the allocator pool).
-    try std.testing.expectEqual(@as(usize, 24), rs.alloc_regs.len);
+    // 23 allocatable GPRs, 15 caller-saved + 8 callee-saved (x19 is
+    // pinned to vmctx per issue #465 and x20 is pinned to memory_base
+    // per issue #466; neither is in the allocator pool).
+    try std.testing.expectEqual(@as(usize, 23), rs.alloc_regs.len);
     try std.testing.expectEqual(@as(usize, 15), rs.caller_saved_indices.len);
-    try std.testing.expectEqual(@as(usize, 9), rs.callee_saved_indices.len);
+    try std.testing.expectEqual(@as(usize, 8), rs.callee_saved_indices.len);
     // Spill stride grows upward (away from fp).
     try std.testing.expect(rs.spill_stride > 0);
     // Spills live above the locals area (saved fp/lr + vmctx + locals = 24 bytes min).

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1487,21 +1487,23 @@ const regalloc = @import("../../ir/regalloc.zig");
 const analysis = @import("../../ir/analysis.zig");
 
 /// x86-64 allocatable GPR set: rdx(2), rsi(6), rdi(7), r8(8), r9(9),
-/// r12(12), r13(13), r14(14), r15(15). `rbx`(3) is permanently pinned to
-/// `vmctx` for the function body (issue #465) and excluded from the
-/// allocator pool; the prologue copies `param_regs[0]` (rdi/rcx) into
-/// rbx once, and every site that previously reloaded vmctx from
-/// `[rbp - 8]` reads rbx directly.
+/// r12(12), r13(13), r14(14). `rbx`(3) is permanently pinned to
+/// `vmctx` for the function body (issue #465) and `r15`(15) is
+/// permanently pinned to `memory_base` (issue #466); both are excluded
+/// from the allocator pool. The prologue copies `param_regs[0]`
+/// (rdi/rcx) into rbx and loads `[rbx + 0]` into r15 once. Every
+/// linear-memory access reads r15 directly; every site that previously
+/// reloaded vmctx from `[rbp - 8]` reads rbx directly.
 ///
 /// `caller_saved_indices` / `callee_saved_indices` are stable indices
 /// into `alloc_regs` and match the bit positions used in clobber masks below.
-const x86_64_alloc_regs = [_]regalloc.PhysReg{ 2, 6, 7, 8, 9, 12, 13, 14, 15 };
+const x86_64_alloc_regs = [_]regalloc.PhysReg{ 2, 6, 7, 8, 9, 12, 13, 14 };
 
 /// Indices into `x86_64_alloc_regs` of callee-saved registers (same on
-/// Win64 and SysV): r12..r15 (idx 5..8). rbx is excluded — it is the
-/// pinned vmctx register and saved/restored unconditionally by the
-/// prologue/epilogue rather than by the allocator.
-const x86_64_callee_saved_indices = [_]u8{ 5, 6, 7, 8 };
+/// Win64 and SysV): r12..r14 (idx 5..7). rbx (vmctx, issue #465) and
+/// r15 (memory_base, issue #466) are excluded — both are saved/restored
+/// unconditionally by the prologue/epilogue rather than by the allocator.
+const x86_64_callee_saved_indices = [_]u8{ 5, 6, 7 };
 
 /// Indices into `x86_64_alloc_regs` of caller-saved registers, by ABI.
 /// On Win64: rdx, r8, r9. On SysV: add rsi, rdi.
@@ -1850,6 +1852,15 @@ fn compileFunctionRAWithGlobalOffsets(
     // preserve the caller's value) before the prologue copies vmctx
     // (`param_regs[0]`) into it.
     used_callee_saved[0] = true;
+    // r15 is permanently pinned to memory_base for the function body
+    // (issue #466). Locate it in `callee_saved_alloc` (Win64 index 6,
+    // SysV index 4) and force its slot on so the prologue / epilogue
+    // push-pop it around the body, and so the prologue's
+    // `mov r15, [rbx + 0]` load can rely on its caller value having
+    // been preserved.
+    inline for (callee_saved_alloc, 0..) |cs_reg, i| {
+        if (cs_reg == .r15) used_callee_saved[i] = true;
+    }
     {
         var it = alloc_result.assignments.iterator();
         while (it.next()) |entry| {
@@ -1980,6 +1991,14 @@ fn compileFunctionRAWithGlobalOffsets(
     // rax). Doing the move AFTER `push rbx` preserves the caller's
     // rbx in the slot reserved by the push.
     try code.movRegReg(.rbx, vmctx_reg);
+
+    // Pin VmCtx.memory_base in r15 for the whole function body
+    // (issue #466). `push r15` above preserved the caller's r15, so
+    // we can now overwrite it. Every linear-memory access reads r15
+    // directly instead of doing `mov r10, rbx; mov r10, [r10 + 0]`.
+    // memory.grow and every wasm call reload r15 from [rbx + 0]
+    // afterward because either can invalidate the cached base.
+    try code.movRegMem(.r15, .rbx, vmctx_membase_field);
 
     var block_offsets = std.AutoHashMap(ir.BlockId, usize).init(allocator);
     defer block_offsets.deinit();
@@ -2147,12 +2166,11 @@ fn emitSmallMemoryCopy(
     try emitStaticBulkMemBoundsCheck(code, alloc_result, src, len);
     if (len == 0) return;
 
-    try code.movRegReg(.r10, .rbx);
+    // Address arithmetic uses the pinned memory_base in r15 (issue #466).
     try loadWasmU32Addr(code, alloc_result, dst, .rax);
-    try code.movRegMem(.r10, .r10, vmctx_membase_field);
-    try code.addRegReg(.rax, .r10);
+    try code.addRegReg(.rax, .r15);
     try loadWasmU32Addr(code, alloc_result, src, .rcx);
-    try code.addRegReg(.rcx, .r10);
+    try code.addRegReg(.rcx, .r15);
 
     try code.cmpRegReg(.rax, .rcx);
     const forward_jcc = code.len();
@@ -2175,10 +2193,9 @@ fn emitSmallMemoryFill(
     try emitStaticBulkMemBoundsCheck(code, alloc_result, dst, len);
     if (len == 0) return;
 
-    try code.movRegReg(.r10, .rbx);
+    // Address arithmetic uses the pinned memory_base in r15 (issue #466).
     try loadWasmU32Addr(code, alloc_result, dst, .rax);
-    try code.movRegMem(.r10, .r10, vmctx_membase_field);
-    try code.addRegReg(.rax, .r10);
+    try code.addRegReg(.rax, .r15);
 
     const val_reg = try useVReg(code, alloc_result, val, .r11);
     if (val_reg != .r11) try code.movRegReg(.r11, val_reg);
@@ -2830,6 +2847,15 @@ fn compileInstRA(
                 return;
             }
 
+            // Refresh the pinned memory_base in r15 (issue #466). The
+            // callee may have invoked `memory.grow`, which reallocs
+            // the wasm linear memory and updates `[vmctx + 0]`. The
+            // callee's epilogue restored *our* (pre-call) r15, so our
+            // cached value is stale; reload from the now-current
+            // `[vmctx + 0]`. Skip after tail-calls (control doesn't
+            // return to us).
+            try code.movRegMem(.r15, .rbx, vmctx_membase_field);
+
             if (inst.dest) |dest| {
                 try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
             }
@@ -2984,6 +3010,11 @@ fn compileInstRA(
                 return;
             }
 
+            // Refresh pinned memory_base in r15 (issue #466) — the
+            // called function may have invoked `memory.grow`; see the
+            // .call handler for the full rationale.
+            try code.movRegMem(.r15, .rbx, vmctx_membase_field);
+
             if (inst.dest) |dest| {
                 try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
             }
@@ -3077,6 +3108,11 @@ fn compileInstRA(
                 return;
             }
 
+            // Refresh pinned memory_base in r15 (issue #466) — the
+            // called function may have invoked `memory.grow`; see the
+            // .call handler for the full rationale.
+            try code.movRegMem(.r15, .rbx, vmctx_membase_field);
+
             if (inst.dest) |dest| {
                 try writeDefTyped(code, alloc_result, dest, .rax, inst.type);
             }
@@ -3095,10 +3131,10 @@ fn compileInstRA(
         // ── Memory ────────────────────────────────────────────────────
         .load => |ld| {
             const dest = inst.dest orelse return;
-            // Load memory base from VMContext frame slot, add wasm offset.
-            // Bounds check is inserted between vmctx load and mem_base load so
-            // the check can read VmCtx.memory_size while r10 still holds the
-            // VmCtx pointer.
+            // Bounds check reads memory_size from `[vmctx + 8]`, so we
+            // still need vmctx in r10 across the check. The actual
+            // address arithmetic uses the pinned memory_base in r15
+            // (issue #466) — no per-access reload of `[vmctx + 0]`.
             try code.movRegReg(.r10, .rbx); // load VmCtx*
             const base_reg = try useVReg(code, alloc_result, ld.base, .rax);
             if (base_reg != .rax) try code.movRegReg(.rax, base_reg);
@@ -3107,8 +3143,7 @@ fn compileInstRA(
                 const end_offset = if (ld.checked_end > 0) ld.checked_end else @as(u64, ld.offset) + @as(u64, ld.size);
                 try emitMemBoundsCheck(code, end_offset);
             }
-            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base
-            try code.addRegReg(.rax, .r10); // rax = mem_base + wasm_addr
+            try code.addRegReg(.rax, .r15); // rax = mem_base + wasm_addr
             // Fold wasm offset into mov displacement when it fits in i32.
             // For out-of-range offsets (address.wast uses 0xFFFFFFFF), first
             // add the offset to rax via a 64-bit imm.
@@ -3140,10 +3175,10 @@ fn compileInstRA(
             }
         },
         .store => |st| {
-            // Load memory base from VMContext frame slot into r10.
-            // Bounds check is inserted between vmctx load and mem_base load so
-            // the check can read VmCtx.memory_size while r10 still holds the
-            // VmCtx pointer.
+            // Bounds check reads memory_size from `[vmctx + 8]`, so we
+            // still need vmctx in r10 across the check. The actual
+            // address arithmetic uses the pinned memory_base in r15
+            // (issue #466) — no per-access reload of `[vmctx + 0]`.
             try code.movRegReg(.r10, .rbx); // load VmCtx*
             // Compute final address in rax (not allocatable — safe to clobber).
             const base_reg = try useVReg(code, alloc_result, st.base, .rax);
@@ -3153,8 +3188,7 @@ fn compileInstRA(
                 const end_offset = if (st.checked_end > 0) st.checked_end else @as(u64, st.offset) + @as(u64, st.size);
                 try emitMemBoundsCheck(code, end_offset);
             }
-            try code.movRegMem(.r10, .r10, vmctx_membase_field); // load VmCtx.memory_base
-            try code.addRegReg(.rax, .r10); // rax = mem_base + wasm_addr
+            try code.addRegReg(.rax, .r15); // rax = mem_base + wasm_addr
             // Load value into rcx (not allocatable — safe to clobber).
             // useVReg writes spill loads into scratch=.rcx, so rax is preserved.
             const val_reg = try useVReg(code, alloc_result, st.val, .rcx);
@@ -3254,6 +3288,12 @@ fn compileInstRA(
             if (stack_adjust > 0) try code.subRegImm32(.rsp, @intCast(stack_adjust));
             try code.callReg(.rax);
             if (stack_adjust > 0) try code.addRegImm32(.rsp, @intCast(stack_adjust));
+
+            // mem_grow_fn may realloc the wasm linear memory and
+            // invalidate the pinned memory_base in r15 (issue #466).
+            // Refresh from [vmctx + 0] now so subsequent memory
+            // accesses see the new base.
+            try code.movRegMem(.r15, .rbx, vmctx_membase_field);
 
             // Helper returns i32 (old pages or -1); sign-extend not needed since
             // writeDefTyped honors inst.type and consumers use 32-bit semantics.
@@ -4974,11 +5014,13 @@ test "compileFunctionRA: iconst_32 + ret" {
     try std.testing.expectEqual(@as(u8, 0xC3), code[code.len - 1]);
 }
 
-test "compileFunctionRA: prologue pins vmctx in rbx (issue #465)" {
+test "compileFunctionRA: prologue pins vmctx in rbx (#465) and memory_base in r15 (#466)" {
     // Every function's prologue must (a) `push rbx` (preserve the
-    // caller's rbx, since x86-64 callee-saved discipline requires it)
-    // and (b) `mov rbx, param_regs[0]` (capture vmctx). The two
-    // instructions must appear together in the prologue.
+    // caller's rbx, since x86-64 callee-saved discipline requires it),
+    // (b) `mov rbx, param_regs[0]` (capture vmctx), (c) `push r15`
+    // (preserve caller's r15), and (d) `mov r15, [rbx + 0]` (capture
+    // memory_base). The mov of vmctx must precede the load of
+    // memory_base, since the load reads through rbx.
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -4996,6 +5038,8 @@ test "compileFunctionRA: prologue pins vmctx in rbx (issue #465)" {
 
     // `push rbx` = 0x53 (single byte, low-8 register, no REX prefix).
     const push_rbx: u8 = 0x53;
+    // `push r15` = REX.B (0x41) + 0x57 = 41 57.
+    const push_r15: [2]u8 = .{ 0x41, 0x57 };
     // `mov rbx, param_regs[0]`:
     //   SysV:  rdi → rbx → REX.W 0x48, MOV opcode 0x89, ModR/M 0xFB
     //          (mod=11, reg=rdi=7, r/m=rbx=3) = 48 89 FB.
@@ -5006,13 +5050,71 @@ test "compileFunctionRA: prologue pins vmctx in rbx (issue #465)" {
     else
         .{ 0x48, 0x89, 0xFB };
 
-    const idx_mov = std.mem.indexOf(u8, code, &mov_rbx) orelse
+    // `mov r15, [rbx + 0]` via movRegMem (always disp32):
+    //   REX.WR (0x4C) + opcode 0x8B + ModR/M 0xBB (mod=10, reg=r15=7
+    //   low3, rm=rbx=3) + disp32 = 00 00 00 00.
+    const mov_r15_membase: [7]u8 = .{ 0x4C, 0x8B, 0xBB, 0x00, 0x00, 0x00, 0x00 };
+
+    const idx_mov_rbx = std.mem.indexOf(u8, code, &mov_rbx) orelse
         return error.TestExpectedMovRbxFromParam0;
+    const idx_mov_r15 = std.mem.indexOf(u8, code, &mov_r15_membase) orelse
+        return error.TestExpectedMovR15FromMembase;
     // The `push rbx` byte must appear earlier in the prologue.
-    const prologue = code[0..idx_mov];
-    const idx_push = std.mem.indexOfScalar(u8, prologue, push_rbx) orelse
+    const prologue_before_rbx = code[0..idx_mov_rbx];
+    const idx_push_rbx = std.mem.indexOfScalar(u8, prologue_before_rbx, push_rbx) orelse
         return error.TestExpectedPushRbxBeforeMov;
-    try std.testing.expect(idx_push < idx_mov);
+    try std.testing.expect(idx_push_rbx < idx_mov_rbx);
+    // `push r15` must appear before the r15 load (caller's r15 is
+    // preserved on stack before we overwrite it).
+    const prologue_before_r15 = code[0..idx_mov_r15];
+    const idx_push_r15 = std.mem.indexOf(u8, prologue_before_r15, &push_r15) orelse
+        return error.TestExpectedPushR15BeforeMov;
+    try std.testing.expect(idx_push_r15 < idx_mov_r15);
+    // rbx must be set BEFORE r15 (the load reads `[rbx + 0]`).
+    try std.testing.expect(idx_mov_rbx < idx_mov_r15);
+}
+
+test "compileFunctionRA: memory.grow refreshes pinned r15 (issue #466)" {
+    // The helper call to mem_grow_fn can realloc the linear memory and
+    // invalidate r15's cached `[vmctx + 0]`. Codegen must emit a fresh
+    // mov r15, [rbx + 0] right after the call returns.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .memory_grow = v0 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v1 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // The mem_grow_fn dispatch is `call rax` (FF D0). Find the LAST
+    // such pair — there may be earlier `call` patches for other
+    // operations, and we want the grow helper itself.
+    const call_rax: [2]u8 = .{ 0xFF, 0xD0 };
+    var idx_call: ?usize = null;
+    var i: usize = 0;
+    while (i + 2 <= code.len) : (i += 1) {
+        if (std.mem.eql(u8, code[i..][0..2], &call_rax)) idx_call = i;
+    }
+    try std.testing.expect(idx_call != null);
+
+    // After the call, we expect `mov r15, [rbx + 0]` =
+    //   4C 8B BB 00 00 00 00.
+    const reload: [7]u8 = .{ 0x4C, 0x8B, 0xBB, 0x00, 0x00, 0x00, 0x00 };
+    const tail = code[idx_call.? + 2 ..];
+    const reload_off = std.mem.indexOf(u8, tail, &reload) orelse
+        return error.TestExpectedR15ReloadAfterGrow;
+    // The reload must come BEFORE any later writeDef or return. Just
+    // assert it exists in the post-call region — codegen places it
+    // immediately after the stack adjust, before writeDefTyped.
+    _ = reload_off;
 }
 
 test "compileFunctionRA: add two constants" {

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -4460,6 +4460,36 @@ test "differential: memory.grow then memory.size" {
     try expectDiffI32(wasm, "f", 3);
 }
 
+test "differential: memory.grow then store+load in the new page (issue #466)" {
+    // (module (memory 1) (func (export "f") (result i32)
+    //   i32.const 2 memory.grow drop
+    //   i32.const 131072 i32.const 0xDEADBEEF i32.store
+    //   i32.const 131072 i32.load))
+    //
+    // Address 131072 (page 2 start) is OUT OF BOUNDS in the original
+    // 1-page memory but valid after the grow. If codegen fails to
+    // refresh the pinned memory_base register after memory.grow
+    // (issue #466), the store/load would use the *old* (potentially
+    // freed) base — either crashing or returning the wrong value.
+    // Encoded by `wabt text parse` (5-byte LEB128 padded section
+    // headers; functionally identical to the compact form used by
+    // the surrounding tests).
+    const wasm = &[_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x85, 0x80, 0x80, 0x80, 0x00, 0x01, 0x60,
+        0x00, 0x01, 0x7f, 0x03, 0x82, 0x80, 0x80, 0x80,
+        0x00, 0x01, 0x00, 0x05, 0x83, 0x80, 0x80, 0x80,
+        0x00, 0x01, 0x00, 0x01, 0x07, 0x85, 0x80, 0x80,
+        0x80, 0x00, 0x01, 0x01, 0x66, 0x00, 0x00, 0x0a,
+        0xa1, 0x80, 0x80, 0x80, 0x00, 0x01, 0x9b, 0x80,
+        0x80, 0x80, 0x00, 0x00, 0x41, 0x02, 0x40, 0x00,
+        0x1a, 0x41, 0x80, 0x80, 0x08, 0x41, 0xef, 0xfd,
+        0xb6, 0xf5, 0x7d, 0x36, 0x00, 0x00, 0x41, 0x80,
+        0x80, 0x08, 0x28, 0x00, 0x00, 0x0b,
+    };
+    try expectDiffI32(wasm, "f", @bitCast(@as(u32, 0xDEADBEEF)));
+}
+
 test "differential: memory.fill writes value and readback" {
     // (module (memory 1) (func (export "f") (result i32)
     //   i32.const 100 i32.const 0x5a i32.const 4 memory.fill


### PR DESCRIPTION
Closes #466. Stacks on #465 (merged in d8c05091).

## What

Reserve a second callee-saved GPR per arch to hold `VmCtx.memory_base`:

| Arch    | Pinned | Loaded from |
| ------- | ------ | ----------- |
| aarch64 | x20    | `[x19 + 0]` |
| x86_64  | r15    | `[rbx + 0]` |

Prologue does one fresh load right after the #465 vmctx pin. Every memory access collapses from 3 instructions to one:

```diff
-mov  x16, x19              ; vmctx (#465)
-ldr  x16, [x16]            ; load memory_base
-add  x16, x16, <wasm_addr> ; ea
+add  x16, x20, <wasm_addr> ; ea (single instruction!)
 ldrb w4,  [x16]            ; actual wasm load
```

Bounds-check memsize also goes from `mov x16, x19; ldr x16, [x16, #8]` to `ldr x16, [x19, #8]` directly (one fewer instruction per bounds check).

## Invalidation discipline

`memory_base` can change. Reload the pinned reg after:

- ✅ `memory.grow` (mandatory).
- ✅ `.call` / `.call_indirect` / `.call_ref` (callee could transitively invoke `memory.grow`; the callee's epilogue restores caller's pinned reg, so our cached value is stale).
- ❌ Trap helpers (noreturn).
- ❌ `memory.fill` / `memory.copy` / `memory.init` (modify contents only).
- ❌ `table.*`, futex, WASI imports (don't touch memory base).

## Measured impact (aarch64 D16pds_v6, native, mean of 3 runs)

| Workload            | Baseline (post-#465) | + #466    | Δ        |
| ------------------- | -------------------- | --------- | -------- |
| `coremark_wasi.wasm`| 8479 i/s             | 8909 i/s  | **+5.06 %** |

`coremark_wasi_nofp` is capped at the integer-tick ceiling (9166 i/s) so isn't a useful comparison; CoreMark CI on x86_64 hardware will give the authoritative cross-arch numbers.

## Disassembly proof

`core_state_transition` (#393 hot function), one inner iteration:

```diff
   c4: mov  x16, x19          ; vmctx
-  c8: ldr  x16, [x16, #8]    ; memory_size for bounds check
+  c8: ldr  x16, [x19, #8]    ; ← direct (1 instr saved)
   ...
-  e4: mov  x16, x19          ; vmctx
-  e8: ldr  x16, [x16]        ; memory_base
-  ec: add  x16, x16, x15     ; ea
+  e4: add  x16, x20, x15     ; ← single instr (2 instr saved)
   f0: ldrb w4,  [x16]        ; the actual wasm load
```

## Tests

- aarch64 prologue invariant: assert `LDR X20, [X19, #0]` (0xF9400274) at offset 52, right after the `MOV X19, X0` from #465.
- aarch64 after-grow regression: compile `memory.grow`, scan past the BLR (0xD63F0200), assert the `LDR X20, [X19, #0]` reload follows.
- x86_64 prologue invariant: assert `push r15` (41 57) and `mov r15, [rbx + 0]` (4C 8B BB 00 00 00 00) in the prologue, and that rbx is set before r15 (the load reads through rbx).
- x86_64 after-grow regression: same byte-pattern scan after `call rax`.
- New differential test `memory.grow then store+load in the new page`: writes `0xDEADBEEF` at address 131072 (only valid after grow by 2 pages) and loads it back. If the reload is missing/buggy, the AOT path dereferences a stale (potentially freed) base — either crashes or returns garbage; the interpreter uses the up-to-date base and always returns `0xDEADBEEF`. Differential framework asserts identical results.

## Acceptance criteria

1. `zig build test` — ✅ 1940 tests pass on aarch64 native (up from 1939 — the new differential test adds one).
2. `zig build coremark-aot` — ✅ aarch64: +5.06 %. x86_64 CI to follow.
3. Spec-test coverage for memory.grow correctness — ✅ via existing `differential: memory.grow then memory.size` + new `differential: memory.grow then store+load in the new page`.
4. New regression test for reload-after-grow invariant — ✅ aarch64 byte-pattern test + x86_64 byte-pattern test + the differential end-to-end test.

## Risk

Allocatable GPR pool shrinks once more: aarch64 24 → 23, x86_64 9 → 8. Per the prior `regalloc.zig` note in the session memory, x86_64 is the more sensitive arch — but #465 just demonstrated that on real x86_64 hardware (where qemu TCG was misleading) the elimination of memory loads dominates the spill cost (+10.28 % CoreMark from 10→9 cut). The 9→8 cut here has the same shape, with even bigger absolute load-elimination savings since every memory access benefits.

If x86_64 CI shows regression beyond the −5 % gate, the follow-up is to gate pinning per-function based on the presence of memory accesses.