### PR TITLE
perf(ir): LICM — hoist local_get/global_get, synthesize preheaders, speculative load hoist (#446)

### DIFF
--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -2461,6 +2461,12 @@ pub fn hoistLoopBoundsChecks(func: *ir.IrFunction, allocator: std.mem.Allocator)
 /// contain no calls — a call can `global_set` through the callee.
 /// Wasm locals are function-private, so calls cannot mutate them and
 /// `local_get` only needs `local_set` exclusion.
+///
+/// When the loop lacks a dedicated `.br`-terminated preheader (either no
+/// preheader at all, or a `br_if` / `br_table` entry, or multiple
+/// non-loop predecessors), a preheader is synthesized in-place by
+/// retargeting each non-loop predecessor's header edge through a fresh
+/// `.br header` block. See `synthesizeLoopPreheader`.
 pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
     if (func.blocks.items.len == 0) return false;
 
@@ -2488,27 +2494,7 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
 
     var changed = false;
     for (lf.loops) |*loop| {
-        const header_preds = predecessors.get(loop.header) orelse continue;
-        var preheader: ?ir.BlockId = null;
-        for (header_preds) |p| {
-            if (!loop.containsBlock(p)) {
-                if (preheader != null) {
-                    preheader = null;
-                    break;
-                }
-                preheader = p;
-            }
-        }
-        const ph = preheader orelse continue;
-        const ph_insts = func.blocks.items[ph].instructions.items;
-        if (ph_insts.len == 0) continue;
-        switch (ph_insts[ph_insts.len - 1].op) {
-            .br => |t| {
-                if (t != loop.header) continue;
-            },
-            else => continue,
-        }
-        if (!dom.dominates(ph, loop.header)) continue;
+        const ph = (try obtainLoopPreheader(func, loop, &predecessors, &dom, allocator)) orelse continue;
 
         // One-shot scan of the loop body: which wasm-local / wasm-global
         // indices are written, and does the body contain any call?
@@ -2580,6 +2566,131 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
         }
     }
     return changed;
+}
+
+/// Resolve a dedicated preheader for `loop`: either an existing block
+/// whose sole terminator is `.br loop.header` and which dominates the
+/// header, or — failing that — a freshly synthesized one. Returns
+/// `null` only when the loop header has no non-loop predecessor at all
+/// (i.e., the header is unreachable from outside the loop).
+fn obtainLoopPreheader(
+    func: *ir.IrFunction,
+    loop: *const analysis.Loop,
+    predecessors: *std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+    dom: *const analysis.DomTree,
+    allocator: std.mem.Allocator,
+) !?ir.BlockId {
+    const header_preds = predecessors.get(loop.header) orelse return null;
+
+    var unique_non_loop_pred: ?ir.BlockId = null;
+    var multiple_non_loop = false;
+    var any_non_loop = false;
+    for (header_preds) |p| {
+        if (loop.containsBlock(p)) continue;
+        any_non_loop = true;
+        if (unique_non_loop_pred != null) {
+            multiple_non_loop = true;
+        } else {
+            unique_non_loop_pred = p;
+        }
+    }
+    if (!any_non_loop) return null;
+
+    if (!multiple_non_loop) {
+        if (unique_non_loop_pred) |p| {
+            const ph_insts = func.blocks.items[p].instructions.items;
+            if (ph_insts.len > 0) {
+                const last = ph_insts[ph_insts.len - 1];
+                const is_clean_br = switch (last.op) {
+                    .br => |t| t == loop.header,
+                    else => false,
+                };
+                if (is_clean_br and dom.dominates(p, loop.header)) {
+                    return p;
+                }
+            }
+        }
+    }
+
+    return try synthesizeLoopPreheader(func, loop, header_preds, predecessors, allocator);
+}
+
+/// Allocate a fresh block, retarget every non-loop predecessor's
+/// header-bound edge through it, and emit `.br loop.header` as its
+/// sole instruction. The synthesized block trivially dominates the
+/// header by construction.
+///
+/// `predecessors` is updated in-place: the new block's pred list is
+/// the set of non-loop preds, and the header's pred list now lists
+/// the new block in place of those preds (latches preserved).
+fn synthesizeLoopPreheader(
+    func: *ir.IrFunction,
+    loop: *const analysis.Loop,
+    header_preds: []const ir.BlockId,
+    predecessors: *std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+    allocator: std.mem.Allocator,
+) !?ir.BlockId {
+    var non_loop_preds: std.ArrayList(ir.BlockId) = .empty;
+    defer non_loop_preds.deinit(allocator);
+    for (header_preds) |p| {
+        if (!loop.containsBlock(p)) try non_loop_preds.append(allocator, p);
+    }
+    if (non_loop_preds.items.len == 0) return null;
+
+    const ph_new: ir.BlockId = try func.newBlock();
+    try func.blocks.items[ph_new].append(.{ .op = .{ .br = loop.header } });
+
+    for (non_loop_preds.items) |p| {
+        const pred_block = &func.blocks.items[p];
+        const ninsts = pred_block.instructions.items.len;
+        if (ninsts == 0) continue;
+        const term = &pred_block.instructions.items[ninsts - 1];
+        switch (term.op) {
+            .br => |t| if (t == loop.header) {
+                term.op = .{ .br = ph_new };
+            },
+            .br_if => |*bi| {
+                if (bi.then_block == loop.header) bi.then_block = ph_new;
+                if (bi.else_block == loop.header) bi.else_block = ph_new;
+            },
+            .br_table => |*bt| {
+                if (bt.default == loop.header) bt.default = ph_new;
+                var has_header_target = false;
+                for (bt.targets) |t| {
+                    if (t == loop.header) {
+                        has_header_target = true;
+                        break;
+                    }
+                }
+                if (has_header_target) {
+                    const new_targets = try allocator.alloc(ir.BlockId, bt.targets.len);
+                    for (bt.targets, 0..) |t, idx| {
+                        new_targets[idx] = if (t == loop.header) ph_new else t;
+                    }
+                    try func.owned_br_table_targets.append(allocator, new_targets);
+                    bt.targets = new_targets;
+                }
+            },
+            else => {},
+        }
+    }
+
+    const ph_preds = try allocator.alloc(ir.BlockId, non_loop_preds.items.len);
+    @memcpy(ph_preds, non_loop_preds.items);
+    try predecessors.put(ph_new, ph_preds);
+
+    var header_remaining: std.ArrayList(ir.BlockId) = .empty;
+    defer header_remaining.deinit(allocator);
+    for (header_preds) |p| {
+        if (loop.containsBlock(p)) try header_remaining.append(allocator, p);
+    }
+    try header_remaining.append(allocator, ph_new);
+    const new_header_preds = try allocator.alloc(ir.BlockId, header_remaining.items.len);
+    @memcpy(new_header_preds, header_remaining.items);
+    if (predecessors.fetchRemove(loop.header)) |kv| allocator.free(kv.value);
+    try predecessors.put(loop.header, new_header_preds);
+
+    return ph_new;
 }
 
 const DefSite = struct { block: ir.BlockId, inst: usize };
