### PR TITLE
feat(component): async-lifted callees + future/stream/error-context/waitable-set canons (#478 sub-PRs 2+3)

### DIFF
--- a/src/component/canonical_abi.zig
+++ b/src/component/canonical_abi.zig
@@ -230,6 +230,9 @@ pub fn alignment(t: ctypes.ValType) u32 {
         .s64, .u64, .f64 => 8,
         .string => 4,
         .own, .borrow => 4,
+        // Async ABI handle types (future / stream / error-context) share
+        // the resource-handle layout: a 4-byte i32 handle. (#478 sub-PR 3.)
+        .future, .stream, .error_context => 4,
         .list => 4,
         .record, .variant, .tuple, .flags, .enum_, .option, .result, .type_idx => 0,
     };
@@ -245,6 +248,7 @@ pub fn elemSize(t: ctypes.ValType) u32 {
         .s64, .u64, .f64 => 8,
         .string => 8,
         .own, .borrow => 4,
+        .future, .stream, .error_context => 4,
         .list => 8,
         .record, .variant, .tuple, .flags, .enum_, .option, .result, .type_idx => 0,
     };
@@ -410,6 +414,7 @@ pub const MAX_FLAT_RESULTS: u32 = 1;
 pub fn flatten(t: ctypes.ValType) []const ctypes.CoreValType {
     return switch (t) {
         .bool, .s8, .u8, .s16, .u16, .s32, .u32, .char, .own, .borrow => &.{.i32},
+        .future, .stream, .error_context => &.{.i32},
         .s64, .u64 => &.{.i64},
         .f32 => &.{.f32},
         .f64 => &.{.f64},
@@ -426,6 +431,7 @@ pub fn flatten(t: ctypes.ValType) []const ctypes.CoreValType {
 pub fn flattenCount(reg: TypeRegistry, t: ctypes.ValType) u32 {
     return switch (t) {
         .bool, .s8, .u8, .s16, .u16, .s32, .u32, .char, .own, .borrow => 1,
+        .future, .stream, .error_context => 1,
         .s64, .u64 => 1,
         .f32, .f64 => 1,
         .string => 2,
@@ -527,7 +533,7 @@ pub fn loadVal(memory: []const u8, ptr: u32, t: ctypes.ValType) !InterfaceValue 
         .f32 => .{ .f32 = @bitCast(loadU32(memory, ptr)) },
         .f64 => .{ .f64 = @bitCast(loadU64(memory, ptr)) },
         .char => .{ .char = loadU32(memory, ptr) },
-        .own, .borrow => .{ .handle = loadU32(memory, ptr) },
+        .own, .borrow, .future, .stream, .error_context => .{ .handle = loadU32(memory, ptr) },
         .string => .{ .string = .{
             .ptr = loadU32(memory, ptr),
             .len = loadU32At(memory, ptr, 4),
@@ -552,7 +558,7 @@ pub const LoadError = error{
 pub fn loadValReg(memory: []const u8, ptr: u32, t: ctypes.ValType, reg: TypeRegistry, alloc: Allocator) LoadError!InterfaceValue {
     return switch (t) {
         // Primitives delegate to existing path
-        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .own, .borrow, .string, .list => loadVal(memory, ptr, t),
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .own, .borrow, .future, .stream, .error_context, .string, .list => loadVal(memory, ptr, t),
         .enum_ => |idx| blk: {
             const td = reg.get(idx) orelse break :blk error.InvalidTypeIndex;
             const disc_sz = discriminantSize(td.enum_.names.len);
@@ -769,7 +775,7 @@ pub fn storeVal(memory: []u8, ptr: u32, t: ctypes.ValType, val: InterfaceValue) 
         .f32 => storeU32(memory, ptr, @bitCast(val.f32)),
         .f64 => storeU64(memory, ptr, @bitCast(val.f64)),
         .char => storeU32(memory, ptr, val.char),
-        .own, .borrow => storeU32(memory, ptr, val.handle),
+        .own, .borrow, .future, .stream, .error_context => storeU32(memory, ptr, val.handle),
         .string => {
             storeU32(memory, ptr, val.string.ptr);
             storeU32At(memory, ptr, 4, val.string.len);
@@ -791,7 +797,7 @@ pub const StoreError = error{
 /// Store any value to linear memory, resolving compound types via registry.
 pub fn storeValReg(memory: []u8, ptr: u32, t: ctypes.ValType, val: InterfaceValue, reg: TypeRegistry) StoreError!void {
     switch (t) {
-        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .own, .borrow, .string, .list => try storeVal(memory, ptr, t, val),
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .s64, .u64, .f32, .f64, .char, .own, .borrow, .future, .stream, .error_context, .string, .list => try storeVal(memory, ptr, t, val),
         .enum_ => {
             const idx = t.enum_;
             const td = reg.get(idx) orelse return error.InvalidTypeIndex;
@@ -1004,7 +1010,7 @@ pub fn liftFlat(core_vals: []const u32, t: ctypes.ValType) !InterfaceValue {
         .u64 => .{ .u64 = if (core_vals.len > 1) @as(u64, core_vals[1]) << 32 | core_vals[0] else core_vals[0] },
         .f32 => .{ .f32 = core_vals[0] },
         .f64 => .{ .f64 = if (core_vals.len > 1) @as(u64, core_vals[1]) << 32 | core_vals[0] else core_vals[0] },
-        .own, .borrow => .{ .handle = core_vals[0] },
+        .own, .borrow, .future, .stream, .error_context => .{ .handle = core_vals[0] },
         .string => .{ .string = .{
             .ptr = core_vals[0],
             .len = if (core_vals.len > 1) core_vals[1] else 0,
@@ -1069,7 +1075,7 @@ pub fn lowerFlat(val: InterfaceValue, t: ctypes.ValType, out: []u32) !u32 {
             if (out.len > 1) out[1] = @truncate(val.f64 >> 32);
             return 2;
         },
-        .own, .borrow => {
+        .own, .borrow, .future, .stream, .error_context => {
             out[0] = val.handle;
             return 1;
         },

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -512,7 +512,7 @@ fn pushInterfaceValue(env: *ExecEnv, val: InterfaceValue, t: ctypes.ValType, reg
         .u64 => try env.pushI64(@bitCast(val.u64)),
         .f32 => try env.push(.{ .f32 = @bitCast(val.f32) }),
         .f64 => try env.push(.{ .f64 = @bitCast(val.f64) }),
-        .own, .borrow => try env.pushI32(@bitCast(val.handle)),
+        .own, .borrow, .future, .stream, .error_context => try env.pushI32(@bitCast(val.handle)),
         .string => {
             try env.pushI32(@bitCast(val.string.ptr));
             try env.pushI32(@bitCast(val.string.len));
@@ -621,7 +621,7 @@ fn popInterfaceValue(env: *ExecEnv, t: ctypes.ValType, registry: TypeRegistry, a
                 else => 0,
             } };
         },
-        .own, .borrow => .{ .handle = @bitCast(try env.popI32()) },
+        .own, .borrow, .future, .stream, .error_context => .{ .handle = @bitCast(try env.popI32()) },
         .string => .{ .string = .{
             .len = @bitCast(try env.popI32()),
             .ptr = @bitCast(try env.popI32()),
@@ -904,7 +904,156 @@ pub fn dispatchCanonBuiltin(
             }
             async_canon.asyncReturn(tm, handle, flat);
         },
+        .async_canon => |op| try dispatchAsyncCanon(comp_inst, op, env, task_manager, allocator),
         .lift, .lower => {}, // Handled by callComponentFunc
+    }
+}
+
+/// Dispatch the WASIp3 async-canon surface (#478 sub-PR 3): subtask /
+/// future / stream / error-context / waitable-set / waitable.join.
+///
+/// **Scope**: this is the minimum dispatch needed for the conformance
+/// suite to stop failing at load. Every `.new`-flavoured op allocates
+/// a per-instance handle; every `.drop` releases it. The read / write /
+/// cancel-* ops trap with `error.FunctionNotFound` — they require
+/// real fiber-based scheduling integration that lands as a follow-up.
+fn dispatchAsyncCanon(
+    comp_inst: *ComponentInstance,
+    op: ctypes.AsyncCanonOp,
+    env: *ExecEnv,
+    task_manager: ?*async_mod.TaskManager,
+    allocator: Allocator,
+) ExecutionError!void {
+    switch (op) {
+        .subtask_drop => {
+            // Pop the subtask handle. We simply discard — the task's
+            // memory belongs to the TaskManager whose lifetime exceeds
+            // any single subtask.drop call.
+            _ = env.popI32() catch return error.StackUnderflow;
+        },
+        .subtask_cancel => |info| {
+            _ = info;
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            if (task_manager) |tm| tm.cancelTask(handle);
+            // `async?` info is ignored: cancellation is idempotent and
+            // synchronous in the single-threaded runtime.
+        },
+
+        // ── Stream handles ──────────────────────────────────────────────
+        .stream_new => |info| {
+            _ = info;
+            const handle = comp_inst.allocAsyncHandle();
+            comp_inst.streams.put(comp_inst.allocator, handle, .{}) catch return error.OutOfMemory;
+            // Spec packs read+write handles into one i64; in our
+            // single-handle prototype we publish the same idx for both
+            // ends to keep the wire format compatible with i64 pops.
+            const packed_handles: u64 = (@as(u64, handle) << 32) | @as(u64, handle);
+            env.pushI64(@bitCast(packed_handles)) catch return error.StackOverflow;
+        },
+        .stream_drop_readable => |info| {
+            _ = info;
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            if (comp_inst.streams.fetchRemove(handle)) |kv| {
+                var s = kv.value;
+                s.deinit(comp_inst.allocator);
+            }
+        },
+        .stream_drop_writable => |info| {
+            _ = info;
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            if (comp_inst.streams.fetchRemove(handle)) |kv| {
+                var s = kv.value;
+                s.deinit(comp_inst.allocator);
+            }
+        },
+        .stream_read, .stream_write, .stream_cancel_read, .stream_cancel_write => return error.FunctionNotFound,
+
+        // ── Future handles ──────────────────────────────────────────────
+        .future_new => |info| {
+            _ = info;
+            const handle = comp_inst.allocAsyncHandle();
+            comp_inst.futures.put(comp_inst.allocator, handle, .{}) catch return error.OutOfMemory;
+            const packed_handles: u64 = (@as(u64, handle) << 32) | @as(u64, handle);
+            env.pushI64(@bitCast(packed_handles)) catch return error.StackOverflow;
+        },
+        .future_drop_readable => |info| {
+            _ = info;
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            _ = comp_inst.futures.remove(handle);
+        },
+        .future_drop_writable => |info| {
+            _ = info;
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            _ = comp_inst.futures.remove(handle);
+        },
+        .future_read, .future_write, .future_cancel_read, .future_cancel_write => return error.FunctionNotFound,
+
+        // ── error-context ───────────────────────────────────────────────
+        .error_context_new => |info| {
+            _ = info;
+            // Per spec: pops (ptr, len) for the debug-message string and
+            // returns a new error-context handle. We don't yet eagerly
+            // copy the message from guest memory — that requires
+            // memory/realloc options threading. Store an empty string;
+            // `debug-message` returns it as-is.
+            _ = env.popI32() catch return error.StackUnderflow; // len
+            _ = env.popI32() catch return error.StackUnderflow; // ptr
+            const handle = comp_inst.allocAsyncHandle();
+            const empty = allocator.alloc(u8, 0) catch return error.OutOfMemory;
+            comp_inst.error_contexts.put(comp_inst.allocator, handle, empty) catch {
+                allocator.free(empty);
+                return error.OutOfMemory;
+            };
+            env.pushI32(@bitCast(handle)) catch return error.StackOverflow;
+        },
+        .error_context_debug_message => |info| {
+            _ = info;
+            // Pops error-context handle + (ptr, length) of the
+            // caller-allocated buffer; writes the debug message into
+            // guest memory. We don't yet bridge into guest memory, so
+            // pop and no-op for now.
+            _ = env.popI32() catch return error.StackUnderflow;
+            _ = env.popI32() catch return error.StackUnderflow;
+            _ = env.popI32() catch return error.StackUnderflow;
+        },
+        .error_context_drop => {
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            if (comp_inst.error_contexts.fetchRemove(handle)) |kv| {
+                comp_inst.allocator.free(kv.value);
+            }
+        },
+
+        // ── Waitable-set ────────────────────────────────────────────────
+        .waitable_set_new => {
+            const handle = comp_inst.allocAsyncHandle();
+            comp_inst.waitable_sets.put(comp_inst.allocator, handle, .{}) catch return error.OutOfMemory;
+            env.pushI32(@bitCast(handle)) catch return error.StackOverflow;
+        },
+        .waitable_set_drop => {
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            if (comp_inst.waitable_sets.fetchRemove(handle)) |kv| {
+                var ws = kv.value;
+                ws.deinit(comp_inst.allocator);
+            }
+        },
+        .waitable_set_wait, .waitable_set_poll => {
+            // wait/poll expect a (ws_handle, out_ptr) and write a 2-tuple
+            // (event-kind, payload) into guest memory. Without
+            // guest-memory bridging we can't honour that contract — pop
+            // arguments and push a zero status to keep the core stack
+            // balanced for the conformance "load + don't crash" target.
+            _ = env.popI32() catch return error.StackUnderflow; // ws handle
+            _ = env.popI32() catch return error.StackUnderflow; // out ptr
+            env.pushI32(0) catch return error.StackOverflow;
+        },
+
+        .waitable_join => {
+            // Pops (waitable_handle, ws_handle). We simply drop both —
+            // the join becomes a no-op until real WaitableItem-typed
+            // registration lands alongside the read/write canon ops.
+            _ = env.popI32() catch return error.StackUnderflow;
+            _ = env.popI32() catch return error.StackUnderflow;
+        },
     }
 }
 
@@ -1582,6 +1731,174 @@ test "dispatchCanonBuiltin: task.return without a task manager is malformed" {
     const result = dispatchCanonBuiltin(
         inst,
         .{ .task_return = .{ .results = .none, .opts = &.{} } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectError(error.FunctionNotFound, result);
+}
+
+// ── Sub-PR 3: async_canon smoke tests ────────────────────────────────────────
+
+test "dispatchCanonBuiltin: waitable-set.new allocates a fresh handle; drop frees it" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .waitable_set_new },
+        env,
+        null,
+        testing.allocator,
+    );
+    const handle: u32 = @bitCast(try env.popI32());
+    try testing.expect(handle > 0);
+    try testing.expectEqual(@as(u32, 1), inst.waitable_sets.count());
+
+    // Drop releases it from the table.
+    try env.pushI32(@bitCast(handle));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .waitable_set_drop },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(u32, 0), inst.waitable_sets.count());
+}
+
+test "dispatchCanonBuiltin: future.new + drop-readable round-trip" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_new = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    // future.new pushes i64 packed handle pair — pop and unpack.
+    const packed_handles: u64 = @bitCast(try env.popI64());
+    const r_idx: u32 = @truncate(packed_handles >> 32);
+    const w_idx: u32 = @truncate(packed_handles & 0xFFFF_FFFF);
+    try testing.expectEqual(r_idx, w_idx); // sub-PR 3 stub uses the same idx for both ends
+    try testing.expect(r_idx > 0);
+    try testing.expectEqual(@as(u32, 1), inst.futures.count());
+
+    try env.pushI32(@bitCast(r_idx));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_drop_readable = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(u32, 0), inst.futures.count());
+}
+
+test "dispatchCanonBuiltin: error-context.new + drop round-trip" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    // error-context.new pops (ptr, len) for the debug-message — push
+    // synthetic values; the sub-PR 3 stub doesn't actually read from
+    // guest memory yet.
+    try env.pushI32(0); // ptr
+    try env.pushI32(0); // len
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .error_context_new = .{ .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const handle: u32 = @bitCast(try env.popI32());
+    try testing.expect(handle > 0);
+    try testing.expectEqual(@as(u32, 1), inst.error_contexts.count());
+
+    try env.pushI32(@bitCast(handle));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .error_context_drop },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(u32, 0), inst.error_contexts.count());
+}
+
+test "dispatchCanonBuiltin: stream.read traps with FunctionNotFound (sub-PR 3 scope)" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    const result = dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .stream_read = .{ .type_idx = 0, .opts = &.{} } } },
         env,
         null,
         testing.allocator,

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -53,6 +53,14 @@ pub const LiftOptions = struct {
     realloc_idx: ?u32 = null,
     post_return_idx: ?u32 = null,
     string_encoding: ctypes.StringEncoding = .utf8,
+    /// Whether this lift uses the async ABI (Binary.md `canonopt 0x06`).
+    /// Async lifts return a packed status immediately; results are
+    /// delivered via `task.return`. (#478 sub-PR 2.)
+    is_async: bool = false,
+    /// Optional resumption callback core funcidx (Binary.md `canonopt 0x07`).
+    /// Only meaningful when `is_async`; the single-threaded poll-cycle
+    /// dispatcher invokes it once after each yield. (#478 sub-PR 2.)
+    callback_idx: ?u32 = null,
 
     pub fn fromOpts(opts: []const ctypes.CanonOpt) LiftOptions {
         var lo = LiftOptions{};
@@ -62,6 +70,8 @@ pub const LiftOptions = struct {
                 .realloc => |idx| lo.realloc_idx = idx,
                 .post_return => |idx| lo.post_return_idx = idx,
                 .string_encoding => |enc| lo.string_encoding = enc,
+                .async_lift => lo.is_async = true,
+                .callback => |idx| lo.callback_idx = idx,
             }
         }
         return lo;
@@ -326,6 +336,93 @@ pub fn callComponentFuncByLocal(
             env.pushI32(@bitCast(result_ptr_for_post_return)) catch {};
         }
         interp.executeFunction(env, pr_idx) catch {};
+    }
+}
+
+/// Async-lifted variant of `callComponentFuncByLocal`. Lifts args and
+/// drives the core wasm body the same way, but the callee delivers its
+/// results via `canon task.return` (#478 sub-PR 2). On return from the
+/// core function, `out_status` is set to the i32 the core fn left on
+/// the stack — for an async lift with no callback the spec says this
+/// is always `0` (the "task returned synchronously" sentinel); with a
+/// callback set it's the packed status that selects the callback's
+/// follow-up action. The actual results land in
+/// `task_manager.tasks[handle].return_values` via `dispatchCanonBuiltin`.
+pub fn callComponentFuncByLocalAsyncLifted(
+    owner_inst: *const ComponentInstance,
+    exported: ComponentInstance.ExportedFunc.Local,
+    args: []const InterfaceValue,
+    out_status: *u32,
+    allocator: Allocator,
+) ExecutionError!void {
+    out_status.* = 0;
+
+    if (exported.core_instance_idx >= owner_inst.core_instances.len)
+        return error.CoreInstanceNotAvailable;
+    const core_entry = owner_inst.core_instances[exported.core_instance_idx];
+    const module_inst = core_entry.module_inst orelse return error.CoreInstanceNotAvailable;
+
+    const lift_opts = LiftOptions.fromOpts(exported.opts);
+    if (!lift_opts.is_async) return error.InvalidFuncType;
+
+    const registry = TypeRegistry.init(owner_inst.component);
+
+    const func_type = blk: {
+        const td = registry.get(exported.func_type_idx) orelse return error.InvalidFuncType;
+        switch (td) {
+            .func => |ft| break :blk ft,
+            else => return error.InvalidFuncType,
+        }
+    };
+
+    const param_types = getParamValTypes(func_type, allocator) catch return error.OutOfMemory;
+    defer allocator.free(param_types);
+
+    const flat_param_count = countFlatTypes(registry, param_types);
+
+    const env = ExecEnv.create(module_inst, 4096, allocator) catch return error.OutOfMemory;
+    defer env.destroy();
+
+    const memory: ?[]u8 = if (lift_opts.memory_idx) |mem_idx|
+        if (module_inst.getMemory(mem_idx)) |mem| mem.data else null
+    else
+        null;
+
+    // Lower args — same logic as the sync path.
+    if (flat_param_count <= MAX_FLAT_PARAMS) {
+        for (args, param_types) |arg, pt| {
+            pushInterfaceValue(env, arg, pt, registry) catch return error.LowerError;
+        }
+    } else {
+        const mem = memory orelse return error.MemoryNotAvailable;
+        const realloc_idx = lift_opts.realloc_idx orelse return error.ReallocNotAvailable;
+        const tuple_size = computeTupleSize(registry, param_types);
+        const tuple_align = computeTupleAlign(registry, param_types);
+        const ptr = try callRealloc(env, realloc_idx, 0, 0, tuple_align, tuple_size);
+
+        var offset: u32 = 0;
+        for (args, param_types) |arg, pt| {
+            const al = typeAlign(registry, pt);
+            offset = abi.alignUp(offset, al);
+            storeInterfaceValue(mem, offset, arg, pt, registry);
+            offset += typeSize(registry, pt);
+        }
+        env.pushI32(@bitCast(ptr)) catch return error.StackOverflow;
+    }
+
+    // Drive the core body. It is the callee's responsibility to invoke
+    // `canon task.return` before returning — which deposits the lifted
+    // results onto the task via `dispatchCanonBuiltin`.
+    interp.executeFunction(env, exported.core_func_idx) catch {
+        return error.TrapInCoreFunction;
+    };
+
+    // Spec: with `callback` set, the core fn leaves a packed status i32
+    // on the stack; otherwise (stackful async) it returns no value. We
+    // probe optimistically: if the core fn returned an i32, peel it
+    // off; otherwise leave status at 0 (the default).
+    if (lift_opts.callback_idx != null) {
+        out_status.* = @bitCast(env.popI32() catch 0);
     }
 }
 
@@ -780,6 +877,33 @@ pub fn dispatchCanonBuiltin(
             if (info.slot >= async_mod.N_CONTEXT_SLOTS) return error.StackUnderflow;
             comp_inst.implicit_task_context[info.slot] = value;
         },
+        .task_return => |info| {
+            // `canon task.return rs:<resultlist> opts:<opts>` — Binary.md
+            // tag 0x09. Pops the lifted-callee's results off the env stack
+            // (flat i32 representation per the Canonical ABI), stores them
+            // on the current task, and notifies the parent waitable.
+            // Caller without a task manager is malformed (a sync lift
+            // never emits task.return).
+            const tm = task_manager orelse return error.FunctionNotFound;
+            const handle = tm.current_task orelse return error.FunctionNotFound;
+            const flat_count: usize = switch (info.results) {
+                .none => 0,
+                .unnamed => 1,
+                .named => |named| named.len,
+            };
+            const flat = allocator.alloc(u32, flat_count) catch return error.OutOfMemory;
+            // The Canonical ABI pushes results left-to-right, so the last
+            // result is on top — pop in reverse.
+            var i: usize = flat_count;
+            while (i > 0) {
+                i -= 1;
+                flat[i] = @bitCast(env.popI32() catch {
+                    allocator.free(flat);
+                    return error.StackUnderflow;
+                });
+            }
+            async_canon.asyncReturn(tm, handle, flat);
+        },
         .lift, .lower => {}, // Handled by callComponentFunc
     }
 }
@@ -825,7 +949,35 @@ pub fn callComponentFuncAsync(
     const owner_for_type = flat.owner;
     const exported_local = flat.local;
 
-    // Get function type for result count
+    // Inspect the lift options to choose between the async-lifted ABI
+    // (callee invokes `task.return`) and the legacy sync-wrapped-in-task
+    // path (host lifts the results and stashes them on the task).
+    const lift_opts = LiftOptions.fromOpts(exported_local.opts);
+
+    // Make the just-created subtask discoverable to context.{get,set},
+    // task.yield, and task.return invoked from inside the core body.
+    // Restored on return regardless of success/failure. (#478 sub-PR 1/2.)
+    const saved_current_task = task_manager.current_task;
+    task_manager.current_task = handle;
+    defer task_manager.current_task = saved_current_task;
+
+    if (lift_opts.is_async) {
+        // Async-lifted ABI: drive the core fn and let `task.return`
+        // populate task.return_values on its own.
+        var status: u32 = 0;
+        _ = &status;
+        callComponentFuncByLocalAsyncLifted(owner_for_type, exported_local, args, &status, allocator) catch |e| {
+            task_manager.cancelTask(handle);
+            return e;
+        };
+        // If a callback is configured, sub-PR 2's poll-cycle stub would
+        // invoke it once after each yield. Real future/stream-driven
+        // polling lands in sub-PR 3; for now we surface the status by
+        // ignoring it (the caller can re-inspect it via the task).
+        return handle;
+    }
+
+    // Legacy sync-lift path: lift results, populate the task manually.
     const result_count: usize = blk: {
         const reg = TypeRegistry.init(owner_for_type.component);
         if (reg.get(exported_local.func_type_idx)) |td| {
@@ -848,14 +1000,6 @@ pub fn callComponentFuncAsync(
         task_manager.cancelTask(handle);
         return error.OutOfMemory;
     };
-
-    // Make the just-created subtask discoverable to context.{get,set} and
-    // task.yield invoked from inside the synchronous body. Restored on
-    // return regardless of success/failure so nested calls see the
-    // surrounding caller's task afterwards. (#478 sub-PR 1.)
-    const saved_current_task = task_manager.current_task;
-    task_manager.current_task = handle;
-    defer task_manager.current_task = saved_current_task;
 
     callComponentFunc(comp_inst, func_name, args, results, allocator) catch |e| {
         allocator.free(results);
@@ -908,6 +1052,20 @@ test "LiftOptions: defaults" {
     try std.testing.expectEqual(@as(?u32, null), lo.realloc_idx);
     try std.testing.expectEqual(@as(?u32, null), lo.post_return_idx);
     try std.testing.expectEqual(ctypes.StringEncoding.utf8, lo.string_encoding);
+    try std.testing.expectEqual(false, lo.is_async);
+    try std.testing.expectEqual(@as(?u32, null), lo.callback_idx);
+}
+
+test "LiftOptions: async + callback (#478 sub-PR 2)" {
+    const opts = [_]ctypes.CanonOpt{
+        .{ .memory = 0 },
+        .async_lift,
+        .{ .callback = 7 },
+    };
+    const lo = LiftOptions.fromOpts(&opts);
+    try std.testing.expectEqual(@as(?u32, 0), lo.memory_idx);
+    try std.testing.expectEqual(true, lo.is_async);
+    try std.testing.expectEqual(@as(?u32, 7), lo.callback_idx);
 }
 
 test "countFlatTypes: primitives" {
@@ -1352,6 +1510,85 @@ test "dispatchCanonBuiltin: context.get out-of-range slot traps" {
     try testing.expectError(error.StackUnderflow, result);
 }
 
+test "dispatchCanonBuiltin: task.return delivers results to the current task (#478 sub-PR 2)" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    var tm = async_mod.TaskManager{};
+    defer tm.deinit(testing.allocator);
+    const lift = try async_canon.asyncLift(.{
+        .task_manager = &tm,
+        .allocator = testing.allocator,
+    });
+    tm.current_task = lift.subtask_handle;
+
+    // Push the single i32 result on the env stack, then dispatch task.return.
+    try env.pushI32(0x1234_5678);
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .task_return = .{
+            .results = .{ .unnamed = .s32 },
+            .opts = &.{},
+        } },
+        env,
+        &tm,
+        testing.allocator,
+    );
+
+    // Task should now be in .returned with the value visible to pollers.
+    try testing.expectEqual(async_mod.TaskState.returned, tm.getState(lift.subtask_handle).?);
+    const ret = async_canon.asyncPollResult(&tm, lift.subtask_handle).?;
+    defer testing.allocator.free(ret);
+    try testing.expectEqual(@as(usize, 1), ret.len);
+    try testing.expectEqual(@as(u32, 0x1234_5678), ret[0]);
+}
+
+test "dispatchCanonBuiltin: task.return without a task manager is malformed" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    const result = dispatchCanonBuiltin(
+        inst,
+        .{ .task_return = .{ .results = .none, .opts = &.{} } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectError(error.FunctionNotFound, result);
+}
+
 // ── Canon-lower host trampoline ─────────────────────────────────────────────
 
 const core_runtime_types = @import("../runtime/common/types.zig");
@@ -1373,6 +1610,10 @@ pub const LowerOptions = struct {
                 .realloc => |idx| lo.realloc_idx = idx,
                 .post_return => {},
                 .string_encoding => |enc| lo.string_encoding = enc,
+                // `async` and `callback` only meaningful on the lift side
+                // (Binary.md grammar reuses one `opts` vec for both, so
+                // we must accept them here without effect).
+                .async_lift, .callback => {},
             }
         }
         return lo;

--- a/src/component/indexspace.zig
+++ b/src/component/indexspace.zig
@@ -251,6 +251,8 @@ pub const CoreFuncRef = union(enum) {
     context_get: u32,
     /// Index into `component.canons` for a `.context_set` entry. (#478)
     context_set: u32,
+    /// Index into `component.canons` for a `.task_return` entry. (#478)
+    task_return: u32,
     /// Index into `component.aliases`.
     aliased: u32,
 };
@@ -273,6 +275,7 @@ pub fn resolveCoreFunc(component: *const ctypes.Component, idx: u32) ?CoreFuncRe
                 .task_yield => .{ .task_yield = canon_idx },
                 .context_get => .{ .context_get = canon_idx },
                 .context_set => .{ .context_set = canon_idx },
+                .task_return => .{ .task_return = canon_idx },
                 .lift => null, // lift never contributes to core-func indexspace
             },
         };
@@ -308,6 +311,10 @@ pub fn resolveCoreFunc(component: *const ctypes.Component, idx: u32) ?CoreFuncRe
             },
             .context_set => {
                 if (n == idx) return .{ .context_set = @intCast(i) };
+                n += 1;
+            },
+            .task_return => {
+                if (n == idx) return .{ .task_return = @intCast(i) };
                 n += 1;
             },
             .lift => {},
@@ -722,6 +729,7 @@ test "resolveCoreFunc: async ABI built-ins contribute core-func slots" {
         .{ .task_yield = .{ .cancellable = false } },
         .{ .context_get = .{ .val_type = .i32, .slot = 0 } },
         .{ .context_set = .{ .val_type = .i32, .slot = 0 } },
+        .{ .task_return = .{ .results = .none, .opts = &.{} } },
     };
     const comp = ctypes.Component{
         .core_modules = &.{},
@@ -739,7 +747,8 @@ test "resolveCoreFunc: async ABI built-ins contribute core-func slots" {
     try testing.expect(resolveCoreFunc(&comp, 1).? == .task_yield);
     try testing.expect(resolveCoreFunc(&comp, 2).? == .context_get);
     try testing.expect(resolveCoreFunc(&comp, 3).? == .context_set);
-    try testing.expect(resolveCoreFunc(&comp, 4) == null);
+    try testing.expect(resolveCoreFunc(&comp, 4).? == .task_return);
+    try testing.expect(resolveCoreFunc(&comp, 5) == null);
 }
 
 test "lookupLocalInstanceMember: finds named export in inline-exports instance" {

--- a/src/component/indexspace.zig
+++ b/src/component/indexspace.zig
@@ -253,6 +253,11 @@ pub const CoreFuncRef = union(enum) {
     context_set: u32,
     /// Index into `component.canons` for a `.task_return` entry. (#478)
     task_return: u32,
+    /// Index into `component.canons` for a `.async_canon` entry —
+    /// covers the broader WASIp3 async surface (subtask / future /
+    /// stream / error-context / waitable-set). The inner
+    /// `AsyncCanonOp` tag is the actual semantic discriminator. (#478)
+    async_canon: u32,
     /// Index into `component.aliases`.
     aliased: u32,
 };
@@ -276,6 +281,7 @@ pub fn resolveCoreFunc(component: *const ctypes.Component, idx: u32) ?CoreFuncRe
                 .context_get => .{ .context_get = canon_idx },
                 .context_set => .{ .context_set = canon_idx },
                 .task_return => .{ .task_return = canon_idx },
+                .async_canon => .{ .async_canon = canon_idx },
                 .lift => null, // lift never contributes to core-func indexspace
             },
         };
@@ -315,6 +321,10 @@ pub fn resolveCoreFunc(component: *const ctypes.Component, idx: u32) ?CoreFuncRe
             },
             .task_return => {
                 if (n == idx) return .{ .task_return = @intCast(i) };
+                n += 1;
+            },
+            .async_canon => {
+                if (n == idx) return .{ .async_canon = @intCast(i) };
                 n += 1;
             },
             .lift => {},
@@ -730,6 +740,10 @@ test "resolveCoreFunc: async ABI built-ins contribute core-func slots" {
         .{ .context_get = .{ .val_type = .i32, .slot = 0 } },
         .{ .context_set = .{ .val_type = .i32, .slot = 0 } },
         .{ .task_return = .{ .results = .none, .opts = &.{} } },
+        .{ .async_canon = .subtask_drop },
+        .{ .async_canon = .{ .future_new = .{ .type_idx = 0 } } },
+        .{ .async_canon = .{ .stream_new = .{ .type_idx = 0 } } },
+        .{ .async_canon = .waitable_set_new },
     };
     const comp = ctypes.Component{
         .core_modules = &.{},
@@ -748,7 +762,11 @@ test "resolveCoreFunc: async ABI built-ins contribute core-func slots" {
     try testing.expect(resolveCoreFunc(&comp, 2).? == .context_get);
     try testing.expect(resolveCoreFunc(&comp, 3).? == .context_set);
     try testing.expect(resolveCoreFunc(&comp, 4).? == .task_return);
-    try testing.expect(resolveCoreFunc(&comp, 5) == null);
+    try testing.expect(resolveCoreFunc(&comp, 5).? == .async_canon);
+    try testing.expect(resolveCoreFunc(&comp, 6).? == .async_canon);
+    try testing.expect(resolveCoreFunc(&comp, 7).? == .async_canon);
+    try testing.expect(resolveCoreFunc(&comp, 8).? == .async_canon);
+    try testing.expect(resolveCoreFunc(&comp, 9) == null);
 }
 
 test "lookupLocalInstanceMember: finds named export in inline-exports instance" {

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -278,6 +278,28 @@ pub const ComponentInstance = struct {
     /// (#478 sub-PR 1.)
     implicit_task_context: [async_mod.N_CONTEXT_SLOTS]u32 = [_]u32{0} ** async_mod.N_CONTEXT_SLOTS,
 
+    /// Per-instance async-handle tables for the WASIp3 canonical-ABI
+    /// surface (#478 sub-PR 3). Each table maps a u32 handle to the
+    /// host-side state allocated by the corresponding `.new` canon op:
+    /// futures, streams, error-contexts, and waitable-sets. Handles are
+    /// drawn from `next_async_handle` (starting at 1; zero is the spec
+    /// sentinel meaning "no value yet").
+    futures: std.AutoHashMapUnmanaged(u32, async_mod.Future) = .empty,
+    streams: std.AutoHashMapUnmanaged(u32, async_mod.AsyncStream) = .empty,
+    error_contexts: std.AutoHashMapUnmanaged(u32, []u8) = .empty,
+    waitable_sets: std.AutoHashMapUnmanaged(u32, async_mod.WaitableSet) = .empty,
+    next_async_handle: u32 = 1,
+
+    /// Allocate a fresh async-handle (#478 sub-PR 3). Used by every
+    /// `.new`-flavoured canon-builtin to mint a unique key into the
+    /// per-instance future / stream / error-context / waitable-set
+    /// tables.
+    pub fn allocAsyncHandle(self: *ComponentInstance) u32 {
+        const h = self.next_async_handle;
+        self.next_async_handle += 1;
+        return h;
+    }
+
     pub const LinkState = enum { unlinked, linking, linked, poisoned };
 
     pub const CoreInstanceEntry = struct {
@@ -399,6 +421,7 @@ pub const ComponentInstance = struct {
             .context_get,
             .context_set,
             .task_return,
+            .async_canon,
             => return null,
             .aliased => |alias_idx| {
                 const ie = self.component.aliases[alias_idx].instance_export;
@@ -1096,6 +1119,21 @@ pub const ComponentInstance = struct {
         var rt_it = self.resource_tables.valueIterator();
         while (rt_it.next()) |rt| rt.deinit(self.allocator);
         self.resource_tables.deinit(self.allocator);
+
+        // Tear down per-instance async-handle tables (#478 sub-PR 3).
+        // Streams and waitable-sets own heap memory; futures and
+        // error-contexts don't (the latter stores `[]u8` debug strings
+        // which we free below).
+        self.futures.deinit(self.allocator);
+        var stream_it = self.streams.valueIterator();
+        while (stream_it.next()) |s| s.deinit(self.allocator);
+        self.streams.deinit(self.allocator);
+        var ec_it = self.error_contexts.valueIterator();
+        while (ec_it.next()) |msg| self.allocator.free(msg.*);
+        self.error_contexts.deinit(self.allocator);
+        var ws_it = self.waitable_sets.valueIterator();
+        while (ws_it.next()) |ws| ws.deinit(self.allocator);
+        self.waitable_sets.deinit(self.allocator);
         for (self.trampoline_ctxs.items) |ctx| {
             ctx.deinit(self.allocator);
             self.allocator.destroy(ctx);
@@ -2009,6 +2047,7 @@ fn resolveCoreFuncLower(component: *const ctypes.Component, core_func_idx: u32) 
         .context_get,
         .context_set,
         .task_return,
+        .async_canon,
         .aliased,
         => null,
     };
@@ -2478,6 +2517,7 @@ fn resolveLiftedCoreFunc(
         .context_get,
         .context_set,
         .task_return,
+        .async_canon,
         => return null,
         .aliased => |alias_idx| {
             const a = component.aliases[alias_idx];

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -398,6 +398,7 @@ pub const ComponentInstance = struct {
             .task_yield,
             .context_get,
             .context_set,
+            .task_return,
             => return null,
             .aliased => |alias_idx| {
                 const ie = self.component.aliases[alias_idx].instance_export;
@@ -2007,6 +2008,7 @@ fn resolveCoreFuncLower(component: *const ctypes.Component, core_func_idx: u32) 
         .task_yield,
         .context_get,
         .context_set,
+        .task_return,
         .aliased,
         => null,
     };
@@ -2475,6 +2477,7 @@ fn resolveLiftedCoreFunc(
         .task_yield,
         .context_get,
         .context_set,
+        .task_return,
         => return null,
         .aliased => |alias_idx| {
             const a = component.aliases[alias_idx];

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -258,6 +258,7 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
                         .task_yield,
                         .context_get,
                         .context_set,
+                        .task_return,
                         => true,
                         .lift => false,
                     };
@@ -715,6 +716,23 @@ fn parseCanon(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!cty
             };
             break :blk .{ .task_yield = .{ .cancellable = cancellable } };
         },
+        0x09 => blk: {
+            // canon task.return rs:<resultlist> opts:<opts>. The resultlist
+            // shares its encoding with `FuncType` results (see parseTypeDef
+            // 0x40 above).
+            const result_tag = try reader.readByte();
+            const results: ctypes.FuncType.ResultList = switch (result_tag) {
+                0x00 => .{ .unnamed = try readValType(reader) },
+                0x01 => blk2: {
+                    const zero = try reader.readByte();
+                    if (zero != 0x00) return error.InvalidEncoding;
+                    break :blk2 .none;
+                },
+                else => return error.InvalidEncoding,
+            };
+            const opts = try readCanonOpts(reader, allocator);
+            break :blk .{ .task_return = .{ .results = results, .opts = opts } };
+        },
         else => error.InvalidEncoding,
     };
 }
@@ -745,6 +763,8 @@ fn readCanonOpts(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!
             0x03 => .{ .memory = try reader.readU32() },
             0x04 => .{ .realloc = try reader.readU32() },
             0x05 => .{ .post_return = try reader.readU32() },
+            0x06 => .async_lift,
+            0x07 => .{ .callback = try reader.readU32() },
             else => return error.InvalidEncoding,
         };
     }
@@ -968,6 +988,39 @@ test "parseCanon: context.get rejects non-i32 valtype" {
 
 test "parseCanon: context.set rejects non-i32 valtype" {
     var reader = BinaryReader{ .data = &[_]u8{ 0x0b, 0x7D, 0x00 } };
+    try std.testing.expectError(error.InvalidEncoding, parseCanon(&reader, std.testing.allocator));
+}
+
+test "readCanonOpts: async_lift + callback opts (#478 sub-PR 2)" {
+    // count=2, [0x06], [0x07 0x09]
+    var reader = BinaryReader{ .data = &[_]u8{ 0x02, 0x06, 0x07, 0x09 } };
+    const opts = try readCanonOpts(&reader, std.testing.allocator);
+    defer std.testing.allocator.free(opts);
+    try std.testing.expectEqual(@as(usize, 2), opts.len);
+    try std.testing.expect(opts[0] == .async_lift);
+    try std.testing.expect(opts[1] == .callback);
+    try std.testing.expectEqual(@as(u32, 9), opts[1].callback);
+}
+
+test "parseCanon: task.return with one unnamed i32 result" {
+    // tag 0x09, resultlist `0x00 0x7F` (unnamed i32 valtype), no opts (count=0)
+    var reader = BinaryReader{ .data = &[_]u8{ 0x09, 0x00, 0x7F, 0x00 } };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .task_return);
+    try std.testing.expect(c.task_return.results == .unnamed);
+    try std.testing.expectEqual(@as(usize, 0), c.task_return.opts.len);
+}
+
+test "parseCanon: task.return with no results" {
+    // tag 0x09, resultlist `0x01 0x00`, no opts.
+    var reader = BinaryReader{ .data = &[_]u8{ 0x09, 0x01, 0x00, 0x00 } };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .task_return);
+    try std.testing.expect(c.task_return.results == .none);
+}
+
+test "parseCanon: task.return rejects malformed resultlist" {
+    var reader = BinaryReader{ .data = &[_]u8{ 0x09, 0x02, 0x7F, 0x00 } };
     try std.testing.expectError(error.InvalidEncoding, parseCanon(&reader, std.testing.allocator));
 }
 

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -259,6 +259,7 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
                         .context_get,
                         .context_set,
                         .task_return,
+                        .async_canon,
                         => true,
                         .lift => false,
                     };
@@ -672,7 +673,31 @@ fn readValType(reader: *BinaryReader) LoadError!ctypes.ValType {
         0x73 => .string,
         0x69 => .{ .own = try reader.readU32() },
         0x68 => .{ .borrow = try reader.readU32() },
+        0x64 => .error_context,
+        0x66 => try readPayloadedValType(reader, .stream),
+        0x65 => try readPayloadedValType(reader, .future),
         else => error.InvalidEncoding,
+    };
+}
+
+/// Read `(stream|future) t?` per defvaltype 0x66/0x65. Sub-PR 3 of #478
+/// accepts only the `t?` = present form (`0x01 valtype`); the empty
+/// form is rejected with `InvalidEncoding` until a follow-up wires
+/// payload-less streams/futures. The inner valtype must be a typeidx —
+/// the host-side `async_mod.{Future,AsyncStream}` only carries `u32`
+/// values today, so primitive-only payloads suffice but aren't yet
+/// modelled in the IR.
+fn readPayloadedValType(reader: *BinaryReader, comptime kind: enum { future, stream }) LoadError!ctypes.ValType {
+    const present = try reader.readByte();
+    if (present != 0x01) return error.InvalidEncoding;
+    const inner = try readValType(reader);
+    const idx = switch (inner) {
+        .type_idx => |i| i,
+        else => return error.InvalidEncoding,
+    };
+    return switch (kind) {
+        .future => .{ .future = idx },
+        .stream => .{ .stream = idx },
     };
 }
 
@@ -733,6 +758,75 @@ fn parseCanon(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!cty
             const opts = try readCanonOpts(reader, allocator);
             break :blk .{ .task_return = .{ .results = results, .opts = opts } };
         },
+        // ── Async ABI canon tags (#478 sub-PR 3) ────────────────────────────
+        // All of these route through the unified `Canon.async_canon` union.
+        0x06 => blk: {
+            const async_byte = try parseAsyncByte(reader);
+            break :blk .{ .async_canon = .{ .subtask_cancel = .{ .is_async = async_byte } } };
+        },
+        0x0d => .{ .async_canon = .subtask_drop },
+        0x0e => .{ .async_canon = .{ .stream_new = .{ .type_idx = try reader.readU32() } } },
+        0x0f => blk: {
+            const ti = try reader.readU32();
+            const opts = try readCanonOpts(reader, allocator);
+            break :blk .{ .async_canon = .{ .stream_read = .{ .type_idx = ti, .opts = opts } } };
+        },
+        0x10 => blk: {
+            const ti = try reader.readU32();
+            const opts = try readCanonOpts(reader, allocator);
+            break :blk .{ .async_canon = .{ .stream_write = .{ .type_idx = ti, .opts = opts } } };
+        },
+        0x11 => blk: {
+            const ti = try reader.readU32();
+            const is_async = try parseAsyncByte(reader);
+            break :blk .{ .async_canon = .{ .stream_cancel_read = .{ .type_idx = ti, .is_async = is_async } } };
+        },
+        0x12 => blk: {
+            const ti = try reader.readU32();
+            const is_async = try parseAsyncByte(reader);
+            break :blk .{ .async_canon = .{ .stream_cancel_write = .{ .type_idx = ti, .is_async = is_async } } };
+        },
+        0x13 => .{ .async_canon = .{ .stream_drop_readable = .{ .type_idx = try reader.readU32() } } },
+        0x14 => .{ .async_canon = .{ .stream_drop_writable = .{ .type_idx = try reader.readU32() } } },
+        0x15 => .{ .async_canon = .{ .future_new = .{ .type_idx = try reader.readU32() } } },
+        0x16 => blk: {
+            const ti = try reader.readU32();
+            const opts = try readCanonOpts(reader, allocator);
+            break :blk .{ .async_canon = .{ .future_read = .{ .type_idx = ti, .opts = opts } } };
+        },
+        0x17 => blk: {
+            const ti = try reader.readU32();
+            const opts = try readCanonOpts(reader, allocator);
+            break :blk .{ .async_canon = .{ .future_write = .{ .type_idx = ti, .opts = opts } } };
+        },
+        0x18 => blk: {
+            const ti = try reader.readU32();
+            const is_async = try parseAsyncByte(reader);
+            break :blk .{ .async_canon = .{ .future_cancel_read = .{ .type_idx = ti, .is_async = is_async } } };
+        },
+        0x19 => blk: {
+            const ti = try reader.readU32();
+            const is_async = try parseAsyncByte(reader);
+            break :blk .{ .async_canon = .{ .future_cancel_write = .{ .type_idx = ti, .is_async = is_async } } };
+        },
+        0x1a => .{ .async_canon = .{ .future_drop_readable = .{ .type_idx = try reader.readU32() } } },
+        0x1b => .{ .async_canon = .{ .future_drop_writable = .{ .type_idx = try reader.readU32() } } },
+        0x1c => .{ .async_canon = .{ .error_context_new = .{ .opts = try readCanonOpts(reader, allocator) } } },
+        0x1d => .{ .async_canon = .{ .error_context_debug_message = .{ .opts = try readCanonOpts(reader, allocator) } } },
+        0x1e => .{ .async_canon = .error_context_drop },
+        0x1f => .{ .async_canon = .waitable_set_new },
+        0x20 => blk: {
+            const cancellable = try parseCancelByte(reader);
+            const mem = try reader.readU32();
+            break :blk .{ .async_canon = .{ .waitable_set_wait = .{ .cancellable = cancellable, .memory = mem } } };
+        },
+        0x21 => blk: {
+            const cancellable = try parseCancelByte(reader);
+            const mem = try reader.readU32();
+            break :blk .{ .async_canon = .{ .waitable_set_poll = .{ .cancellable = cancellable, .memory = mem } } };
+        },
+        0x22 => .{ .async_canon = .waitable_set_drop },
+        0x23 => .{ .async_canon = .waitable_join },
         else => error.InvalidEncoding,
     };
 }
@@ -748,6 +842,25 @@ fn parseContextCanon(reader: *BinaryReader, comptime kind: enum { get, set }) Lo
         .get => .{ .context_get = .{ .val_type = ctypes.CoreValType.i32, .slot = slot } },
         .set => .{ .context_set = .{ .val_type = ctypes.CoreValType.i32, .slot = slot } },
     };
+}
+
+/// Parse the `async?` immediate byte: 0x00 → false, 0x01 → true, else
+/// InvalidEncoding. Used by `subtask.cancel` and the stream/future
+/// `cancel-*` tags. (#478 sub-PR 3.)
+fn parseAsyncByte(reader: *BinaryReader) LoadError!bool {
+    const b = try reader.readByte();
+    return switch (b) {
+        0x00 => false,
+        0x01 => true,
+        else => error.InvalidEncoding,
+    };
+}
+
+/// Parse the `cancel?` immediate byte. Same encoding as `async?` but
+/// different semantic name — kept distinct so the IR matches Binary.md
+/// vocabulary at the leaf. (#478 sub-PR 3.)
+fn parseCancelByte(reader: *BinaryReader) LoadError!bool {
+    return parseAsyncByte(reader);
 }
 
 fn readCanonOpts(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError![]const ctypes.CanonOpt {
@@ -1022,6 +1135,118 @@ test "parseCanon: task.return with no results" {
 test "parseCanon: task.return rejects malformed resultlist" {
     var reader = BinaryReader{ .data = &[_]u8{ 0x09, 0x02, 0x7F, 0x00 } };
     try std.testing.expectError(error.InvalidEncoding, parseCanon(&reader, std.testing.allocator));
+}
+
+// ── Sub-PR 3: future / stream / error-context / waitable-set canon tags ──
+
+test "readValType: error-context (0x64)" {
+    var reader = BinaryReader{ .data = &[_]u8{0x64} };
+    const v = try readValType(&reader);
+    try std.testing.expect(v == .error_context);
+}
+
+test "readValType: future<u32>" {
+    // 0x65 0x01 0x79 (future + present + u32 primvaltype). Inner u32 is
+    // a primvaltype, so it lands as `.u32` not `.type_idx`; sub-PR 3
+    // only accepts the typeidx form so this is `error.InvalidEncoding`.
+    var reader = BinaryReader{ .data = &[_]u8{ 0x65, 0x01, 0x79 } };
+    try std.testing.expectError(error.InvalidEncoding, readValType(&reader));
+}
+
+test "readValType: stream with typeidx payload" {
+    // typeidx 3 = 0x03 (signed LEB single byte).
+    var reader = BinaryReader{ .data = &[_]u8{ 0x66, 0x01, 0x03 } };
+    const v = try readValType(&reader);
+    try std.testing.expect(v == .stream);
+    try std.testing.expectEqual(@as(u32, 3), v.stream);
+}
+
+test "readValType: future with typeidx payload" {
+    var reader = BinaryReader{ .data = &[_]u8{ 0x65, 0x01, 0x05 } };
+    const v = try readValType(&reader);
+    try std.testing.expect(v == .future);
+    try std.testing.expectEqual(@as(u32, 5), v.future);
+}
+
+test "readValType: stream rejects empty payload (sub-PR 3 scope)" {
+    var reader = BinaryReader{ .data = &[_]u8{ 0x66, 0x00 } };
+    try std.testing.expectError(error.InvalidEncoding, readValType(&reader));
+}
+
+test "parseCanon: subtask.cancel async?=0x01" {
+    var reader = BinaryReader{ .data = &[_]u8{ 0x06, 0x01 } };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .async_canon);
+    try std.testing.expect(c.async_canon == .subtask_cancel);
+    try std.testing.expectEqual(true, c.async_canon.subtask_cancel.is_async);
+}
+
+test "parseCanon: subtask.drop" {
+    var reader = BinaryReader{ .data = &[_]u8{0x0d} };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .async_canon);
+    try std.testing.expect(c.async_canon == .subtask_drop);
+}
+
+test "parseCanon: stream.new with typeidx" {
+    // tag 0x0e, typeidx u32 = 7
+    var reader = BinaryReader{ .data = &[_]u8{ 0x0e, 0x07 } };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .async_canon);
+    try std.testing.expect(c.async_canon == .stream_new);
+    try std.testing.expectEqual(@as(u32, 7), c.async_canon.stream_new.type_idx);
+}
+
+test "parseCanon: future.new with typeidx" {
+    var reader = BinaryReader{ .data = &[_]u8{ 0x15, 0x02 } };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .async_canon);
+    try std.testing.expect(c.async_canon == .future_new);
+}
+
+test "parseCanon: stream.read with opts" {
+    // tag 0x0f, typeidx=1, opts count=1, memory=0
+    var reader = BinaryReader{ .data = &[_]u8{ 0x0f, 0x01, 0x01, 0x03, 0x00 } };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    defer std.testing.allocator.free(c.async_canon.stream_read.opts);
+    try std.testing.expect(c == .async_canon);
+    try std.testing.expect(c.async_canon == .stream_read);
+    try std.testing.expectEqual(@as(u32, 1), c.async_canon.stream_read.type_idx);
+    try std.testing.expectEqual(@as(usize, 1), c.async_canon.stream_read.opts.len);
+}
+
+test "parseCanon: error-context.{new,drop,debug-message}" {
+    // new with no opts
+    var r1 = BinaryReader{ .data = &[_]u8{ 0x1c, 0x00 } };
+    const c1 = try parseCanon(&r1, std.testing.allocator);
+    try std.testing.expect(c1.async_canon == .error_context_new);
+    // debug-message with no opts
+    var r2 = BinaryReader{ .data = &[_]u8{ 0x1d, 0x00 } };
+    const c2 = try parseCanon(&r2, std.testing.allocator);
+    try std.testing.expect(c2.async_canon == .error_context_debug_message);
+    // drop
+    var r3 = BinaryReader{ .data = &[_]u8{0x1e} };
+    const c3 = try parseCanon(&r3, std.testing.allocator);
+    try std.testing.expect(c3.async_canon == .error_context_drop);
+}
+
+test "parseCanon: waitable-set.{new,wait,poll,drop} + waitable.join" {
+    var r1 = BinaryReader{ .data = &[_]u8{0x1f} };
+    try std.testing.expect((try parseCanon(&r1, std.testing.allocator)).async_canon == .waitable_set_new);
+    // wait cancel?=0, memory=0
+    var r2 = BinaryReader{ .data = &[_]u8{ 0x20, 0x00, 0x00 } };
+    try std.testing.expect((try parseCanon(&r2, std.testing.allocator)).async_canon == .waitable_set_wait);
+    // poll
+    var r3 = BinaryReader{ .data = &[_]u8{ 0x21, 0x01, 0x00 } };
+    const c3 = try parseCanon(&r3, std.testing.allocator);
+    try std.testing.expect(c3.async_canon == .waitable_set_poll);
+    try std.testing.expectEqual(true, c3.async_canon.waitable_set_poll.cancellable);
+    // drop
+    var r4 = BinaryReader{ .data = &[_]u8{0x22} };
+    try std.testing.expect((try parseCanon(&r4, std.testing.allocator)).async_canon == .waitable_set_drop);
+    // join
+    var r5 = BinaryReader{ .data = &[_]u8{0x23} };
+    try std.testing.expect((try parseCanon(&r5, std.testing.allocator)).async_canon == .waitable_join);
 }
 
 test "parseTypeDef: instance type with `sub resource` type decl" {

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -41,6 +41,18 @@ pub const ValType = union(enum) {
     own: u32, // resource type index
     borrow: u32, // resource type index
 
+    // Async ABI value types (Component Model 🔀 / 📝). Per Binary.md:
+    //   0x64                       => error-context
+    //   0x65 t?:<valtype>?         => (future t?)
+    //   0x66 t?:<valtype>?         => (stream t?)
+    // Sub-PR 3 of #478 only accepts the typeidx-carrying form; the
+    // payload-less spelling (`0x65 0x00` / `0x66 0x00`) is rejected at
+    // load with `error.InvalidEncoding` — Wasmtime's tests don't emit it
+    // either, and supporting it cleanly requires a payload variant.
+    error_context,
+    future: u32, // typeidx of payload element
+    stream: u32, // typeidx of payload element
+
     /// Type index reference (for recursive/named types).
     type_idx: u32,
 };
@@ -372,6 +384,71 @@ pub const Canon = union(enum) {
     /// core-wasm body to transition its task from `.started` to
     /// `.returned`. (#478 sub-PR 2.)
     task_return: struct { results: FuncType.ResultList, opts: []const CanonOpt },
+
+    /// Catch-all for the broader WASIp3 async-canon surface: subtask /
+    /// future / stream / error-context / waitable-set / waitable.join.
+    /// Each entry retains its binary-tag-specific payload via
+    /// `AsyncCanonOp`. Sub-PR 3 of #478 lands the IR + loader + a
+    /// minimum dispatch wiring so the conformance suite stops bailing
+    /// on `error.InvalidEncoding`; semantics for some operations remain
+    /// placeholders (documented per-arm in `dispatchCanonBuiltin`).
+    async_canon: AsyncCanonOp,
+};
+
+/// Per-tag payload for `Canon.async_canon`. Tag bytes come straight from
+/// Binary.md "Canonical Definitions" (the 🔀 / 📝-annotated entries that
+/// aren't handled by their own dedicated `Canon` variants). Keeping a
+/// single union variant on `Canon` (instead of ~17 separate ones) avoids
+/// rippling exhaustive switches across every consumer.
+pub const AsyncCanonOp = union(enum) {
+    /// `canon subtask.cancel async?` — Binary.md tag `0x06`.
+    subtask_cancel: struct { is_async: bool },
+    /// `canon subtask.drop` — tag `0x0d`.
+    subtask_drop,
+    /// `canon stream.new t` — tag `0x0e`.
+    stream_new: struct { type_idx: u32 },
+    /// `canon stream.read t opts` — tag `0x0f`.
+    stream_read: struct { type_idx: u32, opts: []const CanonOpt },
+    /// `canon stream.write t opts` — tag `0x10`.
+    stream_write: struct { type_idx: u32, opts: []const CanonOpt },
+    /// `canon stream.cancel-read t async?` — tag `0x11`.
+    stream_cancel_read: struct { type_idx: u32, is_async: bool },
+    /// `canon stream.cancel-write t async?` — tag `0x12`.
+    stream_cancel_write: struct { type_idx: u32, is_async: bool },
+    /// `canon stream.drop-readable t` — tag `0x13`.
+    stream_drop_readable: struct { type_idx: u32 },
+    /// `canon stream.drop-writable t` — tag `0x14`.
+    stream_drop_writable: struct { type_idx: u32 },
+    /// `canon future.new t` — tag `0x15`.
+    future_new: struct { type_idx: u32 },
+    /// `canon future.read t opts` — tag `0x16`.
+    future_read: struct { type_idx: u32, opts: []const CanonOpt },
+    /// `canon future.write t opts` — tag `0x17`.
+    future_write: struct { type_idx: u32, opts: []const CanonOpt },
+    /// `canon future.cancel-read t async?` — tag `0x18`.
+    future_cancel_read: struct { type_idx: u32, is_async: bool },
+    /// `canon future.cancel-write t async?` — tag `0x19`.
+    future_cancel_write: struct { type_idx: u32, is_async: bool },
+    /// `canon future.drop-readable t` — tag `0x1a`.
+    future_drop_readable: struct { type_idx: u32 },
+    /// `canon future.drop-writable t` — tag `0x1b`.
+    future_drop_writable: struct { type_idx: u32 },
+    /// `canon error-context.new opts` — tag `0x1c`.
+    error_context_new: struct { opts: []const CanonOpt },
+    /// `canon error-context.debug-message opts` — tag `0x1d`.
+    error_context_debug_message: struct { opts: []const CanonOpt },
+    /// `canon error-context.drop` — tag `0x1e`.
+    error_context_drop,
+    /// `canon waitable-set.new` — tag `0x1f`.
+    waitable_set_new,
+    /// `canon waitable-set.wait cancel? (memory m)` — tag `0x20`.
+    waitable_set_wait: struct { cancellable: bool, memory: u32 },
+    /// `canon waitable-set.poll cancel? (memory m)` — tag `0x21`.
+    waitable_set_poll: struct { cancellable: bool, memory: u32 },
+    /// `canon waitable-set.drop` — tag `0x22`.
+    waitable_set_drop,
+    /// `canon waitable.join` — tag `0x23`.
+    waitable_join,
 };
 
 // ── Imports and exports ─────────────────────────────────────────────────────

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -309,6 +309,15 @@ pub const CanonOpt = union(enum) {
     post_return: u32, // core func index
     /// String encoding to use.
     string_encoding: StringEncoding,
+    /// Lift this function asynchronously (Binary.md canonopt tag `0x06`).
+    /// Forces the canonical-ABI to return a packed status immediately and
+    /// expect `task.return` to deliver the real results. (#478 sub-PR 2.)
+    async_lift,
+    /// Callback core funcidx for resumption after an async yield
+    /// (Binary.md canonopt tag `0x07`). Single-threaded poll-cycle stub
+    /// in sub-PR 2; sub-PR 3 wires it into the real `future`/`stream`
+    /// polling story. (#478 sub-PR 2.)
+    callback: u32,
 };
 
 /// Canonical function definitions.
@@ -353,6 +362,16 @@ pub const Canon = union(enum) {
     /// Write a per-task context slot. Tag `0x0b`. Same `i32`-only restriction
     /// as `context_get`.
     context_set: struct { val_type: CoreValType, slot: u32 },
+
+    /// Deliver the results of an async-lifted callee. Tag `0x09`. The
+    /// `results` shape matches the lifted-callee's result types (encoded
+    /// identically to `FuncType.ResultList`: `0x00 valtype` for one
+    /// unnamed result, `0x01 0x00` for none). `opts` carries memory /
+    /// realloc / string-encoding needed to lower compound results back
+    /// into the caller's memory. The callee invokes this from inside the
+    /// core-wasm body to transition its task from `.started` to
+    /// `.returned`. (#478 sub-PR 2.)
+    task_return: struct { results: FuncType.ResultList, opts: []const CanonOpt },
 };
 
 // ── Imports and exports ─────────────────────────────────────────────────────


### PR DESCRIPTION
Completes #478 (parent: #451). Sub-PR 1 already landed in #492; this PR squashes sub-PRs **2 and 3** into a single commit history.

## Sub-PR 2 — async-lifted callees (commit 8727c3c3)

Lands the lift side of the `(async)` import-call boundary. The host can now dispatch into an async-lifted callee that delivers its results via `canon task.return` rather than by leaving them on the core stack.

- `CanonOpt.async_lift` (`0x06`) and `CanonOpt.callback : u32` (`0x07`).
- `Canon.task_return { results, opts }` (`0x09`). Result list shares its encoding with `FuncType` results.
- `LiftOptions.is_async` + `callback_idx`.
- `callComponentFuncByLocalAsyncLifted`: lifts args, drives the core body, leaves result delivery to `task.return`. With `callback` set, peels a status i32; without, treats the status as zero.
- `callComponentFuncAsync` branches on `LiftOptions.is_async` to choose between the async-lifted path and the legacy "wrap a sync call in an async task" path.
- `dispatchCanonBuiltin` arm for `task.return`: pops the lifted results in reverse order (Canonical ABI pushes results left-to-right), transitions the current task `.started → .returned`.

## Sub-PR 3 — future / stream / error-context / waitable-set / subtask (commit 656a86fd)

Broader WASIp3 async-canon surface so the conformance suite stops bailing at load:

- `ValType.{error_context, future, stream}` — primvaltype `0x64`, defvaltype `0x65`/`0x66`. Sub-PR 3 accepts only the typeidx-carrying payload form for future/stream.
- `Canon.async_canon: AsyncCanonOp` — unified IR variant covering tags `0x06, 0x0d, 0x0e..0x23`. Bundling under one variant keeps per-canon-kind switches tractable.
- `CoreFuncRef.async_canon` for the core-func indexspace.

Dispatch (`dispatchAsyncCanon`):

- `subtask.{cancel,drop}`: cancel → `TaskManager.cancelTask`; drop is a no-op pop.
- `waitable-set.{new,drop}`: per-instance hashmap, `allocAsyncHandle()` mints fresh handles.
- `waitable-set.{wait,poll}` + `waitable.join`: pop args, push zero status. (Real polling needs guest-memory bridging to write the event 2-tuple — explicitly deferred.)
- `future.new` / `stream.new`: allocate per-instance state, push packed `i64` handle pair.
- `future.drop-*` / `stream.drop-*`: remove from the appropriate table.
- `error-context.{new,debug-message,drop}`: minimum bookkeeping.
- All `read` / `write` / `cancel-*` trap with `error.FunctionNotFound`.

Per-instance state on `ComponentInstance`: `futures`, `streams`, `waitable_sets`, `error_contexts` hashmaps + `next_async_handle` counter, all torn down in `deinit`.

## Out of scope (deferred to follow-ups)

- Real stream/future read/write semantics — needs `WaitableItem` registration tied to per-instance hashmap handles + guest-memory bridging.
- `wasi:io/poll.pollable → future<T>` bridge — belongs to #481 per the tracker.
- error-context message read/write — same memory-bridging dependency.
- Real fiber scheduling for `task.yield` — the poll-cycle stub from sub-PR 1 remains; sub-PR 3's read/write traps stand in until a scheduler lands.

## Tests

- Sub-PR 2: +7 (loader for new opts/task.return, executor for `LiftOptions.fromOpts` + `dispatchCanonBuiltin .task_return`, indexspace).
- Sub-PR 3: +16 (loader for every new tag, dispatch smoke tests for waitable-set / future / error-context, indexspace).
- Cumulative across #478: **+38** new tests. **1978/1978 pass** locally.

## Verification

- `zig build test`: 1978/1978 pass.
- `zig build` clean on both aarch64 (native) and x86_64 (cross).
- No perf gate (out of CoreMark scope).