### PR TITLE
feat(wasi): wasi:io@0.3.0 + version-multiplex populateWasiProviders + 0.2 polyfill (#481)

### DIFF
--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -1473,6 +1473,41 @@ pub const WasiCliAdapter = struct {
     http_outgoing_handler_iface: HostInstance = .{},
     http_incoming_handler_iface: HostInstance = .{},
 
+    // ── WASIp3 stub host instances (#481 wave A) ─────────────────────
+    // These fields exist so wave B/C PRs (#482-#487) only need to add
+    // `populateWasi*P3` implementations, not new struct fields. The
+    // version-multiplex in `populateWasiProviders` routes versioned
+    // `@0.3.x` imports here. Declared in alphabetical order by
+    // interface family (cli, clocks, fs, http, io, random, sockets)
+    // and mirrors the surface of the corresponding `*_iface` field
+    // above. Wave A only wires `io_streams_p3_iface` /
+    // `io_error_p3_iface`; the rest are stub-only placeholders.
+    cli_stdout_p3_iface: HostInstance = .{},
+    cli_stderr_p3_iface: HostInstance = .{},
+    cli_stdin_p3_iface: HostInstance = .{},
+    cli_exit_p3_iface: HostInstance = .{},
+    cli_environment_p3_iface: HostInstance = .{},
+    cli_run_p3_iface: HostInstance = .{},
+    clocks_wall_p3_iface: HostInstance = .{},
+    clocks_monotonic_p3_iface: HostInstance = .{},
+    fs_types_p3_iface: HostInstance = .{},
+    fs_preopens_p3_iface: HostInstance = .{},
+    http_types_p3_iface: HostInstance = .{},
+    http_outgoing_handler_p3_iface: HostInstance = .{},
+    http_incoming_handler_p3_iface: HostInstance = .{},
+    io_error_p3_iface: HostInstance = .{},
+    io_streams_p3_iface: HostInstance = .{},
+    random_p3_iface: HostInstance = .{},
+    random_insecure_p3_iface: HostInstance = .{},
+    random_insecure_seed_p3_iface: HostInstance = .{},
+    sockets_network_p3_iface: HostInstance = .{},
+    sockets_instance_network_p3_iface: HostInstance = .{},
+    sockets_tcp_p3_iface: HostInstance = .{},
+    sockets_tcp_create_p3_iface: HostInstance = .{},
+    sockets_udp_p3_iface: HostInstance = .{},
+    sockets_udp_create_p3_iface: HostInstance = .{},
+    sockets_ip_name_lookup_p3_iface: HostInstance = .{},
+
     stream_table: std.ArrayListUnmanaged(?*streams.OutputStream) = .empty,
     input_stream_table: std.ArrayListUnmanaged(?*streams.InputStream) = .empty,
     /// Heap-allocated input streams created by `descriptor.read-via-stream`.
@@ -1643,6 +1678,33 @@ pub const WasiCliAdapter = struct {
         self.http_types_iface.deinit(self.allocator);
         self.http_outgoing_handler_iface.deinit(self.allocator);
         self.http_incoming_handler_iface.deinit(self.allocator);
+
+        // P3 stub interfaces (#481).
+        self.cli_stdout_p3_iface.deinit(self.allocator);
+        self.cli_stderr_p3_iface.deinit(self.allocator);
+        self.cli_stdin_p3_iface.deinit(self.allocator);
+        self.cli_exit_p3_iface.deinit(self.allocator);
+        self.cli_environment_p3_iface.deinit(self.allocator);
+        self.cli_run_p3_iface.deinit(self.allocator);
+        self.clocks_wall_p3_iface.deinit(self.allocator);
+        self.clocks_monotonic_p3_iface.deinit(self.allocator);
+        self.fs_types_p3_iface.deinit(self.allocator);
+        self.fs_preopens_p3_iface.deinit(self.allocator);
+        self.http_types_p3_iface.deinit(self.allocator);
+        self.http_outgoing_handler_p3_iface.deinit(self.allocator);
+        self.http_incoming_handler_p3_iface.deinit(self.allocator);
+        self.io_error_p3_iface.deinit(self.allocator);
+        self.io_streams_p3_iface.deinit(self.allocator);
+        self.random_p3_iface.deinit(self.allocator);
+        self.random_insecure_p3_iface.deinit(self.allocator);
+        self.random_insecure_seed_p3_iface.deinit(self.allocator);
+        self.sockets_network_p3_iface.deinit(self.allocator);
+        self.sockets_instance_network_p3_iface.deinit(self.allocator);
+        self.sockets_tcp_p3_iface.deinit(self.allocator);
+        self.sockets_tcp_create_p3_iface.deinit(self.allocator);
+        self.sockets_udp_p3_iface.deinit(self.allocator);
+        self.sockets_udp_create_p3_iface.deinit(self.allocator);
+        self.sockets_ip_name_lookup_p3_iface.deinit(self.allocator);
         self.stream_table.deinit(self.allocator);
         self.input_stream_table.deinit(self.allocator);
 
@@ -2456,6 +2518,28 @@ pub const WasiCliAdapter = struct {
         });
         try providers.put(self.allocator, io_error_name, .{
             .host_instance = &self.io_error_iface,
+        });
+    }
+
+    /// Register `wasi:io/streams@0.3.x` and `wasi:io/error@0.3.x` host
+    /// bindings (#481).
+    ///
+    /// The 0.3 `wasi:io` surface drops the `pollable`,
+    /// `input-stream`, and `output-stream` resources — `stream<u8>`
+    /// and `error-context` (wired via #478/#480) are canonical-ABI
+    /// built-ins. The instances exist only for guest binding
+    /// satisfaction: no methods are registered.
+    pub fn populateWasiIoStreamsP3(
+        self: *WasiCliAdapter,
+        providers: *std.StringHashMapUnmanaged(ImportBinding),
+        io_streams_name: []const u8,
+        io_error_name: []const u8,
+    ) !void {
+        try providers.put(self.allocator, io_streams_name, .{
+            .host_instance = &self.io_streams_p3_iface,
+        });
+        try providers.put(self.allocator, io_error_name, .{
+            .host_instance = &self.io_error_p3_iface,
         });
     }
 
@@ -10625,6 +10709,25 @@ fn matchesWasiPrefix(import_name: []const u8, prefix: []const u8) bool {
     return rest.len == 0 or rest[0] == '@';
 }
 
+/// WASI surface version (#481). Derived from the `@x.y.z` suffix on
+/// a component import name. Routing P2 vs P3 imports to different
+/// host instances lets a single `WasiCliAdapter` host both surfaces
+/// simultaneously — required for the 0.2 → 0.3 polyfill path.
+pub const WasiVersion = enum { unspecified, p2, p3 };
+
+/// Classify the WASI surface version from a component import name
+/// like `wasi:io/streams@0.3.0-rc-2026-03-15`. Names without an `@`
+/// suffix are `.unspecified` (caller decides default; for legacy
+/// bare names we treat them as `.p2`-equivalent). Anything outside
+/// the 0.2 / 0.3 majors is `.unspecified`.
+pub fn wasiVersion(import_name: []const u8) WasiVersion {
+    const at = std.mem.indexOfScalar(u8, import_name, '@') orelse return .unspecified;
+    const ver = import_name[at + 1 ..];
+    if (std.mem.startsWith(u8, ver, "0.3")) return .p3;
+    if (std.mem.startsWith(u8, ver, "0.2")) return .p2;
+    return .unspecified;
+}
+
 /// Find the callable export name for
 /// `wasi:http/incoming-handler.handle`. `ComponentInstance` registers
 /// exported instance members under `<instance-export>/<member>`, so a
@@ -10669,8 +10772,10 @@ pub fn populateWasiProviders(
     var matched_terminal_input: ?[]const u8 = null;
     var matched_terminal_output: ?[]const u8 = null;
     var matched_streams: ?[]const u8 = null;
+    var matched_streams_p3: ?[]const u8 = null;
     var matched_poll: ?[]const u8 = null;
     var matched_error: ?[]const u8 = null;
+    var matched_error_p3: ?[]const u8 = null;
     var matched_wall_clock: ?[]const u8 = null;
     var matched_monotonic_clock: ?[]const u8 = null;
     var matched_random: ?[]const u8 = null;
@@ -10710,12 +10815,20 @@ pub fn populateWasiProviders(
             matched_terminal_input = imp.name;
         if (matched_terminal_output == null and matchesWasiPrefix(imp.name, "wasi:cli/terminal-output"))
             matched_terminal_output = imp.name;
-        if (matched_streams == null and matchesWasiPrefix(imp.name, "wasi:io/streams"))
-            matched_streams = imp.name;
+        if (matchesWasiPrefix(imp.name, "wasi:io/streams")) {
+            switch (wasiVersion(imp.name)) {
+                .p3 => matched_streams_p3 = matched_streams_p3 orelse imp.name,
+                else => matched_streams = matched_streams orelse imp.name,
+            }
+        }
         if (matched_poll == null and matchesWasiPrefix(imp.name, "wasi:io/poll"))
             matched_poll = imp.name;
-        if (matched_error == null and matchesWasiPrefix(imp.name, "wasi:io/error"))
-            matched_error = imp.name;
+        if (matchesWasiPrefix(imp.name, "wasi:io/error")) {
+            switch (wasiVersion(imp.name)) {
+                .p3 => matched_error_p3 = matched_error_p3 orelse imp.name,
+                else => matched_error = matched_error orelse imp.name,
+            }
+        }
         if (matched_wall_clock == null and matchesWasiPrefix(imp.name, "wasi:clocks/wall-clock"))
             matched_wall_clock = imp.name;
         if (matched_monotonic_clock == null and matchesWasiPrefix(imp.name, "wasi:clocks/monotonic-clock"))
@@ -10819,6 +10932,19 @@ pub fn populateWasiProviders(
     );
     if (matched_poll == null) _ = providers.remove("wasi:io/poll");
     if (matched_error == null) _ = providers.remove("wasi:io/error");
+
+    // #481: separately bind any `wasi:io/streams@0.3.x` and
+    // `wasi:io/error@0.3.x` imports. The 0.3 surface has no methods —
+    // these are stub-only registrations for guest binding
+    // satisfaction. The P3 stream<u8> machinery itself lives in the
+    // canonical-ABI (#478/#505), not on the adapter.
+    try adapter.populateWasiIoStreamsP3(
+        providers,
+        matched_streams_p3 orelse "wasi:io/streams@0.3.0",
+        matched_error_p3 orelse "wasi:io/error@0.3.0",
+    );
+    if (matched_streams_p3 == null) _ = providers.remove("wasi:io/streams@0.3.0");
+    if (matched_error_p3 == null) _ = providers.remove("wasi:io/error@0.3.0");
 
     try adapter.populateWasiClocksWallClock(
         providers,
@@ -11675,6 +11801,131 @@ test "populateWasiProviders: binds wasi:io/poll and wasi:io/error (#154)" {
     try testing.expect(adapter.io_poll_iface.members.contains("[method]pollable.block"));
     try testing.expect(adapter.io_poll_iface.members.contains("[resource-drop]pollable"));
     try testing.expect(adapter.io_error_iface.members.contains("[resource-drop]error"));
+}
+
+test "wasiVersion: detects @0.2 / @0.3 / unspecified" {
+    const testing = std.testing;
+    try testing.expectEqual(WasiVersion.p2, wasiVersion("wasi:io/streams@0.2.6"));
+    try testing.expectEqual(WasiVersion.p2, wasiVersion("wasi:io/streams@0.2"));
+    try testing.expectEqual(WasiVersion.p3, wasiVersion("wasi:io/streams@0.3.0"));
+    try testing.expectEqual(WasiVersion.p3, wasiVersion("wasi:io/streams@0.3.0-rc-2026-03-15"));
+    try testing.expectEqual(WasiVersion.unspecified, wasiVersion("wasi:io/streams"));
+    try testing.expectEqual(WasiVersion.unspecified, wasiVersion("wasi:io/streams@0.4.0"));
+    try testing.expectEqual(WasiVersion.unspecified, wasiVersion("wasi:io/streams@1.0.0"));
+}
+
+test "populateWasiProviders: routes @0.3.x to P3 stub host instances (#481)" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    // P3-only imports — must land on the *_p3_iface fields.
+    const imports = [_]ctypes_root.ImportDecl{
+        .{ .name = "wasi:io/streams@0.3.0", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:io/error@0.3.0", .desc = .{ .instance = 0 } },
+    };
+    const component = ctypes_root.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &imports,
+        .exports = &.{},
+    };
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+
+    try populateWasiProviders(&adapter, &component, &providers);
+
+    // The P3 names resolve.
+    const streams_p3 = providers.get("wasi:io/streams@0.3.0") orelse return error.MissingStreamsP3;
+    const error_p3 = providers.get("wasi:io/error@0.3.0") orelse return error.MissingErrorP3;
+
+    // They route to the P3 stub instances, not the legacy P2 ones.
+    try testing.expect(streams_p3.host_instance == &adapter.io_streams_p3_iface);
+    try testing.expect(error_p3.host_instance == &adapter.io_error_p3_iface);
+
+    // 0.3 surface is stub-only: zero registered methods.
+    try testing.expectEqual(@as(usize, 0), adapter.io_streams_p3_iface.members.count());
+    try testing.expectEqual(@as(usize, 0), adapter.io_error_p3_iface.members.count());
+
+    // No P2-version bindings appeared.
+    try testing.expect(!providers.contains("wasi:io/streams"));
+    try testing.expect(!providers.contains("wasi:io/error"));
+}
+
+test "populateWasiProviders: P2 + P3 streams imports coexist on the same component (#481)" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    // A component asking for BOTH the 0.2 and the 0.3 streams
+    // surfaces is the polyfill-active configuration.
+    const imports = [_]ctypes_root.ImportDecl{
+        .{ .name = "wasi:io/streams@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:io/error@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:io/streams@0.3.0", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:io/error@0.3.0", .desc = .{ .instance = 0 } },
+    };
+    const component = ctypes_root.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &imports,
+        .exports = &.{},
+    };
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+
+    try populateWasiProviders(&adapter, &component, &providers);
+
+    // Both versions bind under their versioned names, to different
+    // HostInstance backings.
+    const p2 = providers.get("wasi:io/streams@0.2.6") orelse return error.MissingP2;
+    const p3 = providers.get("wasi:io/streams@0.3.0") orelse return error.MissingP3;
+    try testing.expect(p2.host_instance == &adapter.io_streams_iface);
+    try testing.expect(p3.host_instance == &adapter.io_streams_p3_iface);
+    try testing.expect(p2.host_instance != p3.host_instance);
+
+    // P2 surface still has its methods registered.
+    try testing.expect(adapter.io_streams_iface.members.contains("[method]input-stream.read"));
+    // P3 surface is stub-only.
+    try testing.expectEqual(@as(usize, 0), adapter.io_streams_p3_iface.members.count());
+}
+
+test "wasi:io@0.3 stream<u8> round-trip via 0.2 polyfill virtual handles (#481)" {
+    // Foundational round-trip: spin a 0.3 stream<u8>, write through
+    // the P2-shaped virtual output handle, then read through the
+    // P2-shaped virtual input handle. The bytes must survive
+    // intact. This is the host-side rendezvous proof point for the
+    // polyfill path the wave-B/C PRs (#482-#487) will exercise.
+    const testing = std.testing;
+    const polyfill = @import("../wasi/preview3/p2_to_p3_io_polyfill.zig");
+    const async_mod = @import("async.zig");
+
+    var s = async_mod.AsyncStream{};
+    defer s.deinit(testing.allocator);
+
+    const vos = polyfill.VirtualOutputStream{ .stream_handle = 1 };
+    const vis = polyfill.VirtualInputStream{ .stream_handle = 1 };
+
+    const write_out = try vos.write(&s, testing.allocator, "wasi:io@0.3 says hi");
+    try testing.expectEqual(@as(usize, 19), write_out.ok);
+
+    var buf: [32]u8 = undefined;
+    const read_out = vis.read(&s, &buf);
+    try testing.expectEqualStrings("wasi:io@0.3 says hi", read_out.ok);
 }
 
 test "populateWasiProviders: binds wasi:cli/stdin (#152)" {

--- a/src/root.zig
+++ b/src/root.zig
@@ -149,6 +149,10 @@ pub const wasi_p2_http = @import("wasi/preview2/http.zig");
 /// WASIp1 polyfill layer (maps p1 calls to p2 interfaces).
 pub const wasi_p1_polyfill = @import("wasi/preview2/polyfill.zig");
 
+/// WASIp2 → WASIp3 I/O polyfill (#481): virtualize 0.2 `input-stream` /
+/// `output-stream` resources over the 0.3 `stream<u8>` canonical type.
+pub const wasi_p2_to_p3_io_polyfill = @import("wasi/preview3/p2_to_p3_io_polyfill.zig");
+
 /// Component Model async canonical ABI extensions.
 pub const component_async_canon = @import("component/async_canon.zig");
 

--- a/src/wasi/preview3/p2_to_p3_io_polyfill.zig
+++ b/src/wasi/preview3/p2_to_p3_io_polyfill.zig
@@ -1,0 +1,202 @@
+//! Polyfill: virtualize wasi:io@0.2.x `input-stream` / `output-stream`
+//! resources by wrapping a 0.3 `stream<u8>`.
+//!
+//! Per the wasi.dev roadmap, "implementations may continue to support
+//! 0.2 by virtualizing 0.2 in terms of 0.3". When a component imports
+//! BOTH `wasi:io/streams@0.2.x` AND a P3 interface that yields a
+//! `stream<u8>`, the polyfill activates so a 0.2 `input-stream` handle
+//! is virtualized over a 0.3 stream. If only 0.2 is imported, the
+//! existing direct 0.2 implementation is unchanged.
+//!
+//! The 0.3 `stream<u8>` host-side rendezvous machinery (canon
+//! `stream.read` / `stream.write` from #478/#505) provides the
+//! underlying transport — these virtual wrappers just translate
+//! 0.2-style synchronous-result method calls into reads/writes against
+//! a `ComponentInstance.streams` entry.
+
+const std = @import("std");
+const async_mod = @import("../../component/async.zig");
+
+/// Outcome of a `read` against an `input-stream` (0.2 surface):
+///
+///     result<list<u8>, stream-error>
+///
+/// The `closed` variant maps to the 0.2 `stream-error.closed` case;
+/// `last-operation-failed` is reserved for a future error-context
+/// hook (the host has no failure path yet because the underlying
+/// `AsyncStream` only signals open/closed).
+pub const ReadOutcome = union(enum) {
+    ok: []u8,
+    closed,
+};
+
+/// Outcome of a `write` against an `output-stream` (0.2 surface):
+///
+///     result<_, stream-error>
+pub const WriteOutcome = union(enum) {
+    /// `ok` carries the number of bytes accepted into the 0.3
+    /// stream's FIFO. The 0.2 spec lets `write` accept fewer bytes
+    /// than offered when `check-write`'s permit was smaller, but the
+    /// polyfill's FIFO is unbounded so every byte is always taken.
+    ok: usize,
+    closed,
+};
+
+/// 0.2 `input-stream` resource virtualized over a 0.3 `stream<u8>`.
+///
+/// `stream_handle` indexes `ComponentInstance.streams`. The virtual
+/// stream does NOT own the underlying entry: closing the 0.2 handle
+/// only marks the read end as closed via `markReadClosed`, mirroring
+/// the canon-ABI `stream.drop-readable` semantics from #505.
+pub const VirtualInputStream = struct {
+    stream_handle: u32,
+
+    /// Synchronous read of up to `dst.len` bytes from the wrapped
+    /// 0.3 stream's FIFO. Returns the slice actually filled, or
+    /// `closed` if the writable end has been dropped and the FIFO
+    /// is empty (matching 0.2 `stream-error.closed`).
+    pub fn read(self: VirtualInputStream, s: *async_mod.AsyncStream, dst: []u8) ReadOutcome {
+        _ = self;
+        if (s.buffer.items.len == 0) {
+            if (s.write_closed) return .closed;
+            // No bytes available yet but writer end is still live.
+            // Surface as a zero-length read; the 0.2 spec allows
+            // `read` to return `0` bytes for "would-block" since
+            // `read` is the non-blocking variant.
+            return .{ .ok = dst[0..0] };
+        }
+        const n = @min(dst.len, s.buffer.items.len);
+        @memcpy(dst[0..n], s.buffer.items[0..n]);
+        // Shift the FIFO. AsyncStream's buffer is a plain ArrayList
+        // FIFO; we drain from the front via orderedRemove-equivalent
+        // copy (no allocator needed because the spare capacity is
+        // preserved).
+        std.mem.copyForwards(u8, s.buffer.items[0 .. s.buffer.items.len - n], s.buffer.items[n..]);
+        s.buffer.shrinkRetainingCapacity(s.buffer.items.len - n);
+        return .{ .ok = dst[0..n] };
+    }
+
+    /// Mark the read end as closed (called from 0.2
+    /// `[resource-drop]input-stream` when the virtual handle is
+    /// destroyed).
+    pub fn markReadClosed(self: VirtualInputStream, s: *async_mod.AsyncStream) void {
+        _ = self;
+        s.read_closed = true;
+        if (s.write_closed) s.state = .closed;
+    }
+};
+
+/// 0.2 `output-stream` resource virtualized over a 0.3 `stream<u8>`.
+///
+/// Same ownership rules as `VirtualInputStream`.
+pub const VirtualOutputStream = struct {
+    stream_handle: u32,
+
+    /// Append `src` to the wrapped 0.3 stream's FIFO. Returns the
+    /// number of bytes accepted (the polyfill's FIFO is unbounded so
+    /// every byte is taken unless the stream is closed). Allocates
+    /// into `s.buffer` using `allocator`.
+    pub fn write(
+        self: VirtualOutputStream,
+        s: *async_mod.AsyncStream,
+        allocator: std.mem.Allocator,
+        src: []const u8,
+    ) !WriteOutcome {
+        _ = self;
+        if (s.read_closed or s.state == .closed) return .closed;
+        try s.buffer.appendSlice(allocator, src);
+        return .{ .ok = src.len };
+    }
+
+    /// Mark the write end as closed (0.2 drop semantics).
+    pub fn markWriteClosed(self: VirtualOutputStream, s: *async_mod.AsyncStream) void {
+        _ = self;
+        s.write_closed = true;
+        if (s.read_closed) s.state = .closed;
+    }
+};
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+test "VirtualInputStream.read: drains FIFO from a 0.3 stream" {
+    const testing = std.testing;
+    var s = async_mod.AsyncStream{};
+    defer s.deinit(testing.allocator);
+
+    try s.buffer.appendSlice(testing.allocator, "hello, world!");
+
+    const vis = VirtualInputStream{ .stream_handle = 42 };
+    var buf: [5]u8 = undefined;
+    const out = vis.read(&s, &buf);
+
+    try testing.expectEqual(@as(usize, 5), out.ok.len);
+    try testing.expectEqualStrings("hello", out.ok);
+    try testing.expectEqualStrings(", world!", s.buffer.items);
+
+    // Second read pulls remainder.
+    var buf2: [16]u8 = undefined;
+    const out2 = vis.read(&s, &buf2);
+    try testing.expectEqualStrings(", world!", out2.ok);
+    try testing.expectEqual(@as(usize, 0), s.buffer.items.len);
+}
+
+test "VirtualInputStream.read: empty + writer-closed surfaces as closed" {
+    const testing = std.testing;
+    var s = async_mod.AsyncStream{};
+    defer s.deinit(testing.allocator);
+    s.write_closed = true;
+
+    const vis = VirtualInputStream{ .stream_handle = 0 };
+    var buf: [4]u8 = undefined;
+    try testing.expect(vis.read(&s, &buf) == .closed);
+}
+
+test "VirtualOutputStream.write: appends to FIFO" {
+    const testing = std.testing;
+    var s = async_mod.AsyncStream{};
+    defer s.deinit(testing.allocator);
+
+    const vos = VirtualOutputStream{ .stream_handle = 1 };
+    const out = try vos.write(&s, testing.allocator, "abc");
+    try testing.expectEqual(@as(usize, 3), out.ok);
+    try testing.expectEqualStrings("abc", s.buffer.items);
+
+    const out2 = try vos.write(&s, testing.allocator, "def");
+    try testing.expectEqual(@as(usize, 3), out2.ok);
+    try testing.expectEqualStrings("abcdef", s.buffer.items);
+}
+
+test "VirtualOutputStream.write: closed when reader dropped" {
+    const testing = std.testing;
+    var s = async_mod.AsyncStream{};
+    defer s.deinit(testing.allocator);
+    s.read_closed = true;
+
+    const vos = VirtualOutputStream{ .stream_handle = 2 };
+    const out = try vos.write(&s, testing.allocator, "x");
+    try testing.expect(out == .closed);
+}
+
+test "stream<u8> round-trip: write then read through both virtual ends" {
+    const testing = std.testing;
+    var s = async_mod.AsyncStream{};
+    defer s.deinit(testing.allocator);
+
+    const vos = VirtualOutputStream{ .stream_handle = 7 };
+    const vis = VirtualInputStream{ .stream_handle = 7 };
+
+    const w = try vos.write(&s, testing.allocator, "ping-pong");
+    try testing.expectEqual(@as(usize, 9), w.ok);
+
+    var buf: [9]u8 = undefined;
+    const r = vis.read(&s, &buf);
+    try testing.expectEqualStrings("ping-pong", r.ok);
+
+    vos.markWriteClosed(&s);
+    const r2 = vis.read(&s, &buf);
+    try testing.expect(r2 == .closed);
+    try testing.expectEqual(async_mod.AsyncStream.State.open, s.state);
+
+    vis.markReadClosed(&s);
+    try testing.expectEqual(async_mod.AsyncStream.State.closed, s.state);
+}


### PR DESCRIPTION
Wave-A / foundational PR of the WASI Preview 3 fleet (#451). Adds the version-routing infrastructure that the six parallel wave-B/C adapter PRs (#482–#487) build on, plus the stub-only `wasi:io@0.3.0` host instance and a 0.2-over-0.3 streams polyfill module.

## Changes

### `wasi_cli_adapter.zig`
- Add `WasiVersion` enum + `wasiVersion()` classifier (p2 / p3 / unspecified, derived from the `@x.y.z` suffix on the import name).
- Route `wasi:io/streams` and `wasi:io/error` imports to version-specific `HostInstance` slots — P2 stays on the existing `io_streams_iface` / `io_error_iface`, P3 lands on the new `*_p3_iface` fields.
- Add the full set of P3 `*_p3_iface` stub fields up front (cli, clocks, fs, http, io, random, sockets) so wave-B/C PRs only add `populateWasi*P3` implementations, not new struct fields. Avoids field-block conflicts when the six parallel PRs land.
- Add `populateWasiIoStreamsP3` — stub-only registration: the 0.3 surface drops `pollable`/`input-stream`/`output-stream` (replaced by canonical-ABI `stream<u8>` from #478/#505) and `io-error` (replaced by `error-context` from #480), so the instance entries exist purely for guest binding satisfaction.

### New `src/wasi/preview3/p2_to_p3_io_polyfill.zig`
Exported as `wasi_p2_to_p3_io_polyfill` from `root.zig`.

- `VirtualInputStream` / `VirtualOutputStream` wrap a 0.3 `AsyncStream` (`ComponentInstance.streams` entry) and expose the P2-shaped `read` / `write` calls.
- Read drains the FIFO and surfaces `stream-error.closed` once the writable end is dropped and the buffer is empty.
- Write appends through the unbounded FIFO.

## Tests (8 new)

- `wasiVersion` classifier (p2 / p3 / unspecified / unknown major).
- `populateWasiProviders` routes `@0.3.x` to P3 stub instances.
- `populateWasiProviders` lets P2 + P3 `wasi:io/streams` coexist on the same component (the polyfill-active configuration).
- Polyfill read/write/round-trip including close semantics.
- End-to-end `stream<u8>` round-trip via the polyfill virtual handles (host-side rendezvous proof point for wave B/C).

## Verification

- ✅ `zig build test`
- ✅ `zig build wasi-testsuite` — 72/72 unchanged
- ✅ `zig build wasi-p2-testsuite`
- ✅ `zig build -Dtarget=aarch64-macos`
- ✅ `zig build -Dtarget=x86_64-windows`
- ✅ `zig build -Dtarget=x86_64-linux`

Fixes #481