### PR TITLE
feat(wasi): complete wasi:cli@0.3.0 adapter — env/exit/stdio/run-with-err (#537)

### DIFF
--- a/src/component/async.zig
+++ b/src/component/async.zig
@@ -306,11 +306,26 @@ pub const AsyncStream = struct {
     /// kept for the future high-water-mark backpressure PR.
     pending_write: ?PendingWrite = null,
 
-    /// Optional host-side I/O hook (#535). When set, the executor's
-    /// stream ops invoke the driver before parking / buffering so a
-    /// long-lived TCP fd, accept queue, or UDP socket can keep the FIFO
-    /// fed without a per-call host fn dispatch.
+    /// Optional host-side I/O hook for long-lived sockets (#535). When
+    /// set, the executor's stream ops invoke the driver before parking
+    /// / buffering so a long-lived TCP fd, accept queue, or UDP socket
+    /// can keep the FIFO fed without a per-call host fn dispatch.
     host_driver: ?HostStreamDriver = null,
+    /// Optional host-attached sink/source for `wasi:cli` stdio (#537).
+    /// When set, `stream.write` / `stream.read` from the guest is
+    /// forwarded directly to the host (via `on_write` / `on_read`)
+    /// instead of being buffered. This is how
+    /// `wasi:cli/{stdout,stderr,stdin}@0.3.x.{write,read}-via-stream`
+    /// keep WAMR's single-threaded synchronous model in sync with the
+    /// guest's `futures::join!` style concurrent writers — the host
+    /// effectively stays "parked" on its end indefinitely, draining /
+    /// producing synchronously at every guest op.
+    ///
+    /// Distinct from `host_driver` (#535): `host_driver` integrates a
+    /// long-lived socket fd into the rendezvous loop with optional
+    /// would-block fallback to buffering, whereas `host_handler`
+    /// targets synchronous-once stdio with future-coupled completion.
+    host_handler: ?HostStreamHandler = null,
 
     /// Waitable plumbing for `waitable.join` integration.
     waitable_set: ?*WaitableSet = null,
@@ -333,6 +348,46 @@ pub const AsyncStream = struct {
     pub fn deinit(self: *AsyncStream, allocator: std.mem.Allocator) void {
         self.buffer.deinit(allocator);
     }
+};
+
+/// Host-side callbacks attached to an `AsyncStream` so the host can
+/// participate in guest stream I/O without an asynchronous scheduler.
+/// A stream has two ends; the host always attaches to the end opposite
+/// the guest:
+///
+///   * `wasi:cli/stdout@0.3.x.write-via-stream` — host is on the READ
+///     end. `on_write` fires from `stream.write` to drain guest data
+///     directly into a host sink; `on_drop_writable` fires when the
+///     guest closes its writer.
+///   * `wasi:cli/stdin@0.3.x.read-via-stream` — host is on the WRITE
+///     end. `on_read` fires from `stream.read` (when the buffer is
+///     empty) so the host can produce bytes from a real fd.
+///
+/// Installed by the corresponding adapter functions in
+/// `wasi_cli_adapter.zig` (#537).
+pub const HostStreamHandler = struct {
+    /// Host-on-read-end: drain guest write directly to a host sink.
+    /// Returns `true` on success, `false` if the sink rejected
+    /// (closed / errored).
+    on_write: ?*const fn (ctx: ?*anyopaque, bytes: []const u8) bool = null,
+    /// Host-on-read-end: notification fired from `stream.drop-writable`
+    /// when the guest closes its writer end. Used to settle the
+    /// companion `future<result<_,error-code>>`.
+    on_drop_writable: ?*const fn (ctx: ?*anyopaque) void = null,
+
+    /// Host-on-write-end: produce bytes for a guest read. Returns:
+    ///   * `> 0` — number of bytes written into `dst`.
+    ///   * `0`   — EOF; caller should mark the stream `write_closed`.
+    ///   * `< 0` — error; caller should surface as DROPPED to the guest.
+    on_read: ?*const fn (ctx: ?*anyopaque, dst: []u8) i32 = null,
+
+    /// Optional destructor — fired when the stream is fully closed
+    /// (both ends dropped) and removed from the table. Lets the host
+    /// release its `ctx` allocation without leaking on Debug builds.
+    on_destroy: ?*const fn (ctx: ?*anyopaque) void = null,
+
+    /// Opaque user context passed back to the callbacks.
+    ctx: ?*anyopaque = null,
 };
 
 // ── Tests ───────────────────────────────────────────────────────────────────

--- a/src/component/async_canon.zig
+++ b/src/component/async_canon.zig
@@ -72,21 +72,40 @@ pub const YieldOutcome = enum(u32) {
     cancelled = 1,
 };
 
-/// Discriminant for `future.read` / `future.write` / `future.cancel-*`
-/// status words (Binary.md "Async Calls"). The on-the-wire status word
-/// is `packStatus(status, count)` — bits 0..3 carry the discriminant,
-/// bits 4..31 carry the number of elements transferred (for `future<T>`
-/// always 0 or 1 since the channel is one-shot).
+/// Discriminant for `future.read` / `future.write` / `stream.read` /
+/// `stream.write` / `{future,stream}.cancel-*` status words. The
+/// on-the-wire encoding (post-`WebAssembly/component-model#541`) is:
+///
+///   * `BLOCKED = 0xFFFFFFFF` — operation has not completed; caller must
+///     wait for a `waitable` event before re-checking. Pushed as a raw
+///     sentinel via `BLOCKED_STATUS` (not via `packStatus`).
+///   * `packStatus(.completed, count)` — operation finished successfully
+///     transferring `count` elements. Low 4 bits = 0.
+///   * `packStatus(.dropped, count)` — other end of the channel dropped
+///     before/during the operation. `count` elements were transferred
+///     before the drop. Low 4 bits = 1.
+///   * `packStatus(.cancelled, count)` — operation was explicitly
+///     cancelled via `cancel-read`/`cancel-write`. `count` elements
+///     were transferred before the cancellation took effect. Low 4
+///     bits = 2.
+///
+/// Matches the encoding wit-bindgen ≥ 0.53 decodes in
+/// `crates/guest-rust/src/rt/async_support.rs::ReturnCode::decode`.
 pub const FutureStatus = enum(u32) {
-    starting = 0,
-    started = 1,
-    returned = 2,
-    cancelled = 3,
+    completed = 0,
+    dropped = 1,
+    cancelled = 2,
 };
 
-/// Pack a future read/write status discriminant + element count into the
-/// single i32 status word the spec returns from `future.{read,write}` and
-/// `future.cancel-{read,write}`.
+/// Sentinel pushed onto the wasm operand stack when an async operation
+/// (`stream.{read,write}` / `future.{read,write}`) is parked pending a
+/// waitable event. Distinct from any `packStatus(...)` value because
+/// the spec assigns `0xFFFFFFFF` to BLOCKED — see `FutureStatus`.
+pub const BLOCKED_STATUS: u32 = 0xFFFF_FFFF;
+
+/// Pack a future/stream read/write status discriminant + element count
+/// into the single i32 status word the spec returns from
+/// `{future,stream}.{read,write,cancel-read,cancel-write}`.
 pub fn packStatus(status: FutureStatus, count: u32) u32 {
     return @intFromEnum(status) | (count << 4);
 }
@@ -246,12 +265,15 @@ test "taskYield: unknown handle is a no-op" {
     try std.testing.expectEqual(YieldOutcome.resumed, taskYield(&tm, 999, true, allocator));
 }
 
-test "packStatus: encodes discriminant + element count" {
-    try std.testing.expectEqual(@as(u32, 0), packStatus(.starting, 0));
-    try std.testing.expectEqual(@as(u32, 1), packStatus(.started, 0));
-    try std.testing.expectEqual(@as(u32, 2), packStatus(.returned, 0));
+test "packStatus: encodes discriminant + element count (post-#541 spec)" {
+    try std.testing.expectEqual(@as(u32, 0), packStatus(.completed, 0));
+    try std.testing.expectEqual(@as(u32, 1), packStatus(.dropped, 0));
+    try std.testing.expectEqual(@as(u32, 2), packStatus(.cancelled, 0));
     // `future<T>` only ever transfers 0 or 1 elements; verify the count
     // lands in bits 4..31.
-    try std.testing.expectEqual(@as(u32, 2 | (1 << 4)), packStatus(.returned, 1));
-    try std.testing.expectEqual(@as(u32, 3), packStatus(.cancelled, 0));
+    try std.testing.expectEqual(@as(u32, 0 | (1 << 4)), packStatus(.completed, 1));
+    try std.testing.expectEqual(@as(u32, 1 | (3 << 4)), packStatus(.dropped, 3));
+    // BLOCKED is a raw sentinel (not packed) — verify it's distinct from
+    // any `packStatus(...)` value.
+    try std.testing.expectEqual(@as(u32, 0xFFFF_FFFF), BLOCKED_STATUS);
 }

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -809,6 +809,43 @@ pub fn canonResourceRep(
 /// `task.yield` is a no-op resume and `context.{get,set}` operate on
 /// `comp_inst.implicit_task_context`, matching Wasmtime's per-instance
 /// fallback for sync calls. (#478 sub-PR 1.)
+/// Resolve the per-element byte size for `stream.{read,write}` /
+/// `future.{read,write}` from the canon's `type_idx` immediate.
+///
+/// The component-model canon `stream.read t` / `future.read t` carries
+/// the typeidx of the *stream/future type def* — the element type sits
+/// one level inside, encoded by the loader as
+/// `TypeDef.val(.stream{inner})` / `TypeDef.val(.future{inner})` where
+/// `inner` is either a typeidx or a sentinel-encoded primitive (see
+/// `types.zig::decodeStreamFutureInner`).
+///
+/// To preserve compatibility with the hand-crafted test fixtures from
+/// #478 sub-PR 3 — which pass an *element* typeidx directly — this helper
+/// falls back to `abi.sizeOfType(.type_idx = type_idx)` when the typeidx
+/// does NOT resolve to a wrapping stream/future deftype.
+fn streamFutureElemSize(reg: TypeRegistry, type_idx: u32) u32 {
+    if (reg.resolve(ctypes.ValType{ .type_idx = type_idx })) |td| {
+        switch (td) {
+            .val => |v| switch (v) {
+                .stream => |inner| return decodeAndSize(reg, inner),
+                .future => |inner| return decodeAndSize(reg, inner),
+                else => {},
+            },
+            else => {},
+        }
+    }
+    // Test-fixture / element-typeidx fallback path.
+    return abi.sizeOfType(reg, ctypes.ValType{ .type_idx = type_idx });
+}
+
+fn decodeAndSize(reg: TypeRegistry, inner: u32) u32 {
+    switch (ctypes.decodeStreamFutureInner(inner)) {
+        .empty => return 0,
+        .primitive => |prim| return abi.sizeOfType(reg, prim),
+        .typeidx => |idx| return abi.sizeOfType(reg, ctypes.ValType{ .type_idx = idx }),
+    }
+}
+
 pub fn dispatchCanonBuiltin(
     comp_inst: *ComponentInstance,
     canon: ctypes.Canon,
@@ -971,18 +1008,21 @@ fn dispatchAsyncCanon(
             const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
 
             const s = comp_inst.streams.getPtr(handle) orelse {
-                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                // Unknown handle ⇒ treat as "other end gone" so wit-bindgen
+                // surfaces `ReturnCode::Dropped(0)` rather than an unknown
+                // sentinel that would trap.
+                env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
                     return error.StackOverflow;
                 return;
             };
 
             const registry = TypeRegistry.init(comp_inst.component);
-            const elem_size = abi.sizeOfType(registry, ctypes.ValType{ .type_idx = info.type_idx });
+            const elem_size = streamFutureElemSize(registry, info.type_idx);
             if (elem_size == 0) return error.LowerError;
 
             // Zero-length read: synchronous no-op completion.
             if (max_count == 0) {
-                env.pushI32(@bitCast(async_canon.packStatus(.returned, 0))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
             }
@@ -1033,21 +1073,52 @@ fn dispatchAsyncCanon(
                     s.buffer.items[take_bytes..],
                 );
                 s.buffer.items.len -= take_bytes;
-                env.pushI32(@bitCast(async_canon.packStatus(.returned, take))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, take))) catch
                     return error.StackOverflow;
                 return;
             }
 
-            // Writer dropped and buffer drained → cancelled (EOF).
+            // Writer dropped and buffer drained → reader observes the
+            // drop with zero additional elements transferred.
             if (s.write_closed) {
-                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
                     return error.StackOverflow;
                 return;
             }
 
-            // No data yet — park.
+            // Host-attached source (#537): the host installed a
+            // synchronous producer callback (e.g.
+            // `wasi:cli/stdin.read-via-stream`). Read directly into the
+            // guest's destination buffer instead of parking.
+            if (s.host_handler) |h| if (h.on_read) |reader| {
+                const max_bytes = max_count * elem_size;
+                const dst = comp_inst.writableGuestBytes(guest_ptr, max_bytes) orelse
+                    return error.MemoryNotAvailable;
+                const got = reader(h.ctx, dst);
+                if (got < 0) {
+                    env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
+                        return error.StackOverflow;
+                    return;
+                }
+                if (got == 0) {
+                    // EOF — flag write_closed so subsequent reads
+                    // observe the drop without re-invoking the host.
+                    s.write_closed = true;
+                    env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
+                        return error.StackOverflow;
+                    return;
+                }
+                const got_count: u32 = @as(u32, @intCast(got)) / elem_size;
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, got_count))) catch
+                    return error.StackOverflow;
+                return;
+            };
+
+            // No data yet — park; signal BLOCKED (post-#541) so the
+            // guest's `WaitableOperation` waits for the completion
+            // callback rather than treating us as cancelled.
             s.pending_read = .{ .guest_ptr = guest_ptr, .max_count = max_count };
-            env.pushI32(@bitCast(async_canon.packStatus(.starting, 0))) catch
+            env.pushI32(@bitCast(async_canon.BLOCKED_STATUS)) catch
                 return error.StackOverflow;
         },
         .stream_write => |info| {
@@ -1058,25 +1129,25 @@ fn dispatchAsyncCanon(
             const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
 
             const s = comp_inst.streams.getPtr(handle) orelse {
-                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
                     return error.StackOverflow;
                 return;
             };
 
-            // Reader end already dropped → writer is cancelled.
+            // Reader end already dropped → writer observes the drop.
             if (s.read_closed) {
-                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
                     return error.StackOverflow;
                 return;
             }
 
             const registry = TypeRegistry.init(comp_inst.component);
-            const elem_size = abi.sizeOfType(registry, ctypes.ValType{ .type_idx = info.type_idx });
+            const elem_size = streamFutureElemSize(registry, info.type_idx);
             if (elem_size == 0) return error.LowerError;
 
             // Zero-length write: synchronous no-op completion.
             if (count == 0) {
-                env.pushI32(@bitCast(async_canon.packStatus(.returned, 0))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
             }
@@ -1084,6 +1155,23 @@ fn dispatchAsyncCanon(
             const byte_len: u32 = elem_size * count;
             const src = comp_inst.readGuestBytes(guest_ptr, byte_len) orelse
                 return error.MemoryNotAvailable;
+
+            // Host-attached sink (#537): the host installed a synchronous
+            // drain callback (e.g. `wasi:cli/stdout.write-via-stream`).
+            // Forward directly to the sink instead of buffering — this is
+            // what keeps WAMR's single-threaded model in sync with guests
+            // that use `futures::join!` to interleave a host I/O await
+            // with a writer task.
+            if (s.host_handler) |h| if (h.on_write) |writer| {
+                if (!writer(h.ctx, src)) {
+                    env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
+                        return error.StackOverflow;
+                    return;
+                }
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, count))) catch
+                    return error.StackOverflow;
+                return;
+            };
 
             // Reader parked first: fulfil it directly (no buffering).
             if (s.pending_read) |pr| {
@@ -1103,7 +1191,7 @@ fn dispatchAsyncCanon(
                 s.pending_read = null;
                 if (s.waitable_set) |ws| if (s.read_waitable_idx) |idx|
                     ws.setReady(idx, allocator);
-                env.pushI32(@bitCast(async_canon.packStatus(.returned, transfer_count))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, transfer_count))) catch
                     return error.StackOverflow;
                 return;
             }
