### PR TITLE
perf(codegen): suppress iconst mov when all uses fold as immediates (#523)

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -590,6 +590,13 @@ const FuncCompileCtx = struct {
     /// ADD/SUB imm). The iconst itself is still materialized into its home
     /// register, so downstream uses that don't fold still work.
     const_vals: ?*const std.AutoHashMap(ir.VReg, i64) = null,
+    /// Set of `iconst_*` dest vregs whose every use folds as an immediate
+    /// operand (currently: ADD/SUB imm12). For these vregs the codegen-side
+    /// `mov xN, #K` materialization is suppressed — the physreg is allocated
+    /// (so regalloc bookkeeping stays consistent) but never written. See
+    /// issue #523. The IR-level def stays in place; only the asm emit is
+    /// elided.
+    suppress_iconst_emit: ?*const std.AutoHashMap(ir.VReg, void) = null,
     /// Set of mul dest vregs whose computation should be skipped because
     /// the single consumer is an add/sub that will be emitted as a fused
     /// MADD/MSUB (Phase 4 FMA fusion). When the mul handler sees a dest
@@ -1153,6 +1160,118 @@ pub fn compileFunctionImpl(
     fctx.fma_info = &fma_info;
     fctx.simd_mul_fused = &simd_mul_fused;
     fctx.simd_fma_info = &simd_fma_info;
+
+    // Build iconst-mov suppression set. An `iconst_*` def whose every use
+    // folds as an immediate operand (currently: the imm12 path of ADD/SUB
+    // in `emitBinOp`) doesn't need its `mov xN, #K` materialization at
+    // all — the consuming op encodes the value directly. The IR-level def
+    // stays so regalloc/liveness book-keeping is unchanged; only the asm
+    // emit is suppressed.
+    //
+    // Conservative conjunctive rule (issue #523): if ANY use of an iconst
+    // vreg needs a real register (binop reg/reg fallback, store address
+    // base, call argument, phi, spill, divisor, comparison, …), the mov
+    // stays — otherwise we'd have to re-emit it per use. Mirrors the pick
+    // logic in `emitBinOp` exactly so the suppression decision can never
+    // disagree with the consumer.
+    var iconst_total: std.AutoHashMap(ir.VReg, u32) = .init(allocator);
+    defer iconst_total.deinit();
+    var iconst_foldable: std.AutoHashMap(ir.VReg, u32) = .init(allocator);
+    defer iconst_foldable.deinit();
+    {
+        const Ctx = struct {
+            cv: *const std.AutoHashMap(ir.VReg, i64),
+            tot: *std.AutoHashMap(ir.VReg, u32),
+            fol: *std.AutoHashMap(ir.VReg, u32),
+            fma: *const std.AutoHashMap(ir.VReg, FmaInfo),
+            mul_fused_set: *const std.AutoHashMap(ir.VReg, void),
+
+            fn bumpTotal(self: *@This(), v: ir.VReg) !void {
+                if (!self.cv.contains(v)) return;
+                const e = try self.tot.getOrPut(v);
+                if (!e.found_existing) e.value_ptr.* = 0;
+                e.value_ptr.* += 1;
+            }
+            fn bumpFold(self: *@This(), v: ir.VReg) !void {
+                if (!self.cv.contains(v)) return;
+                const e = try self.fol.getOrPut(v);
+                if (!e.found_existing) e.value_ptr.* = 0;
+                e.value_ptr.* += 1;
+            }
+            fn visitDefault(self: *@This(), v: ir.VReg) !void {
+                try self.bumpTotal(v);
+            }
+        };
+        var cls_ctx: Ctx = .{
+            .cv = &const_vals,
+            .tot = &iconst_total,
+            .fol = &iconst_foldable,
+            .fma = &fma_info,
+            .mul_fused_set = &mul_fused,
+        };
+
+        for (block_order) |bo_bid| {
+            for (scheduled.instructions(bo_bid)) |inst| {
+                // The mul itself is skipped if fused; its operand reads
+                // happen at the MADD site via `useInto`. Either way, the
+                // operands are read into real registers — non-foldable.
+                // For ADD/SUB, mirror emitBinOp's pick: if the FMA path
+                // is taken, neither lhs nor rhs of the add/sub is folded
+                // as an immediate (they take the FMA branch instead).
+                switch (inst.op) {
+                    .add, .sub => |b| {
+                        const dest = inst.dest;
+                        const fma_taken = if (dest) |d| cls_ctx.fma.contains(d) else false;
+                        if (fma_taken or (inst.type != .i32 and inst.type != .i64)) {
+                            try cls_ctx.bumpTotal(b.lhs);
+                            try cls_ctx.bumpTotal(b.rhs);
+                            continue;
+                        }
+                        const is_add = inst.op == .add;
+                        const rhs_const = cls_ctx.cv.get(b.rhs);
+                        const lhs_const = if (is_add) cls_ctx.cv.get(b.lhs) else null;
+                        var pick_rhs = false;
+                        var pick_lhs = false;
+                        if (rhs_const) |v| {
+                            if (encodeAddSubImm(v) != null) pick_rhs = true;
+                        }
+                        if (!pick_rhs) {
+                            if (lhs_const) |v| {
+                                if (encodeAddSubImm(v) != null) pick_lhs = true;
+                            }
+                        }
+                        // Always count totals; only count foldables on
+                        // the picked side.
+                        try cls_ctx.bumpTotal(b.lhs);
+                        try cls_ctx.bumpTotal(b.rhs);
+                        if (pick_lhs) try cls_ctx.bumpFold(b.lhs);
+                        if (pick_rhs) try cls_ctx.bumpFold(b.rhs);
+                    },
+                    else => {
+                        try schedule.forEachUse(inst, &cls_ctx, Ctx.visitDefault);
+                    },
+                }
+            }
+        }
+    }
+
+    var suppress_iconst: std.AutoHashMap(ir.VReg, void) = .init(allocator);
+    defer suppress_iconst.deinit();
+    {
+        var it = const_vals.iterator();
+        while (it.next()) |entry| {
+            const v = entry.key_ptr.*;
+            const total = iconst_total.get(v) orelse 0;
+            const fold = iconst_foldable.get(v) orelse 0;
+            // total > 0 guards against vregs with zero uses (those should
+            // already have been DCE'd by PR #508; if any survive, leaving
+            // the mov is harmless).
+            if (total > 0 and total == fold) {
+                try suppress_iconst.put(v, {});
+            }
+        }
+    }
+    fctx.suppress_iconst_emit = &suppress_iconst;
 
     // Compute live ranges using the SAME block order as code emission.
     const live_ranges = try computeLiveRangesScheduled(func, block_order, &scheduled, allocator);
@@ -2414,12 +2533,29 @@ fn compileInst(
         // ── Constants ────────────────────────────────────────────────
         .iconst_32 => |val| {
             const dest = inst.dest orelse return;
+            if (fctx.suppress_iconst_emit) |s| {
+                if (s.contains(dest)) {
+                    // All uses fold as immediates (#523). Skip the
+                    // `mov xN, #K` materialization but still call
+                    // `assign` so callee-save mask / spill bookkeeping
+                    // stays consistent. The allocated physreg is never
+                    // written; consumers encode the value directly.
+                    _ = try reg_map.assign(dest);
+                    return;
+                }
+            }
             const info = try destBegin(reg_map, dest, RegMap.tmp0);
             try code.movImm32(info.reg, val);
             try destCommit(code, reg_map, info);
         },
         .iconst_64 => |val| {
             const dest = inst.dest orelse return;
+            if (fctx.suppress_iconst_emit) |s| {
+                if (s.contains(dest)) {
+                    _ = try reg_map.assign(dest);
+                    return;
+                }
+            }
             const info = try destBegin(reg_map, dest, RegMap.tmp0);
             try code.movImm64(info.reg, @bitCast(val));
             try destCommit(code, reg_map, info);
@@ -8099,6 +8235,132 @@ test "compileFunction: add two constants" {
 
     try std.testing.expect(code.len > 0);
     try std.testing.expect(code.len % 4 == 0);
+}
+
+// Count MOVZ instructions in `code`. MOVZ encoding: 1|10|100101|hw|imm16|Rd
+// → top 9 bits == 110100101 (mask 0xFF800000 against base 0xD2800000).
+fn countMovzImm(code: []const u8) u32 {
+    var i: usize = 0;
+    var n: u32 = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if ((w & 0xFF800000) == 0xD2800000) n += 1;
+    }
+    return n;
+}
+
+test "iconst suppress (#523): iconst feeding add-imm12 emits no MOVZ" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 2, 0);
+    defer func.deinit();
+    const lt = try allocator.alloc(ir.IrType, 1);
+    lt[0] = .i32;
+    func.local_types = lt;
+
+    const bid = try func.newBlock();
+    const block = func.getBlock(bid);
+    const param = func.newVReg();
+    const k = func.newVReg();
+    const sum = func.newVReg();
+    // sum = param + 5 ; ret sum   — `5` fits imm12, all uses fold.
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = param, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 5 }, .dest = k, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = param, .rhs = k } }, .dest = sum, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = sum } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    // No MOVZ should appear: prologue+epilogue use STP/LDP/ADD/SUB only,
+    // and the iconst's mov is suppressed (#523).
+    try std.testing.expectEqual(@as(u32, 0), countMovzImm(code));
+}
+
+test "iconst suppress (#523): out-of-imm12 constant keeps its MOVZ" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 2, 0);
+    defer func.deinit();
+    const lt = try allocator.alloc(ir.IrType, 1);
+    lt[0] = .i32;
+    func.local_types = lt;
+
+    const bid = try func.newBlock();
+    const block = func.getBlock(bid);
+    const param = func.newVReg();
+    const k = func.newVReg();
+    const sum = func.newVReg();
+    // 0x1_0001 doesn't fit imm12 nor imm12<<12 — encodeAddSubImm returns
+    // null, the consumer falls through to reg/reg ADD which reads `k`
+    // as a real register, so the iconst must materialize.
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = param, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 0x1_0001 }, .dest = k, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = param, .rhs = k } }, .dest = sum, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = sum } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    try std.testing.expect(countMovzImm(code) >= 1);
+}
+
+test "iconst suppress (#523): one foldable + one non-foldable use keeps MOVZ" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 2, 0);
+    defer func.deinit();
+    const lt = try allocator.alloc(ir.IrType, 1);
+    lt[0] = .i32;
+    func.local_types = lt;
+
+    const bid = try func.newBlock();
+    const block = func.getBlock(bid);
+    const param = func.newVReg();
+    const k = func.newVReg();
+    const sum = func.newVReg();
+    const eq = func.newVReg();
+    const out = func.newVReg();
+    // `k=7` is folded into ADD-imm12 (foldable use), but also feeds an
+    // EQ comparison which has no immediate-fold path on aarch64 — the
+    // cmp reads `k` as a register. Conjunctive rule keeps the mov.
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = param, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 7 }, .dest = k, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = param, .rhs = k } }, .dest = sum, .type = .i32 });
+    try block.append(.{ .op = .{ .eq = .{ .lhs = sum, .rhs = k } }, .dest = eq, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = sum, .rhs = eq } }, .dest = out, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = out } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    try std.testing.expect(countMovzImm(code) >= 1);
+}
+
+test "iconst suppress (#523): iconst as store base keeps MOVZ" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 1, 1, 0);
+    defer func.deinit();
+    const lt = try allocator.alloc(ir.IrType, 1);
+    lt[0] = .i32;
+    func.local_types = lt;
+
+    const bid = try func.newBlock();
+    const block = func.getBlock(bid);
+    const val = func.newVReg();
+    const base = func.newVReg();
+    // store i32 value at constant base address. Address goes through
+    // foldLoadStoreOffset but uses the IR `.offset` field (literal),
+    // not a vreg — `base` is read as a register. Not foldable.
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = val, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 0 }, .dest = base, .type = .i32 });
+    try block.append(.{ .op = .{ .store = .{ .base = base, .offset = 0, .val = val, .size = 4 } } });
+    try block.append(.{ .op = .{ .ret = null } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+
+    // base=0 is materialized via MOVZ #0; can't be folded into the store
+    // address (the IR `.offset` field handles literal displacements, not
+    // vreg-based ones).
+    try std.testing.expect(countMovzImm(code) >= 1);
 }
 
 test "compileFunction: global_get then global_set round-trips" {

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1486,6 +1486,7 @@ const GlobalCallPatch = struct {
 const regalloc = @import("../../ir/regalloc.zig");
 const analysis = @import("../../ir/analysis.zig");
 const local_init = @import("../../ir/local_init.zig");
+const range_split = @import("../../ir/range_split.zig");
 
 /// x86-64 allocatable GPR set: rdx(2), rsi(6), rdi(7), r8(8), r9(9),
 /// r12(12), r13(13), r14(14). `rbx`(3) is permanently pinned to
@@ -1585,7 +1586,7 @@ fn x86_64_reg_set(local_count: u32) regalloc.RegSet {
     };
 }
 
-fn buildConstVals(func: *const ir.IrFunction, allocator: std.mem.Allocator) !std.AutoHashMap(ir.VReg, i64) {
+pub fn buildConstVals(func: *const ir.IrFunction, allocator: std.mem.Allocator) !std.AutoHashMap(ir.VReg, i64) {
     var const_vals = std.AutoHashMap(ir.VReg, i64).init(allocator);
     errdefer const_vals.deinit();
     for (func.blocks.items) |block| {
@@ -1606,6 +1607,101 @@ fn smallFixedBulkMemLen(const_vals: *const std.AutoHashMap(ir.VReg, i64), len: i
     const val = const_vals.get(len) orelse return null;
     if (val < 0 or val > small_bulk_mem_max_len) return null;
     return @intCast(val);
+}
+
+/// Build the per-function suppression set for `iconst_*` mov elision
+/// (#523). A vreg is in the result iff it is an `iconst_32` / `iconst_64`
+/// def AND every IR use folds as an immediate operand on x86_64.
+///
+/// Foldable uses on x86_64 (mirrors the `const_vals.get(...)` checks in
+/// `compileInstRA`):
+///   - integer `add/sub/mul/and/or/xor` RHS, value in i32 range.
+///   - shift count of `shl/shr_s/shr_u/rotl/rotr` RHS (always fits, the
+///     emitter masks to the wasm-semantic 5/6 bits).
+///   - `len` of `memory_copy` / `memory_fill`, when
+///     `smallFixedBulkMemLen` returns non-null.
+///
+/// Every other read of an iconst vreg (cmp, store address, load base,
+/// call arg, local_set, ret, phi, float arithmetic, etc.) is
+/// non-foldable; under the conjunctive rule a single non-foldable use
+/// suppresses suppression. Spilled vregs aren't a concern here: if all
+/// uses fold, no consumer reads the spill slot either.
+pub fn buildIconstSuppress(
+    func: *const ir.IrFunction,
+    const_vals: *const std.AutoHashMap(ir.VReg, i64),
+    allocator: std.mem.Allocator,
+) !std.AutoHashMap(ir.VReg, void) {
+    var totals = std.AutoHashMap(ir.VReg, u32).init(allocator);
+    defer totals.deinit();
+    var folds = std.AutoHashMap(ir.VReg, u32).init(allocator);
+    defer folds.deinit();
+
+    const TotalCtx = struct {
+        cv: *const std.AutoHashMap(ir.VReg, i64),
+        tot: *std.AutoHashMap(ir.VReg, u32),
+        fn visit(self: *@This(), v: ir.VReg) !void {
+            if (!self.cv.contains(v)) return;
+            const e = try self.tot.getOrPut(v);
+            if (!e.found_existing) e.value_ptr.* = 0;
+            e.value_ptr.* += 1;
+        }
+    };
+    var tctx: TotalCtx = .{ .cv = const_vals, .tot = &totals };
+
+    const bumpFold = struct {
+        fn f(m: *std.AutoHashMap(ir.VReg, u32), v: ir.VReg) !void {
+            const e = try m.getOrPut(v);
+            if (!e.found_existing) e.value_ptr.* = 0;
+            e.value_ptr.* += 1;
+        }
+    }.f;
+
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |inst| {
+            // Total uses: visit every operand. Authoritative single
+            // source of truth — kept in sync with codegen by piggy-
+            // backing on `range_split.forEachUseInst`.
+            try range_split.forEachUseInst(inst, &tctx, TotalCtx.visit);
+
+            // Foldable uses: per-op classifier matching the const_vals
+            // checks in compileInstRA.
+            switch (inst.op) {
+                .add, .sub, .mul, .@"and", .@"or", .xor => |b| {
+                    if (inst.type != .i32 and inst.type != .i64) continue;
+                    if (const_vals.get(b.rhs)) |imm| {
+                        if (imm >= std.math.minInt(i32) and imm <= std.math.maxInt(i32)) {
+                            try bumpFold(&folds, b.rhs);
+                        }
+                    }
+                },
+                .shl, .shr_s, .shr_u, .rotl, .rotr => |b| {
+                    if (const_vals.contains(b.rhs)) try bumpFold(&folds, b.rhs);
+                },
+                .memory_copy => |mc| {
+                    if (smallFixedBulkMemLen(const_vals, mc.len) != null) {
+                        try bumpFold(&folds, mc.len);
+                    }
+                },
+                .memory_fill => |mf| {
+                    if (smallFixedBulkMemLen(const_vals, mf.len) != null) {
+                        try bumpFold(&folds, mf.len);
+                    }
+                },
+                else => {},
+            }
+        }
+    }
+
+    var suppress = std.AutoHashMap(ir.VReg, void).init(allocator);
+    errdefer suppress.deinit();
+    var it = const_vals.iterator();
+    while (it.next()) |entry| {
+        const v = entry.key_ptr.*;
+        const total = totals.get(v) orelse 0;
+        const fold = folds.get(v) orelse 0;
+        if (total > 0 and total == fold) try suppress.put(v, {});
+    }
+    return suppress;
 }
 
 fn functionUsesV128(func: *const ir.IrFunction) bool {
@@ -2024,6 +2120,16 @@ fn compileFunctionRAWithGlobalOffsets(
     var table_patches: std.ArrayList(TablePatch) = .empty;
     defer table_patches.deinit(allocator);
 
+    // Build iconst-mov suppression set (#523). An iconst dest vreg whose
+    // every IR use folds as an immediate operand on x86_64 (add/sub/mul/
+    // and/or/xor RHS with sign_extends_to_i32, shift count, or
+    // memory.copy/fill length via smallFixedBulkMemLen) doesn't need its
+    // mov: the consuming op encodes the value directly. Conjunctive: any
+    // non-foldable use (cmp, store, call arg, local_set, base address,
+    // float op, …) keeps the mov.
+    var suppress_iconst = try buildIconstSuppress(func, &const_vals, allocator);
+    defer suppress_iconst.deinit();
+
     // block_order already computed above — reuse for emission.
 
     var last_was_ret = false;
@@ -2033,7 +2139,7 @@ fn compileFunctionRAWithGlobalOffsets(
         const next_block_id: ?ir.BlockId = if (order_idx + 1 < block_order.len) block_order[order_idx + 1] else null;
         for (block.instructions.items) |inst| {
             last_was_ret = isRet(inst.op);
-            try compileInstRA(&code, inst, &alloc_result, &const_vals, &branch_patches, &call_patches, &table_patches, import_count, &used_caller_saved, &used_callee_saved, func.local_count, global_offsets);
+            try compileInstRA(&code, inst, &alloc_result, &const_vals, &suppress_iconst, &branch_patches, &call_patches, &table_patches, import_count, &used_caller_saved, &used_callee_saved, func.local_count, global_offsets);
         }
         // C3 fall-through peephole: if the block's terminator emitted a
         // trailing `E9 disp32` (br, or br_if's unconditional else) whose
@@ -2387,6 +2493,7 @@ fn compileInstRA(
     inst: ir.Inst,
     alloc_result: *const regalloc.AllocResult,
     const_vals: *const std.AutoHashMap(ir.VReg, i64),
+    suppress_iconst: *const std.AutoHashMap(ir.VReg, void),
     patches: *std.ArrayList(BranchPatch),
     call_patches: *std.ArrayList(CallPatch),
     table_patches: *std.ArrayList(TablePatch),
@@ -2400,6 +2507,8 @@ fn compileInstRA(
         // ── Constants ─────────────────────────────────────────────────
         .iconst_32 => |val| {
             const dest = inst.dest orelse return;
+            // #523: skip the mov entirely if every use folds.
+            if (suppress_iconst.contains(dest)) return;
             const dr = destReg(alloc_result, dest);
             if (val == 0) {
                 try code.xorReg32(dr);
@@ -2412,6 +2521,7 @@ fn compileInstRA(
         },
         .iconst_64 => |val| {
             const dest = inst.dest orelse return;
+            if (suppress_iconst.contains(dest)) return;
             const dr = destReg(alloc_result, dest);
             try code.movRegImm64(dr, @bitCast(val));
             try writeDefTyped(code, alloc_result, dest, dr, inst.type);
@@ -5130,6 +5240,62 @@ test "compileFunctionRA: memory.grow refreshes pinned r15 (issue #466)" {
     // assert it exists in the post-call region — codegen places it
     // immediately after the stack adjust, before writeDefTyped.
     _ = reload_off;
+}
+
+test "iconst suppress (#523, x86_64): foldable add-imm32 use is in suppress set" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    // v1=42 fits i32 and is the rhs of an integer add — fully foldable.
+    try block.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 42 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v2, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v2 } });
+
+    var const_vals = try buildConstVals(&func, allocator);
+    defer const_vals.deinit();
+    var suppress = try buildIconstSuppress(&func, &const_vals, allocator);
+    defer suppress.deinit();
+
+    // v1 is rhs of an integer add → foldable. v0 is lhs (the i32 imm
+    // form folds rhs only) → not foldable. Conjunctive rule keeps v0.
+    try std.testing.expect(suppress.contains(v1));
+    try std.testing.expect(!suppress.contains(v0));
+}
+
+test "iconst suppress (#523, x86_64): mixed foldable/non-foldable use stays materialised" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const a = func.newVReg();
+    const k = func.newVReg();
+    const sum = func.newVReg();
+    const eq = func.newVReg();
+    const out = func.newVReg();
+    // k=7 used as ADD-imm32 rhs (foldable) AND as cmp rhs (non-foldable
+    // — cmp has no const_vals fold path). Conjunctive rule keeps it.
+    try block.append(.{ .op = .{ .iconst_32 = 100 }, .dest = a, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 7 }, .dest = k, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = a, .rhs = k } }, .dest = sum, .type = .i32 });
+    try block.append(.{ .op = .{ .eq = .{ .lhs = sum, .rhs = k } }, .dest = eq, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = sum, .rhs = eq } }, .dest = out, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = out } });
+
+    var const_vals = try buildConstVals(&func, allocator);
+    defer const_vals.deinit();
+    var suppress = try buildIconstSuppress(&func, &const_vals, allocator);
+    defer suppress.deinit();
+
+    try std.testing.expect(!suppress.contains(k));
 }
 
 test "compileFunctionRA: add two constants" {

--- a/src/compiler/ir/range_split.zig
+++ b/src/compiler/ir/range_split.zig
@@ -551,7 +551,7 @@ fn collectUses(inst: ir.Inst, into: *VRegSet, allocator: std.mem.Allocator) !voi
 /// breaches the `src/compiler/ir/` module path under Zig 0.16's strict
 /// per-module file-tree boundary. Stays in sync with that source — any
 /// new op variant must be added in both places.
-fn forEachUseInst(
+pub fn forEachUseInst(
     inst: ir.Inst,
     context: anytype,
     comptime visit: fn (@TypeOf(context), ir.VReg) anyerror!void,


### PR DESCRIPTION
Closes #523.

## Summary

When every use of an `iconst_32`/`iconst_64` def folds as an immediate operand on the target ISA, skip emitting the `mov xN, #K` materialization. Register allocation still assigns the vreg (so callee-save bookkeeping is unchanged), but the asm emit is suppressed, removing dead `movz`/`mov-imm` instructions from hot paths.

Implemented for both `aarch64` and `x86_64` codegen.

## Approach

Per function, after IR construction and before the emit loop, classify each `iconst_*` vreg by:
- **total uses** — counted via `range_split.forEachUseInst` (canonical full-coverage use enumerator).
- **foldable uses** — per-target classifier mirroring the actual `const_vals.get(...)` checks in the emitter:
  - **aarch64**: `add`/`sub` operand that fits `encodeAddSubImm` (rhs preferred, lhs only for commutative `add`); skipped if the parent op is FMA-fused or float-typed.
  - **x86_64**: `add`/`sub`/`mul`/`and`/`or`/`xor` RHS in i32 range; shift count for `shl`/`shr_*`/`rotl`/`rotr`; `memory.copy`/`memory.fill` length via `smallFixedBulkMemLen`.

A vreg is suppressed iff `total_uses > 0 && total_uses == foldable_uses`. The conjunction guards against zero-use vregs (those should be DCE'd by #508; if any leak through, leaving the mov is harmless).

At the iconst emit sites, the emitter early-returns (after `reg_map.assign(dest)` on aarch64, to keep `used_callee_mask` consistent).

## Files changed

```
src/compiler/codegen/aarch64/compile.zig | 262 +++++++++++++++++++++-
src/compiler/codegen/x86_64/compile.zig  | 170 +++++++++++++-
src/compiler/ir/range_split.zig          |   2 +-
3 files changed, 431 insertions(+), 3 deletions(-)
```

## Validation

| Check | Result |
|---|---|
| `zig build test` (native aarch64) | ✅ all pass; 6 new tests (4 aarch64, 2 x86_64) |
| `zig build -Dtarget=x86_64-linux` | ✅ clean cross-build |
| `zig build coremark-aot` (nofp + fp) | ✅ CRC OK |
| CoreMark Δ (5 runs)  | **+0.20%** (9746.7 → 9766.2 iter/s) |
| CoreMark Δ (10 runs) | **+0.05%** (9750.1 → 9755.4 iter/s) |
| SIMD bench (`scripts/bench_simd.py --runs 3`) | All AOT/interp results functionally identical to baseline |

### Native code size & movz count (CoreMark, aarch64)

```
coremark_main.aot: size=149004 movz_candidates=1071
coremark_head.aot: size=147592 movz_candidates= 818
                              -1412 bytes (-0.95%)   -253 movz (-23.6%)
```

253 fewer `movz`-pattern words emitted across the 73 functions of CoreMark — direct evidence that the suppression is firing on real hot code.

### Gap vs the issue's bar

Issue #523 targets a CoreMark uplift on the order of **+0.5%**. Measured Δ on this VM is **+0.05–0.20%** depending on run count, below the bar but consistently positive and consistent with the code-size reduction (most freed mov slots are in cold setup blocks; the hottest CoreMark loops were already mostly mov-free thanks to existing folding). Following the precedent from PR #511, opening anyway with the gap disclosed — the code-size and `movz` reductions are unambiguous wins, and this lays the groundwork for further fold-coverage extensions (e.g., compare immediates, mem ops on x86_64) which can stack toward the bar.

## Related

- Issue #523 (this PR)
- Builds on #469 (const-vals plumbing) and #508 (DCE of dead iconst vregs).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
