### PR TITLE
chore(tests): double cold-start budget on macOS to absorb runner jitter (#395)

### DIFF
--- a/src/tests/coldstart_test.zig
+++ b/src/tests/coldstart_test.zig
@@ -24,8 +24,8 @@
 //! positives, while a real ≥3× regression — the kind a stray eager init
 //! would introduce — fails the test loudly.
 //!
-//!     wasm budget   500 µs
-//!     cwasm budget  200 µs
+//!     wasm budget   500 µs   (1000 µs on macOS — see #395 jitter note)
+//!     cwasm budget  200 µs   (400 µs on macOS — see #395 jitter note)
 //!
 //! Skip from the build with `-Dskip-coldstart=true`. See
 //! https://github.com/cataggar/wamr/issues/395 for context and #394 for
@@ -58,10 +58,18 @@ const WARMUP = 5;
 const SAMPLES = 25;
 
 /// Wasm-path budget — see top-of-file rationale.
-const WASM_BUDGET_NS: u64 = 500_000;
+///
+/// macOS GHA runners exhibit higher variance than Linux/Windows
+/// counterparts; the macos-arm64 job hit `median=344µs vs budget=200µs`
+/// on PR #496's cwasm test despite no compiler change touching the
+/// cold-start path. Double the budgets on macOS to absorb runner
+/// jitter without losing the real-regression detection on the more
+/// stable archs.
+const WASM_BUDGET_NS: u64 = if (builtin.os.tag == .macos) 1_000_000 else 500_000;
 
-/// Cwasm-path budget — see top-of-file rationale.
-const CWASM_BUDGET_NS: u64 = 200_000;
+/// Cwasm-path budget — see top-of-file rationale (and macOS note on
+/// `WASM_BUDGET_NS`).
+const CWASM_BUDGET_NS: u64 = if (builtin.os.tag == .macos) 400_000 else 200_000;
 
 /// Runtime arch gate for the cwasm half. Mirrors `aot_supported` in
 /// `differential.zig`. On non-AOT-executable targets the cwasm test


### PR DESCRIPTION
## Problem

The macos-arm64 GHA runners exhibit substantially higher variance on the in-process cold-start budget test (`src/tests/coldstart_test.zig`, issue #395) than their Linux / Windows counterparts. PR #496 — an unrelated `hoistLoopBoundsChecks` IR change that doesn't touch the cold-start path — tripped a false-positive failure on macOS:

```
[coldstart] noop.cwasm regressed: median=344000ns budget=200000ns
            min=157000ns max=526000ns (samples=25)
```

The minimum is well under budget (157µs); the maximum is more than 3× the median (526µs). That spread is characteristic of macOS runner jitter, not a real regression — the WAMR-attributable cwasm slice is documented in the file-header rationale as "< 100 µs (load + instantiate + map + call)", and the 200µs Linux/Windows budget already represents 3× the realistic upper bound.

## Fix

Double the budgets on macOS only:

| Constant | Linux/Windows | macOS (this PR) |
| --- | ---: | ---: |
| `WASM_BUDGET_NS` | 500 µs | **1 000 µs** |
| `CWASM_BUDGET_NS` | 200 µs | **400 µs** |

The new macOS budgets are 6× the documented WAMR-internal slice. A real ≥6× regression — the kind a stray eager init would introduce — still fails loudly; routine timer jitter on the macOS shared runner no longer fires false positives.

## Why per-OS, not raise everywhere

Linux (self-hosted aarch64 + GHA x64) and Windows are stable; PR #466's bench history shows their cold-start budget never approached the limit. Bumping their budgets too would hide real regressions on the more reliable arches.

## Validation

* `zig build` (Debug + ReleaseFast, aarch64-linux dev host) — clean.
* `zig build test` — `Build Summary: 29/29 steps succeeded; 2014/2014 tests passed`.
* CI will exercise the new macOS budgets in the linked workflow.

## References

* #395 — coldstart budget test infrastructure.
* #496 — the PR whose macOS unit-test job failed on the prior tight budget.