@@ -1118,13 +1206,13 @@ fn dispatchAsyncCanon(
                     const action = cb(drv.context, s, src, comp_inst.allocator);
                     switch (action) {
                         .progressed => {
-                            env.pushI32(@bitCast(async_canon.packStatus(.returned, count))) catch
+                            env.pushI32(@bitCast(async_canon.packStatus(.completed, count))) catch
                                 return error.StackOverflow;
                             return;
                         },
                         .eof, .err => {
                             s.read_closed = true;
-                            env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                            env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
                                 return error.StackOverflow;
                             return;
                         },
@@ -1142,7 +1230,7 @@ fn dispatchAsyncCanon(
                 return error.OutOfMemory;
             if (s.waitable_set) |ws| if (s.read_waitable_idx) |idx|
                 ws.setReady(idx, allocator);
-            env.pushI32(@bitCast(async_canon.packStatus(.returned, count))) catch
+            env.pushI32(@bitCast(async_canon.packStatus(.completed, count))) catch
                 return error.StackOverflow;
         },
         .stream_cancel_read => |info| {
@@ -1178,6 +1266,8 @@ fn dispatchAsyncCanon(
                 if (s.waitable_set) |ws| if (s.write_waitable_idx) |idx|
                     ws.setReady(idx, allocator);
                 if (s.read_closed and s.write_closed) {
+                    if (s.host_handler) |h| if (h.on_destroy) |cb|
+                        cb(h.ctx);
                     s.deinit(comp_inst.allocator);
                     _ = comp_inst.streams.remove(handle);
                 }
@@ -1188,10 +1278,24 @@ fn dispatchAsyncCanon(
             const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
             if (comp_inst.streams.getPtr(handle)) |s| {
                 s.write_closed = true;
+                // Notify any host-attached sink that the guest has
+                // closed its writer end (#537). The host handler is
+                // responsible for settling its companion future.
+                if (s.host_handler) |h| if (h.on_drop_writable) |cb| {
+                    cb(h.ctx);
+                    // A host-attached sink only needs the read end open
+                    // long enough to receive synchronous `stream.write`
+                    // forwards. After the writer drops, the host is
+                    // done — close the read end so the stream entry is
+                    // freed (and `on_destroy` reclaims `ctx`).
+                    s.read_closed = true;
+                };
                 // Wake a parked reader so it can observe CANCELLED.
                 if (s.waitable_set) |ws| if (s.read_waitable_idx) |idx|
                     ws.setReady(idx, allocator);
                 if (s.read_closed and s.write_closed) {
+                    if (s.host_handler) |h| if (h.on_destroy) |cb|
+                        cb(h.ctx);
                     s.deinit(comp_inst.allocator);
                     _ = comp_inst.streams.remove(handle);
                 }
@@ -1214,7 +1318,7 @@ fn dispatchAsyncCanon(
             const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
 
             const fut = comp_inst.futures.getPtr(handle) orelse {
-                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
                     return error.StackOverflow;
                 return;
             };
@@ -1226,14 +1330,15 @@ fn dispatchAsyncCanon(
             // the writer-dropped check below so a host-completed unit
             // future is not mis-reported as cancelled.
             if (fut.state == .ready and fut.payload == null) {
-                env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
             }
 
-            // Writer dropped without ever delivering a value → cancelled.
+            // Writer dropped without ever delivering a value → DROPPED
+            // (post-#541 spec).
             if (fut.write_closed and fut.payload == null) {
-                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
                     return error.StackOverflow;
                 return;
             }
@@ -1241,13 +1346,13 @@ fn dispatchAsyncCanon(
             // Unit-type (`future<()>`) fast-path (#483): a `wait-for` /
             // `wait-until` timer fired and set `state = .ready` with no
             // payload — there are zero bytes to copy. Distinct from the
-            // writer-dropped cancelled case above because `write_closed`
+            // writer-dropped case above because `write_closed`
             // is false here. `count = 1` reports one unit element.
             if (fut.state == .ready and fut.payload == null and !fut.write_closed) {
                 fut.state = .closed;
                 if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
                     ws.setReady(idx, allocator);
-                env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
             }
@@ -1262,7 +1367,7 @@ fn dispatchAsyncCanon(
                 fut.state = .ready;
                 if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
                     ws.setReady(idx, allocator);
-                env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
             }
@@ -1272,7 +1377,7 @@ fn dispatchAsyncCanon(
             // ptr here.
             _ = info;
             fut.pending_read = .{ .guest_ptr = guest_ptr };
-            env.pushI32(@bitCast(async_canon.packStatus(.starting, 0))) catch
+            env.pushI32(@bitCast(async_canon.BLOCKED_STATUS)) catch
                 return error.StackOverflow;
         },
         .future_write => |info| {
@@ -1281,28 +1386,29 @@ fn dispatchAsyncCanon(
             const handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
 
             const fut = comp_inst.futures.getPtr(handle) orelse {
-                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
                     return error.StackOverflow;
                 return;
             };
 
-            // Reader already dropped → writer is cancelled.
+            // Reader already dropped → writer observes the drop.
             if (fut.read_closed) {
-                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
                     return error.StackOverflow;
                 return;
             }
 
-            // Already buffered (double-write); reject with cancelled. Spec
-            // forbids two writes on a one-shot future.
+            // Already buffered (double-write); reject. Spec forbids two
+            // writes on a one-shot future — surface as DROPPED so the
+            // guest's WaitableOperation observes the rejection.
             if (fut.payload != null) {
-                env.pushI32(@bitCast(async_canon.packStatus(.cancelled, 0))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.dropped, 0))) catch
                     return error.StackOverflow;
                 return;
             }
 
             const registry = TypeRegistry.init(comp_inst.component);
-            const elem_size = abi.sizeOfType(registry, ctypes.ValType{ .type_idx = info.type_idx });
+            const elem_size = streamFutureElemSize(registry, info.type_idx);
             if (elem_size == 0) return error.LowerError;
 
             const src = comp_inst.readGuestBytes(guest_ptr, elem_size) orelse
@@ -1318,7 +1424,7 @@ fn dispatchAsyncCanon(
                 fut.state = .ready;
                 if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
                     ws.setReady(idx, allocator);
-                env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
             }
@@ -1332,7 +1438,7 @@ fn dispatchAsyncCanon(
             fut.state = .ready;
             if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
                 ws.setReady(idx, allocator);
-            env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+            env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                 return error.StackOverflow;
         },
         .future_cancel_read => |info| {
@@ -1344,9 +1450,9 @@ fn dispatchAsyncCanon(
                 return;
             };
             // If a value was already delivered before cancel arrived,
-            // surface RETURNED so the caller still observes the transfer.
+            // surface COMPLETED so the caller still observes the transfer.
             if (fut.state == .ready and fut.payload == null) {
-                env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
             }
@@ -1363,9 +1469,9 @@ fn dispatchAsyncCanon(
                 return;
             };
             // If the reader already consumed the buffered payload, the
-            // write completed before cancel; report RETURNED.
+            // write completed before cancel; report COMPLETED.
             if (fut.state == .ready and fut.payload == null and fut.pending_read == null) {
-                env.pushI32(@bitCast(async_canon.packStatus(.returned, 1))) catch
+                env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
             }
@@ -1488,8 +1594,8 @@ fn dispatchAsyncCanon(
             // guest-memory bridging we can't honour that contract — pop
             // arguments and push a zero status to keep the core stack
             // balanced for the conformance "load + don't crash" target.
-            _ = env.popI32() catch return error.StackUnderflow; // ws handle
             _ = env.popI32() catch return error.StackUnderflow; // out ptr
+            _ = env.popI32() catch return error.StackUnderflow; // ws handle
             env.pushI32(0) catch return error.StackOverflow;
         },
 
@@ -2622,7 +2728,7 @@ test "future.write then future.read: round-trips a u32" {
         testing.allocator,
     );
     const write_status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.returned, 1), write_status);
+    try testing.expectEqual(async_canon.packStatus(.completed, 0), write_status);
     try testing.expect(inst.futures.getPtr(handle).?.payload != null);
 
     // Issue future.read — should copy buffered bytes into dst.
@@ -2636,7 +2742,7 @@ test "future.write then future.read: round-trips a u32" {
         testing.allocator,
     );
     const read_status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.returned, 1), read_status);
+    try testing.expectEqual(async_canon.packStatus(.completed, 0), read_status);
 
     const dst_bytes = inst.writableGuestBytes(dst_ptr, 4).?;
     try testing.expectEqual(@as(u32, 0xDEAD_BEEF), std.mem.readInt(u32, dst_bytes[0..4], .little));
@@ -2695,7 +2801,7 @@ test "future.read parks then future.write wakes a waitable" {
         testing.allocator,
     );
     const read_status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.starting, 0), read_status);
+    try testing.expectEqual(async_canon.BLOCKED_STATUS, read_status);
     try testing.expectEqual(@as(u32, dst_ptr), inst.futures.getPtr(handle).?.pending_read.?.guest_ptr);
 
     // Writer arrives — copies straight into the parked dst, returns RETURNED.
@@ -2709,7 +2815,7 @@ test "future.read parks then future.write wakes a waitable" {
         testing.allocator,
     );
     const write_status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.returned, 1), write_status);
+    try testing.expectEqual(async_canon.packStatus(.completed, 0), write_status);
 
     // Destination memory updated, payload not buffered, waitable woken.
     const dst_bytes = inst.writableGuestBytes(dst_ptr, 4).?;
@@ -2770,7 +2876,7 @@ test "future.cancel-read on empty future returns CANCELLED" {
     try testing.expect(inst.futures.getPtr(handle).?.pending_read == null);
 }
 
-test "future.drop-writable while reader parked: subsequent read is CANCELLED" {
+test "future.drop-writable while reader parked: subsequent read is DROPPED" {
     const testing = std.testing;
     const core_types_mod = @import("../runtime/common/types.zig");
     const inst_mod_core = @import("../runtime/interpreter/instance.zig");
@@ -2833,7 +2939,7 @@ test "future.drop-writable while reader parked: subsequent read is CANCELLED" {
         testing.allocator,
     );
     const status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.cancelled, 0), status);
+    try testing.expectEqual(async_canon.packStatus(.dropped, 0), status);
 }
 
 test "future.drop both ends: table entry is freed" {
@@ -3012,7 +3118,7 @@ test "stream.write then stream.read: round-trips 3×u32" {
         testing.allocator,
     );
     const write_status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.returned, 3), write_status);
