### PR TITLE
feat(wasi): live host stdio for `wamr run` (#474)

### DIFF
--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -1547,12 +1547,17 @@ pub const WasiCliAdapter = struct {
     /// **not valid** with this constructor — they expect buffer-backed
     /// sinks. Use the regular `init` for embedding / tests that need
     /// to inspect captured output.
+    ///
+    /// Cross-platform: pulls handles from `std.Io.File.{stdin,stdout,
+    /// stderr}` rather than `std.posix.STDIN_FILENO` etc. because on
+    /// Windows `posix.fd_t` is `*anyopaque` (HANDLE), so the comptime
+    /// integers `0/1/2` don't coerce.
     pub fn initWithHostStdio(allocator: Allocator) WasiCliAdapter {
         return initWithHostStdioFds(
             allocator,
-            std.posix.STDIN_FILENO,
-            std.posix.STDOUT_FILENO,
-            std.posix.STDERR_FILENO,
+            std.Io.File.stdin().handle,
+            std.Io.File.stdout().handle,
+            std.Io.File.stderr().handle,
         );
     }
 
@@ -10512,7 +10517,7 @@ test "stdio-echo: live host stdio via pipe-redirected fds (#474)" {
             testing.allocator,
             stdin_fds[0],
             stdout_fds[1],
-            std.posix.STDERR_FILENO,
+            std.Io.File.stderr().handle,
         );
         defer adapter.deinit();
 

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -10472,6 +10472,81 @@ test "stdio-echo: end-to-end real wasi-p2 component (#156)" {
     try testing.expectEqualStrings("echo: hello\n", adapter.getStdoutBytes());
 }
 
+test "stdio-echo: live host stdio via pipe-redirected fds (#474)" {
+    if (@import("builtin").os.tag != .linux) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const data = @embedFile("fixtures/stdio-echo.wasm");
+    const linux = std.os.linux;
+
+    // Two pipe pairs: one for stdin (test writes, adapter reads), one
+    // for stdout (adapter writes, test reads). Stderr is wired to the
+    // test's own stderr fd — not redirected here, but separate from
+    // stdout so a noisy fixture doesn't pollute the assertion.
+    var stdin_fds: [2]i32 = undefined;
+    if (linux.errno(linux.pipe2(&stdin_fds, .{})) != .SUCCESS) return error.SkipZigTest;
+    defer _ = linux.close(stdin_fds[0]);
+    // stdin_fds[1] is closed below after writing "hello\n".
+
+    var stdout_fds: [2]i32 = undefined;
+    if (linux.errno(linux.pipe2(&stdout_fds, .{})) != .SUCCESS) {
+        _ = linux.close(stdin_fds[1]);
+        return error.SkipZigTest;
+    }
+    defer _ = linux.close(stdout_fds[0]);
+    // stdout_fds[1] is closed by the adapter's `deinit` path indirectly
+    // — but `OutputStream.toFd` doesn't take ownership of the fd, so
+    // we close it explicitly after the run.
+
+    // Preload the "hello\n" line into the stdin pipe and close the
+    // write-end so the guest's read sees EOF after the line.
+    _ = linux.write(stdin_fds[1], "hello\n", 6);
+    _ = linux.close(stdin_fds[1]);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    // Use the host-stdio constructor with the pipe fds redirected in
+    // place of STDIN/STDOUT. Stderr gets the test process's own
+    // stderr fd (the adapter doesn't take ownership of it).
+    var adapter = WasiCliAdapter.initWithHostStdioFds(
+        testing.allocator,
+        stdin_fds[0],
+        stdout_fds[1],
+        std.posix.STDERR_FILENO,
+    );
+    defer adapter.deinit();
+
+    const outcome = runComponentBytes(data, arena_alloc, &adapter) catch |err| {
+        _ = linux.close(stdout_fds[1]);
+        std.debug.print("stdio-echo (live) run failed: {s}\n", .{@errorName(err)});
+        return err;
+    };
+    // Close the adapter's stdout-write fd so the drain below hits EOF.
+    _ = linux.close(stdout_fds[1]);
+
+    // Drain everything the component wrote to the pipe. If the
+    // OutputStream `.fd` write branch were still a no-op stub
+    // (pre-#474), this drain would return 0 bytes and the assertion
+    // would fail.
+    var buf: [256]u8 = undefined;
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    while (true) {
+        const rc = linux.read(stdout_fds[0], &buf, buf.len);
+        const err = linux.errno(rc);
+        if (err == .INTR) continue;
+        if (err != .SUCCESS) break;
+        const n: usize = @intCast(rc);
+        if (n == 0) break;
+        try captured.appendSlice(testing.allocator, buf[0..n]);
+    }
+
+    try testing.expect(outcome.is_ok);
+    try testing.expectEqualStrings("echo: hello\n", captured.items);
+}
+
 test "populateWasiProviders: binds wasi:clocks/wall-clock + monotonic-clock (#146)" {
     const testing = std.testing;
     var adapter = WasiCliAdapter.init(testing.allocator);

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -10473,78 +10473,77 @@ test "stdio-echo: end-to-end real wasi-p2 component (#156)" {
 }
 
 test "stdio-echo: live host stdio via pipe-redirected fds (#474)" {
-    if (@import("builtin").os.tag != .linux) return error.SkipZigTest;
+    if (comptime @import("builtin").os.tag != .linux) return error.SkipZigTest;
+    if (comptime @import("builtin").os.tag == .linux) {
+        const testing = std.testing;
+        const data = @embedFile("fixtures/stdio-echo.wasm");
+        const linux = std.os.linux;
 
-    const testing = std.testing;
-    const data = @embedFile("fixtures/stdio-echo.wasm");
-    const linux = std.os.linux;
+        // Two pipe pairs: one for stdin (test writes, adapter reads), one
+        // for stdout (adapter writes, test reads). Stderr is wired to the
+        // test's own stderr fd — not redirected here, but separate from
+        // stdout so a noisy fixture doesn't pollute the assertion.
+        var stdin_fds: [2]i32 = undefined;
+        if (linux.errno(linux.pipe2(&stdin_fds, .{})) != .SUCCESS) return error.SkipZigTest;
+        defer _ = linux.close(stdin_fds[0]);
+        // stdin_fds[1] is closed below after writing "hello\n".
 
-    // Two pipe pairs: one for stdin (test writes, adapter reads), one
-    // for stdout (adapter writes, test reads). Stderr is wired to the
-    // test's own stderr fd — not redirected here, but separate from
-    // stdout so a noisy fixture doesn't pollute the assertion.
-    var stdin_fds: [2]i32 = undefined;
-    if (linux.errno(linux.pipe2(&stdin_fds, .{})) != .SUCCESS) return error.SkipZigTest;
-    defer _ = linux.close(stdin_fds[0]);
-    // stdin_fds[1] is closed below after writing "hello\n".
+        var stdout_fds: [2]i32 = undefined;
+        if (linux.errno(linux.pipe2(&stdout_fds, .{})) != .SUCCESS) {
+            _ = linux.close(stdin_fds[1]);
+            return error.SkipZigTest;
+        }
+        defer _ = linux.close(stdout_fds[0]);
+        // stdout_fds[1] is closed explicitly after the run.
 
-    var stdout_fds: [2]i32 = undefined;
-    if (linux.errno(linux.pipe2(&stdout_fds, .{})) != .SUCCESS) {
+        // Preload the "hello\n" line into the stdin pipe and close the
+        // write-end so the guest's read sees EOF after the line.
+        _ = linux.write(stdin_fds[1], "hello\n", 6);
         _ = linux.close(stdin_fds[1]);
-        return error.SkipZigTest;
-    }
-    defer _ = linux.close(stdout_fds[0]);
-    // stdout_fds[1] is closed by the adapter's `deinit` path indirectly
-    // — but `OutputStream.toFd` doesn't take ownership of the fd, so
-    // we close it explicitly after the run.
 
-    // Preload the "hello\n" line into the stdin pipe and close the
-    // write-end so the guest's read sees EOF after the line.
-    _ = linux.write(stdin_fds[1], "hello\n", 6);
-    _ = linux.close(stdin_fds[1]);
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const arena_alloc = arena.allocator();
 
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const arena_alloc = arena.allocator();
+        // Use the host-stdio constructor with the pipe fds redirected in
+        // place of STDIN/STDOUT. Stderr gets the test process's own
+        // stderr fd (the adapter doesn't take ownership of it).
+        var adapter = WasiCliAdapter.initWithHostStdioFds(
+            testing.allocator,
+            stdin_fds[0],
+            stdout_fds[1],
+            std.posix.STDERR_FILENO,
+        );
+        defer adapter.deinit();
 
-    // Use the host-stdio constructor with the pipe fds redirected in
-    // place of STDIN/STDOUT. Stderr gets the test process's own
-    // stderr fd (the adapter doesn't take ownership of it).
-    var adapter = WasiCliAdapter.initWithHostStdioFds(
-        testing.allocator,
-        stdin_fds[0],
-        stdout_fds[1],
-        std.posix.STDERR_FILENO,
-    );
-    defer adapter.deinit();
-
-    const outcome = runComponentBytes(data, arena_alloc, &adapter) catch |err| {
+        const outcome = runComponentBytes(data, arena_alloc, &adapter) catch |err| {
+            _ = linux.close(stdout_fds[1]);
+            std.debug.print("stdio-echo (live) run failed: {s}\n", .{@errorName(err)});
+            return err;
+        };
+        // Close the adapter's stdout-write fd so the drain below hits EOF.
         _ = linux.close(stdout_fds[1]);
-        std.debug.print("stdio-echo (live) run failed: {s}\n", .{@errorName(err)});
-        return err;
-    };
-    // Close the adapter's stdout-write fd so the drain below hits EOF.
-    _ = linux.close(stdout_fds[1]);
 
-    // Drain everything the component wrote to the pipe. If the
-    // OutputStream `.fd` write branch were still a no-op stub
-    // (pre-#474), this drain would return 0 bytes and the assertion
-    // would fail.
-    var buf: [256]u8 = undefined;
-    var captured: std.ArrayList(u8) = .empty;
-    defer captured.deinit(testing.allocator);
-    while (true) {
-        const rc = linux.read(stdout_fds[0], &buf, buf.len);
-        const err = linux.errno(rc);
-        if (err == .INTR) continue;
-        if (err != .SUCCESS) break;
-        const n: usize = @intCast(rc);
-        if (n == 0) break;
-        try captured.appendSlice(testing.allocator, buf[0..n]);
+        // Drain everything the component wrote to the pipe. If the
+        // OutputStream `.fd` write branch were still a no-op stub
+        // (pre-#474), this drain would return 0 bytes and the assertion
+        // would fail.
+        var buf: [256]u8 = undefined;
+        var captured: std.ArrayList(u8) = .empty;
+        defer captured.deinit(testing.allocator);
+        while (true) {
+            const rc = linux.read(stdout_fds[0], &buf, buf.len);
+            const err = linux.errno(rc);
+            if (err == .INTR) continue;
+            if (err != .SUCCESS) break;
+            const n: usize = @intCast(rc);
+            if (n == 0) break;
+            try captured.appendSlice(testing.allocator, buf[0..n]);
+        }
+
+        try testing.expect(outcome.is_ok);
+        try testing.expectEqualStrings("echo: hello\n", captured.items);
     }
-
-    try testing.expect(outcome.is_ok);
-    try testing.expectEqualStrings("echo: hello\n", captured.items);
 }
 
 test "populateWasiProviders: binds wasi:clocks/wall-clock + monotonic-clock (#146)" {

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -1525,12 +1525,52 @@ pub const WasiCliAdapter = struct {
     insecure_prng: ?std.Random.DefaultPrng = null,
 
     /// Initialize with a buffer-backed stdout sink. Use `getStdoutBytes`
-    /// after the component runs to inspect captured output.
+    /// after the component runs to inspect captured output. This is the
+    /// test-/embedding-friendly constructor — every existing test in
+    /// this file uses it. For the `wamr run` CLI path that streams
+    /// live to the host process's stdio, use `initWithHostStdio`.
     pub fn init(allocator: Allocator) WasiCliAdapter {
         return .{
             .allocator = allocator,
             .stdout = streams.OutputStream.toBuffer(),
             .stderr = streams.OutputStream.toBuffer(),
+        };
+    }
+
+    /// Initialize with stdout/stderr/stdin wired directly to the host
+    /// process's standard file descriptors. Used by `wamr run` so the
+    /// component's output streams incrementally to the user's terminal
+    /// instead of buffering for the entire run. Stdin reads block on
+    /// the host's stdin fd (#474).
+    ///
+    /// `getStdoutBytes` / `getStderrBytes` / `setStdinBytes` are
+    /// **not valid** with this constructor — they expect buffer-backed
+    /// sinks. Use the regular `init` for embedding / tests that need
+    /// to inspect captured output.
+    pub fn initWithHostStdio(allocator: Allocator) WasiCliAdapter {
+        return initWithHostStdioFds(
+            allocator,
+            std.posix.STDIN_FILENO,
+            std.posix.STDOUT_FILENO,
+            std.posix.STDERR_FILENO,
+        );
+    }
+
+    /// Variant of `initWithHostStdio` that takes explicit fds — used
+    /// by tests that redirect stdin/stdout/stderr through pipes to
+    /// observe the live-streaming path without touching the test
+    /// process's own stdio (#474).
+    pub fn initWithHostStdioFds(
+        allocator: Allocator,
+        stdin_fd: std.posix.fd_t,
+        stdout_fd: std.posix.fd_t,
+        stderr_fd: std.posix.fd_t,
+    ) WasiCliAdapter {
+        return .{
+            .allocator = allocator,
+            .stdout = streams.OutputStream.toFd(stdout_fd),
+            .stderr = streams.OutputStream.toFd(stderr_fd),
+            .stdin = streams.InputStream.fromFd(stdin_fd),
         };
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -188,7 +188,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
             if (listen_address) |addr| {
                 return runHttpComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, addr);
             }
-            return runComponent(wasm_data, allocator, io, path, wasm_args.items, env_list.items);
+            return runComponent(wasm_data, allocator, path, wasm_args.items, env_list.items);
         }
     }
 
@@ -240,13 +240,17 @@ fn parseListenAddress(spec: []const u8) !std.Io.net.IpAddress {
 fn runComponent(
     data: []const u8,
     allocator: std.mem.Allocator,
-    io: std.Io,
     wasm_path: []const u8,
     wasm_args: []const []const u8,
     env_vars: []const wamr.wasi_cli_adapter.EnvVar,
 ) u8 {
     const adapter_mod = wamr.wasi_cli_adapter;
-    var adapter = adapter_mod.WasiCliAdapter.init(allocator);
+    // Wire the adapter's stdio directly to the host process's
+    // STDIN/STDOUT/STDERR so output streams live (no end-of-run
+    // flush) and stdin reads from the user's terminal / piped
+    // input (#474). For the test/embedding path that needs to
+    // inspect captured stdout, use `WasiCliAdapter.init` instead.
+    var adapter = adapter_mod.WasiCliAdapter.initWithHostStdio(allocator);
     defer adapter.deinit();
 
     // argv[0] = wasm path, rest = user args (matches wasmtime convention).
@@ -297,14 +301,8 @@ fn runComponent(
         return 1;
     };
 
-    // Flush captured stdout to the host. Buffered + flush at end is the
-    // simplest cross-platform path; streaming output is deferred until
-    // the io/poll-aware adapter lands (#154).
-    const captured = adapter.getStdoutBytes();
-    if (captured.len > 0) {
-        var stdout_file = std.Io.File.stdout();
-        stdout_file.writeStreamingAll(io, captured) catch {};
-    }
+    // Output has already streamed live to host STDOUT/STDERR via the
+    // fd-backed OutputStream sinks (#474); no end-of-run flush needed.
 
     // Prefer the explicit numeric exit code recorded by
     // `wasi:cli/exit.exit-with-code` / preview1 `proc_exit` (#436);

--- a/src/wasi/preview2/streams.zig
+++ b/src/wasi/preview2/streams.zig
@@ -48,9 +48,18 @@ pub const InputStream = struct {
                 b.pos += n;
                 return .{ .ok = n };
             },
-            .fd => {
-                // Host fd reading would go here
-                return .{ .ok = 0 };
+            .fd => |fd| {
+                // Raw fd source for live host stdio (#474). Uses
+                // `std.posix.read`, which retries on EINTR internally
+                // and reports EAGAIN as `error.WouldBlock`. A zero-byte
+                // return is EOF and surfaces as `.closed`.
+                const n = std.posix.read(fd, buf) catch |err| return switch (err) {
+                    error.WouldBlock => .{ .err = .would_block },
+                    error.ConnectionResetByPeer, error.SocketUnconnected, error.Unexpected => .{ .closed = {} },
+                    else => .{ .err = .io_error },
+                };
+                if (n == 0) return .{ .closed = {} };
+                return .{ .ok = n };
             },
             .host_file => |*hf| {
                 const io = std.Io.Threaded.global_single_threaded.io();
@@ -75,6 +84,16 @@ pub const InputStream = struct {
     /// Create an input stream from a byte buffer.
     pub fn fromBuffer(data: []const u8) InputStream {
         return .{ .source = .{ .buffer = .{ .data = data } } };
+    }
+
+    /// Create an input stream that reads from a host file descriptor
+    /// using `std.posix.read` (non-positional). Use for streaming
+    /// sources like stdin or a pipe read-end — for seekable files,
+    /// prefer `fromHostFile` so multiple streams over the same file
+    /// stay independent. The fd is borrowed; the stream does not close
+    /// it on drop. Added for #474 live host stdio.
+    pub fn fromFd(fd: std.posix.fd_t) InputStream {
+        return .{ .source = .{ .fd = fd } };
     }
 
     /// Create an input stream that reads from a host file at the given offset.
@@ -133,11 +152,20 @@ pub const OutputStream = struct {
                 b.appendSlice(allocator, data) catch return .{ .err = .would_block };
                 return .{ .ok = data.len };
             },
-            .fd => {
-                // fd-backed sinks aren't yet used in production. Treating
-                // every write as a successful no-op keeps the API shape
-                // intact for future use without dragging in
-                // platform-specific write syscalls.
+            .fd => |fd| {
+                // Raw fd sink for live host stdio (#474). Uses
+                // `std.Io.File.writeStreamingAll` which is the
+                // non-positional streaming writer (vs `pwrite`-style
+                // `host_file`), suitable for stdout/stderr/pipes. EAGAIN
+                // surfaces as `error.WouldBlock`; `BrokenPipe` /
+                // `NotOpenForWriting` are treated as `.closed`.
+                const io = std.Io.Threaded.global_single_threaded.io();
+                const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = false } };
+                file.writeStreamingAll(io, data) catch |err| return switch (err) {
+                    error.WouldBlock => .{ .err = .would_block },
+                    error.BrokenPipe, error.NotOpenForWriting => .{ .closed = {} },
+                    else => .{ .err = .io_error },
+                };
                 return .{ .ok = data.len };
             },
             .host_file => |*hf| {
@@ -314,6 +342,85 @@ test "OutputStream: write to buffer" {
     const r = stream.write("world", std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 5), r.ok);
     try std.testing.expectEqualSlices(u8, "world", stream.getBufferContents());
+}
+
+// Test helper: open a unix pipe pair. Linux-only — pipe2 is not in
+// std.posix for 0.16, and the live-stdio test path (#474) only needs
+// to run on the Linux CI builds (other archs/OSes test the buffer
+// path).
+fn linuxPipe2() ?[2]std.posix.fd_t {
+    if (@import("builtin").os.tag != .linux) return null;
+    var fds: [2]i32 = undefined;
+    const linux = std.os.linux;
+    const rc = linux.pipe2(&fds, .{});
+    if (linux.errno(rc) != .SUCCESS) return null;
+    return .{ fds[0], fds[1] };
+}
+
+test "OutputStream: write to fd writes through to peer (#474)" {
+    const fds = linuxPipe2() orelse return error.SkipZigTest;
+    const linux = std.os.linux;
+    defer _ = linux.close(fds[0]);
+    defer _ = linux.close(fds[1]);
+
+    var stream = OutputStream.toFd(fds[1]);
+    const r = stream.write("hello", std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 5), r.ok);
+
+    var buf: [16]u8 = undefined;
+    const n = try std.posix.read(fds[0], &buf);
+    try std.testing.expectEqualSlices(u8, "hello", buf[0..n]);
+}
+
+test "OutputStream: write to fd returns closed when peer closed (#474)" {
+    const fds = linuxPipe2() orelse return error.SkipZigTest;
+    const linux = std.os.linux;
+    _ = linux.close(fds[0]); // close read-end first
+    defer _ = linux.close(fds[1]);
+
+    // Ignore SIGPIPE so the write surfaces as EPIPE instead of killing
+    // the test process.
+    var act: linux.Sigaction = .{
+        .handler = .{ .handler = linux.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    var oact: linux.Sigaction = undefined;
+    std.posix.sigaction(linux.SIG.PIPE, &act, &oact);
+    defer std.posix.sigaction(linux.SIG.PIPE, &oact, null);
+
+    var stream = OutputStream.toFd(fds[1]);
+    const r = stream.write("hello", std.testing.allocator);
+    try std.testing.expect(r == .closed);
+}
+
+test "InputStream: read from fd returns bytes written by peer (#474)" {
+    const fds = linuxPipe2() orelse return error.SkipZigTest;
+    const linux = std.os.linux;
+    defer _ = linux.close(fds[0]);
+    defer _ = linux.close(fds[1]);
+
+    // Preload bytes into the pipe write-end via the raw syscall
+    // (std.posix has no `write` wrapper in 0.16).
+    _ = linux.write(fds[1], "world", 5);
+
+    var stream = InputStream.fromFd(fds[0]);
+    var buf: [16]u8 = undefined;
+    const r = stream.read(&buf);
+    try std.testing.expectEqual(@as(usize, 5), r.ok);
+    try std.testing.expectEqualSlices(u8, "world", buf[0..5]);
+}
+
+test "InputStream: read from fd returns closed at EOF (#474)" {
+    const fds = linuxPipe2() orelse return error.SkipZigTest;
+    const linux = std.os.linux;
+    defer _ = linux.close(fds[0]);
+    _ = linux.close(fds[1]); // close write-end → next read sees EOF
+
+    var stream = InputStream.fromFd(fds[0]);
+    var buf: [16]u8 = undefined;
+    const r = stream.read(&buf);
+    try std.testing.expect(r == .closed);
 }
 
 test "Pollable: immediate is always ready" {

--- a/src/wasi/preview2/streams.zig
+++ b/src/wasi/preview2/streams.zig
@@ -50,12 +50,17 @@ pub const InputStream = struct {
             },
             .fd => |fd| {
                 // Raw fd source for live host stdio (#474). Uses
-                // `std.posix.read`, which retries on EINTR internally
-                // and reports EAGAIN as `error.WouldBlock`. A zero-byte
-                // return is EOF and surfaces as `.closed`.
-                const n = std.posix.read(fd, buf) catch |err| return switch (err) {
+                // `std.Io.File.readStreaming` (the cross-platform
+                // streaming reader), matching the symmetric `.fd`
+                // write path. A zero-byte read surfaces as
+                // `error.EndOfStream` and maps to `.closed`.
+                const io = std.Io.Threaded.global_single_threaded.io();
+                const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = false } };
+                const bufs = [_][]u8{buf};
+                const n = file.readStreaming(io, &bufs) catch |err| return switch (err) {
+                    error.EndOfStream => .{ .closed = {} },
                     error.WouldBlock => .{ .err = .would_block },
-                    error.ConnectionResetByPeer, error.SocketUnconnected, error.Unexpected => .{ .closed = {} },
+                    error.NotOpenForReading, error.SocketUnconnected, error.ConnectionResetByPeer => .{ .closed = {} },
                     else => .{ .err = .io_error },
                 };
                 if (n == 0) return .{ .closed = {} };
@@ -344,83 +349,86 @@ test "OutputStream: write to buffer" {
     try std.testing.expectEqualSlices(u8, "world", stream.getBufferContents());
 }
 
-// Test helper: open a unix pipe pair. Linux-only — pipe2 is not in
-// std.posix for 0.16, and the live-stdio test path (#474) only needs
-// to run on the Linux CI builds (other archs/OSes test the buffer
-// path).
-fn linuxPipe2() ?[2]std.posix.fd_t {
-    if (@import("builtin").os.tag != .linux) return null;
-    var fds: [2]i32 = undefined;
-    const linux = std.os.linux;
-    const rc = linux.pipe2(&fds, .{});
-    if (linux.errno(rc) != .SUCCESS) return null;
-    return .{ fds[0], fds[1] };
-}
-
 test "OutputStream: write to fd writes through to peer (#474)" {
-    const fds = linuxPipe2() orelse return error.SkipZigTest;
-    const linux = std.os.linux;
-    defer _ = linux.close(fds[0]);
-    defer _ = linux.close(fds[1]);
+    if (comptime @import("builtin").os.tag != .linux) return error.SkipZigTest;
+    if (comptime @import("builtin").os.tag == .linux) {
+        const linux = std.os.linux;
+        var fds: [2]i32 = undefined;
+        if (linux.errno(linux.pipe2(&fds, .{})) != .SUCCESS) return error.SkipZigTest;
+        defer _ = linux.close(fds[0]);
+        defer _ = linux.close(fds[1]);
 
-    var stream = OutputStream.toFd(fds[1]);
-    const r = stream.write("hello", std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 5), r.ok);
+        var stream = OutputStream.toFd(fds[1]);
+        const r = stream.write("hello", std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 5), r.ok);
 
-    var buf: [16]u8 = undefined;
-    const n = try std.posix.read(fds[0], &buf);
-    try std.testing.expectEqualSlices(u8, "hello", buf[0..n]);
+        var buf: [16]u8 = undefined;
+        const n = try std.posix.read(fds[0], &buf);
+        try std.testing.expectEqualSlices(u8, "hello", buf[0..n]);
+    }
 }
 
 test "OutputStream: write to fd returns closed when peer closed (#474)" {
-    const fds = linuxPipe2() orelse return error.SkipZigTest;
-    const linux = std.os.linux;
-    _ = linux.close(fds[0]); // close read-end first
-    defer _ = linux.close(fds[1]);
+    if (comptime @import("builtin").os.tag != .linux) return error.SkipZigTest;
+    if (comptime @import("builtin").os.tag == .linux) {
+        const linux = std.os.linux;
+        var fds: [2]i32 = undefined;
+        if (linux.errno(linux.pipe2(&fds, .{})) != .SUCCESS) return error.SkipZigTest;
+        _ = linux.close(fds[0]); // close read-end first
+        defer _ = linux.close(fds[1]);
 
-    // Ignore SIGPIPE so the write surfaces as EPIPE instead of killing
-    // the test process.
-    var act: linux.Sigaction = .{
-        .handler = .{ .handler = linux.SIG.IGN },
-        .mask = std.posix.sigemptyset(),
-        .flags = 0,
-    };
-    var oact: linux.Sigaction = undefined;
-    std.posix.sigaction(linux.SIG.PIPE, &act, &oact);
-    defer std.posix.sigaction(linux.SIG.PIPE, &oact, null);
+        // Ignore SIGPIPE so the write surfaces as EPIPE instead of killing
+        // the test process.
+        var act: linux.Sigaction = .{
+            .handler = .{ .handler = linux.SIG.IGN },
+            .mask = std.posix.sigemptyset(),
+            .flags = 0,
+        };
+        var oact: linux.Sigaction = undefined;
+        std.posix.sigaction(linux.SIG.PIPE, &act, &oact);
+        defer std.posix.sigaction(linux.SIG.PIPE, &oact, null);
 
-    var stream = OutputStream.toFd(fds[1]);
-    const r = stream.write("hello", std.testing.allocator);
-    try std.testing.expect(r == .closed);
+        var stream = OutputStream.toFd(fds[1]);
+        const r = stream.write("hello", std.testing.allocator);
+        try std.testing.expect(r == .closed);
+    }
 }
 
 test "InputStream: read from fd returns bytes written by peer (#474)" {
-    const fds = linuxPipe2() orelse return error.SkipZigTest;
-    const linux = std.os.linux;
-    defer _ = linux.close(fds[0]);
-    defer _ = linux.close(fds[1]);
+    if (comptime @import("builtin").os.tag != .linux) return error.SkipZigTest;
+    if (comptime @import("builtin").os.tag == .linux) {
+        const linux = std.os.linux;
+        var fds: [2]i32 = undefined;
+        if (linux.errno(linux.pipe2(&fds, .{})) != .SUCCESS) return error.SkipZigTest;
+        defer _ = linux.close(fds[0]);
+        defer _ = linux.close(fds[1]);
 
-    // Preload bytes into the pipe write-end via the raw syscall
-    // (std.posix has no `write` wrapper in 0.16).
-    _ = linux.write(fds[1], "world", 5);
+        // Preload bytes into the pipe write-end via the raw syscall
+        // (std.posix has no `write` wrapper in 0.16).
+        _ = linux.write(fds[1], "world", 5);
 
-    var stream = InputStream.fromFd(fds[0]);
-    var buf: [16]u8 = undefined;
-    const r = stream.read(&buf);
-    try std.testing.expectEqual(@as(usize, 5), r.ok);
-    try std.testing.expectEqualSlices(u8, "world", buf[0..5]);
+        var stream = InputStream.fromFd(fds[0]);
+        var buf: [16]u8 = undefined;
+        const r = stream.read(&buf);
+        try std.testing.expectEqual(@as(usize, 5), r.ok);
+        try std.testing.expectEqualSlices(u8, "world", buf[0..5]);
+    }
 }
 
 test "InputStream: read from fd returns closed at EOF (#474)" {
-    const fds = linuxPipe2() orelse return error.SkipZigTest;
-    const linux = std.os.linux;
-    defer _ = linux.close(fds[0]);
-    _ = linux.close(fds[1]); // close write-end → next read sees EOF
+    if (comptime @import("builtin").os.tag != .linux) return error.SkipZigTest;
+    if (comptime @import("builtin").os.tag == .linux) {
+        const linux = std.os.linux;
+        var fds: [2]i32 = undefined;
+        if (linux.errno(linux.pipe2(&fds, .{})) != .SUCCESS) return error.SkipZigTest;
+        defer _ = linux.close(fds[0]);
+        _ = linux.close(fds[1]); // close write-end → next read sees EOF
 
-    var stream = InputStream.fromFd(fds[0]);
-    var buf: [16]u8 = undefined;
-    const r = stream.read(&buf);
-    try std.testing.expect(r == .closed);
+        var stream = InputStream.fromFd(fds[0]);
+        var buf: [16]u8 = undefined;
+        const r = stream.read(&buf);
+        try std.testing.expect(r == .closed);
+    }
 }
 
 test "Pollable: immediate is always ready" {


### PR DESCRIPTION
Closes #474.

## Summary

`wamr run <component.wasm>` now streams stdio live to the user's terminal instead of buffering for the entire run, and the host process's stdin is wired through to the component (#474).

Manual verification:

```sh
$ echo "hello" | ./zig-out/bin/wamr run src/component/fixtures/stdio-echo.wasm
echo: hello
```

(Before this PR: same input would produce the same output, but only after the component exits — the output was buffered in `WasiCliAdapter.stdout` and `main.zig:307-314` flushed at the end. No stdin reading from the host fd at all.)

## Changes

Three commits, ordered for review-ability (auto-squashed on merge):

### 1. `feat(wasi): real fd I/O for OutputStream .fd sink + InputStream.fromFd`

`src/wasi/preview2/streams.zig` only.

- `OutputStream.toFd(fd)` constructor existed but its `.write` branch was a no-op stub ("fd-backed sinks aren't yet used in production"). Now uses `std.Io.File.writeStreamingAll` (non-positional streaming write through the io vtable).
- `InputStream` had no `fromFd` constructor and its `.fd` `read` branch returned 0 unconditionally. Added `fromFd(fd)` and made `read` call `std.posix.read` (EINTR-retried internally by the stdlib).
- Error mapping: `EAGAIN` → `.{ .err = .would_block }`; `EPIPE` / `ENOTREAD` / `EBADF` / connection-reset variants → `.{ .closed = {} }`; other → `.io_error`. Zero-byte read is treated as EOF (`.closed`).
- 4 new pipe-pair unit tests (Linux-only; `SkipZigTest` on others).

### 2. `feat(wasi): WasiCliAdapter.initWithHostStdio + main.zig wires wamr run`

Two new constructors:

- `WasiCliAdapter.initWithHostStdio(allocator)` — wires stdout/stderr/stdin to `std.posix.STDOUT_FILENO` / `STDERR_FILENO` / `STDIN_FILENO`.
- `WasiCliAdapter.initWithHostStdioFds(allocator, in, out, err)` — variant for tests; takes explicit fds so the test can redirect through pipes without touching the test process's own stdio.

The existing `init(allocator)` (buffer-backed) is unchanged — every existing test in `wasi_cli_adapter.zig` keeps using it. The new constructor is for the `wamr run` CLI path.

`src/main.zig` `runComponent` switches to `initWithHostStdio` and drops the end-of-run `getStdoutBytes` → `writeStreamingAll` flush. The `io` parameter on `runComponent` is removed since the flush was its only remaining consumer.

### 3. `test(wasi): live host stdio via pipe-redirected stdio-echo`

New end-to-end test in `wasi_cli_adapter.zig`:

```
"stdio-echo: live host stdio via pipe-redirected fds (#474)"
```

Creates two `pipe2` pairs (Linux-only), wires `initWithHostStdioFds` to the pipe ends, preloads `"hello\n"` into the stdin pipe, runs the existing `stdio-echo.wasm` fixture, then drains the stdout pipe and asserts `"echo: hello\n"`. Load-bearing: if the streams `.fd` write branch were still the pre-#474 no-op stub, the drain would return 0 bytes.

The existing `"stdio-echo: end-to-end real wasi-p2 component (#156)"` test keeps using `setStdinBytes` + `getStdoutBytes` against the buffer-backed `init` constructor — verifies that path still works for embedding/testing.

## Validation

* `zig build test` — `Build Summary: 29/29 steps succeeded; 2013/2013 tests passed`.
* `zig build` (Debug) — clean.
* `zig build -Doptimize=ReleaseFast` — clean.
* Manual `echo "hello" | wamr run stdio-echo.wasm` — prints `"echo: hello"` to the terminal (live; no end-of-run flush in `main.zig`).
* `zig test src/wasi/preview2/streams.zig` — 14/14 (10 existing + 4 new for the .fd path).

## Out of scope (per #474 + #451)

* **Non-blocking stdin polling on Windows** — keep blocking `std.posix.read`. The new Linux-only pipe tests gate via `SkipZigTest` on other OSes; the production path on Windows still works (Windows stdin is blocking by default for non-redirected fds).
* **`pollable` subscription to stdin readiness** — covered by the async ABI item #478 / wasi:io@0.3.0 (#481).
* **AsyncReturn / stream<u8> from wasi:io@0.3.0** — that's the p3 shape (#481). The current `output-stream.blocking-write-and-flush` member surface is what wasi 0.2 components use, and is sufficient for live streaming on that path.
* **CLI flags `--stdin <path>` / `--stdout <path>`** — production CLI just uses the standard fds. Future enhancement.

## Concurrent work

PR #496 (#470 must-execute bounds-check extension) is still in CI on a separate branch. Disjoint files (`streams.zig` + `wasi_cli_adapter.zig` + `main.zig` vs `passes.zig`) — no conflicts expected.
