### PR TITLE
feat(component): canon task.yield + context.{get,set} built-ins (#478 sub-PR 1)

### DIFF
--- a/src/component/async.zig
+++ b/src/component/async.zig
@@ -19,6 +19,13 @@ pub const TaskState = enum(u8) {
     cancelled = 3,
 };
 
+/// Per-task `context.{get,set} i32 i` slots. The spec allows arbitrary
+/// `valtype` and arbitrary index range; sub-PR 1 of #478 caps both
+/// (`i32` only, `slot < N_CONTEXT_SLOTS`). Wasmtime currently exposes a
+/// single `i32` slot; pick a small headroom value here so we don't have
+/// to revisit the constant on the first conformance suite that uses 2.
+pub const N_CONTEXT_SLOTS: u32 = 2;
+
 /// A task represents an in-flight async component function call.
 pub const Task = struct {
     id: u32,
@@ -27,6 +34,9 @@ pub const Task = struct {
     return_values: []u32 = &.{},
     /// Waiters to notify when state changes.
     waitable_set: ?*WaitableSet = null,
+    /// Per-task `context.{get,set} i32` slots. Default-initialised to 0
+    /// to match Wasmtime's behaviour for a freshly-started task.
+    context_slots: [N_CONTEXT_SLOTS]u32 = [_]u32{0} ** N_CONTEXT_SLOTS,
 };
 
 // ── Waitable Set ────────────────────────────────────────────────────────────
@@ -90,6 +100,12 @@ pub const WaitableSet = struct {
 pub const TaskManager = struct {
     tasks: std.ArrayListUnmanaged(Task) = .empty,
     next_id: u32 = 1,
+    /// Handle of the task currently executing a core-wasm body, or `null`
+    /// when no async task is on the dispatch stack. `context.{get,set}`
+    /// and `task.yield` consult this to find their target task; when it's
+    /// `null` (synchronous canon-lift call path), callers should fall
+    /// back to `ComponentInstance.implicit_task`.
+    current_task: ?u32 = null,
 
     /// Create a new task. Returns the task handle.
     pub fn createTask(self: *TaskManager, allocator: std.mem.Allocator) !u32 {
@@ -131,6 +147,24 @@ pub const TaskManager = struct {
     pub fn getState(self: *const TaskManager, handle: u32) ?TaskState {
         if (handle >= self.tasks.items.len) return null;
         return self.tasks.items[handle].state;
+    }
+
+    /// Read a per-task `context.get i32 i` slot. Returns `null` if the
+    /// task handle is unknown or the slot index is out of range.
+    pub fn getContextSlot(self: *const TaskManager, handle: u32, slot: u32) ?u32 {
+        if (handle >= self.tasks.items.len) return null;
+        if (slot >= N_CONTEXT_SLOTS) return null;
+        return self.tasks.items[handle].context_slots[slot];
+    }
+
+    /// Write a per-task `context.set i32 i` slot. Returns `false` if the
+    /// task handle is unknown or the slot index is out of range; the
+    /// caller surfaces this as a component trap.
+    pub fn setContextSlot(self: *TaskManager, handle: u32, slot: u32, value: u32) bool {
+        if (handle >= self.tasks.items.len) return false;
+        if (slot >= N_CONTEXT_SLOTS) return false;
+        self.tasks.items[handle].context_slots[slot] = value;
+        return true;
     }
 
     pub fn deinit(self: *TaskManager, allocator: std.mem.Allocator) void {
@@ -242,6 +276,53 @@ test "TaskManager: cancel" {
     const h = try tm.createTask(allocator);
     tm.cancelTask(h);
     try std.testing.expectEqual(TaskState.cancelled, tm.getState(h).?);
+}
+
+test "TaskManager: context slot get/set round-trip" {
+    const allocator = std.testing.allocator;
+    var tm = TaskManager{};
+    defer tm.deinit(allocator);
+
+    const h = try tm.createTask(allocator);
+
+    // Fresh task → all slots zero.
+    try std.testing.expectEqual(@as(?u32, 0), tm.getContextSlot(h, 0));
+    try std.testing.expectEqual(@as(?u32, 0), tm.getContextSlot(h, 1));
+
+    try std.testing.expect(tm.setContextSlot(h, 0, 0xDEAD_BEEF));
+    try std.testing.expect(tm.setContextSlot(h, 1, 42));
+    try std.testing.expectEqual(@as(?u32, 0xDEAD_BEEF), tm.getContextSlot(h, 0));
+    try std.testing.expectEqual(@as(?u32, 42), tm.getContextSlot(h, 1));
+}
+
+test "TaskManager: context slot bounds" {
+    const allocator = std.testing.allocator;
+    var tm = TaskManager{};
+    defer tm.deinit(allocator);
+
+    const h = try tm.createTask(allocator);
+
+    // Out-of-range slot index.
+    try std.testing.expect(tm.getContextSlot(h, N_CONTEXT_SLOTS) == null);
+    try std.testing.expect(!tm.setContextSlot(h, N_CONTEXT_SLOTS, 1));
+
+    // Unknown handle.
+    try std.testing.expect(tm.getContextSlot(h + 999, 0) == null);
+    try std.testing.expect(!tm.setContextSlot(h + 999, 0, 1));
+}
+
+test "TaskManager: context slots are per-task" {
+    const allocator = std.testing.allocator;
+    var tm = TaskManager{};
+    defer tm.deinit(allocator);
+
+    const a = try tm.createTask(allocator);
+    const b = try tm.createTask(allocator);
+
+    try std.testing.expect(tm.setContextSlot(a, 0, 10));
+    try std.testing.expect(tm.setContextSlot(b, 0, 20));
+    try std.testing.expectEqual(@as(?u32, 10), tm.getContextSlot(a, 0));
+    try std.testing.expectEqual(@as(?u32, 20), tm.getContextSlot(b, 0));
 }
 
 test "WaitableSet: register and poll" {

--- a/src/component/async_canon.zig
+++ b/src/component/async_canon.zig
@@ -63,6 +63,60 @@ pub fn asyncCancel(
     task_manager.cancelTask(handle);
 }
 
+/// Outcome of `task.yield` (`canon thread.yield`, Binary.md tag 0x0c).
+/// The component-model spec encodes the result as a single i32: zero on
+/// a normal resumption, non-zero when the task observed a cancellation
+/// request while parked (only possible if invoked with `cancellable`).
+pub const YieldOutcome = enum(u32) {
+    resumed = 0,
+    cancelled = 1,
+};
+
+/// Execute `canon thread.yield cancel?` for the currently executing task.
+///
+/// Single-threaded runtime semantics: a "yield" is the smallest possible
+/// cooperative-scheduling primitive. We don't (yet) have a fiber stack to
+/// suspend onto, so we drain one round of readiness on any waitable set
+/// the task is registered with and immediately resume. Sub-PR 3 of #478
+/// replaces this with the real `future<T>` / `stream<T>` integration; the
+/// surface this function exposes is stable.
+///
+/// When `cancellable == true` and the task is `.cancelled`, returns
+/// `.cancelled` so the dispatcher can lower the right discriminant onto
+/// the core wasm stack.
+pub fn taskYield(
+    task_manager: *async_mod.TaskManager,
+    handle: u32,
+    cancellable: bool,
+    allocator: std.mem.Allocator,
+) YieldOutcome {
+    _ = allocator; // reserved for future scheduler hooks (sub-PR 3)
+
+    if (handle >= task_manager.tasks.items.len) return .resumed;
+    const task = &task_manager.tasks.items[handle];
+
+    // Cancellation gets priority: if a cancellation arrived while the task
+    // was on the dispatch stack, surface it before we drain readiness.
+    if (cancellable and task.state == .cancelled) return .cancelled;
+
+    // Drain one round of readiness on the task's waitable set, if any.
+    // The dispatcher consumes the ready_queue via `pollReady` separately;
+    // here we only need to clear the per-task suspend point — the
+    // single-threaded scheduler is implicit (re-entry into wasm resumes
+    // the task immediately on return from this built-in).
+    if (task.waitable_set) |ws| {
+        var sink: [16]u32 = undefined;
+        _ = ws.pollReady(&sink);
+    }
+
+    // Re-arm. If the task was somehow flipped to `.returned` while we
+    // were not looking, leave that alone — only `.created` would be
+    // surprising, but defensively re-mark started just in case.
+    if (task.state == .created) task.state = .started;
+
+    return .resumed;
+}
+
 /// Check if a subtask has completed and retrieve its return values.
 pub fn asyncPollResult(
     task_manager: *const async_mod.TaskManager,
@@ -126,4 +180,49 @@ test "asyncCancel: cancels subtask" {
     asyncCancel(&tm, result.subtask_handle);
     try std.testing.expectEqual(async_mod.TaskState.cancelled, tm.getState(result.subtask_handle).?);
     try std.testing.expect(asyncPollResult(&tm, result.subtask_handle) == null);
+}
+
+test "taskYield: resume on a live task" {
+    const allocator = std.testing.allocator;
+    var tm = async_mod.TaskManager{};
+    defer tm.deinit(allocator);
+    var ws = async_mod.WaitableSet{};
+    defer ws.deinit(allocator);
+
+    const result = try asyncLift(.{
+        .waitable_set = &ws,
+        .task_manager = &tm,
+        .allocator = allocator,
+    });
+
+    const outcome = taskYield(&tm, result.subtask_handle, false, allocator);
+    try std.testing.expectEqual(YieldOutcome.resumed, outcome);
+    try std.testing.expectEqual(async_mod.TaskState.started, tm.getState(result.subtask_handle).?);
+}
+
+test "taskYield: cancellable observes cancellation" {
+    const allocator = std.testing.allocator;
+    var tm = async_mod.TaskManager{};
+    defer tm.deinit(allocator);
+
+    const result = try asyncLift(.{
+        .task_manager = &tm,
+        .allocator = allocator,
+    });
+
+    asyncCancel(&tm, result.subtask_handle);
+
+    // Plain yield still reports `.resumed` (spec: non-cancellable yield
+    // is opaque to cancellation observation).
+    try std.testing.expectEqual(YieldOutcome.resumed, taskYield(&tm, result.subtask_handle, false, allocator));
+    // Cancellable yield surfaces the pending cancellation.
+    try std.testing.expectEqual(YieldOutcome.cancelled, taskYield(&tm, result.subtask_handle, true, allocator));
+}
+
+test "taskYield: unknown handle is a no-op" {
+    const allocator = std.testing.allocator;
+    var tm = async_mod.TaskManager{};
+    defer tm.deinit(allocator);
+
+    try std.testing.expectEqual(YieldOutcome.resumed, taskYield(&tm, 999, true, allocator));
 }

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -704,11 +704,19 @@ pub fn canonResourceRep(
 }
 
 /// Dispatch a canonical built-in function call. Used when the canon section
-/// references resource.new/drop/rep instead of lift/lower.
+/// references resource.new/drop/rep, task.yield, or context.{get,set}
+/// instead of lift/lower.
+///
+/// `task_manager` is the async runtime state for this dispatch (nullable
+/// because synchronous canon-lift paths don't construct one). When null,
+/// `task.yield` is a no-op resume and `context.{get,set}` operate on
+/// `comp_inst.implicit_task_context`, matching Wasmtime's per-instance
+/// fallback for sync calls. (#478 sub-PR 1.)
 pub fn dispatchCanonBuiltin(
     comp_inst: *ComponentInstance,
     canon: ctypes.Canon,
     env: *ExecEnv,
+    task_manager: ?*async_mod.TaskManager,
     allocator: Allocator,
 ) ExecutionError!void {
     switch (canon) {
@@ -731,6 +739,46 @@ pub fn dispatchCanonBuiltin(
             const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
             const rep_val = canonResourceRep(rt, handle) orelse 0;
             env.pushI32(@bitCast(rep_val)) catch return error.StackOverflow;
+        },
+        .task_yield => |info| {
+            // `canon thread.yield cancel?` — Binary.md tag 0x0c. Pushes
+            // an i32 discriminant: 0 on normal resume, 1 if the task was
+            // cancelled while parked (cancellable-only).
+            const outcome: u32 = if (task_manager) |tm| blk: {
+                const handle = tm.current_task orelse break :blk 0;
+                break :blk @intFromEnum(async_canon.taskYield(tm, handle, info.cancellable, allocator));
+            } else 0;
+            env.pushI32(@bitCast(outcome)) catch return error.StackOverflow;
+        },
+        .context_get => |info| {
+            // Sub-PR 1 only admits i32; the loader rejects others. Defend
+            // here too so a hand-constructed Canon doesn't bypass the
+            // limit silently.
+            if (info.val_type != .i32) return error.FunctionNotFound;
+            const value: u32 = blk: {
+                if (task_manager) |tm| {
+                    if (tm.current_task) |handle| {
+                        if (tm.getContextSlot(handle, info.slot)) |v| break :blk v;
+                        // Slot out of range on a known task → trap.
+                        return error.StackUnderflow;
+                    }
+                }
+                if (info.slot >= async_mod.N_CONTEXT_SLOTS) return error.StackUnderflow;
+                break :blk comp_inst.implicit_task_context[info.slot];
+            };
+            env.pushI32(@bitCast(value)) catch return error.StackOverflow;
+        },
+        .context_set => |info| {
+            if (info.val_type != .i32) return error.FunctionNotFound;
+            const value: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            if (task_manager) |tm| {
+                if (tm.current_task) |handle| {
+                    if (!tm.setContextSlot(handle, info.slot, value)) return error.StackUnderflow;
+                    return;
+                }
+            }
+            if (info.slot >= async_mod.N_CONTEXT_SLOTS) return error.StackUnderflow;
+            comp_inst.implicit_task_context[info.slot] = value;
         },
         .lift, .lower => {}, // Handled by callComponentFunc
     }
@@ -800,6 +848,14 @@ pub fn callComponentFuncAsync(
         task_manager.cancelTask(handle);
         return error.OutOfMemory;
     };
+
+    // Make the just-created subtask discoverable to context.{get,set} and
+    // task.yield invoked from inside the synchronous body. Restored on
+    // return regardless of success/failure so nested calls see the
+    // surrounding caller's task afterwards. (#478 sub-PR 1.)
+    const saved_current_task = task_manager.current_task;
+    task_manager.current_task = handle;
+    defer task_manager.current_task = saved_current_task;
 
     callComponentFunc(comp_inst, func_name, args, results, allocator) catch |e| {
         allocator.free(results);
@@ -1076,6 +1132,224 @@ test "async waitable set: multiple subtasks" {
     var vals2 = [_]u32{20};
     async_canon.asyncReturn(&tm, r2.subtask_handle, &vals2);
     try std.testing.expect(async_canon.asyncPollResult(&tm, r2.subtask_handle) != null);
+}
+
+// ── dispatchCanonBuiltin: async ABI built-ins (#478 sub-PR 1) ────────────────
+
+test "dispatchCanonBuiltin: task.yield pushes resumed=0 with no task manager" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .task_yield = .{ .cancellable = false } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(i32, 0), try env.popI32());
+}
+
+test "dispatchCanonBuiltin: task.yield observes cancellation via TaskManager" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    var tm = async_mod.TaskManager{};
+    defer tm.deinit(testing.allocator);
+
+    const lift = try async_canon.asyncLift(.{
+        .task_manager = &tm,
+        .allocator = testing.allocator,
+    });
+    tm.current_task = lift.subtask_handle;
+    async_canon.asyncCancel(&tm, lift.subtask_handle);
+
+    // Non-cancellable yield: opaque, always reports resumed=0.
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .task_yield = .{ .cancellable = false } },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(i32, 0), try env.popI32());
+
+    // Cancellable yield: surfaces the pending cancellation as 1.
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .task_yield = .{ .cancellable = true } },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(i32, 1), try env.popI32());
+}
+
+test "dispatchCanonBuiltin: context set+get round-trip on implicit task" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    // Push 0x1234 then `context.set i32 0` → stored on implicit task.
+    try env.pushI32(@bitCast(@as(u32, 0x1234)));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .context_set = .{ .val_type = .i32, .slot = 0 } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(u32, 0x1234), inst.implicit_task_context[0]);
+
+    // `context.get i32 0` → pushes the value back onto the stack.
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .context_get = .{ .val_type = .i32, .slot = 0 } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(i32, 0x1234), try env.popI32());
+}
+
+test "dispatchCanonBuiltin: context set+yield+get round-trip on async task" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    var tm = async_mod.TaskManager{};
+    defer tm.deinit(testing.allocator);
+    const lift = try async_canon.asyncLift(.{
+        .task_manager = &tm,
+        .allocator = testing.allocator,
+    });
+    tm.current_task = lift.subtask_handle;
+
+    // `context.set i32 1`(value=0xDEAD_BEEF) → task.yield → `context.get i32 1`
+    try env.pushI32(@bitCast(@as(u32, 0xDEAD_BEEF)));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .context_set = .{ .val_type = .i32, .slot = 1 } },
+        env,
+        &tm,
+        testing.allocator,
+    );
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .task_yield = .{ .cancellable = false } },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    // task.yield pushes its outcome — pop and discard.
+    try testing.expectEqual(@as(i32, 0), try env.popI32());
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .context_get = .{ .val_type = .i32, .slot = 1 } },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(u32, 0xDEAD_BEEF), @as(u32, @bitCast(try env.popI32())));
+
+    // Slot stored on the task, NOT on the instance's implicit context.
+    try testing.expectEqual(@as(u32, 0), inst.implicit_task_context[1]);
+    try testing.expectEqual(@as(?u32, 0xDEAD_BEEF), tm.getContextSlot(lift.subtask_handle, 1));
+}
+
+test "dispatchCanonBuiltin: context.get out-of-range slot traps" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    const oob_slot: u32 = async_mod.N_CONTEXT_SLOTS;
+    const result = dispatchCanonBuiltin(
+        inst,
+        .{ .context_get = .{ .val_type = .i32, .slot = oob_slot } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectError(error.StackUnderflow, result);
 }
 
 // ── Canon-lower host trampoline ─────────────────────────────────────────────

--- a/src/component/indexspace.zig
+++ b/src/component/indexspace.zig
@@ -245,6 +245,12 @@ pub const CoreFuncRef = union(enum) {
     resource_new: u32,
     /// Index into `component.canons` for a `.resource_rep` entry.
     resource_rep: u32,
+    /// Index into `component.canons` for a `.task_yield` entry. (#478)
+    task_yield: u32,
+    /// Index into `component.canons` for a `.context_get` entry. (#478)
+    context_get: u32,
+    /// Index into `component.canons` for a `.context_set` entry. (#478)
+    context_set: u32,
     /// Index into `component.aliases`.
     aliased: u32,
 };
@@ -264,6 +270,9 @@ pub fn resolveCoreFunc(component: *const ctypes.Component, idx: u32) ?CoreFuncRe
                 .resource_drop => .{ .resource_drop = canon_idx },
                 .resource_new => .{ .resource_new = canon_idx },
                 .resource_rep => .{ .resource_rep = canon_idx },
+                .task_yield => .{ .task_yield = canon_idx },
+                .context_get => .{ .context_get = canon_idx },
+                .context_set => .{ .context_set = canon_idx },
                 .lift => null, // lift never contributes to core-func indexspace
             },
         };