+    try testing.expectEqual(async_canon.packStatus(.completed, 3), write_status);
     try testing.expectEqual(@as(usize, 12), inst.streams.getPtr(handle).?.buffer.items.len);
 
     // stream.read with max_count=3 — drains the FIFO.
@@ -3027,7 +3133,7 @@ test "stream.write then stream.read: round-trips 3×u32" {
         testing.allocator,
     );
     const read_status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.returned, 3), read_status);
+    try testing.expectEqual(async_canon.packStatus(.completed, 3), read_status);
 
     const dst_bytes = inst.writableGuestBytes(dst_ptr, 12).?;
     try testing.expectEqual(@as(u32, 0x1111_1111), std.mem.readInt(u32, dst_bytes[0..4], .little));
@@ -3088,7 +3194,7 @@ test "stream.read parks; stream.write delivers and wakes waitable" {
         testing.allocator,
     );
     const read_status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.starting, 0), read_status);
+    try testing.expectEqual(async_canon.BLOCKED_STATUS, read_status);
     try testing.expectEqual(@as(u32, dst_ptr), inst.streams.getPtr(handle).?.pending_read.?.guest_ptr);
     try testing.expectEqual(@as(u32, 2), inst.streams.getPtr(handle).?.pending_read.?.max_count);
 
