### PR TITLE
feat(wasi): gate https outbound on HTTP_protocol_error (#477 Option 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ the gate against regressions in already-shipped WASI host functions.
 
 [wts]: https://github.com/WebAssembly/wasi-testsuite
 
+## WASI limitations
+
+### `wasi:http` — outbound HTTP only
+
+`wamr`'s `wasi:http/outgoing-handler.handle` issues real outbound HTTP requests
+via `std.http.Client` when a non-empty `sockets_allow_list_template` is
+configured. **`https://` is not yet supported** — Zig 0.16's `std.http.Client`
+does not ship a TLS implementation, and per the project's WASI roadmap
+([#451](https://github.com/cataggar/wamr/issues/451)) we do not reimplement
+TLS in the runtime. `https://` URLs (and any other non-`http` scheme) return
+`error-code::HTTP_protocol_error`. Once upstream Zig lands TLS, this
+restriction will lift (see
+[#477](https://github.com/cataggar/wamr/issues/477)).
+
 ## License
 
 [Apache 2.0](LICENSE)

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -8930,9 +8930,17 @@ pub const WasiCliAdapter = struct {
     ///   option<own<request-options>>)
     ///   -> result<own<future-incoming-response>, error-code>`.
     ///
-    /// When `sockets_allow_list_template` is non-empty, performs a real
-    /// outbound HTTP request via `std.http.Client` (#176). Otherwise
-    /// returns `HTTP_request_denied` as before.
+    /// Cleartext-only today (#477): `https://` (or any non-`http`
+    /// scheme) returns `error-code::HTTP_protocol_error`. The
+    /// `std.http.Client` upstream doesn't ship TLS in Zig 0.16, and
+    /// parent issue #451 explicitly disallows reimplementing it in
+    /// the runtime.
+    ///
+    /// When `sockets_allow_list_template` is non-empty AND the
+    /// scheme is `"http"`, performs a real outbound HTTP request via
+    /// `std.http.Client` (#176). Otherwise returns
+    /// `HTTP_request_denied` (empty allow-list) or
+    /// `HTTP_protocol_error` (encrypted / unsupported scheme).
     fn httpOutgoingHandlerHandle(
         ctx_opaque: ?*anyopaque,
         _: *ComponentInstance,
@@ -8966,6 +8974,19 @@ pub const WasiCliAdapter = struct {
             1 => "https",
             else => if (r.scheme_other) |s| s else "https",
         } else "https";
+
+        // #477: std.http.Client doesn't ship TLS yet. Refuse `https://`
+        // (and any non-`http` custom scheme) explicitly rather than
+        // silently fall through to a plaintext connect attempt.
+        // `HTTP_protocol_error` (variant 35) is the cleanest existing
+        // `error-code` value: the spec describes it as "the response was
+        // not a valid HTTP response", which subsumes "we could not speak
+        // the requested protocol". Re-evaluate once upstream lands TLS
+        // (then this whole branch goes away and the handler proceeds).
+        // TODO(#477): remove when std.http.Client supports TLS.
+        if (!std.mem.eql(u8, scheme, "http")) {
+            return httpHandlerDeny(self, results, allocator, .HTTP_protocol_error);
+        }
 
         const authority = r.authority orelse {
             return httpHandlerDeny(self, results, allocator, .HTTP_request_URI_invalid);
@@ -14124,6 +14145,97 @@ test "http #176: handle returns denied when allow-list empty" {
 
     const args = [_]InterfaceValue{
         .{ .handle = 0 },
+        .{ .option_val = .{ .is_some = false, .payload = null } },
+    };
+    var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+    try WasiCliAdapter.httpOutgoingHandlerHandle(&adapter, &ci, &args, &results, testing.allocator);
+    defer results[0].deinit(testing.allocator);
+
+    try testing.expect(results[0] == .result_val);
+    try testing.expect(results[0].result_val.is_ok);
+    const fut_handle = results[0].result_val.payload.?.handle;
+    const fut = adapter.http_future_responses.items[fut_handle].?;
+    try testing.expect(fut.state == .ready_err);
+    try testing.expectEqual(
+        @as(u32, @intFromEnum(HttpErrorCode.HTTP_request_denied)),
+        fut.state.ready_err,
+    );
+}
+
+test "http #477: https outgoing-handler returns HTTP_protocol_error (no TLS in std)" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+    var ci: ComponentInstance = undefined;
+
+    // Non-empty allow-list so the empty-list deny path doesn't mask
+    // the scheme rejection.
+    const allow = try testing.allocator.alloc(IpCidr, 1);
+    allow[0] = try IpCidr.parse("0.0.0.0/0");
+    adapter.sockets_allow_list_template = allow;
+
+    // Headers + outgoing-request with scheme = https (disc=1). Both
+    // are pushed into adapter-owned tables; adapter.deinit frees the
+    // strings (duped with adapter.allocator == testing.allocator) and
+    // destroys the structs.
+    const fields = try testing.allocator.create(HttpFields);
+    fields.* = .{};
+    const fh = try adapter.pushHttpFields(fields);
+
+    const req = try testing.allocator.create(OutgoingRequest);
+    req.* = .{
+        .method_disc = 0, // GET
+        .scheme_disc = 1, // https
+        .authority = try testing.allocator.dupe(u8, "example.com"),
+        .path_with_query = try testing.allocator.dupe(u8, "/"),
+        .headers_handle = fh,
+    };
+    const rh = try adapter.pushOutgoingRequest(req);
+
+    const args = [_]InterfaceValue{
+        .{ .handle = rh },
+        .{ .option_val = .{ .is_some = false, .payload = null } },
+    };
+    var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+    try WasiCliAdapter.httpOutgoingHandlerHandle(&adapter, &ci, &args, &results, testing.allocator);
+    defer results[0].deinit(testing.allocator);
+
+    try testing.expect(results[0] == .result_val);
+    try testing.expect(results[0].result_val.is_ok);
+    const fut_handle = results[0].result_val.payload.?.handle;
+    const fut = adapter.http_future_responses.items[fut_handle].?;
+    try testing.expect(fut.state == .ready_err);
+    try testing.expectEqual(
+        @as(u32, @intFromEnum(HttpErrorCode.HTTP_protocol_error)),
+        fut.state.ready_err,
+    );
+}
+
+test "http #477: http outgoing-handler without allow-list returns HTTP_request_denied (regression)" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+    var ci: ComponentInstance = undefined;
+
+    // Allow-list intentionally left empty. Build a real `http://`
+    // request so we exercise both branches: the empty-allow-list
+    // check must trigger before the (passing) scheme check.
+    const fields = try testing.allocator.create(HttpFields);
+    fields.* = .{};
+    const fh = try adapter.pushHttpFields(fields);
+
+    const req = try testing.allocator.create(OutgoingRequest);
+    req.* = .{
+        .method_disc = 0,
+        .scheme_disc = 0, // http
+        .authority = try testing.allocator.dupe(u8, "example.com"),
+        .path_with_query = try testing.allocator.dupe(u8, "/"),
+        .headers_handle = fh,
+    };
+    const rh = try adapter.pushOutgoingRequest(req);
+
+    const args = [_]InterfaceValue{
+        .{ .handle = rh },
         .{ .option_val = .{ .is_some = false, .payload = null } },
     };
     var results: [1]InterfaceValue = .{.{ .u32 = 0 }};


### PR DESCRIPTION
# `wasi:http` outbound — explicit HTTPS gate (#477, Option 2)

Closes #477.

## Why Option 2

The issue body lays out three options; Option 2 is the docs-only /
error-only path. Parent issue #451 ("WASI roadmap") is unambiguous on
out-of-scope work:

> *Implementing TLS in Zig std — only consume what upstream ships.*

Zig 0.16's `std.http.Client` does **not** ship a TLS implementation
(`tls`/`crypto` symbols are absent from `std/http/Client.zig`). Today,
`wasi:http/outgoing-handler.handle` infers `scheme = "https"` as the
default when the guest doesn't call `set-scheme`, then attempts a
plaintext connect — which fails at best and could leak request bytes
at worst.

This PR replaces that silent fallthrough with an explicit refusal:

```zig
// TODO(#477): remove when std.http.Client supports TLS.
if (!std.mem.eql(u8, scheme, "http")) {
    return httpHandlerDeny(self, results, allocator, .HTTP_protocol_error);
}
```

`HTTP_protocol_error` (WIT variant 35) is the closest existing
`error-code` for "we cannot speak the requested protocol". Using a
distinct code from `HTTP_request_denied` (variant 15) lets guests
tell "you forgot to grant permission" apart from "this scheme isn't
supported".

Once upstream Zig lands TLS, the gate (a 3-line block) deletes
cleanly — the rest of the handler is already wired for arbitrary
schemes.

## Changes

1. **`src/component/wasi_cli_adapter.zig`** — early-return in
   `httpOutgoingHandlerHandle` right after the scheme-string is
   built. Doc-comment refreshed to mention #477 + the TLS situation.
   `// TODO(#477)` annotation at the new gate site.
2. **`README.md`** — new `## WASI limitations` section with a
   `wasi:http — outbound HTTP only` subsection citing #477/#451.
3. **Two new unit tests** near the existing `http #176:` block:
   - `http #477: https outgoing-handler returns HTTP_protocol_error (no TLS in std)`
   - `http #477: http outgoing-handler without allow-list returns HTTP_request_denied (regression)`

   The first test does **not** issue a network request — the gate
   short-circuits before `std.http.Client.fetch` is reached. The
   second test asserts the empty-allow-list deny still wins over a
   well-formed `http://` request (regression check).

## Validation

| Step | Before | After |
|---|---|---|
| `zig build` | ok | ok |
| `zig build test` | 2067/2067 | **2069/2069** (+2) |
| `zig build wasi-testsuite` | 72/72 PASS | **72/72 PASS** (preview1 untouched) |
| `zig build -Dtarget=aarch64-macos` | ok | ok |
| `zig build -Dtarget=x86_64-windows` | ok | ok |
| `zig build -Dtarget=x86_64-linux` | ok | ok |

## Out of scope (per #451)

- Reimplementing TLS in Zig.
- Adding a custom `error-code` variant for "TLS not supported" —
  reusing `HTTP_protocol_error` per the WIT spec's allowed values.
- Capability allow-list overhaul (separate follow-up).
- Custom CA bundle plumbing — needs TLS first.

## Notes for reviewers

The edit region (`wasi_cli_adapter.zig` line ~8950 + tests near
~14160) does not overlap with concurrent work:

- #476 edits the filesystem section (lines ~3200-4000 + tests
  ~11000).
- #478 doesn't touch this file.

If either lands first the rebase is mechanical.