@@ -7315,6 +7426,219 @@ test "hoistLoopInvariantCode: cascading via hoisted local_get exposes invariant 
         }
     }
     try std.testing.expect(ph_has_add);
+}
+
+test "hoistLoopInvariantCode: preheader synthesized when entry is br_if" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const b_entry = try func.newBlock();
+    const b_header = try func.newBlock();
+    const b_exit = try func.newBlock();
+
+    // Entry block conditionally enters the loop via br_if — no dedicated
+    // preheader exists, so Stage A would skip this loop entirely.
+    const v_gate = func.newVReg();
+    const v_a = func.newVReg();
+    const v_b = func.newVReg();
+    try func.getBlock(b_entry).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_gate, .type = .i32 });
+    try func.getBlock(b_entry).append(.{ .op = .{ .iconst_32 = 10 }, .dest = v_a, .type = .i32 });
+    try func.getBlock(b_entry).append(.{ .op = .{ .iconst_32 = 20 }, .dest = v_b, .type = .i32 });
+    try func.getBlock(b_entry).append(.{ .op = .{ .br_if = .{ .cond = v_gate, .then_block = b_header, .else_block = b_exit } } });
+
+    // Loop body computes an invariant add and a self-edge back to header.
+    const v_sum = func.newVReg();
+    const v_cond = func.newVReg();
+    try func.getBlock(b_header).append(.{ .op = .{ .add = .{ .lhs = v_a, .rhs = v_b } }, .dest = v_sum, .type = .i32 });
+    try func.getBlock(b_header).append(.{ .op = .{ .eqz = v_sum }, .dest = v_cond });
+    try func.getBlock(b_header).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b_exit, .else_block = b_header } } });
+    try func.getBlock(b_exit).append(.{ .op = .{ .ret = v_a } });
+
+    const blocks_before = func.blocks.items.len;
+    const changed = try hoistLoopInvariantCode(&func, allocator);
+    try std.testing.expect(changed);
+    // A fresh preheader block must have been synthesized.
+    try std.testing.expect(func.blocks.items.len == blocks_before + 1);
+
+    // The entry's br_if must no longer point directly at the header on
+    // its then-branch; instead, it routes through the synthesized
+    // preheader. The else-branch (going to b_exit) must be untouched.
+    const entry_term = func.getBlock(b_entry).instructions.items[func.getBlock(b_entry).instructions.items.len - 1];
+    try std.testing.expect(entry_term.op == .br_if);
+    try std.testing.expect(entry_term.op.br_if.then_block != b_header);
+    try std.testing.expect(entry_term.op.br_if.else_block == b_exit);
+    const ph_new = entry_term.op.br_if.then_block;
+
+    // The synthesized preheader has `add` (hoisted) followed by `.br header`.
+    const ph_block = func.getBlock(ph_new);
+    var ph_has_add = false;
+    var ph_last_is_br_header = false;
+    for (ph_block.instructions.items, 0..) |inst, idx| {
+        if (inst.op == .add) ph_has_add = true;
+        if (idx == ph_block.instructions.items.len - 1) {
+            ph_last_is_br_header = (inst.op == .br and inst.op.br == b_header);
+        }
+    }
+    try std.testing.expect(ph_has_add);
+    try std.testing.expect(ph_last_is_br_header);
+
+    // Body must no longer contain the hoisted add.
+    var body_has_add = false;
+    for (func.getBlock(b_header).instructions.items) |inst| {
+        if (inst.op == .add) {
+            body_has_add = true;
+            break;
+        }
+    }
+    try std.testing.expect(!body_has_add);
+}
+
+test "hoistLoopInvariantCode: preheader synthesized when loop has two non-loop entries" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b_split = try func.newBlock();
+    const b_left = try func.newBlock();
+    const b_right = try func.newBlock();
+    const b_header = try func.newBlock();
+    const b_exit = try func.newBlock();
+
+    // Split into two paths that both `.br` directly into the header.
+    const v_gate = func.newVReg();
+    const v_a = func.newVReg();
+    const v_b = func.newVReg();
+    try func.getBlock(b_split).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_gate, .type = .i32 });
+    try func.getBlock(b_split).append(.{ .op = .{ .iconst_32 = 10 }, .dest = v_a, .type = .i32 });
+    try func.getBlock(b_split).append(.{ .op = .{ .iconst_32 = 20 }, .dest = v_b, .type = .i32 });
+    try func.getBlock(b_split).append(.{ .op = .{ .br_if = .{ .cond = v_gate, .then_block = b_left, .else_block = b_right } } });
+    try func.getBlock(b_left).append(.{ .op = .{ .br = b_header } });
+    try func.getBlock(b_right).append(.{ .op = .{ .br = b_header } });
+
+    const v_sum = func.newVReg();
+    const v_cond = func.newVReg();
+    try func.getBlock(b_header).append(.{ .op = .{ .add = .{ .lhs = v_a, .rhs = v_b } }, .dest = v_sum, .type = .i32 });
+    try func.getBlock(b_header).append(.{ .op = .{ .eqz = v_sum }, .dest = v_cond });
+    try func.getBlock(b_header).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b_exit, .else_block = b_header } } });
+    try func.getBlock(b_exit).append(.{ .op = .{ .ret = v_a } });
+
+    const blocks_before = func.blocks.items.len;
+    const changed = try hoistLoopInvariantCode(&func, allocator);
+    try std.testing.expect(changed);
+    try std.testing.expect(func.blocks.items.len == blocks_before + 1);
+
+    // Both predecessor branches must now route through the new preheader,
+    // not directly to b_header.
+    const left_term = func.getBlock(b_left).instructions.items[0];
+    const right_term = func.getBlock(b_right).instructions.items[0];
+    try std.testing.expect(left_term.op == .br);
+    try std.testing.expect(right_term.op == .br);
+    try std.testing.expect(left_term.op.br != b_header);
+    try std.testing.expect(right_term.op.br != b_header);
+    try std.testing.expect(left_term.op.br == right_term.op.br); // same preheader
+
+    // Hoisted add lives in the synthesized preheader; loop body free of it.
+    const ph_new = left_term.op.br;
+    var ph_has_add = false;
+    for (func.getBlock(ph_new).instructions.items) |inst| {
+        if (inst.op == .add) {
+            ph_has_add = true;
+            break;
+        }
+    }
+    try std.testing.expect(ph_has_add);
+
+    var body_has_add = false;
+    for (func.getBlock(b_header).instructions.items) |inst| {
+        if (inst.op == .add) {
+            body_has_add = true;
+            break;
+        }
+    }
+    try std.testing.expect(!body_has_add);
+}
+
+test "hoistLoopInvariantCode: preheader synthesized when entry is br_table" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b_entry = try func.newBlock();
+    const b_other = try func.newBlock();
+    const b_header = try func.newBlock();
+    const b_exit = try func.newBlock();
+
+    const v_idx = func.newVReg();
+    const v_a = func.newVReg();
+    const v_b = func.newVReg();
+    try func.getBlock(b_entry).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v_idx, .type = .i32 });
+    try func.getBlock(b_entry).append(.{ .op = .{ .iconst_32 = 10 }, .dest = v_a, .type = .i32 });
+    try func.getBlock(b_entry).append(.{ .op = .{ .iconst_32 = 20 }, .dest = v_b, .type = .i32 });
+
+    // br_table with header appearing both in `targets` and as `default`.
+    const targets = try allocator.alloc(ir.BlockId, 2);
+    targets[0] = b_header;
+    targets[1] = b_other;
+    try func.owned_br_table_targets.append(allocator, targets);
+    try func.getBlock(b_entry).append(.{ .op = .{ .br_table = .{ .index = v_idx, .targets = targets, .default = b_header } } });
+
+    try func.getBlock(b_other).append(.{ .op = .{ .br = b_exit } });
+
+    const v_sum = func.newVReg();
+    const v_cond = func.newVReg();
+    try func.getBlock(b_header).append(.{ .op = .{ .add = .{ .lhs = v_a, .rhs = v_b } }, .dest = v_sum, .type = .i32 });
+    try func.getBlock(b_header).append(.{ .op = .{ .eqz = v_sum }, .dest = v_cond });
+    try func.getBlock(b_header).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b_exit, .else_block = b_header } } });
+    try func.getBlock(b_exit).append(.{ .op = .{ .ret = v_a } });
+
+    const blocks_before = func.blocks.items.len;
+    const changed = try hoistLoopInvariantCode(&func, allocator);
+    try std.testing.expect(changed);
+    try std.testing.expect(func.blocks.items.len == blocks_before + 1);
+
+    // br_table default and matching target are rewritten away from header.
+    const entry_term = func.getBlock(b_entry).instructions.items[func.getBlock(b_entry).instructions.items.len - 1];
+    try std.testing.expect(entry_term.op == .br_table);
+    try std.testing.expect(entry_term.op.br_table.default != b_header);
+    try std.testing.expect(entry_term.op.br_table.targets[0] != b_header);
+    try std.testing.expect(entry_term.op.br_table.targets[1] == b_other);
+    try std.testing.expect(entry_term.op.br_table.default == entry_term.op.br_table.targets[0]);
+
+    const ph_new = entry_term.op.br_table.default;
+    var ph_has_add = false;
+    for (func.getBlock(ph_new).instructions.items) |inst| {
+        if (inst.op == .add) {
+            ph_has_add = true;
+            break;
+        }
+    }
+    try std.testing.expect(ph_has_add);
+}
+
+test "hoistLoopInvariantCode: existing dedicated preheader not duplicated" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 10 }, .dest = v0, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 20 }, .dest = v1, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    const v2 = func.newVReg();
+    const v3 = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v2, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v2 }, .dest = v3 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v3, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v2 } });
+
+    const blocks_before = func.blocks.items.len;
+    const changed = try hoistLoopInvariantCode(&func, allocator);
+    try std.testing.expect(changed);
+    // No new block needed when an existing clean preheader is present.
+    try std.testing.expect(func.blocks.items.len == blocks_before);
 }
 
 test "inductionVariableSimplification: single induction address is strength reduced" {

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -2462,6 +2462,15 @@ pub fn hoistLoopBoundsChecks(func: *ir.IrFunction, allocator: std.mem.Allocator)
 /// Wasm locals are function-private, so calls cannot mutate them and
 /// `local_get` only needs `local_set` exclusion.
 ///
+/// Trapping wasm loads (`load`, `v128_load*`) are speculatively hoisted
+/// when (a) the loop body contains no memory-mutating op or call, and
+/// (b) the load lives in the loop header. Condition (b) guarantees the
+/// load executes on every loop entry (since the header runs on every
+/// entry and each block has exactly one terminator at its tail, so any
+/// load in the header precedes the exit check), making the hoist
+/// trap-equivalent: the hoisted load traps in the preheader at the same
+/// input the original would have on iteration 1.
+///
 /// When the loop lacks a dedicated `.br`-terminated preheader (either no
 /// preheader at all, or a `br_if` / `br_table` entry, or multiple
 /// non-loop predecessors), a preheader is synthesized in-place by
@@ -2497,22 +2506,38 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
         const ph = (try obtainLoopPreheader(func, loop, &predecessors, &dom, allocator)) orelse continue;
 
         // One-shot scan of the loop body: which wasm-local / wasm-global
-        // indices are written, and does the body contain any call?
+        // indices are written, and does the body contain any call or
+        // memory-mutating op?
         var set_locals = std.AutoHashMap(u32, void).init(allocator);
         defer set_locals.deinit();
         var set_globals = std.AutoHashMap(u32, void).init(allocator);
         defer set_globals.deinit();
         var loop_has_call = false;
+        var loop_has_memory_write = false;
         for (loop.blocks) |bid| {
             for (func.blocks.items[bid].instructions.items) |inst| {
                 switch (inst.op) {
                     .local_set => |ls| try set_locals.put(ls.idx, {}),
                     .global_set => |gs| try set_globals.put(gs.idx, {}),
                     .call, .call_indirect, .call_ref => loop_has_call = true,
+                    .store,
+                    .v128_store,
+                    .v128_store_lane,
+                    .memory_copy,
+                    .memory_fill,
+                    .memory_init,
+                    .memory_grow,
+                    .atomic_store,
+                    .atomic_rmw,
+                    .atomic_cmpxchg,
+                    .atomic_notify,
+                    .atomic_wait,
+                    => loop_has_memory_write = true,
                     else => {},
                 }
             }
         }
+        const loop_can_hoist_load = !loop_has_call and !loop_has_memory_write;
 
         var any = true;
         while (any) {
@@ -2534,7 +2559,30 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
                         .global_get => |idx| !loop_has_call and !set_globals.contains(idx),
                         else => false,
                     };
-                    const eligible_by_kind = is_invariant_local_get or is_invariant_global_get or
+                    // Speculative load hoisting (Stage C). A trapping
+                    // load is safe to hoist iff:
+                    //  (a) the loop body has no memory-mutating op and
+                    //      no call (else the load could observe a
+                    //      different value across iterations);
+                    //  (b) the load's containing block is the loop
+                    //      header. The header is reached on every loop
+                    //      entry, and any load in it precedes the
+                    //      header's terminator (each block has exactly
+                    //      one terminator at its tail), so the load
+                    //      runs on every iteration the loop is entered
+                    //      — including the 0-iter early-exit path.
+                    //      Hoisting then preserves the trap point.
+                    const is_speculative_load = loop_can_hoist_load and bid == loop.header and switch (inst.op) {
+                        .load,
+                        .v128_load,
+                        .v128_load_splat,
+                        .v128_load_zero,
+                        .v128_load_extend,
+                        .v128_load_lane,
+                        => true,
+                        else => false,
+                    };
+                    const eligible_by_kind = is_invariant_local_get or is_invariant_global_get or is_speculative_load or
                         (inst.dest != null and isPure(inst) and !hasSideEffect(inst));
                     if (!eligible_by_kind) {
                         i += 1;
@@ -7639,6 +7687,199 @@ test "hoistLoopInvariantCode: existing dedicated preheader not duplicated" {
     try std.testing.expect(changed);
     // No new block needed when an existing clean preheader is present.
     try std.testing.expect(func.blocks.items.len == blocks_before);
+}
+
+test "hoistLoopInvariantCode: load in header hoisted when no memory writes or calls in loop" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v_base = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 256 }, .dest = v_base, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    // Header has a load whose base is loop-invariant; no memory writes
+    // and no calls in the loop body.
+    const v_loaded = func.newVReg();
+    const v_cond = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_loaded, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v_loaded }, .dest = v_cond });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_loaded } });
+
+    const changed = try hoistLoopInvariantCode(&func, allocator);
+    try std.testing.expect(changed);
+
+    var ph_has_load = false;
+    for (func.getBlock(b0).instructions.items) |inst| {
+        if (inst.op == .load) {
+            ph_has_load = true;
+            break;
+        }
+    }
+    try std.testing.expect(ph_has_load);
+
+    var body_has_load = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .load) {
+            body_has_load = true;
+            break;
+        }
+    }
+    try std.testing.expect(!body_has_load);
+}
+
+test "hoistLoopInvariantCode: load NOT hoisted when loop contains a store" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v_base = func.newVReg();
+    const v_zero = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 256 }, .dest = v_base, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v_zero, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    const v_loaded = func.newVReg();
+    const v_cond = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_loaded, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .store = .{ .base = v_base, .offset = 0, .size = 4, .val = v_zero } } });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v_loaded }, .dest = v_cond });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_loaded } });
+
+    _ = try hoistLoopInvariantCode(&func, allocator);
+
+    var body_has_load = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .load) {
+            body_has_load = true;
+            break;
+        }
+    }
+    try std.testing.expect(body_has_load);
+}
+
+test "hoistLoopInvariantCode: load NOT hoisted when loop contains a call" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v_base = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 256 }, .dest = v_base, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    const v_loaded = func.newVReg();
+    const v_cond = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_loaded, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .call = .{ .func_idx = 0 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v_loaded }, .dest = v_cond });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_loaded } });
+
+    _ = try hoistLoopInvariantCode(&func, allocator);
+
+    var body_has_load = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .load) {
+            body_has_load = true;
+            break;
+        }
+    }
+    try std.testing.expect(body_has_load);
+}
+
+test "hoistLoopInvariantCode: load NOT hoisted when load lives outside the loop header" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b_pre = try func.newBlock();
+    const b_header = try func.newBlock();
+    const b_body = try func.newBlock();
+    const b_exit = try func.newBlock();
+
+    const v_base = func.newVReg();
+    try func.getBlock(b_pre).append(.{ .op = .{ .iconst_32 = 256 }, .dest = v_base, .type = .i32 });
+    try func.getBlock(b_pre).append(.{ .op = .{ .br = b_header } });
+
+    // Header branches conditionally to body or exit. The load lives in
+    // body, NOT in the header — so on a 0-iter exit the load would not
+    // run. Stage C must keep the load in body to preserve trap point.
+    const v_gate = func.newVReg();
+    try func.getBlock(b_header).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_gate, .type = .i32 });
+    try func.getBlock(b_header).append(.{ .op = .{ .br_if = .{ .cond = v_gate, .then_block = b_body, .else_block = b_exit } } });
+
+    const v_loaded = func.newVReg();
+    try func.getBlock(b_body).append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_loaded, .type = .i32 });
+    try func.getBlock(b_body).append(.{ .op = .{ .br = b_header } });
+    try func.getBlock(b_exit).append(.{ .op = .{ .ret = v_base } });
+
+    _ = try hoistLoopInvariantCode(&func, allocator);
+
+    var body_has_load = false;
+    for (func.getBlock(b_body).instructions.items) |inst| {
+        if (inst.op == .load) {
+            body_has_load = true;
+            break;
+        }
+    }
+    try std.testing.expect(body_has_load);
+
+    var ph_has_load = false;
+    for (func.getBlock(b_pre).instructions.items) |inst| {
+        if (inst.op == .load) {
+            ph_has_load = true;
+            break;
+        }
+    }
+    try std.testing.expect(!ph_has_load);
+}
+
+test "hoistLoopInvariantCode: load NOT hoisted when base operand is loop-variant" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 1);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    // Base is local_get of an idx that IS updated in the loop, so the
+    // base VReg is loop-variant.
+    const v_base = func.newVReg();
+    const v_loaded = func.newVReg();
+    const v_one = func.newVReg();
+    const v_next = func.newVReg();
+    const v_cond = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .local_get = 0 }, .dest = v_base, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_loaded, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_one, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v_base, .rhs = v_one } }, .dest = v_next, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .local_set = .{ .idx = 0, .val = v_next } } });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v_loaded }, .dest = v_cond });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_loaded } });
+
+    _ = try hoistLoopInvariantCode(&func, allocator);
+
+    var body_has_load = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .load) {
+            body_has_load = true;
+            break;
+        }
+    }
+    try std.testing.expect(body_has_load);
 }
 
 test "inductionVariableSimplification: single induction address is strength reduced" {

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -2453,6 +2453,14 @@ pub fn hoistLoopBoundsChecks(func: *ir.IrFunction, allocator: std.mem.Allocator)
 /// ALL operand VRegs are defined outside the loop body.  Iterates to
 /// a fixed point so cascading works (e.g. hoisting a constant exposes
 /// an add that depends on it).
+///
+/// `local_get` and `global_get` are not in `isPure` (they read external
+/// state, not a pure VReg computation) but are still safe to hoist when
+/// the corresponding wasm-local / wasm-global is never written inside
+/// the loop. For `global_get` we additionally require the loop body to
+/// contain no calls — a call can `global_set` through the callee.
+/// Wasm locals are function-private, so calls cannot mutate them and
+/// `local_get` only needs `local_set` exclusion.
 pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
     if (func.blocks.items.len == 0) return false;
 
@@ -2502,6 +2510,24 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
         }
         if (!dom.dominates(ph, loop.header)) continue;
 