@@ -3104,7 +3210,7 @@ test "stream.read parks; stream.write delivers and wakes waitable" {
         testing.allocator,
     );
     const write_status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.returned, 2), write_status);
+    try testing.expectEqual(async_canon.packStatus(.completed, 2), write_status);
 
     const dst_bytes = inst.writableGuestBytes(dst_ptr, 8).?;
     try testing.expectEqual(@as(u32, 0xAAAA_AAAA), std.mem.readInt(u32, dst_bytes[0..4], .little));
@@ -3171,7 +3277,7 @@ test "stream.write count > pending reader max: extra bytes buffer for next read"
         testing.allocator,
     );
     const write_status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.returned, 1), write_status);
+    try testing.expectEqual(async_canon.packStatus(.completed, 1), write_status);
 
     // Reader got the first element; remaining 2 elements (8 bytes)
     // sit in the FIFO awaiting the next reader.
@@ -3193,7 +3299,7 @@ test "stream.write count > pending reader max: extra bytes buffer for next read"
         testing.allocator,
     );
     const read2_status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.returned, 2), read2_status);
+    try testing.expectEqual(async_canon.packStatus(.completed, 2), read2_status);
 
     const dst2_bytes = inst.writableGuestBytes(dst2_ptr, 8).?;
     try testing.expectEqual(@as(u32, 0xAAAA_0002), std.mem.readInt(u32, dst2_bytes[0..4], .little));
@@ -3252,7 +3358,7 @@ test "stream.cancel-read on parked reader returns CANCELLED and clears slot" {
     try testing.expect(inst.streams.getPtr(handle).?.pending_read == null);
 }
 
-test "stream.drop-writable while buffer drained: subsequent read returns CANCELLED (EOF)" {
+test "stream.drop-writable while buffer drained: subsequent read returns DROPPED (EOF)" {
     const testing = std.testing;
     const core_types_mod = @import("../runtime/common/types.zig");
     const inst_mod_core = @import("../runtime/interpreter/instance.zig");
@@ -3320,7 +3426,7 @@ test "stream.drop-writable while buffer drained: subsequent read returns CANCELL
     try testing.expectEqual(@as(u32, 1), inst.streams.count());
     try testing.expect(inst.streams.getPtr(r_idx).?.write_closed);
 
-    // A subsequent read observes EOF as CANCELLED.
+    // A subsequent read observes EOF as DROPPED.
     try env.pushI32(@bitCast(r_idx));
     try env.pushI32(@bitCast(dst_ptr));
     try env.pushI32(@bitCast(@as(u32, 1)));
@@ -3332,7 +3438,7 @@ test "stream.drop-writable while buffer drained: subsequent read returns CANCELL
         testing.allocator,
     );
     const status: u32 = @bitCast(try env.popI32());
-    try testing.expectEqual(async_canon.packStatus(.cancelled, 0), status);
+    try testing.expectEqual(async_canon.packStatus(.dropped, 0), status);
 }
 
 test "dispatchCanonBuiltin: error-context.new + drop round-trip" {

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -918,19 +918,45 @@ fn readValType(reader: *BinaryReader) LoadError!ctypes.ValType {
     };
 }
 