@@ -287,6 +296,18 @@ pub fn resolveCoreFunc(component: *const ctypes.Component, idx: u32) ?CoreFuncRe
             },
             .resource_rep => {
                 if (n == idx) return .{ .resource_rep = @intCast(i) };
+                n += 1;
+            },
+            .task_yield => {
+                if (n == idx) return .{ .task_yield = @intCast(i) };
+                n += 1;
+            },
+            .context_get => {
+                if (n == idx) return .{ .context_get = @intCast(i) };
+                n += 1;
+            },
+            .context_set => {
+                if (n == idx) return .{ .context_set = @intCast(i) };
                 n += 1;
             },
             .lift => {},
@@ -693,6 +714,32 @@ test "resolveCoreFunc: canon.lowers → core(.func) aliases" {
     try testing.expect(resolveCoreFunc(&comp, 1).? == .lowered);
     try testing.expect(resolveCoreFunc(&comp, 2).? == .aliased);
     try testing.expect(resolveCoreFunc(&comp, 3) == null);
+}
+
+test "resolveCoreFunc: async ABI built-ins contribute core-func slots" {
+    const canons = [_]ctypes.Canon{
+        .{ .lower = .{ .func_idx = 0, .opts = &.{} } },
+        .{ .task_yield = .{ .cancellable = false } },
+        .{ .context_get = .{ .val_type = .i32, .slot = 0 } },
+        .{ .context_set = .{ .val_type = .i32, .slot = 0 } },
+    };
+    const comp = ctypes.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &canons,
+        .imports = &.{},
+        .exports = &.{},
+    };
+    try testing.expect(resolveCoreFunc(&comp, 0).? == .lowered);
+    try testing.expect(resolveCoreFunc(&comp, 1).? == .task_yield);
+    try testing.expect(resolveCoreFunc(&comp, 2).? == .context_get);
+    try testing.expect(resolveCoreFunc(&comp, 3).? == .context_set);
+    try testing.expect(resolveCoreFunc(&comp, 4) == null);
 }
 
 test "lookupLocalInstanceMember: finds named export in inline-exports instance" {

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -8,6 +8,7 @@ const ctypes = @import("types.zig");
 const core_types = @import("../runtime/common/types.zig");
 const executor_mod = @import("executor.zig");
 const indexspace = @import("indexspace.zig");
+const async_mod = @import("async.zig");
 
 // ── Resource Table ──────────────────────────────────────────────────────────
 
@@ -268,6 +269,14 @@ pub const ComponentInstance = struct {
     /// as `.poisoned` lets `deinit` and external callers reject reuse
     /// without depending on hashmap occupancy. (Issue #355.)
     link_state: LinkState = .unlinked,
+    /// Per-instance context slots for `canon context.{get,set}` invoked
+    /// outside any async task (the synchronous canon-lift call path).
+    /// Mirrors Wasmtime's implicit-task fallback: when no async task is
+    /// on the dispatch stack, context.get/set still works, scoped to
+    /// the instance rather than to any caller task. Initialised to all
+    /// zeros — the spec doesn't define a non-zero initial value.
+    /// (#478 sub-PR 1.)
+    implicit_task_context: [async_mod.N_CONTEXT_SLOTS]u32 = [_]u32{0} ** async_mod.N_CONTEXT_SLOTS,
 
     pub const LinkState = enum { unlinked, linking, linked, poisoned };
 
@@ -382,7 +391,14 @@ pub const ComponentInstance = struct {
     ) ?struct { mi: *core_types.ModuleInstance, local_idx: u32 } {
         const ref = indexspace.resolveCoreFunc(self.component, idx) orelse return null;
         switch (ref) {
-            .lowered, .resource_drop, .resource_new, .resource_rep => return null,
+            .lowered,
+            .resource_drop,
+            .resource_new,
+            .resource_rep,
+            .task_yield,
+            .context_get,
+            .context_set,
+            => return null,
             .aliased => |alias_idx| {
                 const ie = self.component.aliases[alias_idx].instance_export;
                 if (ie.instance_idx >= self.core_instances.len) return null;
@@ -1985,7 +2001,14 @@ fn isWasiCliRunName(name: []const u8) bool {
 fn resolveCoreFuncLower(component: *const ctypes.Component, core_func_idx: u32) ?u32 {
     return switch (indexspace.resolveCoreFunc(component, core_func_idx) orelse return null) {
         .lowered => |i| i,
-        .resource_drop, .resource_new, .resource_rep, .aliased => null,
+        .resource_drop,
+        .resource_new,
+        .resource_rep,
+        .task_yield,
+        .context_get,
+        .context_set,
+        .aliased,
+        => null,
     };
 }
 
@@ -2442,10 +2465,17 @@ fn resolveLiftedCoreFunc(
 ) ?struct { core_instance_idx: u32, local_func_idx: u32 } {
     const ref = indexspace.resolveCoreFunc(component, core_func_idx) orelse return null;
     switch (ref) {
-        // Canon entries (lowers and resource.{new,drop,rep}) all produce
-        // imports/host-bound core funcs — not exported callables — so a
-        // canon.lift pointing at one is malformed.
-        .lowered, .resource_drop, .resource_new, .resource_rep => return null,
+        // Canon entries (lowers, resource.{new,drop,rep}, async builtins)
+        // all produce imports/host-bound core funcs — not exported
+        // callables — so a canon.lift pointing at one is malformed.
+        .lowered,
+        .resource_drop,
+        .resource_new,
+        .resource_rep,
+        .task_yield,
+        .context_get,
+        .context_set,
+        => return null,
         .aliased => |alias_idx| {
             const a = component.aliases[alias_idx];
             const ie = a.instance_export;

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -251,7 +251,14 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
                     // Every canon kind except `.lift` contributes a slot
                     // to the core-func indexspace.
                     const contributes = switch (c) {
-                        .lower, .resource_drop, .resource_new, .resource_rep => true,
+                        .lower,
+                        .resource_drop,
+                        .resource_new,
+                        .resource_rep,
+                        .task_yield,
+                        .context_get,
+                        .context_set,
+                        => true,
                         .lift => false,
                     };
                     if (contributes) try core_func_indexspace.append(allocator, .{ .canon = local_idx });
@@ -695,7 +702,33 @@ fn parseCanon(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!cty
         0x02 => .{ .resource_new = try reader.readU32() },
         0x03 => .{ .resource_drop = try reader.readU32() },
         0x04 => .{ .resource_rep = try reader.readU32() },
+        0x0a => try parseContextCanon(reader, .get),
+        0x0b => try parseContextCanon(reader, .set),
+        0x0c => blk: {
+            // canon thread.yield (formerly task.yield) — Binary.md tag 0x0c
+            // immediate is a single `cancel?` byte: 0x00 = plain, 0x01 = cancellable.
+            const cancel = try reader.readByte();
+            const cancellable = switch (cancel) {
+                0x00 => false,
+                0x01 => true,
+                else => return error.InvalidEncoding,
+            };
+            break :blk .{ .task_yield = .{ .cancellable = cancellable } };
+        },
         else => error.InvalidEncoding,
+    };
+}
+
+/// Parse the immediate of `canon context.get v i` / `canon context.set v i`
+/// (Binary.md tags 0x0a / 0x0b). The valtype byte is restricted to `i32`
+/// in sub-PR 1; widen later as conformance grows.
+fn parseContextCanon(reader: *BinaryReader, comptime kind: enum { get, set }) LoadError!ctypes.Canon {
+    const val_byte = try reader.readByte();
+    if (val_byte != @intFromEnum(ctypes.CoreValType.i32)) return error.InvalidEncoding;
+    const slot = try reader.readU32();
+    return switch (kind) {
+        .get => .{ .context_get = .{ .val_type = ctypes.CoreValType.i32, .slot = slot } },
+        .set => .{ .context_set = .{ .val_type = ctypes.CoreValType.i32, .slot = slot } },
     };
 }
 
@@ -889,6 +922,53 @@ test "readValType: rejects unknown negative code" {
     // 0x67 decodes as signed LEB -25, which has no primitive mapping.
     var reader = BinaryReader{ .data = &[_]u8{0x67} };
     try std.testing.expectError(error.InvalidEncoding, readValType(&reader));
+}
+
+test "parseCanon: task.yield with cancel? = 0x00" {
+    // tag 0x0c, cancel? 0x00 → task_yield with cancellable=false
+    var reader = BinaryReader{ .data = &[_]u8{ 0x0c, 0x00 } };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .task_yield);
+    try std.testing.expectEqual(false, c.task_yield.cancellable);
+}
+
+test "parseCanon: task.yield with cancel? = 0x01 (cancellable)" {
+    var reader = BinaryReader{ .data = &[_]u8{ 0x0c, 0x01 } };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .task_yield);
+    try std.testing.expectEqual(true, c.task_yield.cancellable);
+}
+
+test "parseCanon: task.yield rejects invalid cancel byte" {
+    var reader = BinaryReader{ .data = &[_]u8{ 0x0c, 0x02 } };
+    try std.testing.expectError(error.InvalidEncoding, parseCanon(&reader, std.testing.allocator));
+}
+
+test "parseCanon: context.get i32 slot=0" {
+    // tag 0x0a, valtype byte for i32 = 0x7F, slot LEB = 0x00
+    var reader = BinaryReader{ .data = &[_]u8{ 0x0a, 0x7F, 0x00 } };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .context_get);
+    try std.testing.expectEqual(ctypes.CoreValType.i32, c.context_get.val_type);
+    try std.testing.expectEqual(@as(u32, 0), c.context_get.slot);
+}
+
+test "parseCanon: context.set i32 slot=1" {
+    var reader = BinaryReader{ .data = &[_]u8{ 0x0b, 0x7F, 0x01 } };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .context_set);
+    try std.testing.expectEqual(@as(u32, 1), c.context_set.slot);
+}
+
+test "parseCanon: context.get rejects non-i32 valtype" {
+    // tag 0x0a, valtype byte for i64 = 0x7E → rejected in sub-PR 1
+    var reader = BinaryReader{ .data = &[_]u8{ 0x0a, 0x7E, 0x00 } };
+    try std.testing.expectError(error.InvalidEncoding, parseCanon(&reader, std.testing.allocator));
+}
+
+test "parseCanon: context.set rejects non-i32 valtype" {
+    var reader = BinaryReader{ .data = &[_]u8{ 0x0b, 0x7D, 0x00 } };
+    try std.testing.expectError(error.InvalidEncoding, parseCanon(&reader, std.testing.allocator));
 }
 
 test "parseTypeDef: instance type with `sub resource` type decl" {

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -330,6 +330,29 @@ pub const Canon = union(enum) {
     resource_drop: u32, // resource type index
     /// Get the representation of a resource handle.
     resource_rep: u32, // resource type index
+
+    // ── Async ABI canonical built-ins (WASIp3 / Component Model 🔀) ──────────
+    //
+    // Binary tags per design/mvp/Binary.md "Canonical Definitions". The current
+    // upstream spec renames `task.yield` → `thread.yield` but the surface lives
+    // on the per-task state machine; #478 still calls it `task_yield` and
+    // sub-PR 1 keeps that name. Tags here are sub-PR-1 scope; sub-PR 2/3 will
+    // grow the union with subtask/future/stream variants.
+
+    /// Cooperatively suspend the currently executing task. Tag `0x0c`.
+    /// `cancellable == true` corresponds to `cancel? = 0x01` in the binary
+    /// format; when set, the returned discriminant indicates whether the
+    /// suspending task was cancelled while parked.
+    task_yield: struct { cancellable: bool },
+
+    /// Read a per-task context slot. Tag `0x0a`. The spec allows arbitrary
+    /// `valtype`, but sub-PR 1 only admits `i32` (Wasmtime's current limit);
+    /// other types are rejected at load with `error.InvalidEncoding`.
+    context_get: struct { val_type: CoreValType, slot: u32 },
+
+    /// Write a per-task context slot. Tag `0x0b`. Same `i32`-only restriction
+    /// as `context_get`.
+    context_set: struct { val_type: CoreValType, slot: u32 },
 };
 
 // ── Imports and exports ─────────────────────────────────────────────────────
@@ -485,8 +508,8 @@ pub const Component = struct {
 /// A single contributor to the core-func index space.
 pub const CoreFuncContributor = union(enum) {
     /// Index into `component.canons`. Only canon kinds that contribute
-    /// to the core-func indexspace (`.lower`, `.resource_drop`,
-    /// `.resource_new`, `.resource_rep`) appear here; `.lift` does not.
+    /// to the core-func indexspace appear here — every kind except
+    /// `.lift` (which produces a *component* func, not a core func).
     canon: u32,
     /// Index into `component.aliases`.
     alias: u32,


### PR DESCRIPTION
Part of #478 → #451. First of three sub-PRs the parent issue proposes splitting #478 into; lands the smallest surface (the per-task control-flow built-ins).

Without this, every component binary that mentions canon tags `0x0a` / `0x0b` / `0x0c` fails to load with `error.InvalidEncoding` — that blocks the WASIp3 conformance suite from starting.

## Surface

- `Canon.task_yield { cancellable }` — Binary.md tag `0x0c`. The upstream spec now calls this `thread.yield`; the issue title still says `task.yield`, so the IR variant keeps the issue's spelling. The binary encoding follows the current spec (single `cancel?` byte).
- `Canon.context_get` / `context_set` `{ val_type, slot }` — tags `0x0a` / `0x0b`. The loader rejects `val_type != i32` (matches Wasmtime's current limit; widen later as conformance grows).
- `CoreFuncRef.{task_yield, context_get, context_set}` so the new canons contribute to the core-func indexspace alongside `.resource_*`.

## Runtime state

- `async.zig`: `Task.context_slots: [N_CONTEXT_SLOTS]u32` (=2) plus `TaskManager.current_task: ?u32`. `getContextSlot` / `setContextSlot` are bounds-checked.
- `instance.zig`: `ComponentInstance.implicit_task_context` — per-instance fallback for `context.{get,set}` invoked outside any async task (synchronous canon-lift path). Mirrors Wasmtime.
- `async_canon.zig`: `taskYield` is a single-threaded poll-cycle stub. Sub-PR 3 replaces it with real `future<T>` / `stream<T>` / `wasi:io/poll.pollable` integration; the `YieldOutcome.{resumed,cancelled}` discriminant on the ABI side is stable.
- `executor.zig`: three new arms in `dispatchCanonBuiltin`, plus set/clear `task_manager.current_task` around the synchronous body of `callComponentFuncAsync`.

## Tests (22 new)

- `async.zig`: get/set round-trip, slot-bounds rejection, per-task isolation.
- `async_canon.zig`: `taskYield` happy path, cancellable cancellation observation, unknown-handle no-op.
- `loader.zig`: parse all three new tags incl. non-i32 valtype and invalid cancel-byte rejection.
- `indexspace.zig`: the new canon kinds occupy core-func slots in declaration order.
- `executor.zig`: end-to-end `dispatchCanonBuiltin` set+yield+get round-trip via both the implicit per-instance fallback and an `asyncLift`'d task, plus out-of-range slot trap.

## Out of scope (deferred to subsequent #478 sub-PRs)

- Async-lifted callees (sub-PR 2) — the lift side of an `(async)` import-call boundary.
- `future<T>` / `stream<T>` as canonical lift/lower types (sub-PR 3), incl. `wasi:io/poll.pollable`.
- Real fiber-based scheduling — the single-threaded poll-cycle stub is intentional. Sub-PR 3 can replace it without changing the ABI surface.
- Cancellation propagation (`task.cancel`, future/stream close) — that's #488 per the tracker.

## Verification

- \`zig build test\`: **1955/1955** pass (+22 new).
- \`zig build\` clean on both aarch64 (native) and x86_64 (cross-built locally).
- No perf gate applies (out of CoreMark scope per #393).