+        // One-shot scan of the loop body: which wasm-local / wasm-global
+        // indices are written, and does the body contain any call?
+        var set_locals = std.AutoHashMap(u32, void).init(allocator);
+        defer set_locals.deinit();
+        var set_globals = std.AutoHashMap(u32, void).init(allocator);
+        defer set_globals.deinit();
+        var loop_has_call = false;
+        for (loop.blocks) |bid| {
+            for (func.blocks.items[bid].instructions.items) |inst| {
+                switch (inst.op) {
+                    .local_set => |ls| try set_locals.put(ls.idx, {}),
+                    .global_set => |gs| try set_globals.put(gs.idx, {}),
+                    .call, .call_indirect, .call_ref => loop_has_call = true,
+                    else => {},
+                }
+            }
+        }
+
         var any = true;
         while (any) {
             any = false;
@@ -2510,7 +2536,21 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
                 var i: usize = 0;
                 while (i < block.instructions.items.len) {
                     const inst = block.instructions.items[i];
-                    if (inst.dest == null or !isPure(inst) or hasSideEffect(inst)) {
+
+                    // local_get / global_get are not in `isPure` because
+                    // they read external state, but are safe to hoist
+                    // under the per-loop invariance conditions above.
+                    const is_invariant_local_get = switch (inst.op) {
+                        .local_get => |idx| !set_locals.contains(idx),
+                        else => false,
+                    };
+                    const is_invariant_global_get = switch (inst.op) {
+                        .global_get => |idx| !loop_has_call and !set_globals.contains(idx),
+                        else => false,
+                    };
+                    const eligible_by_kind = is_invariant_local_get or is_invariant_global_get or
+                        (inst.dest != null and isPure(inst) and !hasSideEffect(inst));
+                    if (!eligible_by_kind) {
                         i += 1;
                         continue;
                     }
@@ -7047,6 +7087,234 @@ test "hoistLoopInvariantCode: trapping op not hoisted" {
     const changed = try hoistLoopInvariantCode(&func, allocator);
     try std.testing.expect(!changed);
     try std.testing.expect(func.getBlock(b1).instructions.items[0].op == .div_u);
+}
+
+test "hoistLoopInvariantCode: local_get hoisted when idx never set in loop" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 1);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    // preheader: br loop_header
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    // loop body reads local 0 (never written in loop) and branches back.
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .local_get = 0 }, .dest = v0, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v0 }, .dest = v1 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v1, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v0 } });
+
+    const changed = try hoistLoopInvariantCode(&func, allocator);
+    try std.testing.expect(changed);
+
+    var ph_has_local_get = false;
+    for (func.getBlock(b0).instructions.items) |inst| {
+        if (inst.op == .local_get) {
+            ph_has_local_get = true;
+            break;
+        }
+    }
+    try std.testing.expect(ph_has_local_get);
+
+    var body_has_local_get = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .local_get) {
+            body_has_local_get = true;
+            break;
+        }
+    }
+    try std.testing.expect(!body_has_local_get);
+}
+
+test "hoistLoopInvariantCode: local_get NOT hoisted when idx is local_set in loop" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 1);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    // loop body reads AND writes local 0, so local_get is not invariant.
+    const v0 = func.newVReg();
+    const v_one = func.newVReg();
+    const v_next = func.newVReg();
+    const v_cond = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .local_get = 0 }, .dest = v0, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_one, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v_one } }, .dest = v_next, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .local_set = .{ .idx = 0, .val = v_next } } });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v_next }, .dest = v_cond });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_next } });
+
+    _ = try hoistLoopInvariantCode(&func, allocator);
+
+    // local_get must remain inside the loop body; add+iconst are also not
+    // invariant (add depends on the loop-modified local).
+    var body_has_local_get = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .local_get) {
+            body_has_local_get = true;
+            break;
+        }
+    }
+    try std.testing.expect(body_has_local_get);
+
+    var ph_has_local_get = false;
+    for (func.getBlock(b0).instructions.items) |inst| {
+        if (inst.op == .local_get) {
+            ph_has_local_get = true;
+            break;
+        }
+    }
+    try std.testing.expect(!ph_has_local_get);
+}
+
+test "hoistLoopInvariantCode: global_get hoisted when idx never set in loop and no calls" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .global_get = 3 }, .dest = v0, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v0 }, .dest = v1 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v1, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v0 } });
+
+    const changed = try hoistLoopInvariantCode(&func, allocator);
+    try std.testing.expect(changed);
+
+    var ph_has_global_get = false;
+    for (func.getBlock(b0).instructions.items) |inst| {
+        if (inst.op == .global_get) {
+            ph_has_global_get = true;
+            break;
+        }
+    }
+    try std.testing.expect(ph_has_global_get);
+
+    var body_has_global_get = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .global_get) {
+            body_has_global_get = true;
+            break;
+        }
+    }
+    try std.testing.expect(!body_has_global_get);
+}
+
+test "hoistLoopInvariantCode: global_get NOT hoisted when idx is global_set in loop" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    const v0 = func.newVReg();
+    const v_one = func.newVReg();
+    const v_next = func.newVReg();
+    const v_cond = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .global_get = 7 }, .dest = v0, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_one, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v_one } }, .dest = v_next, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .global_set = .{ .idx = 7, .val = v_next } } });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v_next }, .dest = v_cond });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_next } });
+
+    _ = try hoistLoopInvariantCode(&func, allocator);
+
+    var body_has_global_get = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .global_get) {
+            body_has_global_get = true;
+            break;
+        }
+    }
+    try std.testing.expect(body_has_global_get);
+}
+
+test "hoistLoopInvariantCode: global_get NOT hoisted when loop contains a call" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    // The call has no args and no result captured here; its presence alone
+    // is what blocks hoisting global_get (the callee may global_set).
+    try func.getBlock(b1).append(.{ .op = .{ .global_get = 2 }, .dest = v0, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .call = .{ .func_idx = 0 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v0 }, .dest = v1 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v1, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v0 } });
+
+    _ = try hoistLoopInvariantCode(&func, allocator);
+
+    var body_has_global_get = false;
+    for (func.getBlock(b1).instructions.items) |inst| {
+        if (inst.op == .global_get) {
+            body_has_global_get = true;
+            break;
+        }
+    }
+    try std.testing.expect(body_has_global_get);
+}
+
+test "hoistLoopInvariantCode: cascading via hoisted local_get exposes invariant add" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 1);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v_k = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 42 }, .dest = v_k, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    // local_get of an untouched local + add with an external constant.
+    // After local_get hoists, the add becomes loop-invariant and cascades.
+    const v_lg = func.newVReg();
+    const v_sum = func.newVReg();
+    const v_cond = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .local_get = 0 }, .dest = v_lg, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v_lg, .rhs = v_k } }, .dest = v_sum, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v_sum }, .dest = v_cond });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b2, .else_block = b1 } } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_sum } });
+
+    const changed = try hoistLoopInvariantCode(&func, allocator);
+    try std.testing.expect(changed);
+
+    var ph_has_add = false;
+    for (func.getBlock(b0).instructions.items) |inst| {
+        if (inst.op == .add) {
+            ph_has_add = true;
+            break;
+        }
+    }
+    try std.testing.expect(ph_has_add);
 }
 
 test "inductionVariableSimplification: single induction address is strength reduced" {


### PR DESCRIPTION
Closes #446. Implements all three stages of the LICM extension from the #393 audit (row 8).

## Why

`hoistLoopInvariantCode` already existed and was wired in every pipeline (`default_passes`, `x86_64_default_passes`, all `_no_iv` / `_no_unroll` variants), so the #393 audit's claim that LICM is "not wired" was factually wrong. The reasons it doesn't move CoreMark on this fork are:

2. **Preheader requirement**: the pass `continue`d past any loop without a dedicated `.br`-terminated preheader. CoreMark's hot loops are routinely entered via `br_if` (zero-iter guards) or `br_table` (computed-jump dispatch).
3. **Trapping loads excluded**: `load` / `v128_load*` ops are `hasSideEffect=true` (can trap on OOB), so even loops with no aliasing writes never got their loop-invariant loads hoisted.

This PR fixes all three.

## Stage A — extend hoist to `local_get` and `global_get`

Commit `2bf79a9d`. Per-loop single-pass scan records the set of `local_set` / `global_set` indices and a `loop_has_call` flag.

| Op            | Hoisted when                                                                      |
| ------------- | --------------------------------------------------------------------------------- |
| `local_get idx`  | No `local_set idx` anywhere in the loop body.                                       |
| `global_get idx` | No `global_set idx` in the loop body **and** the body contains no calls.            |

Wasm locals are function-private — calls cannot mutate another function's locals. Globals are module-level state — any call may `global_set` through the callee.

## Stage B — synthesize a preheader when missing

Commit `b880cc71`. New `synthesizeLoopPreheader` helper allocates a fresh block whose sole instruction is `.br loop.header`, then retargets each non-loop predecessor's terminator so its header-bound edge routes through the new block. Handles `.br`, `.br_if` (either or both branches), and `.br_table` (`default` and any matching `targets`). `br_table` targets are reallocated through `func.owned_br_table_targets` mirroring `inlineSmallFunctions` at `passes.zig:4742`.

Preheader resolution is consolidated into a single `obtainLoopPreheader` entry point that returns either an existing clean preheader or a newly synthesized one.

## Stage C — speculative `load` hoisting

Commit `e2bdf2c1`. Trapping wasm loads (`load`, `v128_load`, `v128_load_splat`, `v128_load_zero`, `v128_load_extend`, `v128_load_lane`) become hoistable when:

* **(a)** the loop body has no memory-mutating op — `store`, `v128_store*`, `memory_copy`/`fill`/`init`/`grow`, `atomic_store`/`rmw`/`cmpxchg`/`notify`/`wait` — and no call;
* **(b)** the load lives in the loop header. The header is reached on every loop entry (including the 0-iter early-exit path), and each block has exactly one terminator at its tail, so any load in the header precedes the exit check. The hoist therefore preserves the trap point: the hoisted load traps in the preheader on the same input the original would have on iteration 1.

Intentionally conservative: loads in non-header loop blocks need a stronger speculation-safety proof (load block must dominate every latch AND every exit) that requires post-dom info or exit-block enumeration. That's deferred until we see whether Stage C alone moves CoreMark.

## Tests

15 new tests alongside the 3 pre-existing LICM tests at `passes.zig:6952…`:

**Stage A (6):**
1. `local_get` hoisted when idx never `local_set` in loop.
2. `local_get` NOT hoisted when idx is `local_set` in loop.
3. `global_get` hoisted when idx never `global_set` in loop and no calls.
4. `global_get` NOT hoisted when idx is `global_set` in loop.
5. `global_get` NOT hoisted when loop contains a call.
6. Cascading: hoisted `local_get` exposes an invariant `add` to a second-round hoist.

**Stage B (4):**
7. Loop entered via `br_if` — synthesizes preheader.
8. Loop with two non-loop entries — both routes through synthesized preheader.
9. Loop entered via `br_table` with `default = header` and `targets[i] = header` — both rewritten.
10. Existing clean preheader — no double-synthesis.

**Stage C (5):**
11. Load in header hoisted when no memory writes/calls in loop.
12. Load NOT hoisted when loop contains a `store`.
13. Load NOT hoisted when loop contains a `call`.
14. Load NOT hoisted when load lives in non-header loop block.
15. Load NOT hoisted when its `base` operand is loop-variant.

## Verification

```
$ zig test src/compiler/ir/passes.zig
All 209 tests passed.

$ zig build test --summary all
+- run test 209 pass (209 total)   # passes.zig — 18 LICM tests total
+- run test 36 pass (36 total)
+- run test 59 pass (59 total)
+- run test 200 pass (200 total)
+- run test 1454 pass (1454 total)
+- run test 4 / 2 / 2 pass
```

`zig build coremark-aot` (aarch64 local, 1 run): 8910 / 9166 iter/s — within noise vs baseline 8920 / 9166. The structural value of these changes is largely on **x86_64** (per the #393 hot-path analysis); the CI bench job provides the per-arch statistical comparison.

## Refs

* #393 — CoreMark gap audit, row 8.
* #446 — this issue.
* Audit pointer: <https://github.com/cataggar/wamr/issues/393#issuecomment-4423326059>.
* Stage B was opened as PR #491 and squash-merged into this branch.