-/// Read `(stream|future) t?` per defvaltype 0x66/0x65. Sub-PR 3 of #478
-/// accepts only the `t?` = present form (`0x01 valtype`); the empty
-/// form is rejected with `InvalidEncoding` until a follow-up wires
-/// payload-less streams/futures. The inner valtype must be a typeidx —
-/// the host-side `async_mod.{Future,AsyncStream}` only carries `u32`
-/// values today, so primitive-only payloads suffice but aren't yet
-/// modelled in the IR.
+/// Read `(stream|future) t?` per defvaltype 0x66/0x65.
+///
+/// Three legal encodings:
+///   - `0x00`             → empty form: `(stream)` / `(future)`. Stored
+///     with payload `STREAM_FUTURE_EMPTY`.
+///   - `0x01 <typeidx>`   → `(stream T)` / `(future T)` where T is a
+///     component type-indexspace entry. Stored as the raw typeidx.
+///   - `0x01 <primvaltype>` → `(stream p)` / `(future p)` where p is a
+///     primitive value type (e.g. `u8`). Stored with payload
+///     `encodeStreamFuturePrimitiveByte(...)`. Required to load real
+///     wasm32-wasip3 components emitted by wit-bindgen — `wasi:cli` 0.3
+///     declares `stream<u8>` directly in the type section.
 fn readPayloadedValType(reader: *BinaryReader, comptime kind: enum { future, stream }) LoadError!ctypes.ValType {
     const present = try reader.readByte();
+    if (present == 0x00) {
+        return switch (kind) {
+            .future => .{ .future = ctypes.STREAM_FUTURE_EMPTY },
+            .stream => .{ .stream = ctypes.STREAM_FUTURE_EMPTY },
+        };
+    }
     if (present != 0x01) return error.InvalidEncoding;
     const inner = try readValType(reader);
-    const idx = switch (inner) {
+    const idx: u32 = switch (inner) {
         .type_idx => |i| i,
+        // Primitive payloads — encode as a sentinel so downstream code
+        // can recover the original primitive via `decodeStreamFutureInner`.
+        .bool => ctypes.encodeStreamFuturePrimitiveByte(0x7F),
+        .s8 => ctypes.encodeStreamFuturePrimitiveByte(0x7E),
+        .u8 => ctypes.encodeStreamFuturePrimitiveByte(0x7D),
+        .s16 => ctypes.encodeStreamFuturePrimitiveByte(0x7C),
+        .u16 => ctypes.encodeStreamFuturePrimitiveByte(0x7B),
+        .s32 => ctypes.encodeStreamFuturePrimitiveByte(0x7A),
+        .u32 => ctypes.encodeStreamFuturePrimitiveByte(0x79),
+        .s64 => ctypes.encodeStreamFuturePrimitiveByte(0x78),
+        .u64 => ctypes.encodeStreamFuturePrimitiveByte(0x77),
+        .f32 => ctypes.encodeStreamFuturePrimitiveByte(0x76),
+        .f64 => ctypes.encodeStreamFuturePrimitiveByte(0x75),
+        .char => ctypes.encodeStreamFuturePrimitiveByte(0x74),
+        .string => ctypes.encodeStreamFuturePrimitiveByte(0x73),
         else => return error.InvalidEncoding,
     };
     return switch (kind) {
@@ -1384,12 +1410,17 @@ test "readValType: error-context (0x64)" {
     try std.testing.expect(v == .error_context);
 }
 
-test "readValType: future<u32>" {
+test "readValType: future<u32> primitive payload" {
     // 0x65 0x01 0x79 (future + present + u32 primvaltype). Inner u32 is
-    // a primvaltype, so it lands as `.u32` not `.type_idx`; sub-PR 3
-    // only accepts the typeidx form so this is `error.InvalidEncoding`.
+    // a primvaltype; we encode it via the sentinel scheme so downstream
+    // code can recover the primitive ValType. See loader.zig
+    // `readPayloadedValType` for the encoding.
     var reader = BinaryReader{ .data = &[_]u8{ 0x65, 0x01, 0x79 } };
-    try std.testing.expectError(error.InvalidEncoding, readValType(&reader));
+    const v = try readValType(&reader);
+    try std.testing.expect(v == .future);
+    const decoded = ctypes.decodeStreamFutureInner(v.future);
+    try std.testing.expect(decoded == .primitive);
+    try std.testing.expect(decoded.primitive == .u32);
 }
 
 test "readValType: stream with typeidx payload" {
@@ -1398,6 +1429,9 @@ test "readValType: stream with typeidx payload" {
     const v = try readValType(&reader);
     try std.testing.expect(v == .stream);
     try std.testing.expectEqual(@as(u32, 3), v.stream);
+    const decoded = ctypes.decodeStreamFutureInner(v.stream);
+    try std.testing.expect(decoded == .typeidx);
+    try std.testing.expectEqual(@as(u32, 3), decoded.typeidx);
 }
 
 test "readValType: future with typeidx payload" {
@@ -1407,9 +1441,34 @@ test "readValType: future with typeidx payload" {
     try std.testing.expectEqual(@as(u32, 5), v.future);
 }
 
-test "readValType: stream rejects empty payload (sub-PR 3 scope)" {
+test "readValType: stream<u8> primitive payload (#537)" {
+    // wit-bindgen emits `stream<u8>` directly in the type section for
+    // wasi:cli@0.3 — see cli-stdio.wasm fixture. The primvaltype byte
+    // tag for u8 is 0x7D; we encode via the sentinel scheme.
+    var reader = BinaryReader{ .data = &[_]u8{ 0x66, 0x01, 0x7D } };
+    const v = try readValType(&reader);
+    try std.testing.expect(v == .stream);
+    const decoded = ctypes.decodeStreamFutureInner(v.stream);
+    try std.testing.expect(decoded == .primitive);
+    try std.testing.expect(decoded.primitive == .u8);
+}
+
+test "readValType: stream empty form (#537)" {
+    // `(stream)` with no element — encoded as `0x66 0x00`. Required by
+    // some pure-signaling stream uses.
     var reader = BinaryReader{ .data = &[_]u8{ 0x66, 0x00 } };
-    try std.testing.expectError(error.InvalidEncoding, readValType(&reader));
+    const v = try readValType(&reader);
+    try std.testing.expect(v == .stream);
+    const decoded = ctypes.decodeStreamFutureInner(v.stream);
+    try std.testing.expect(decoded == .empty);
+}
+
+test "readValType: future empty form (#537)" {
+    var reader = BinaryReader{ .data = &[_]u8{ 0x65, 0x00 } };
+    const v = try readValType(&reader);
+    try std.testing.expect(v == .future);
+    const decoded = ctypes.decodeStreamFutureInner(v.future);
+    try std.testing.expect(decoded == .empty);
 }
 
 test "parseCanon: subtask.cancel async?=0x01" {

--- a/src/component/types.zig
+++ b/src/component/types.zig
@@ -45,17 +45,80 @@ pub const ValType = union(enum) {
     //   0x64                       => error-context
     //   0x65 t?:<valtype>?         => (future t?)
     //   0x66 t?:<valtype>?         => (stream t?)
-    // Sub-PR 3 of #478 only accepts the typeidx-carrying form; the
-    // payload-less spelling (`0x65 0x00` / `0x66 0x00`) is rejected at
-    // load with `error.InvalidEncoding` — Wasmtime's tests don't emit it
-    // either, and supporting it cleanly requires a payload variant.
+    // The `u32` field encodes the inner element as either:
+    //   - a real typeidx (when bit 31 is clear), or
+    //   - a sentinel of the form `STREAM_FUTURE_PRIM_FLAG | <primvaltype byte tag>`
+    //     for primitive inner payloads (bit 31 set; low byte is the spec's
+    //     primvaltype byte tag, e.g. 0x7D for `u8`). The bare
+    //     `STREAM_FUTURE_PRIM_FLAG` (low byte 0) represents the empty
+    //     form `0x66 0x00` / `0x65 0x00`.
+    //
+    // Decode via `decodeStreamFutureInner` to recover a `ValType`.
     error_context,
-    future: u32, // typeidx of payload element
-    stream: u32, // typeidx of payload element
+    future: u32,
+    stream: u32,
 
     /// Type index reference (for recursive/named types).
     type_idx: u32,
 };
+
+/// Top-bit sentinel that marks `ValType.stream` / `ValType.future` as
+/// carrying a primitive (or empty) payload rather than a real component
+/// type-indexspace typeidx. The low byte (when set) is the spec's
+/// primvaltype byte tag from the component-model Binary.md valtype
+/// encoding. See `decodeStreamFutureInner` for the inverse mapping.
+pub const STREAM_FUTURE_PRIM_FLAG: u32 = 0x8000_0000;
+
+/// Sentinel marking the empty `(stream)` / `(future)` form — no inner
+/// element type.
+pub const STREAM_FUTURE_EMPTY: u32 = STREAM_FUTURE_PRIM_FLAG;
+
+/// Encode a primvaltype byte tag (e.g. 0x7D for `u8`) into the
+/// `ValType.stream` / `ValType.future` `u32` payload.
+pub fn encodeStreamFuturePrimitiveByte(byte_tag: u8) u32 {
+    return STREAM_FUTURE_PRIM_FLAG | @as(u32, byte_tag);
+}
+
+/// Result of decoding a `ValType.stream` / `ValType.future` payload:
+/// either the empty form (no element), a primitive ValType, or a real
+/// typeidx. `from_typeidx` is `true` iff `value` is a `.type_idx` —
+/// callers that need to follow type-indexspace resolution can branch
+/// on this without re-deconstructing.
+pub const StreamFutureInner = union(enum) {
+    empty,
+    /// Primitive element type — already lifted to a `ValType` variant
+    /// (e.g. `.u8`, `.string`).
+    primitive: ValType,
+    /// Typeidx in the component type indexspace.
+    typeidx: u32,
+};
+
+/// Decode a `ValType.stream` / `ValType.future` `u32` payload back to
+/// its semantic form.
+pub fn decodeStreamFutureInner(payload: u32) StreamFutureInner {
+    if ((payload & STREAM_FUTURE_PRIM_FLAG) == 0) {
+        return .{ .typeidx = payload };
+    }
+    const byte_tag: u8 = @intCast(payload & 0xFF);
+    if (byte_tag == 0) return .empty;
+    return .{ .primitive = switch (byte_tag) {
+        0x7F => ValType.bool,
+        0x7E => ValType.s8,
+        0x7D => ValType.u8,
+        0x7C => ValType.s16,
+        0x7B => ValType.u16,
+        0x7A => ValType.s32,
+        0x79 => ValType.u32,
+        0x78 => ValType.s64,
+        0x77 => ValType.u64,
+        0x76 => ValType.f32,
+        0x75 => ValType.f64,
+        0x74 => ValType.char,
+        0x73 => ValType.string,
+        // Unknown byte tag — fall back to typeidx (best-effort).
+        else => return .{ .typeidx = payload },
+    } };
+}
 
 // ── Compound type definitions ───────────────────────────────────────────────
 

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -2946,28 +2946,26 @@ pub const WasiCliAdapter = struct {
         if (results.len == 0) return error.InvalidArgs;
 
         // 1. Allocate a stream<u8> handle in the per-instance table.
+        //    Crucially, we do NOT eagerly drain stdin here (#537) —
+        //    the test harness writes to stdin AFTER `run` starts, and
+        //    eager `posix.read` on a still-open pipe would deadlock.
+        //    Instead we install a host-attached `on_read` handler on
+        //    the stream: bytes are pulled from `self.stdin` lazily,
+        //    once per guest `stream.read`.
         const stream_handle = ci.allocAsyncHandle();
+
+        const ctx = self.allocator.create(ReadViaStreamCtx) catch
+            return error.OutOfMemory;
+        ctx.* = .{ .adapter = self };
+
         var stream_entry = async_mod.AsyncStream{};
-        // Drain stdin eagerly into the stream FIFO using the
-        // cross-platform `InputStream.read` (which dispatches by
-        // source variant — buffer/fd/host_file/tcp_stream/closed —
-        // and works on Windows where `std.posix.read` doesn't compile
-        // for raw fd_t values).
-        var tmp: [4096]u8 = undefined;
-        drain: while (true) {
-            switch (self.stdin.read(&tmp)) {
-                .ok => |n| {
-                    if (n == 0) break :drain;
-                    stream_entry.buffer.appendSlice(self.allocator, tmp[0..n]) catch {
-                        stream_entry.deinit(self.allocator);
-                        return error.OutOfMemory;
-                    };
-                },
-                .closed, .err => break :drain,
-            }
-        }
-        stream_entry.write_closed = true;
+        stream_entry.host_handler = async_mod.HostStreamHandler{
+            .on_read = &readViaStreamOnRead,
+            .on_destroy = &readViaStreamOnDestroy,
+            .ctx = ctx,
+        };
         ci.streams.put(self.allocator, stream_handle, stream_entry) catch {
+            self.allocator.destroy(ctx);
             stream_entry.deinit(self.allocator);
             return error.OutOfMemory;
         };
@@ -2990,6 +2988,28 @@ pub const WasiCliAdapter = struct {
         tuple[0] = .{ .handle = stream_handle };
         tuple[1] = .{ .handle = future_handle };
         results[0] = .{ .tuple_val = tuple };
+    }
+
+    const ReadViaStreamCtx = struct {
+        adapter: *WasiCliAdapter,
+    };
+
+    /// `on_read` callback for `wasi:cli/stdin.read-via-stream` (#537).
+    /// Synchronously reads from the host's stdin into the guest's
+    /// destination buffer. Blocks on pipes; returns 0 on EOF; -1 on
+    /// error.
+    fn readViaStreamOnRead(ctx_opaque: ?*anyopaque, dst: []u8) i32 {
+        const c: *ReadViaStreamCtx = @ptrCast(@alignCast(ctx_opaque.?));
+        switch (c.adapter.stdin.read(dst)) {
+            .ok => |n| return @intCast(n),
+            .closed => return 0,
+            .err => return -1,
+        }
+    }
+
+    fn readViaStreamOnDestroy(ctx_opaque: ?*anyopaque) void {
+        const c: *ReadViaStreamCtx = @ptrCast(@alignCast(ctx_opaque.?));
+        c.adapter.allocator.destroy(c);
     }
 
     /// `wasi:cli/stdout@0.3.x.write-via-stream:
@@ -3019,9 +3039,16 @@ pub const WasiCliAdapter = struct {
     }
 
     /// Common body for `stdout.write-via-stream` / `stderr.write-via-stream`.
-    /// Drains any bytes currently buffered in the guest's `stream<u8>`
-    /// into the captured/host sink, marks the stream's read end closed
-    /// (we've consumed it), and returns a settled-ok future handle.
+    /// Installs a host-attached sink on the guest's `stream<u8>` so every
+    /// subsequent `stream.write` is forwarded synchronously to `target`.
+    /// Returns an open `future<result<_,error-code>>` that settles to
+    /// Ok when the guest finally calls `stream.drop-writable` (#537).
+    ///
+    /// WAMR has no async scheduler, so we can't asynchronously "pump"
+    /// the stream — we instead rely on the executor's `stream.write`
+    /// arm forwarding directly via `AsyncStream.host_handler`. This
+    /// mirrors what a real async runtime would do with a long-lived
+    /// `stream.read` parked on the host side.
     fn writeViaStreamImplP3(
         self: *WasiCliAdapter,
         target: *streams.OutputStream,
@@ -3036,26 +3063,103 @@ pub const WasiCliAdapter = struct {
             else => return error.InvalidArgs,
         };
 
+        // Allocate the companion future first so we can capture its
+        // handle inside the host-handler context.
+        const future_handle = ci.allocAsyncHandle();
+        const fut_entry = async_mod.Future{ .state = .pending, .payload = null };
+        ci.futures.put(self.allocator, future_handle, fut_entry) catch
+            return error.OutOfMemory;
+
+        const ctx = self.allocator.create(WriteViaStreamCtx) catch
+            return error.OutOfMemory;
+        ctx.* = .{
+            .adapter = self,
+            .target = target,
+            .ci = ci,
+            .future_handle = future_handle,
+        };
+
         if (ci.streams.getPtr(stream_handle)) |s| {
+            // Drain any bytes already buffered (e.g. eagerly written
+            // before the host became attached).
             if (s.buffer.items.len > 0) {
                 switch (target.write(s.buffer.items, self.allocator)) {
                     .ok => {},
-                    .err, .closed => return error.IoError,
+                    .err, .closed => {
+                        self.allocator.destroy(ctx);
+                        return error.IoError;
+                    },
                 }
                 s.buffer.clearRetainingCapacity();
             }
-            s.read_closed = true;
+            // Install host handler — every future `stream.write` from
+            // the guest goes synchronously to `target`.
+            s.host_handler = async_mod.HostStreamHandler{
+                .on_write = &writeViaStreamOnWrite,
+                .on_drop_writable = &writeViaStreamOnDropWritable,
+                .on_destroy = &writeViaStreamOnDestroy,
+                .ctx = ctx,
+            };
+            // If the writer was already dropped (the synchronous "no
+            // concurrent writer" case), settle the future immediately.
+            if (s.write_closed) writeViaStreamOnDropWritable(ctx);
+        } else {
+            // Unknown stream handle — settle the future to ok so the
+            // guest's await completes without panicking.
+            writeViaStreamOnDropWritable(ctx);
         }
 
-        const future_handle = ci.allocAsyncHandle();
-        const ok_payload = self.allocator.alloc(u8, 1) catch return error.OutOfMemory;
-        ok_payload[0] = 0;
-        const fut_entry = async_mod.Future{ .state = .ready, .payload = ok_payload };
-        ci.futures.put(self.allocator, future_handle, fut_entry) catch {
-            self.allocator.free(ok_payload);
-            return error.OutOfMemory;
-        };
         results[0] = .{ .handle = future_handle };
+    }
+
+    const WriteViaStreamCtx = struct {
+        adapter: *WasiCliAdapter,
+        target: *streams.OutputStream,
+        ci: *ComponentInstance,
+        future_handle: u32,
+    };
+
+    fn writeViaStreamOnWrite(ctx_opaque: ?*anyopaque, bytes: []const u8) bool {
+        const c: *WriteViaStreamCtx = @ptrCast(@alignCast(ctx_opaque.?));
+        return switch (c.target.write(bytes, c.adapter.allocator)) {
+            .ok => true,
+            .err, .closed => false,
+        };
+    }
+
+    fn writeViaStreamOnDropWritable(ctx_opaque: ?*anyopaque) void {
+        const c: *WriteViaStreamCtx = @ptrCast(@alignCast(ctx_opaque.?));
+        if (c.ci.futures.getPtr(c.future_handle)) |fut| {
+            // Settle as `Ok(())` (discriminant 0). Allocate a 1-byte
+            // payload — `future_read` copies `buf.len` bytes into the
+            // guest's destination, and `result<_, error-code>` only
+            // requires the leading discriminant byte to lift Ok.
+            if (fut.payload == null and !fut.write_closed) {
+                if (c.adapter.allocator.alloc(u8, 1)) |buf| {
+                    buf[0] = 0;
+                    fut.payload = buf;
+                } else |_| {
+                    // Out-of-memory fallback: mark ready with no payload.
+                    // The unit-type fast-path in `future_read` handles
+                    // this by returning COMPLETED(0) — a behaviourally
+                    // equivalent ok-result lift.
+                }
+                fut.state = .ready;
+                fut.write_closed = true;
+            }
+            if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
+                ws.setReady(idx, c.adapter.allocator);
+        }
+        // NB: the ctx is NOT freed here — `stream.drop-readable` /
+        // `stream.drop-writable` fire `on_destroy` once the stream
+        // table entry is removed (both ends dropped). Freeing here
+        // would race that destructor and break the executor's drop
+        // sequence when the writer drops before the reader.
+    }
+
+    fn writeViaStreamOnDestroy(ctx_opaque: ?*anyopaque) void {
+        const c: *WriteViaStreamCtx = @ptrCast(@alignCast(ctx_opaque.?));
+        c.adapter.allocator.destroy(c);
     }
 
     fn pushPollable(self: *WasiCliAdapter, pollable: Pollable) !u32 {
@@ -24013,7 +24117,7 @@ test "populateWasiCliP3: cliExitWithCode(7) routes through P3 exit iface (#482)"
     try testing.expectEqual(@as(?u32, 7), adapter.exit_code);
 }
 
-test "populateWasiCliP3: stdinReadViaStreamP3 pre-seeds stream with stdin bytes (#482)" {
+test "populateWasiCliP3: stdinReadViaStreamP3 attaches lazy host source (#482, #537)" {
     const testing = std.testing;
     var adapter = WasiCliAdapter.init(testing.allocator);
     defer adapter.deinit();
@@ -24027,10 +24131,17 @@ test "populateWasiCliP3: stdinReadViaStreamP3 pre-seeds stream with stdin bytes 
     ci.next_async_handle = 1;
     defer {
         var sit = ci.streams.iterator();
-        while (sit.next()) |e| e.value_ptr.deinit(testing.allocator);
+        while (sit.next()) |e| {
+            // Mimic the on_destroy hook the executor fires on a fully
+            // closed stream — frees the heap-allocated host context.
+            if (e.value_ptr.host_handler) |h| if (h.on_destroy) |cb| cb(h.ctx);
+            e.value_ptr.deinit(testing.allocator);
+        }
         ci.streams.deinit(testing.allocator);
         var fit = ci.futures.iterator();
-        while (fit.next()) |e| e.value_ptr.deinit(testing.allocator);
+        while (fit.next()) |e| {
+            if (e.value_ptr.payload) |p| testing.allocator.free(p);
+        }
         ci.futures.deinit(testing.allocator);
     }
 
@@ -24044,9 +24155,19 @@ test "populateWasiCliP3: stdinReadViaStreamP3 pre-seeds stream with stdin bytes 
     const stream_h = results[0].tuple_val[0].handle;
     const future_h = results[0].tuple_val[1].handle;
 
+    // No eager drain — the buffer is empty; the host source is
+    // attached as a callback that `stream.read` invokes on demand.
     const s = ci.streams.getPtr(stream_h) orelse return error.MissingStream;
-    try testing.expectEqualStrings("hello\n", s.buffer.items);
-    try testing.expect(s.write_closed);
+    try testing.expectEqual(@as(usize, 0), s.buffer.items.len);
+    try testing.expect(s.host_handler != null);
+    try testing.expect(s.host_handler.?.on_read != null);
+
+    // Exercise the on_read callback directly — it must drain the
+    // configured host stdin into the dst buffer.
+    var dst: [16]u8 = undefined;
+    const n = s.host_handler.?.on_read.?(s.host_handler.?.ctx, &dst);
+    try testing.expectEqual(@as(i32, 6), n);
+    try testing.expectEqualStrings("hello\n", dst[0..6]);
 
     const f = ci.futures.getPtr(future_h) orelse return error.MissingFuture;
     try testing.expectEqual(async_mod.Future.State.ready, f.state);
@@ -24054,7 +24175,7 @@ test "populateWasiCliP3: stdinReadViaStreamP3 pre-seeds stream with stdin bytes 
     try testing.expectEqual(@as(u8, 0), f.payload.?[0]); // result<_,_> ok discriminant
 }
 
-test "populateWasiCliP3: writeViaStreamImplP3 drains stream into adapter.stdout (#482)" {
+test "populateWasiCliP3: writeViaStreamImplP3 drains+attaches stream sink (#482, #537)" {
     const testing = std.testing;
     var adapter = WasiCliAdapter.init(testing.allocator);
     defer adapter.deinit();
@@ -24065,14 +24186,23 @@ test "populateWasiCliP3: writeViaStreamImplP3 drains stream into adapter.stdout 
     ci.next_async_handle = 1;
     defer {
         var sit = ci.streams.iterator();
-        while (sit.next()) |e| e.value_ptr.deinit(testing.allocator);
+        while (sit.next()) |e| {
+            // Free the heap-allocated host-handler context (mirrors what
+            // `stream.drop-readable`/`drop-writable` does in the executor).
+            if (e.value_ptr.host_handler) |h| if (h.on_destroy) |cb| cb(h.ctx);
+            e.value_ptr.deinit(testing.allocator);
+        }
         ci.streams.deinit(testing.allocator);
         var fit = ci.futures.iterator();
-        while (fit.next()) |e| e.value_ptr.deinit(testing.allocator);
+        while (fit.next()) |e| {
+            if (e.value_ptr.payload) |p| testing.allocator.free(p);
+        }
         ci.futures.deinit(testing.allocator);
     }
 
-    // Pre-populate a stream with bytes the guest wrote into.
+    // Pre-populate a stream with bytes the guest already wrote into,
+    // simulating an eager write that landed before `write-via-stream`
+    // attached. Those bytes must be drained synchronously.
     const stream_h = ci.allocAsyncHandle();
     var s = async_mod.AsyncStream{};
     try s.buffer.appendSlice(testing.allocator, "world");
@@ -24082,15 +24212,106 @@ test "populateWasiCliP3: writeViaStreamImplP3 drains stream into adapter.stdout 
     var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
     try WasiCliAdapter.stdoutWriteViaStreamP3(&adapter, &ci, &args, &results, testing.allocator);
 
+    // Pre-buffered bytes drained synchronously.
     try testing.expectEqualStrings("world", adapter.getStdoutBytes());
-    const drained = ci.streams.getPtr(stream_h) orelse return error.MissingStream;
-    try testing.expectEqual(@as(usize, 0), drained.buffer.items.len);
-    try testing.expect(drained.read_closed);
+    const attached = ci.streams.getPtr(stream_h) orelse return error.MissingStream;
+    try testing.expectEqual(@as(usize, 0), attached.buffer.items.len);
+    // Host handler installed — subsequent guest `stream.write` will
+    // forward synchronously (verified separately via #537 executor tests).
+    try testing.expect(attached.host_handler != null);
 
-    // Returned future is settled-ok.
+    // Returned future is open (will settle when the guest drops the
+    // writer end, not synchronously here).
     try testing.expect(results[0] == .handle);
     const f = ci.futures.getPtr(results[0].handle) orelse return error.MissingFuture;
-    try testing.expectEqual(async_mod.Future.State.ready, f.state);
+    try testing.expectEqual(async_mod.Future.State.pending, f.state);
+}
+
+test "populateWasiCliP3: host-attached sink forwards stream.write to stdout (#537)" {
+    const testing = std.testing;
+    const dispatch = @import("executor.zig").dispatchCanonBuiltin;
+    const async_canon_mod = @import("async_canon.zig");
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+    const exec_env_mod = @import("../runtime/common/exec_env.zig");
+
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    // Bootstrap a ComponentInstance with usable guest memory + async tables.
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try exec_env_mod.ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    // Minimal component carrying one `TypeDef.val(.u8)` so the canon's
+    // `type_idx=0` resolves to a 1-byte element (matches `stream<u8>`).
+    const StreamFixture = struct {
+        var types_array = [_]ctypes_root.TypeDef{.{ .val = .u8 }};
+        var comp: ctypes_root.Component = .{
+            .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+            .components = &.{},       .instances = &.{},      .aliases = &.{},
+            .types = &.{},            .canons = &.{},         .imports = &.{},
+            .exports = &.{},
+        };
+    };
+    StreamFixture.comp.types = &StreamFixture.types_array;
+    const inst_mod = @import("instance.zig");
+    const ci = try inst_mod.instantiate(&StreamFixture.comp, testing.allocator);
+    defer ci.deinit();
+    try ci.enableTestMem(testing.allocator, 4096);
+    defer ci.disableTestMem();
+
+    // Guest allocates a stream<u8> via `stream.new`.
+    try dispatch(
+        ci,
+        .{ .async_canon = .{ .stream_new = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const handle: u32 = @truncate(@as(u64, @bitCast(try env.popI64())) >> 32);
+
+    // Host installs the write-via-stream sink.
+    const args: [1]InterfaceValue = .{.{ .handle = handle }};
+    var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+    try WasiCliAdapter.stdoutWriteViaStreamP3(&adapter, ci, &args, &results, testing.allocator);
+    const future_handle = results[0].handle;
+    try testing.expect(ci.streams.getPtr(handle).?.host_handler != null);
+
+    // Guest writes 5 bytes via `stream.write` — should forward
+    // synchronously to adapter.stdout and complete with count=5.
+    const src_ptr: u32 = 0;
+    const src_bytes = ci.writableGuestBytes(src_ptr, 5).?;
+    @memcpy(src_bytes, "hello");
+    try env.pushI32(@bitCast(handle));
+    try env.pushI32(@bitCast(src_ptr));
+    try env.pushI32(@bitCast(@as(u32, 5)));
+    try dispatch(
+        ci,
+        .{ .async_canon = .{ .stream_write = .{ .type_idx = 0, .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const write_status: u32 = @bitCast(try env.popI32());
+    try testing.expectEqual(async_canon_mod.packStatus(.completed, 5), write_status);
+    try testing.expectEqualStrings("hello", adapter.getStdoutBytes());
+
+    // Guest drops the writer end → companion future settles to ok.
+    try env.pushI32(@bitCast(handle));
+    try dispatch(
+        ci,
+        .{ .async_canon = .{ .stream_drop_writable = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const fut = ci.futures.getPtr(future_handle).?;
+    try testing.expectEqual(async_mod.Future.State.ready, fut.state);
+    try testing.expect(fut.payload != null);
+    try testing.expectEqual(@as(u8, 0), fut.payload.?[0]); // ok discriminant
 }
 
 test "populateWasiProviders: routes wasi:cli/*@0.3.x to P3 host instances (#482)" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -260,11 +260,13 @@ fn runComponent(
     var adapter = adapter_mod.WasiCliAdapter.initWithHostStdio(allocator);
     defer adapter.deinit();
 
-    // argv[0] = wasm path, rest = user args (matches wasmtime convention).
+    // argv[0] = basename of the wasm path, rest = user args. Matches
+    // the wasmtime convention (and wasi-testsuite fixtures' assumption,
+    // see wasm32-wasip3 `cli-env.rs` asserting on `"cli-env.wasm"`).
     var argv_buf = allocator.alloc([]const u8, 1 + wasm_args.len) catch
         return 1;
     defer allocator.free(argv_buf);
-    argv_buf[0] = wasm_path;
+    argv_buf[0] = std.fs.path.basename(wasm_path);
     for (wasm_args, 0..) |a, i| argv_buf[i + 1] = a;
     adapter.setArguments(argv_buf);
     adapter.setEnvironment(env_vars);

--- a/tests/wasi-p3-testsuite-skip.json
+++ b/tests/wasi-p3-testsuite-skip.json
@@ -31,11 +31,7 @@
         "filesystem-set-size":         "wasi:filesystem@0.3.0 host bindings wired in #484/#522; end-to-end run blocked on wamr P3 CLI loader — tracking #520",
         "filesystem-stat":             "wasi:filesystem@0.3.0 host bindings wired in #484/#522; end-to-end run blocked on wamr P3 CLI loader — tracking #520",
         "filesystem-unlink-errors":    "wasi:filesystem@0.3.0 host bindings wired in #484/#522; end-to-end run blocked on wamr P3 CLI loader — tracking #520",
-        "cli-env":                "wasi:cli@0.3.0 adapter not yet merged — tracking #482",
-        "cli-exit":               "wasi:cli@0.3.0 adapter not yet merged — tracking #482",
-        "cli-stdio":              "wasi:cli@0.3.0 adapter not yet merged — tracking #482",
-        "cli-stdio-roundtrip":    "wasi:cli@0.3.0 adapter not yet merged — tracking #482",
-        "run-with-err":           "wasi:cli@0.3.0 adapter not yet merged — tracking #482",
+        "cli-stdio-roundtrip":    "P3 stdio works but `futures::join!` rendezvous needs `waitable-set.{wait,poll}` event delivery + callback re-entry loop — tracking #537 follow-up",
         "monotonic-clock":        "wasi:clocks@0.3.0 routing fixed in #534; `wait-for`/`wait-until` need canon-lower-of-async-func runtime support — tracking follow-up",
         "multi-clock-wait":       "wasi:clocks@0.3.0 routing fixed in #534; needs canon-lower-of-async-func + task.cancel-aware sleep cancellation — tracking follow-up"
     }


### PR DESCRIPTION
Closes #537.

Flesh out the `wasi:cli@0.3.0` P3 adapter so 4 of the 5 cli-* fixtures
in `zig build wasi-p3-testsuite` pass end-to-end (was 2/40 → 6/40):

| Fixture                 | Status                                              |
|-------------------------|-----------------------------------------------------|
| `cli-env`               | ✅ passing                                          |
| `cli-exit`              | ✅ passing                                          |
| `cli-stdio`             | ✅ passing                                          |
| `run-with-err`          | ✅ passing                                          |
| `cli-stdio-roundtrip`   | ⏸ deferred — needs `waitable-set.{wait,poll}` event delivery + callback re-entry loop (skip-list re-targeted to a #537 follow-up) |

## What this changes

### Loader: `stream<T>` / `future<T>` with primitive payloads

Real wasm32-wasip3 components emitted by wit-bindgen 0.53 declare `(stream u8)` directly in the type section. Our `readPayloadedValType` previously rejected anything but a typeidx payload, so component load failed before any P3 binding could run.

- Accept `0x66/0x65 0x00` empty form and `0x66/0x65 0x01 <primvaltype>` via a sentinel-encoded payload (top bit of the `u32` indicates a primitive; low byte is the spec's primvaltype byte tag).
- `decodeStreamFutureInner(u32) -> StreamFutureInner` restores the semantic form (`empty` / `primitive` / `typeidx`).
- Executor `streamFutureElemSize` navigates through wrapping stream/future deftypes to get the real element size.

### Async status codes — post-#541 spec

wit-bindgen 0.53 decodes `stream.{read,write}` / `future.{read,write}` status words using the post-[WebAssembly/component-model#541](https://github.com/WebAssembly/component-model/pull/541) encoding:

`COMPLETED = 0`, `DROPPED = 1`, `CANCELLED = 2`, `BLOCKED = 0xFFFFFFFF`.

Previously WAMR used the older `starting=0 / started=1 / returned=2 / cancelled=3` encoding. The bottom 4 bits collided so a successful 13-byte read on stdout was decoded by the guest as `Cancelled(1)` and panicked. Renamed `FutureStatus` enum, switched park-and-wait to push `BLOCKED_STATUS` directly, and used `completed(0)` for one-shot `future` ops (per spec convention).

### Host-attached stream sinks/sources (`HostStreamHandler`)

P3 stdio is a `stream<u8>` (not a P2 resource handle). WAMR has no async scheduler, so the host can't asynchronously "pump" the stream. `AsyncStream.host_handler` (new) lets host bindings register direct read/write callbacks that the executor invokes synchronously from inside `stream.read` / `stream.write`:

- `on_write` — host-on-read-end: drain guest writes to a host sink (`write-via-stream` for stdout/stderr).
- `on_read` — host-on-write-end: produce bytes for guest reads (`read-via-stream` for stdin — no eager drain so the test harness can pipe stdin AFTER `run` starts).
- `on_drop_writable` — settle the companion `future<result<_, err>>` when the guest closes its writer.
- `on_destroy` — free the heap-allocated callback context.

### CLI

- `argv[0]` is now `basename(wasm_path)` (matches wasmtime + the `cli-env` fixture which asserts `"cli-env.wasm"`, not the full path).

### Skip-list

- Removes 4 `cli-*` entries from `tests/wasi-p3-testsuite-skip.json`.
- Updates the remaining `cli-stdio-roundtrip` rationale to point at a #537 follow-up.

## Tests

- `src/component/loader.zig` — 3 new tests for primitive-payload stream/future deftypes + empty-form variants.
- `src/component/wasi_cli_adapter.zig` — updated tests for the lazy stdin source + a new end-to-end test that calls `stream.write` through the executor and asserts host stdout received the bytes.

## Verification

- `zig build` clean.
- `zig build test` — 2475/2477 passing (2 unrelated test fixture skips).
- `zig build wasi-testsuite` — 72/72 P1 passing (no regression).
- `zig build wasi-p3-testsuite` — 6/40 passing (was 2/40).
- Cross-compile sweep clean for `aarch64-macos`, `x86_64-windows`, `x86_64-linux`.