### PR TITLE
feat(component): canon task.cancel built-in (#488)

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -938,6 +938,18 @@ fn dispatchAsyncCanon(
             // `async?` info is ignored: cancellation is idempotent and
             // synchronous in the single-threaded runtime.
         },
+        .task_cancel => {
+            // `canon task.cancel` — Binary.md tag 0x05. Cancels the
+            // **currently executing** task (no handle on the stack,
+            // distinct from `subtask.cancel`). Core signature is
+            // `[] -> []`: no pops, no pushes. Traps when there is no
+            // async task manager or no current task — guest code that
+            // issues `task.cancel` from a non-async context is
+            // malformed by the spec.
+            const tm = task_manager orelse return error.FunctionNotFound;
+            const handle = tm.current_task orelse return error.FunctionNotFound;
+            tm.cancelTask(handle);
+        },
 
         // ── Stream handles ──────────────────────────────────────────────
         .stream_new => |info| {
@@ -1852,6 +1864,223 @@ test "dispatchCanonBuiltin: task.yield observes cancellation via TaskManager" {
     async_canon.asyncCancel(&tm, lift.subtask_handle);
 
     // Non-cancellable yield: opaque, always reports resumed=0.
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .task_yield = .{ .cancellable = false } },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(i32, 0), try env.popI32());
+
+    // Cancellable yield: surfaces the pending cancellation as 1.
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .task_yield = .{ .cancellable = true } },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    try testing.expectEqual(@as(i32, 1), try env.popI32());
+}
+
+// ── dispatchCanonBuiltin: task.cancel (Binary.md tag 0x05, issue #488) ──
+
+test "dispatchCanonBuiltin: task.cancel without task manager traps with FunctionNotFound" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    const result = dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .task_cancel },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectError(error.FunctionNotFound, result);
+    // Spec `[] -> []`: nothing popped, nothing pushed even on the trap path.
+    try testing.expectEqual(@as(u32, 0), env.sp);
+}
+
+test "dispatchCanonBuiltin: task.cancel without current_task traps with FunctionNotFound" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    // TaskManager present but `current_task` is null (default).
+    var tm = async_mod.TaskManager{};
+    defer tm.deinit(testing.allocator);
+
+    const result = dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .task_cancel },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    try testing.expectError(error.FunctionNotFound, result);
+    try testing.expectEqual(@as(u32, 0), env.sp);
+}
+
+test "dispatchCanonBuiltin: task.cancel flips current task to .cancelled" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    var tm = async_mod.TaskManager{};
+    defer tm.deinit(testing.allocator);
+    const h = try tm.createTask(testing.allocator);
+    tm.current_task = h;
+    try testing.expect(tm.getState(h).? != .cancelled);
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .task_cancel },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    try testing.expectEqual(async_mod.TaskState.cancelled, tm.getState(h).?);
+    // Core signature is `[] -> []`: nothing pushed.
+    try testing.expectEqual(@as(u32, 0), env.sp);
+}
+
+test "dispatchCanonBuiltin: task.cancel is idempotent" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    var tm = async_mod.TaskManager{};
+    defer tm.deinit(testing.allocator);
+    const h = try tm.createTask(testing.allocator);
+    tm.current_task = h;
+
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .task_cancel },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    try testing.expectEqual(async_mod.TaskState.cancelled, tm.getState(h).?);
+
+    // Second call must be a no-op: state stays `.cancelled`, no trap,
+    // no stack churn.
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .task_cancel },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    try testing.expectEqual(async_mod.TaskState.cancelled, tm.getState(h).?);
+    try testing.expectEqual(@as(u32, 0), env.sp);
+}
+
+test "dispatchCanonBuiltin: task.cancel + cancellable task.yield observes cancellation" {
+    // End-to-end propagation flow: a host invocation of `task.cancel`
+    // followed by a guest `task.yield cancel?=1` must surface the
+    // cancellation as discriminant `1`. Mirrors the existing
+    // `task.yield observes cancellation via TaskManager` test, but
+    // exercises the new `task.cancel` dispatch path instead of the
+    // direct `async_canon.asyncCancel` helper.
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, testing.allocator);
+    defer inst.deinit();
+
+    var tm = async_mod.TaskManager{};
+    defer tm.deinit(testing.allocator);
+    const h = try tm.createTask(testing.allocator);
+    tm.current_task = h;
+
+    // Cancel the currently-executing task via the new dispatch arm.
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .task_cancel },
+        env,
+        &tm,
+        testing.allocator,
+    );
+    try testing.expectEqual(async_mod.TaskState.cancelled, tm.getState(h).?);
+
+    // Non-cancellable yield: opaque, always reports resumed=0 even
+    // when the task has been cancelled.
     try dispatchCanonBuiltin(
         inst,
         .{ .task_yield = .{ .cancellable = false } },

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -728,6 +728,7 @@ fn parseCanon(reader: *BinaryReader, allocator: std.mem.Allocator) LoadError!cty
         0x02 => .{ .resource_new = try reader.readU32() },
         0x03 => .{ .resource_drop = try reader.readU32() },
         0x04 => .{ .resource_rep = try reader.readU32() },
+        0x05 => .{ .async_canon = .task_cancel },
         0x0a => try parseContextCanon(reader, .get),
         0x0b => try parseContextCanon(reader, .set),
         0x0c => blk: {
@@ -1179,6 +1180,16 @@ test "parseCanon: subtask.cancel async?=0x01" {
     try std.testing.expect(c == .async_canon);
     try std.testing.expect(c.async_canon == .subtask_cancel);
     try std.testing.expectEqual(true, c.async_canon.subtask_cancel.is_async);
+}
+
+test "parseCanon: task.cancel (tag 0x05, no immediates)" {
+    // Binary.md `canon task.cancel` is a single tag byte 0x05 with no
+    // payload. Distinct from `subtask.cancel` at tag 0x06 which has
+    // a one-byte `async?` immediate.
+    var reader = BinaryReader{ .data = &[_]u8{0x05} };
+    const c = try parseCanon(&reader, std.testing.allocator);
+    try std.testing.expect(c == .async_canon);
+    try std.testing.expect(c.async_canon == .task_cancel);
 }
 
 test "parseCanon: subtask.drop" {

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -401,6 +401,12 @@ pub const Canon = union(enum) {
 /// single union variant on `Canon` (instead of ~17 separate ones) avoids
 /// rippling exhaustive switches across every consumer.
 pub const AsyncCanonOp = union(enum) {
+    /// `canon task.cancel` — Binary.md tag `0x05`. Cancels the
+    /// **currently executing** task. No immediates, no stack args,
+    /// no result (core signature `[] -> []`). Per spec, traps if
+    /// there is no current task. Distinct from `subtask.cancel`
+    /// (tag `0x06`), which cancels a named child subtask.
+    task_cancel,
     /// `canon subtask.cancel async?` — Binary.md tag `0x06`.
     subtask_cancel: struct { is_async: bool },
     /// `canon subtask.drop` — tag `0x0d`.


### PR DESCRIPTION
Implements `canon task.cancel` — Binary.md tag `0x05` — the
canonical built-in that cancels the **currently executing** task.

## Spec reference

Per the Component Model Binary.md
([source](https://github.com/WebAssembly/component-model/blob/main/design/mvp/Binary.md)):

```
canon ::= ...
        | 0x05  => (canon task.cancel (core func)) 🔀
```

Tag `0x05`, no immediates, no stack params, no stack results. Core
function signature `[] -> []`. Distinct from `subtask.cancel`
(tag `0x06`, already wired) which cancels a **child** subtask
whose handle is on the stack: `task.cancel` takes no handle and
operates on the current task.

## What changed

1. **`src/component/types.zig`** — Add `task_cancel` variant to
   `AsyncCanonOp`, alongside `subtask_cancel`/`subtask_drop`.
2. **`src/component/loader.zig`** — Decode tag `0x05` (no
   payload) into `.{ .async_canon = .task_cancel }`. Adds a
   loader unit test next to the existing `subtask.cancel` test.
3. **`src/component/executor.zig`** — `dispatchAsyncCanon` arm
   that resolves the current task via
   `task_manager.current_task` and calls `cancelTask(handle)`.
   No pops, no pushes (matches the `[] -> []` core signature).
   Traps with `error.FunctionNotFound` when invoked outside an
   async task context (no task manager, or no current task).

## Tests

Six new unit tests (one loader, five executor), all next to
existing `task.yield` / `subtask.cancel` test fixtures:

- `parseCanon: task.cancel (tag 0x05, no immediates)` — loader
  round-trips the single-byte tag with no payload.
- `task.cancel without task manager traps with FunctionNotFound`
  — guest code in a non-async context is malformed.
- `task.cancel without current_task traps with FunctionNotFound`
  — TaskManager present but no current task → trap.
- `task.cancel flips current task to .cancelled` — happy path.
- `task.cancel is idempotent` — second call on an already-
  cancelled task is a no-op (no trap, no stack churn).
- `task.cancel + cancellable task.yield observes cancellation`
  — end-to-end: cancel via `task.cancel`, then yield with
  `cancel?=1` surfaces discriminant `1`. Plain `cancel?=0`
  yield still reports resumed.

### Validation

- `zig build` clean.
- `zig build test`: 2096 → **2102** passing (+6).
- `zig build wasi-testsuite`: **72 / 72** (unchanged).
- `zig build -Dtarget=aarch64-macos` clean.
- `zig build -Dtarget=x86_64-windows` clean.
- `zig build -Dtarget=x86_64-linux` clean.

## Relationship

- Parent: #451 (Component Model async surface)
- Companion: #478 (`task.yield` cancellation observation,
  already landed) — `task.cancel` + cancellable `task.yield` is
  now a complete cancellation loop.
- Related (already landed): `subtask.cancel` (tag `0x06`),
  future/stream `cancel-{read,write}`, and close-propagation
  (#502, #505).

Closes #488.
