### PR TITLE
fix(component): hybrid 0.2/0.3 routing — register wasi:clocks/types@0.3 + resolve top-level type aliases

### DIFF
--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -1501,7 +1501,7 @@ pub fn instantiate(
                                 else
                                     @intCast(component.types.len);
                                 const ext: InstanceTypeExtension = if (rft.decls) |decls|
-                                    buildInstanceTypeExtension(allocator, decls, ext_base) catch {
+                                    buildInstanceTypeExtension(allocator, decls, ext_base, component) catch {
                                         allocator.destroy(ctx_ptr);
                                         continue;
                                     }
@@ -2337,21 +2337,64 @@ const InstanceTypeExtension = struct {
     }
 };
 
+/// True iff `a` is a single-hop outer alias of sort `.type` whose
+/// parent target slot has been resolved (i.e. `type_indexspace[idx]`
+/// is non-null). Used to size the extension's type buffer for #534.
+fn canResolveOuterTypeAlias(a: ctypes.Alias, component: *const ctypes.Component) bool {
+    return resolveOuterTypeAliasToParent(a, component) != null;
+}
+
+/// Resolve a single-hop `.alias outer 1 M (type)` against the parent
+/// component's `type_indexspace`. Returns the parent's `TypeDef` or
+/// `null` when the alias shape is unsupported (multi-level outer,
+/// non-type sort, target slot still unresolved). The returned TypeDef
+/// is structurally shared with the parent — callers MUST NOT deep-free
+/// it when tearing the extension down. Limited to `TypeDef.val` for
+/// now (#534 scope; primitives like `type duration = u64` cover the
+/// clock fixtures). A future slice may extend this to record / variant
+/// payloads with proper deep-copy + type_idx rewriting.
+fn resolveOuterTypeAliasToParent(
+    a: ctypes.Alias,
+    component: *const ctypes.Component,
+) ?ctypes.TypeDef {
+    const outer = switch (a) {
+        .outer => |o| o,
+        else => return null,
+    };
+    if (outer.sort != .type) return null;
+    // Only single-hop outers — i.e. the immediate enclosing component.
+    if (outer.outer_count != 1) return null;
+    if (component.type_indexspace.len == 0) return null;
+    if (outer.idx >= component.type_indexspace.len) return null;
+    const local = component.type_indexspace[outer.idx] orelse return null;
+    if (local >= component.types.len) return null;
+    const td = component.types[local];
+    return switch (td) {
+        .val => td,
+        else => null,
+    };
+}
+
 /// Materialize the per-trampoline TypeRegistry extension covering an
 /// instance-type body's local type space. Walks `decls` in declaration
 /// order, mirroring `resolveInstanceTypeLocal`'s slot-counting rules:
 /// `.type`, `.alias`, and `.@"export"`-with-type each contribute one
-/// indexspace slot. Only `.type` slots materialize a structural typedef;
-/// `.alias` and exported-type slots map to `null` (the trampoline path
-/// for them was already null-fallback under the prior local-only walker).
+/// indexspace slot. `.type` slots materialize a structural typedef;
+/// `.alias outer 1 M (type)` slots resolve through the parent
+/// component's `type_indexspace` (#534); other alias shapes map to
+/// `null` (the trampoline path for them was already null-fallback
+/// under the prior local-only walker).
 ///
 /// The caller is responsible for `deinit`'ing the returned extension.
 fn buildInstanceTypeExtension(
     allocator: std.mem.Allocator,
     decls: []const ctypes.Decl,
     base: u32,
+    component: *const ctypes.Component,
 ) !InstanceTypeExtension {
-    // First pass: count slots and type entries.
+    // First pass: count slots and type entries. Reserve a type slot for
+    // `(alias outer 1 M (type))` decls too — we materialize the parent
+    // type into the extension when possible (#534).
     var slot_count: u32 = 0;
     var type_count: u32 = 0;
     for (decls) |d| switch (d) {
@@ -2359,7 +2402,14 @@ fn buildInstanceTypeExtension(
             slot_count += 1;
             type_count += 1;
         },
-        .alias => slot_count += 1,
+        .alias => |a| {
+            slot_count += 1;
+            // `.alias outer count=1 idx=M (type)` may resolve to a
+            // parent type — reserve a type slot for the copy. Other
+            // alias shapes (inner instance_export aliases, deeper outer
+            // hops) stay unresolved.
+            if (canResolveOuterTypeAlias(a, component)) type_count += 1;
+        },
         .@"export" => |e| if (e.desc == .type) {
             slot_count += 1;
         },
@@ -2387,13 +2437,23 @@ fn buildInstanceTypeExtension(
             type_i += 1;
             slot_i += 1;
         },
-        .alias => {
-            // `.alias outer N M (type)` introduces a slot that aliases an
-            // outer type indexspace. We don't currently plumb the parent's
-            // indexspace into this builder, so the slot remains unresolved.
-            // Type-uses that resolve through this slot will correctly fall
-            // through to the registry's null path. Tracked separately.
-            idxspace_buf[slot_i] = null;
+        .alias => |a| {
+            // `.alias outer count=1 idx=M (type)` — when M points at a
+            // parent type-indexspace slot that has been resolved (e.g.
+            // by the loader's #534 top-level type-alias resolution),
+            // copy that TypeDef into the extension so canon-ABI
+            // lift/lower of values whose declared type goes through this
+            // slot can look up the concrete shape. Deep-copy is not
+            // needed for the `TypeDef.val` case currently handled by
+            // the loader resolver; nested type_idx refs would require
+            // rewriting and are out of scope here.
+            if (resolveOuterTypeAliasToParent(a, component)) |parent_td| {
+                types_buf[type_i] = parent_td;
+                idxspace_buf[slot_i] = type_i;
+                type_i += 1;
+            } else {
+                idxspace_buf[slot_i] = null;
+            }
             slot_i += 1;
         },
         .@"export" => |e| if (e.desc == .type) {

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -151,6 +151,11 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
     // `indexspace.resolveCompInstance` only handles non-interleaved
     // layouts (issue #355).
     var comp_instance_indexspace: std.ArrayListUnmanaged(ctypes.CompInstanceContributor) = .empty;
+    // Parent type_indexspace slot contributed by each alias (or null
+    // for aliases that don't add a type slot). Indexed by alias
+    // position. Used by `resolveTopLevelTypeAliases` to back-fill
+    // null slots produced by `(alias <inst> "<name>" (type …))` (#534).
+    var alias_type_slot: std.ArrayListUnmanaged(?u32) = .empty;
 
     while (reader.remaining() > 0) {
         const section_id_byte = try reader.readByte();
@@ -217,7 +222,12 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
                         .instance_export => |ie| ie.sort,
                         .outer => |o| o.sort,
                     };
-                    if (sort == .type) try type_indexspace.append(allocator, null);
+                    if (sort == .type) {
+                        try alias_type_slot.append(allocator, @intCast(type_indexspace.items.len));
+                        try type_indexspace.append(allocator, null);
+                    } else {
+                        try alias_type_slot.append(allocator, null);
+                    }
                     // Aliases of sort .core(.func) contribute to the
                     // core-func indexspace.
                     const is_core_func = switch (sort) {
@@ -320,6 +330,23 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
         if (reader.pos != section_start + section_size) return error.InvalidSectionSize;
     }
 
+    // Post-parse: resolve top-level type-aliases against imported instance
+    // type bodies. Required for components that import a separate
+    // `wasi:clocks/types@0.3.x` instance to expose `duration` (and
+    // similar) shared types — without this, `canon.lower` lift/lower
+    // of values whose declared type goes through such an alias trips
+    // `CompoundNeedsRegistry`. See `resolveTopLevelTypeAliases` for the
+    // full algorithm and limitations. (#534)
+    try resolveTopLevelTypeAliases(
+        allocator,
+        aliases.items,
+        alias_type_slot.items,
+        imports.items,
+        comp_instance_indexspace.items,
+        &type_defs,
+        type_indexspace.items,
+    );
+
     return .{
         .core_modules = try core_modules.toOwnedSlice(allocator),
         .core_instances = try core_instances.toOwnedSlice(allocator),
@@ -335,7 +362,189 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!ctypes.Com
         .exports = try exports.toOwnedSlice(allocator),
         .core_func_indexspace = try core_func_indexspace.toOwnedSlice(allocator),
         .comp_instance_indexspace = try comp_instance_indexspace.toOwnedSlice(allocator),
+        .alias_type_slot = try alias_type_slot.toOwnedSlice(allocator),
     };
+}
+
+// ── Top-level type-alias resolution (#534) ─────────────────────────────────
+//
+// `(alias instance_export <inst> "<name>" (type …))` produces a parent
+// `type_indexspace` slot whose target is the type exported by the
+// imported instance under `<name>`. The on-wire encoding doesn't include
+// the resolved type — we have to walk the imported instance's type body
+// at load time to recover it.
+//
+// Scope: handles the case where `<inst>` resolves to a *direct* instance
+// import whose type body's exported declarator has bound `eq <inner_idx>`,
+// and `<inner_idx>` points at a `TypeDef.val` (primitive aliases like
+// `type duration = u64`). Compound exported types — records, variants,
+// resources — fall through unresolved (slot stays null); the affected
+// `canon.lower` trampolines will continue to surface `CompoundNeedsRegistry`
+// until a future slice extends this resolver to deep-copy compound
+// payloads through the parent type space. The clock fixtures targeted
+// by #534 only expose `type duration = u64` at the top level, so the
+// primitive case is sufficient.
+//
+// Multi-hop alias chains (`alias-of-alias-of-import-export`) are
+// supported via the fixed-point loop. The pass bails after a defensive
+// bound on the number of iterations.
+fn resolveTopLevelTypeAliases(
+    allocator: std.mem.Allocator,
+    aliases: []const ctypes.Alias,
+    alias_type_slot: []const ?u32,
+    imports: []const ctypes.ImportDecl,
+    comp_instance_indexspace: []const ctypes.CompInstanceContributor,
+    type_defs: *std.ArrayListUnmanaged(ctypes.TypeDef),
+    type_indexspace: []?u32,
+) LoadError!void {
+    if (aliases.len == 0) return;
+    var iteration: u32 = 0;
+    while (iteration < 8) : (iteration += 1) {
+        var any_change = false;
+        for (aliases, 0..) |a, ai| {
+            if (a != .instance_export) continue;
+            const ie = a.instance_export;
+            if (ie.sort != .type) continue;
+            if (ai >= alias_type_slot.len) continue;
+            const slot = alias_type_slot[ai] orelse continue;
+            if (slot >= type_indexspace.len) continue;
+            if (type_indexspace[slot] != null) continue;
+
+            const resolved = resolveAliasInstanceExportType(
+                ie.instance_idx,
+                ie.name,
+                imports,
+                comp_instance_indexspace,
+                type_defs.items,
+                type_indexspace,
+            ) orelse continue;
+
+            // Materialize the resolved TypeDef in the parent's type
+            // pool. For primitive `TypeDef.val` we can copy directly;
+            // any compound shape would require deep-copy + type_idx
+            // rewriting, which this pass leaves for a future slice.
+            switch (resolved) {
+                .val => {
+                    const new_idx: u32 = @intCast(type_defs.items.len);
+                    try type_defs.append(allocator, resolved);
+                    type_indexspace[slot] = new_idx;
+                    any_change = true;
+                },
+                else => {},
+            }
+        }
+        if (!any_change) return;
+    }
+}
+
+/// Resolve `(alias <inst_ci_idx> "<name>" (type …))` to the exported
+/// `TypeDef` of the imported instance, or `null` if the chain can't be
+/// followed yet. See `resolveTopLevelTypeAliases` for scope.
+fn resolveAliasInstanceExportType(
+    inst_ci_idx: u32,
+    name: []const u8,
+    imports: []const ctypes.ImportDecl,
+    comp_instance_indexspace: []const ctypes.CompInstanceContributor,
+    type_defs: []const ctypes.TypeDef,
+    type_indexspace: []const ?u32,
+) ?ctypes.TypeDef {
+    // 1. Resolve the instance reference to a direct import declarator.
+    if (inst_ci_idx >= comp_instance_indexspace.len) return null;
+    const contributor = comp_instance_indexspace[inst_ci_idx];
+    const imp_idx: u32 = switch (contributor) {
+        .import => |i| i,
+        // Local instances / alias-of-instance / exported_alias chains
+        // are unsupported here; the type bodies they reference are
+        // resolved elsewhere (or not at all). Skip.
+        else => return null,
+    };
+    if (imp_idx >= imports.len) return null;
+    const imp = imports[imp_idx];
+    const imp_type_idx: u32 = switch (imp.desc) {
+        .instance => |ti| ti,
+        else => return null,
+    };
+
+    // 2. Look up the import's instance-type body in `type_defs`,
+    // honouring `type_indexspace` indirection when present.
+    const local_idx: u32 = blk: {
+        if (type_indexspace.len > 0) {
+            if (imp_type_idx >= type_indexspace.len) return null;
+            break :blk type_indexspace[imp_type_idx] orelse return null;
+        }
+        break :blk imp_type_idx;
+    };
+    if (local_idx >= type_defs.len) return null;
+    const inst_td = type_defs[local_idx];
+    const inst_decls = switch (inst_td) {
+        .instance => |inst| inst.decls,
+        else => return null,
+    };
+
+    // 3. Walk the instance type body, building the inner type-indexspace
+    // map and locating the named export.
+    return resolveInstanceTypeExportByName(inst_decls, name);
+}
+
+/// Walk an instance-type body's declarator list, build an inner
+/// type-indexspace ↔ inner `TypeDef` table, find the export named
+/// `name`, resolve its bound, and return the corresponding `TypeDef`.
+fn resolveInstanceTypeExportByName(
+    decls: []const ctypes.Decl,
+    name: []const u8,
+) ?ctypes.TypeDef {
+    // Inner type-indexspace, populated in declaration order. Each
+    // entry is either an embedded TypeDef (`.type`), or a `.eq <slot>`
+    // back-reference (introduced by an export-of-type declarator).
+    // The actual storage uses a small fixed-size buffer to avoid an
+    // allocation; instance type bodies in real fixtures rarely exceed
+    // a few dozen entries.
+    const max_inner_slots = 256;
+    var inner_slots: [max_inner_slots]?ctypes.TypeDef = [_]?ctypes.TypeDef{null} ** max_inner_slots;
+    var inner_eq: [max_inner_slots]?u32 = [_]?u32{null} ** max_inner_slots;
+    var slot_count: u32 = 0;
+    for (decls) |d| switch (d) {
+        .type => |td| {
+            if (slot_count >= max_inner_slots) return null;
+            inner_slots[slot_count] = td;
+            slot_count += 1;
+        },
+        .alias => {
+            // Outer / instance-export inner aliases — not resolved
+            // here. The clock fixtures the #534 pass targets don't
+            // use these for top-level `type` exports.
+            if (slot_count >= max_inner_slots) return null;
+            slot_count += 1;
+        },
+        .@"export" => |e| {
+            if (e.desc == .type) {
+                if (slot_count >= max_inner_slots) return null;
+                switch (e.desc.type) {
+                    .eq => |target| {
+                        if (target < slot_count) inner_eq[slot_count] = target;
+                    },
+                    .sub_resource => {},
+                }
+                if (std.mem.eql(u8, e.name, name)) {
+                    // Found the requested export. Follow `eq` chain.
+                    var cur: u32 = slot_count;
+                    var hops: u32 = 0;
+                    while (hops < max_inner_slots) : (hops += 1) {
+                        if (inner_eq[cur]) |t| {
+                            cur = t;
+                            continue;
+                        }
+                        if (inner_slots[cur]) |td| return td;
+                        return null;
+                    }
+                    return null;
+                }
+                slot_count += 1;
+            }
+        },
+        else => {},
+    };
+    return null;
 }
 
 // ── Section parsers ─────────────────────────────────────────────────────────

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -612,6 +612,18 @@ pub const Component = struct {
     /// `wasm-tools compose` output where instance and alias sections
     /// interleave (issue #355).
     comp_instance_indexspace: []const CompInstanceContributor = &.{},
+    /// For each `Alias` in `aliases`, the parent `type_indexspace`
+    /// slot it contributed (or null if the alias contributes to a
+    /// different index space — e.g. core-func, comp-func, instance).
+    /// Indexed by `alias` position. Used by the load-time top-level
+    /// type-alias resolution pass (#534) to back-fill `type_indexspace`
+    /// slots produced by `(alias <instance> "<name>" (type …))` decls
+    /// that target an exported type of an imported instance. Without
+    /// resolution, `canon.lower` lift/lower of values whose declared
+    /// type goes through one of those slots trips
+    /// `CompoundNeedsRegistry`. Empty when the component was
+    /// constructed without a loader (hand-authored fixtures).
+    alias_type_slot: []const ?u32 = &.{},
 };
 
 /// A single contributor to the core-func index space.

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -1831,6 +1831,16 @@ pub const WasiCliAdapter = struct {
     cli_terminal_output_p3_iface: HostInstance = .{},
     clocks_wall_p3_iface: HostInstance = .{},
     clocks_monotonic_p3_iface: HostInstance = .{},
+    // #534: wasi:clocks@0.3.0 hoists `duration` (and, in newer revisions,
+    // `instant`) into a top-level `wasi:clocks/types` interface that the
+    // `monotonic-clock` / `system-clock` ifaces alias from. The instance
+    // carries no functions — just type definitions — so the provider is
+    // an empty `HostInstance` whose sole purpose is to satisfy guest
+    // import resolution. Without it, components emitted by recent rustc
+    // toolchains (e.g. the `wall-clock` / `monotonic-clock` /
+    // `multi-clock-wait` wasi-p3 fixtures) fail to link even when every
+    // other 0.2 / 0.3 clock import has a provider.
+    clocks_types_p3_iface: HostInstance = .{},
     fs_types_p3_iface: HostInstance = .{},
     fs_preopens_p3_iface: HostInstance = .{},
     http_types_p3_iface: HostInstance = .{},
@@ -2077,6 +2087,7 @@ pub const WasiCliAdapter = struct {
         self.cli_terminal_output_p3_iface.deinit(self.allocator);
         self.clocks_wall_p3_iface.deinit(self.allocator);
         self.clocks_monotonic_p3_iface.deinit(self.allocator);
+        self.clocks_types_p3_iface.deinit(self.allocator);
         self.fs_types_p3_iface.deinit(self.allocator);
         self.fs_preopens_p3_iface.deinit(self.allocator);
         self.http_types_p3_iface.deinit(self.allocator);
@@ -3410,6 +3421,32 @@ pub const WasiCliAdapter = struct {
         });
         try providers.put(self.allocator, iface_name, .{
             .host_instance = &self.clocks_wall_p3_iface,
+        });
+    }
+
+    /// Register `wasi:clocks/types@0.3.x` (#534).
+    ///
+    /// The 0.3 clocks WIT hoists shared type aliases (`duration`, and in
+    /// newer revisions `instant`) into a separate top-level instance:
+    ///
+    /// ```wit
+    /// interface types {
+    ///   type duration = u64;
+    ///   record instant { seconds: s64, nanoseconds: u32 }
+    /// }
+    /// ```
+    ///
+    /// Components emitted by recent rustc toolchains import this instance
+    /// at the top level even when the `monotonic-clock` / `system-clock`
+    /// ifaces alias the types from there. There are no functions to wire
+    /// — registration is purely so `linkImports` accepts the import.
+    pub fn populateWasiClocksTypesP3(
+        self: *WasiCliAdapter,
+        providers: *std.StringHashMapUnmanaged(ImportBinding),
+        iface_name: []const u8,
+    ) !void {
+        try providers.put(self.allocator, iface_name, .{
+            .host_instance = &self.clocks_types_p3_iface,
         });
     }
 
@@ -14452,6 +14489,7 @@ pub fn populateWasiProviders(
     var matched_monotonic_clock: ?[]const u8 = null;
     var matched_monotonic_clock_p3: ?[]const u8 = null;
     var matched_system_clock_p3: ?[]const u8 = null;
+    var matched_clocks_types_p3: ?[]const u8 = null;
     var matched_random: ?[]const u8 = null;
     var matched_random_insecure: ?[]const u8 = null;
     var matched_random_insecure_seed: ?[]const u8 = null;
@@ -14577,6 +14615,15 @@ pub fn populateWasiProviders(
         if (matched_system_clock_p3 == null and
             matchesWasiPrefix(imp.name, "wasi:clocks/system-clock"))
             matched_system_clock_p3 = imp.name;
+        // #534: wasi:clocks/types@0.3 — a type-only instance holding
+        // `duration` (and, in newer revisions, `instant`). Components
+        // emitted by recent rustc toolchains import this top-level
+        // even when the monotonic/system clock interfaces alias the
+        // types from it. P3-only; no 0.2 counterpart.
+        if (matched_clocks_types_p3 == null and
+            matchesWasiPrefix(imp.name, "wasi:clocks/types") and
+            wasiVersion(imp.name) == .p3)
+            matched_clocks_types_p3 = imp.name;
         // `wasi:random/insecure-seed` shares the `wasi:random/insecure`
         // prefix, so test the more-specific name first. #485 splits each
         // interface by version so 0.2 and 0.3 imports route to different
@@ -14802,6 +14849,12 @@ pub fn populateWasiProviders(
     }
     if (matched_system_clock_p3) |name| {
         try adapter.populateWasiClocksSystemClockP3(providers, name);
+    }
+    // #534: P3 clocks/types — type-only instance, no functions. Wire
+    // only when imported so `linkImports`'s strict-checking still
+    // catches accidental unmatched imports elsewhere.
+    if (matched_clocks_types_p3) |name| {
+        try adapter.populateWasiClocksTypesP3(providers, name);
     }
 
     try adapter.populateWasiRandomRandom(
@@ -22917,6 +22970,196 @@ test "populateWasiProviders: binds wasi:clocks@0.3 monotonic + system (#483)" {
     try testing.expect(sys_p3.host_instance == &adapter.clocks_wall_p3_iface);
     try testing.expect(adapter.clocks_wall_p3_iface.members.contains("now"));
     try testing.expect(adapter.clocks_wall_p3_iface.members.contains("get-resolution"));
+}
+
+// ── #534 hybrid 0.2/0.3 routing unit tests ───────────────────────────────
+//
+// Recent rustc toolchains emit wasm32-wasip3 components whose `wasi:cli/run`
+// export is the legacy 0.2 sync entrypoint but whose `wasi:clocks/*` imports
+// resolve through a separate `wasi:clocks/types@0.3.x` instance carrying
+// the `duration` type alias. Before #534, `populateWasiProviders` never
+// registered a provider for `wasi:clocks/types@0.3` — so `linkImports`
+// rejected the component with `MissingImport`. The clock fixtures
+// targeted by #534 (`wall-clock`, `monotonic-clock`, `multi-clock-wait`)
+// all exhibit this pattern; the first of those is the simplest sync
+// regression.
+
+test "populateWasiProviders: binds wasi:clocks/types@0.3 alongside 0.2 cli/run (#534)" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    // Mirrors the real wasi-p3 `wall-clock` fixture's top-level imports:
+    // a 0.3 clocks types instance, a 0.3 system-clock that aliases from
+    // it, plus the legacy 0.2 wasi:cli surface. The component would
+    // dispatch through the legacy `runComponentBytes` 0.2 path, so
+    // `populateWasiProviders` must still install P3 clock + types
+    // bindings alongside the 0.2 cli ones.
+    const imports = [_]ctypes_root.ImportDecl{
+        .{ .name = "wasi:clocks/types@0.3.0-rc-2026-03-15", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:clocks/system-clock@0.3.0-rc-2026-03-15", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:cli/exit@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:cli/stdout@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:io/streams@0.2.6", .desc = .{ .instance = 0 } },
+    };
+    const component = ctypes_root.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &imports,
+        .exports = &.{},
+    };
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+
+    try populateWasiProviders(&adapter, &component, &providers);
+
+    // The previously-missing types iface MUST be wired (the regression
+    // surface for #534).
+    try testing.expect(providers.contains("wasi:clocks/types@0.3.0-rc-2026-03-15"));
+    const types_p3 = providers.get("wasi:clocks/types@0.3.0-rc-2026-03-15").?;
+    try testing.expect(types_p3.host_instance == &adapter.clocks_types_p3_iface);
+
+    // 0.3 system-clock still wires (`@0.3.x` import → P3 host instance).
+    try testing.expect(providers.contains("wasi:clocks/system-clock@0.3.0-rc-2026-03-15"));
+
+    // 0.2 cli imports retain their existing P2 routing — the hybrid
+    // case must not regress that side of the multiplex.
+    try testing.expect(providers.contains("wasi:cli/stdout@0.2.6"));
+    try testing.expect(providers.contains("wasi:cli/exit@0.2.6"));
+    try testing.expect(providers.contains("wasi:io/streams@0.2.6"));
+}
+
+test "populateWasiClocksTypesP3: empty host instance suffices for type-only import (#534)" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+
+    try adapter.populateWasiClocksTypesP3(
+        &providers,
+        "wasi:clocks/types@0.3.0-rc-2026-03-15",
+    );
+
+    const binding = providers.get("wasi:clocks/types@0.3.0-rc-2026-03-15").?;
+    try testing.expect(binding == .host_instance);
+    try testing.expect(binding.host_instance == &adapter.clocks_types_p3_iface);
+    // `wasi:clocks/types@0.3.x` is type-only — no callable members.
+    try testing.expectEqual(@as(usize, 0), adapter.clocks_types_p3_iface.members.count());
+}
+
+test "populateWasiProviders: skips clocks/types@0.3 when not imported (#534)" {
+    // Strict-checking via `linkImports.MissingImport` must still flag
+    // accidental unmatched imports elsewhere, so `populateWasiProviders`
+    // only registers a clocks/types provider on demand. A 0.2-only
+    // component with no clocks/types import should leave that name
+    // unbound in the providers map.
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    const imports = [_]ctypes_root.ImportDecl{
+        .{ .name = "wasi:clocks/wall-clock@0.2.6", .desc = .{ .instance = 0 } },
+        .{ .name = "wasi:cli/stdout@0.2.6", .desc = .{ .instance = 0 } },
+    };
+    const component = ctypes_root.Component{
+        .core_modules = &.{},
+        .core_instances = &.{},
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &imports,
+        .exports = &.{},
+    };
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+
+    try populateWasiProviders(&adapter, &component, &providers);
+
+    try testing.expect(!providers.contains("wasi:clocks/types@0.3.0-rc-2026-03-15"));
+    try testing.expect(!providers.contains("wasi:clocks/types@0.3.0"));
+    try testing.expect(providers.contains("wasi:clocks/wall-clock@0.2.6"));
+}
+
+test "loader.resolveTopLevelTypeAliases: alias-of-instance-export resolves type duration=u64 (#534)" {
+    // Mirrors the parent-level `(alias export $clocks-types-instance
+    // "duration" (type 1))` shape used by every wasi-p3 clock fixture.
+    // The imported instance's type body declares `type duration = u64`
+    // and exports it under that name; the loader's post-pass must
+    // back-fill the parent `type_indexspace` slot with `TypeDef.val .u64`
+    // so canon.lower lift/lower of values whose declared type points
+    // there don't trip `CompoundNeedsRegistry`.
+    const testing = std.testing;
+    const loader = @import("loader.zig");
+
+    // Construct the binary by hand. Top-level decls:
+    //   type 0 = (instance (type 0 u64) (export "duration" (type (eq 0))))
+    //   import "wasi:clocks/types@0.3" (instance 0)  ← contributes inst 0
+    //   alias export instance=0 "duration" (type)    ← parent type idx 1
+    const bytes = [_]u8{
+        // magic + component preamble
+        0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00,
+        // section 0x07 (component type), size 0x13 (computed below):
+        // count=1
+        //   tag=0x42 (instance type) count=2
+        //     decl 0x01 (type) tag=0x77 (u64)
+        //     decl 0x04 (export) name="duration" desc=0x05 type bound=eq(0)
+        0x07, 0x13,
+        0x01,
+        0x42, 0x02,
+        0x01, 0x77, // type (val u64)
+        0x04, 0x00, 0x08, 'd', 'u', 'r', 'a', 't', 'i', 'o', 'n', 0x03, 0x00, 0x00,
+        // section 0x0a (component import), size 0x2a
+        // count=1
+        //   importname (with no-prefix marker 0x00) "wasi:clocks/types@0.3.0-rc-2026-03-15"
+        //   desc 0x05 (instance) type_idx=0
+        0x0a, 0x2a,
+        0x01,
+        0x00, 0x25, 'w', 'a', 's', 'i', ':', 'c', 'l', 'o', 'c', 'k', 's', '/', 't', 'y', 'p', 'e',
+        's', '@', '0', '.', '3', '.', '0', '-', 'r', 'c', '-', '2', '0', '2', '6', '-', '0', '3',
+        '-', '1', '5', 0x05, 0x00,
+        // section 0x06 (component alias), size 0x0d
+        // count=1
+        //   sort=0x03 (type) form=0x00 (instance_export) inst_idx=0 name="duration"
+        0x06, 0x0d,
+        0x01,
+        0x03, 0x00, 0x00, 0x08, 'd', 'u', 'r', 'a', 't', 'i', 'o', 'n',
+    };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const component = try loader.load(&bytes, arena.allocator());
+
+    // Parent type indexspace must have 2 slots:
+    //   0 — the instance type def (materialized)
+    //   1 — the type alias to the instance's "duration" export (back-filled by #534)
+    try testing.expectEqual(@as(usize, 2), component.type_indexspace.len);
+    const slot0 = component.type_indexspace[0] orelse return error.MissingSlot0;
+    const slot1 = component.type_indexspace[1] orelse return error.MissingSlot1Resolution;
+    try testing.expect(slot0 < component.types.len);
+    try testing.expect(slot1 < component.types.len);
+    // Slot 1 must resolve to `TypeDef.val u64`.
+    const td1 = component.types[slot1];
+    try testing.expect(td1 == .val);
+    try testing.expect(td1.val == .u64);
+
+    // `alias_type_slot` side-table must record that alias 0 contributed
+    // parent type slot 1 (and is the only alias in the binary).
+    try testing.expectEqual(@as(usize, 1), component.alias_type_slot.len);
+    try testing.expectEqual(@as(?u32, 1), component.alias_type_slot[0]);
 }
 
 // ── #482 wasi:cli@0.3.0 unit tests ──────────────────────────────────────

--- a/tests/wasi-p3-testsuite-skip.json
+++ b/tests/wasi-p3-testsuite-skip.json
@@ -36,8 +36,7 @@
         "cli-stdio":              "wasi:cli@0.3.0 adapter not yet merged — tracking #482",
         "cli-stdio-roundtrip":    "wasi:cli@0.3.0 adapter not yet merged — tracking #482",
         "run-with-err":           "wasi:cli@0.3.0 adapter not yet merged — tracking #482",
-        "monotonic-clock":        "wasi:clocks@0.3.0 adapter not yet merged — tracking #483",
-        "multi-clock-wait":       "wasi:clocks@0.3.0 adapter not yet merged — tracking #483",
-        "wall-clock":             "wasi:clocks@0.3.0 adapter not yet merged — tracking #483"
+        "monotonic-clock":        "wasi:clocks@0.3.0 routing fixed in #534; `wait-for`/`wait-until` need canon-lower-of-async-func runtime support — tracking follow-up",
+        "multi-clock-wait":       "wasi:clocks@0.3.0 routing fixed in #534; needs canon-lower-of-async-func + task.cancel-aware sleep cancellation — tracking follow-up"
     }
 }


### PR DESCRIPTION
## Summary

Components emitted by recent rustc toolchains (the wasi-p3-testsuite `wall-clock` / `monotonic-clock` / `multi-clock-wait` fixtures) export the legacy `wasi:cli/run@0.2.x` sync entrypoint but pull their `wasi:clocks/*` imports through a separate `wasi:clocks/types@0.3.0-rc-*` instance that hoists shared `type duration = u64` (and `instant` in newer revisions). Two gaps were tripping `LinkFailed` / `CompoundNeedsRegistry`:

1. **`populateWasiProviders` had no entry for `wasi:clocks/types@0.3.x`**. The version-multiplex from #481 routed monotonic/system clock imports correctly, but the type-only `types` instance had no provider — `linkImports` rejected it with `MissingImport`.
2. **Even with the provider, top-level `(alias <inst> "duration" (type …))` declarators left their parent `type_indexspace` slot null.** The resulting canon.lower trampolines for `system-clock.get-resolution` (return type `duration`) tripped `CompoundNeedsRegistry` at the lower-results stage.

## Changes

- Register an empty `clocks_types_p3_iface` HostInstance on demand from `populateWasiProviders` (mirrors the existing `cli_types_p3_iface` pattern from #482).
- Add a load-time `resolveTopLevelTypeAliases` pass that walks each `(alias instance_export inst "name" (type …))` against the imported instance's type body, looks up the named export's `TypeBound.eq`, resolves it through the inner type indexspace, and back-fills the parent `type_indexspace` slot with a fresh `TypeDef.val` copy. Scope: primitive `TypeDef.val` resolutions only — covers `type duration = u64`. Compound payloads stay unresolved for a future slice.
- Plumb the parent's `type_indexspace` into `buildInstanceTypeExtension` so `(alias outer 1 M (type))` decls inside an instance type body can pick up the parent's resolved type for canon.lower lift/lower.

## Result

- `wall-clock` (sync-only host calls) now passes `zig build wasi-p3-testsuite`. Skip-list shrinks by 1.
- `monotonic-clock` and `multi-clock-wait` get past linking but still trap at run-time because they exercise `canon.lower (async)` of `wait-for` / `wait-until` — an end-to-end async-canon-lower feature that's outside this PR's scope. Skip-list rationale updated to point at the follow-up.

## Tests added (≥3 per fleet rule)

- `populateWasiProviders: binds wasi:clocks/types@0.3 alongside 0.2 cli/run (#534)`
- `populateWasiClocksTypesP3: empty host instance suffices for type-only import (#534)`
- `populateWasiProviders: skips clocks/types@0.3 when not imported (#534)`
- `loader.resolveTopLevelTypeAliases: alias-of-instance-export resolves type duration=u64 (#534)`

## Verification

- `zig build` clean
- `zig build test` — 228 tests pass
- `zig build wasi-p3-testsuite` — `wall-clock` now PASS; 3 total passes, 37 skipped (was 2/38)
- Cross-compile sweep clean: `aarch64-macos`, `x86_64-windows`, `x86_64-linux`

## Follow-up

`monotonic-clock` + `multi-clock-wait` need end-to-end `canon.lower (async)` support (encode `(handle << 4) | STATUS_STARTED` packed return, register subtask handle with the waitable-set, deliver results on future completion). `multi-clock-wait` additionally needs `task.cancel`-aware sleep cancellation. Both deserve their own tickets.

Closes #534