### PR TITLE
feat(component): canon future.read / future.write rendezvous (#478)

### DIFF
--- a/src/component/async.zig
+++ b/src/component/async.zig
@@ -174,35 +174,51 @@ pub const TaskManager = struct {
 
 // ── Futures ─────────────────────────────────────────────────────────────────
 
-/// A future represents a single async value (one-shot channel).
+/// A future represents a single async value (one-shot channel) parameterised
+/// on element type `T`. Per the component-model spec, a future has two
+/// ends — a readable side and a writable side — and a single value flows
+/// from writer to reader (or the future is dropped before either occurs).
+///
+/// The host-side representation buffers the lowered bytes of T between the
+/// producer `future.write` and consumer `future.read` rendezvous. If the
+/// reader arrives first it parks, recording its destination guest pointer;
+/// the next writer copies straight into that location instead of allocating
+/// a buffer.
 pub const Future = struct {
-    state: State = .pending,
-    value: ?u32 = null,
+    /// Type index of `T`, captured from the originating `future.new t`'s
+    /// `type_idx`. Used by `future.read` / `future.write` to compute the
+    /// byte size of the payload via `canonical_abi.sizeOfType`.
+    elem_type_idx: u32 = 0,
+    /// Buffered payload bytes, set when a writer arrives before a reader.
+    /// Owned by this `Future`; freed by the reader (on consumption) or by
+    /// the `future_drop_*` arm once both ends are closed.
+    payload: ?[]u8 = null,
+    /// Set when a `future.read` arrives before any writer. The destination
+    /// guest pointer is stashed so that a subsequent `future.write` can
+    /// copy straight into the parked reader's memory and complete.
+    pending_read: ?PendingRead = null,
+    /// Waitable plumbing for `waitable.join` integration.
     waitable_set: ?*WaitableSet = null,
-    waitable_idx: ?u32 = null,
+    read_waitable_idx: ?u32 = null,
+    write_waitable_idx: ?u32 = null,
+    state: State = .pending,
+    /// Both ends are closed only after both `drop-readable` and
+    /// `drop-writable`. Tracked separately so cancellation observes the
+    /// correct end (see `dispatchAsyncCanon.future_read`/`future_write`).
+    read_closed: bool = false,
+    write_closed: bool = false,
 
     pub const State = enum { pending, ready, closed };
 
-    /// Write a value to the future (producer side).
-    pub fn write(self: *Future, val: u32, allocator: std.mem.Allocator) bool {
-        if (self.state != .pending) return false;
-        self.value = val;
-        self.state = .ready;
-        if (self.waitable_set) |ws| {
-            if (self.waitable_idx) |idx| {
-                ws.setReady(idx, allocator);
-            }
-        }
-        return true;
-    }
+    pub const PendingRead = struct { guest_ptr: u32 };
 
-    /// Read the value from the future (consumer side).
-    pub fn read(self: *Future) ?u32 {
-        if (self.state == .ready) {
-            self.state = .closed;
-            return self.value;
+    /// Free any heap-owned state (currently just the buffered `payload`).
+    /// Safe to call multiple times.
+    pub fn deinit(self: *Future, allocator: std.mem.Allocator) void {
+        if (self.payload) |b| {
+            allocator.free(b);
+            self.payload = null;
         }
-        return null;
     }
 };
 
@@ -341,20 +357,27 @@ test "WaitableSet: register and poll" {
     try std.testing.expectEqual(idx1, out[0]);
 }
 
-test "Future: write then read" {
+test "Future: state transitions through pending/ready" {
     var f = Future{};
-    try std.testing.expect(f.read() == null);
-
-    try std.testing.expect(f.write(42, std.testing.allocator));
-    try std.testing.expectEqual(@as(?u32, 42), f.read());
-    // Second read returns null (closed)
-    try std.testing.expect(f.read() == null);
+    try std.testing.expectEqual(Future.State.pending, f.state);
+    f.state = .ready;
+    try std.testing.expectEqual(Future.State.ready, f.state);
 }
 
-test "Future: double write fails" {
+test "Future: deinit frees buffered payload" {
+    const allocator = std.testing.allocator;
     var f = Future{};
-    try std.testing.expect(f.write(1, std.testing.allocator));
-    try std.testing.expect(!f.write(2, std.testing.allocator));
+    f.payload = try allocator.alloc(u8, 8);
+    f.deinit(allocator);
+    try std.testing.expect(f.payload == null);
+    // Second deinit is a no-op.
+    f.deinit(allocator);
+}
+
+test "Future: pending_read records guest_ptr" {
+    var f = Future{};
+    f.pending_read = .{ .guest_ptr = 0x1234 };
+    try std.testing.expectEqual(@as(u32, 0x1234), f.pending_read.?.guest_ptr);
 }
 
 test "AsyncStream: write and read" {

--- a/src/component/async_canon.zig
+++ b/src/component/async_canon.zig
@@ -72,6 +72,25 @@ pub const YieldOutcome = enum(u32) {
     cancelled = 1,
 };
 
+/// Discriminant for `future.read` / `future.write` / `future.cancel-*`
+/// status words (Binary.md "Async Calls"). The on-the-wire status word
+/// is `packStatus(status, count)` — bits 0..3 carry the discriminant,
+/// bits 4..31 carry the number of elements transferred (for `future<T>`
+/// always 0 or 1 since the channel is one-shot).
+pub const FutureStatus = enum(u32) {
+    starting = 0,
+    started = 1,
+    returned = 2,
+    cancelled = 3,
+};
+
+/// Pack a future read/write status discriminant + element count into the
+/// single i32 status word the spec returns from `future.{read,write}` and
+/// `future.cancel-{read,write}`.
+pub fn packStatus(status: FutureStatus, count: u32) u32 {
+    return @intFromEnum(status) | (count << 4);
+}
+
 /// Execute `canon thread.yield cancel?` for the currently executing task.
 ///
 /// Single-threaded runtime semantics: a "yield" is the smallest possible
@@ -225,4 +244,14 @@ test "taskYield: unknown handle is a no-op" {
     defer tm.deinit(allocator);
 
     try std.testing.expectEqual(YieldOutcome.resumed, taskYield(&tm, 999, true, allocator));
+}
+
+test "packStatus: encodes discriminant + element count" {
+    try std.testing.expectEqual(@as(u32, 0), packStatus(.starting, 0));
+    try std.testing.expectEqual(@as(u32, 1), packStatus(.started, 0));
+    try std.testing.expectEqual(@as(u32, 2), packStatus(.returned, 0));
+    // `future<T>` only ever transfers 0 or 1 elements; verify the count
+    // lands in bits 4..31.
+    try std.testing.expectEqual(@as(u32, 2 | (1 << 4)), packStatus(.returned, 1));
+    try std.testing.expectEqual(@as(u32, 3), packStatus(.cancelled, 0));
 }

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -2004,6 +2004,393 @@ test "dispatchCanonBuiltin: future.new + drop both ends round-trip" {
     try testing.expectEqual(@as(u32, 0), inst.futures.count());
 }
 
+// ── #478 sub-PR 3a: future.read/write rendezvous tests ──────────────────────
+//
+// Each test wires a minimal `ComponentInstance` whose component-type-index
+// space carries a single `(type u32)` entry; `future.new t=0` therefore
+// names a `future<u32>`. `enableTestMem` provides a 4 KiB backing buffer
+// for the lift/lower memcpy on each side of the rendezvous.
+
+fn newFutureU32Inst(testing_allocator: std.mem.Allocator) !*instance_mod.ComponentInstance {
+    // Static lifetimes — the `Component` and its types live as long as
+    // the instance, so we leak them deliberately. Tests run in their
+    // own process; the test allocator releases bookkeeping on exit.
+    const FutureTypeFixture = struct {
+        var types_array = [_]ctypes.TypeDef{.{ .val = .u32 }};
+        var comp: ctypes.Component = .{
+            .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+            .components = &.{},       .instances = &.{},      .aliases = &.{},
+            .types = &.{},            .canons = &.{},         .imports = &.{},
+            .exports = &.{},
+        };
+    };
+    FutureTypeFixture.comp.types = &FutureTypeFixture.types_array;
+    const inst = try instance_mod.instantiate(&FutureTypeFixture.comp, testing_allocator);
+    try inst.enableTestMem(testing_allocator, 4096);
+    return inst;
+}
+
+fn destroyFutureInst(inst: *instance_mod.ComponentInstance) void {
+    inst.disableTestMem();
+    inst.deinit();
+}
+
+test "future.new: returns packed read|write handles" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    const inst = try newFutureU32Inst(testing.allocator);
+    defer destroyFutureInst(inst);
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_new = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+
+    const packed_handles: u64 = @bitCast(try env.popI64());
+    const r_idx: u32 = @truncate(packed_handles >> 32);
+    const w_idx: u32 = @truncate(packed_handles & 0xFFFF_FFFF);
+    // Single-handle prototype: read+write share the same idx.
+    try testing.expectEqual(r_idx, w_idx);
+    try testing.expect(r_idx > 0);
+    try testing.expectEqual(@as(u32, 1), inst.futures.count());
+
+    const fut = inst.futures.getPtr(r_idx).?;
+    try testing.expectEqual(@as(u32, 0), fut.elem_type_idx);
+    try testing.expect(fut.payload == null);
+    try testing.expect(fut.pending_read == null);
+}
+
+test "future.write then future.read: round-trips a u32" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    const inst = try newFutureU32Inst(testing.allocator);
+    defer destroyFutureInst(inst);
+
+    // Allocate the handle.
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_new = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const handle: u32 = @truncate(@as(u64, @bitCast(try env.popI64())) >> 32);
+
+    // Stage the source u32 in test memory at offset 0; destination at 32.
+    const src_ptr: u32 = 0;
+    const dst_ptr: u32 = 32;
+    const src_bytes = inst.writableGuestBytes(src_ptr, 4).?;
+    std.mem.writeInt(u32, src_bytes[0..4], 0xDEAD_BEEF, .little);
+
+    // Issue future.write — should buffer the bytes (no reader parked yet).
+    try env.pushI32(@bitCast(handle));
+    try env.pushI32(@bitCast(src_ptr));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_write = .{ .type_idx = 0, .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const write_status: u32 = @bitCast(try env.popI32());
+    try testing.expectEqual(async_canon.packStatus(.returned, 1), write_status);
+    try testing.expect(inst.futures.getPtr(handle).?.payload != null);
+
+    // Issue future.read — should copy buffered bytes into dst.
+    try env.pushI32(@bitCast(handle));
+    try env.pushI32(@bitCast(dst_ptr));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_read = .{ .type_idx = 0, .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const read_status: u32 = @bitCast(try env.popI32());
+    try testing.expectEqual(async_canon.packStatus(.returned, 1), read_status);
+
+    const dst_bytes = inst.writableGuestBytes(dst_ptr, 4).?;
+    try testing.expectEqual(@as(u32, 0xDEAD_BEEF), std.mem.readInt(u32, dst_bytes[0..4], .little));
+    // Payload drained.
+    try testing.expect(inst.futures.getPtr(handle).?.payload == null);
+}
+
+test "future.read parks then future.write wakes a waitable" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    const inst = try newFutureU32Inst(testing.allocator);
+    defer destroyFutureInst(inst);
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_new = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const handle: u32 = @truncate(@as(u64, @bitCast(try env.popI64())) >> 32);
+
+    // Wire a waitable set + register the future's read side. This is
+    // the manual plumbing the eventual `waitable.join` arm will set up;
+    // the rendezvous logic only checks that the slots are populated.
+    var ws = async_mod.WaitableSet{};
+    defer ws.deinit(testing.allocator);
+    {
+        const fut = inst.futures.getPtr(handle).?;
+        fut.waitable_set = &ws;
+        const idx = try ws.register(.{ .kind = .future_read, .handle = handle }, testing.allocator);
+        fut.read_waitable_idx = idx;
+    }
+
+    const src_ptr: u32 = 0;
+    const dst_ptr: u32 = 16;
+    const src_bytes = inst.writableGuestBytes(src_ptr, 4).?;
+    std.mem.writeInt(u32, src_bytes[0..4], 0xCAFE_F00D, .little);
+
+    // Reader arrives first — must park with STARTING and remember the dst.
+    try env.pushI32(@bitCast(handle));
+    try env.pushI32(@bitCast(dst_ptr));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_read = .{ .type_idx = 0, .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const read_status: u32 = @bitCast(try env.popI32());
+    try testing.expectEqual(async_canon.packStatus(.starting, 0), read_status);
+    try testing.expectEqual(@as(u32, dst_ptr), inst.futures.getPtr(handle).?.pending_read.?.guest_ptr);
+
+    // Writer arrives — copies straight into the parked dst, returns RETURNED.
+    try env.pushI32(@bitCast(handle));
+    try env.pushI32(@bitCast(src_ptr));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_write = .{ .type_idx = 0, .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const write_status: u32 = @bitCast(try env.popI32());
+    try testing.expectEqual(async_canon.packStatus(.returned, 1), write_status);
+
+    // Destination memory updated, payload not buffered, waitable woken.
+    const dst_bytes = inst.writableGuestBytes(dst_ptr, 4).?;
+    try testing.expectEqual(@as(u32, 0xCAFE_F00D), std.mem.readInt(u32, dst_bytes[0..4], .little));
+    try testing.expect(inst.futures.getPtr(handle).?.payload == null);
+    try testing.expect(inst.futures.getPtr(handle).?.pending_read == null);
+    var ready: [4]u32 = undefined;
+    try testing.expectEqual(@as(u32, 1), ws.pollReady(&ready));
+}
+
+test "future.cancel-read on empty future returns CANCELLED" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    const inst = try newFutureU32Inst(testing.allocator);
+    defer destroyFutureInst(inst);
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_new = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const handle: u32 = @truncate(@as(u64, @bitCast(try env.popI64())) >> 32);
+
+    // Park a reader so cancel has something to clear.
+    try env.pushI32(@bitCast(handle));
+    try env.pushI32(@bitCast(@as(u32, 0)));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_read = .{ .type_idx = 0, .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    _ = try env.popI32(); // discard STARTING
+    try testing.expect(inst.futures.getPtr(handle).?.pending_read != null);
+
+    // Cancel — should clear pending_read and return CANCELLED.
+    try env.pushI32(@bitCast(handle));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_cancel_read = .{ .type_idx = 0, .is_async = false } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const status: u32 = @bitCast(try env.popI32());
+    try testing.expectEqual(async_canon.packStatus(.cancelled, 0), status);
+    try testing.expect(inst.futures.getPtr(handle).?.pending_read == null);
+}
+
+test "future.drop-writable while reader parked: subsequent read is CANCELLED" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    const inst = try newFutureU32Inst(testing.allocator);
+    defer destroyFutureInst(inst);
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_new = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const packed_handles: u64 = @bitCast(try env.popI64());
+    const r_idx: u32 = @truncate(packed_handles >> 32);
+    const w_idx: u32 = @truncate(packed_handles & 0xFFFF_FFFF);
+
+    // Park a reader first so the drop-writable code path observes it.
+    try env.pushI32(@bitCast(r_idx));
+    try env.pushI32(@bitCast(@as(u32, 16)));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_read = .{ .type_idx = 0, .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    _ = try env.popI32(); // discard STARTING
+
+    // Writer drops without ever writing.
+    try env.pushI32(@bitCast(w_idx));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_drop_writable = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    // Entry remains until the reader also drops.
+    try testing.expectEqual(@as(u32, 1), inst.futures.count());
+    try testing.expect(inst.futures.getPtr(r_idx).?.write_closed);
+
+    // Clear the parked-reader slot and re-issue read — it should observe
+    // CANCELLED because the writer is closed and no payload was buffered.
+    inst.futures.getPtr(r_idx).?.pending_read = null;
+    try env.pushI32(@bitCast(r_idx));
+    try env.pushI32(@bitCast(@as(u32, 16)));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_read = .{ .type_idx = 0, .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const status: u32 = @bitCast(try env.popI32());
+    try testing.expectEqual(async_canon.packStatus(.cancelled, 0), status);
+}
+
+test "future.drop both ends: table entry is freed" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    const inst = try newFutureU32Inst(testing.allocator);
+    defer destroyFutureInst(inst);
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_new = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const packed_handles: u64 = @bitCast(try env.popI64());
+    const r_idx: u32 = @truncate(packed_handles >> 32);
+    const w_idx: u32 = @truncate(packed_handles & 0xFFFF_FFFF);
+
+    // Buffer a payload to verify drop frees it (no leak diagnostic from
+    // the test allocator).
+    const src_ptr: u32 = 0;
+    const src_bytes = inst.writableGuestBytes(src_ptr, 4).?;
+    std.mem.writeInt(u32, src_bytes[0..4], 0x1234_5678, .little);
+    try env.pushI32(@bitCast(r_idx));
+    try env.pushI32(@bitCast(src_ptr));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_write = .{ .type_idx = 0, .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    _ = try env.popI32(); // discard RETURNED
+
+    try testing.expectEqual(@as(u32, 1), inst.futures.count());
+    try testing.expect(inst.futures.getPtr(r_idx).?.payload != null);
+
+    try env.pushI32(@bitCast(w_idx));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_drop_writable = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(u32, 1), inst.futures.count());
+
+    try env.pushI32(@bitCast(r_idx));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_drop_readable = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(u32, 0), inst.futures.count());
+}
+
 test "dispatchCanonBuiltin: error-context.new + drop round-trip" {
     const testing = std.testing;
     const core_types_mod = @import("../runtime/common/types.zig");

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -970,23 +970,186 @@ fn dispatchAsyncCanon(
 
         // ── Future handles ──────────────────────────────────────────────
         .future_new => |info| {
-            _ = info;
             const handle = comp_inst.allocAsyncHandle();
-            comp_inst.futures.put(comp_inst.allocator, handle, .{}) catch return error.OutOfMemory;
+            comp_inst.futures.put(comp_inst.allocator, handle, .{
+                .elem_type_idx = info.type_idx,
+            }) catch return error.OutOfMemory;
             const packed_handles: u64 = (@as(u64, handle) << 32) | @as(u64, handle);
             env.pushI64(@bitCast(packed_handles)) catch return error.StackOverflow;
+        },
+        .future_read => |info| {
+            // Stack: (handle, ptr) → status. The destination pointer
+            // is on top; `handle` is below it.
+            const guest_ptr: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+
+            const fut = comp_inst.futures.getPtr(handle) orelse {
+                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                    return error.StackOverflow;
+                return;
+            };
+
+            // Writer dropped without ever delivering a value → cancelled.
+            if (fut.write_closed and fut.payload == null) {
+                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                    return error.StackOverflow;
+                return;
+            }
+
+            // Writer already buffered — deliver and wake any read waitable.
+            if (fut.payload) |buf| {
+                const dst = comp_inst.writableGuestBytes(guest_ptr, @intCast(buf.len)) orelse
+                    return error.MemoryNotAvailable;
+                @memcpy(dst, buf);
+                comp_inst.allocator.free(buf);
+                fut.payload = null;
+                fut.state = .ready;
+                if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
+                    ws.setReady(idx, allocator);
+                env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                    return error.StackOverflow;
+                return;
+            }
+
+            // No writer yet — park. `info.type_idx` is captured into the
+            // table entry at `future.new` time; we only need the guest
+            // ptr here.
+            _ = info;
+            fut.pending_read = .{ .guest_ptr = guest_ptr };
+            env.pushI32(@bitCast(async_canon.packStatus(.starting, 0))) catch
+                return error.StackOverflow;
+        },
+        .future_write => |info| {
+            // Stack: (handle, ptr) → status.
+            const guest_ptr: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+
+            const fut = comp_inst.futures.getPtr(handle) orelse {
+                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                    return error.StackOverflow;
+                return;
+            };
+
+            // Reader already dropped → writer is cancelled.
+            if (fut.read_closed) {
+                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                    return error.StackOverflow;
+                return;
+            }
+
+            // Already buffered (double-write); reject with cancelled. Spec
+            // forbids two writes on a one-shot future.
+            if (fut.payload != null) {
+                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                    return error.StackOverflow;
+                return;
+            }
+
+            const registry = TypeRegistry.init(comp_inst.component);
+            const elem_size = abi.sizeOfType(registry, ctypes.ValType{ .type_idx = info.type_idx });
+            if (elem_size == 0) return error.LowerError;
+
+            const src = comp_inst.readGuestBytes(guest_ptr, elem_size) orelse
+                return error.MemoryNotAvailable;
+
+            // Reader parked first: copy straight into its destination,
+            // skip allocating a heap buffer.
+            if (fut.pending_read) |pr| {
+                const dst = comp_inst.writableGuestBytes(pr.guest_ptr, elem_size) orelse
+                    return error.MemoryNotAvailable;
+                @memcpy(dst, src);
+                fut.pending_read = null;
+                fut.state = .ready;
+                if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
+                    ws.setReady(idx, allocator);
+                env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                    return error.StackOverflow;
+                return;
+            }
+
+            // No reader yet — buffer the payload on the heap. Reader's
+            // future arrival will memcpy out of `payload` and free it.
+            const heap_buf = comp_inst.allocator.alloc(u8, elem_size) catch
+                return error.OutOfMemory;
+            @memcpy(heap_buf, src);
+            fut.payload = heap_buf;
+            fut.state = .ready;
+            if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
+                ws.setReady(idx, allocator);
+            env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                return error.StackOverflow;
+        },
+        .future_cancel_read => |info| {
+            _ = info;
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            const fut = comp_inst.futures.getPtr(handle) orelse {
+                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                    return error.StackOverflow;
+                return;
+            };
+            // If a value was already delivered before cancel arrived,
+            // surface RETURNED so the caller still observes the transfer.
+            if (fut.state == .ready and fut.payload == null) {
+                env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                    return error.StackOverflow;
+                return;
+            }
+            fut.pending_read = null;
+            env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                return error.StackOverflow;
+        },
+        .future_cancel_write => |info| {
+            _ = info;
+            const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            const fut = comp_inst.futures.getPtr(handle) orelse {
+                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                    return error.StackOverflow;
+                return;
+            };
+            // If the reader already consumed the buffered payload, the
+            // write completed before cancel; report RETURNED.
+            if (fut.state == .ready and fut.payload == null and fut.pending_read == null) {
+                env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                    return error.StackOverflow;
+                return;
+            }
+            // Otherwise reclaim any unconsumed buffered payload so the
+            // future returns to the empty state.
+            if (fut.payload) |buf| {
+                comp_inst.allocator.free(buf);
+                fut.payload = null;
+            }
+            env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                return error.StackOverflow;
         },
         .future_drop_readable => |info| {
             _ = info;
             const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
-            _ = comp_inst.futures.remove(handle);
+            if (comp_inst.futures.getPtr(handle)) |fut| {
+                fut.read_closed = true;
+                // Wake a parked writer so it can observe CANCELLED.
+                if (fut.waitable_set) |ws| if (fut.write_waitable_idx) |idx|
+                    ws.setReady(idx, allocator);
+                if (fut.read_closed and fut.write_closed) {
+                    fut.deinit(comp_inst.allocator);
+                    _ = comp_inst.futures.remove(handle);
+                }
+            }
         },
         .future_drop_writable => |info| {
             _ = info;
             const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
-            _ = comp_inst.futures.remove(handle);
+            if (comp_inst.futures.getPtr(handle)) |fut| {
+                fut.write_closed = true;
+                // Wake a parked reader so it can observe CANCELLED.
+                if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
+                    ws.setReady(idx, allocator);
+                if (fut.read_closed and fut.write_closed) {
+                    fut.deinit(comp_inst.allocator);
+                    _ = comp_inst.futures.remove(handle);
+                }
+            }
         },
-        .future_read, .future_write, .future_cancel_read, .future_cancel_write => return error.FunctionNotFound,
 
         // ── error-context ───────────────────────────────────────────────
         .error_context_new => |info| {
@@ -1783,7 +1946,7 @@ test "dispatchCanonBuiltin: waitable-set.new allocates a fresh handle; drop free
     try testing.expectEqual(@as(u32, 0), inst.waitable_sets.count());
 }
 
-test "dispatchCanonBuiltin: future.new + drop-readable round-trip" {
+test "dispatchCanonBuiltin: future.new + drop both ends round-trip" {
     const testing = std.testing;
     const core_types_mod = @import("../runtime/common/types.zig");
     const inst_mod_core = @import("../runtime/interpreter/instance.zig");
@@ -1818,10 +1981,22 @@ test "dispatchCanonBuiltin: future.new + drop-readable round-trip" {
     try testing.expect(r_idx > 0);
     try testing.expectEqual(@as(u32, 1), inst.futures.count());
 
+    // Drop-readable alone retains the table entry — only marks read_closed.
     try env.pushI32(@bitCast(r_idx));
     try dispatchCanonBuiltin(
         inst,
         .{ .async_canon = .{ .future_drop_readable = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(u32, 1), inst.futures.count());
+
+    // Dropping the second end removes the table entry.
+    try env.pushI32(@bitCast(w_idx));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_drop_writable = .{ .type_idx = 0 } } },
         env,
         null,
         testing.allocator,

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -1121,9 +1121,11 @@ pub const ComponentInstance = struct {
         self.resource_tables.deinit(self.allocator);
 
         // Tear down per-instance async-handle tables (#478 sub-PR 3).
-        // Streams and waitable-sets own heap memory; futures and
-        // error-contexts don't (the latter stores `[]u8` debug strings
-        // which we free below).
+        // Streams and waitable-sets own heap memory; futures buffer
+        // their lowered payload (#478 sub-PR 3a) and error-contexts
+        // store `[]u8` debug strings which we free below.
+        var fut_it = self.futures.valueIterator();
+        while (fut_it.next()) |f| f.deinit(self.allocator);
         self.futures.deinit(self.allocator);
         var stream_it = self.streams.valueIterator();
         while (stream_it.next()) |s| s.deinit(self.allocator);


### PR DESCRIPTION
Implements **#478 sub-PR 3a** — `future<T>` read/write canonical-ABI ops.
Companion to sub-PR 1 (`task.yield` + `context.{get,set}`, already
landed) and sub-PR 2 (async-lifted callees, wired alongside it).
`stream<T>` follows as sub-PR 3b.

## What this wires

Four canonical-ABI dispatch arms that previously trapped with
`error.FunctionNotFound`:

| Tag  | Operation                            |
|------|--------------------------------------|
| 0x16 | `canon future.read t opts`           |
| 0x17 | `canon future.write t opts`          |
| 0x18 | `canon future.cancel-read t async?`  |
| 0x19 | `canon future.cancel-write t async?` |

`future.new` (0x15) now captures the element typeidx into the
runtime `Future` entry; `future.drop-{readable,writable}` (0x1a/0x1b)
mark their respective close bit and only remove the table slot once
**both** ends are closed (and wake the opposite end's read/write
waitable so a parked partner observes `CANCELLED`).

## Status word

The lowered i32 status is packed via a new
`async_canon.packStatus(status, count)`:

| Bits 0..3   | Meaning                              |
|-------------|--------------------------------------|
| `0` STARTING| operation has not yet observed a partner |
| `1` STARTED | partner observed; neither has completed |
| `2` RETURNED| operation completed with a value     |
| `3` CANCELLED| operation was cancelled              |

Top 28 bits: number of elements transferred (always 0 or 1 for
one-shot futures).

## `async.Future` shape

Extended to carry the element type, an optional heap-buffered
payload, and a parked-reader slot:

```zig
pub const Future = struct {
    elem_type_idx: u32 = 0,
    payload: ?[]u8 = null,                  // owned, freed on consume or both-ends-drop
    pending_read: ?PendingRead = null,      // dest guest_ptr when reader arrives first
    waitable_set: ?*WaitableSet = null,
    read_waitable_idx: ?u32 = null,
    write_waitable_idx: ?u32 = null,
    state: State = .pending,
    read_closed: bool = false,
    write_closed: bool = false,
    pub const PendingRead = struct { guest_ptr: u32 };
    pub fn deinit(self: *Future, allocator: std.mem.Allocator) void { ... }
};
```

The rendezvous is allocation-free when the reader arrives first: the
next `future.write` copies straight into the parked reader's guest
memory without an intermediate heap buffer. Symmetric WaitableSet
plumbing wakes the partner end on completion or drop.

## Test surface (+6 in `executor.zig`)

1. `future.new` returns packed read|write handles.
2. `future.write` → `future.read` round-trips a u32 through the
   per-instance `TestGuestMem`.
3. Reader parks (STARTING); writer wakes the registered waitable
   and copies into the parked dst (RETURNED, count = 1).
4. `future.cancel-read` on a parked reader returns CANCELLED and
   clears `pending_read`.
5. `future.drop-writable` while reader parked → re-issued
   `future.read` returns CANCELLED.
6. Double drop (`drop-writable` then `drop-readable`) frees the
   table entry — payload allocation balanced (no leak diagnostic).

Three additional tests in `async.zig` (state transitions, deinit
idempotency, pending_read round-trip) and one in `async_canon.zig`
(`packStatus` encoding).

## Validation

| Target              | Result |
|---------------------|--------|
| `zig build test`    | **2075 / 2075 pass** (was 2069 baseline; +6 new) |
| `zig build wasi-testsuite` | **72 / 72 pass** (no fs touch) |
| `zig build -Dtarget=aarch64-macos` | clean |
| `zig build -Dtarget=x86_64-windows` | clean |
| `zig build -Dtarget=x86_64-linux`   | clean |

## Out of scope

- `stream<T>` rendezvous (sub-PR 3b — same status word, but
  `AsyncStream`'s multi-element buffer needs flow control).
- `waitable.join` / `waitable-set.{wait,poll}` real integration
  (currently stubs that pop arguments and push zero).
- Cross-instance futures (single-instance prototype today).
- `wasi:io/poll.pollable` ↔ future-handle bridging (lives in #481).

Closes the read/write half of #478. `stream<T>` follow-up tracked
in the parent issue.
