### PR TITLE
feat(component): waitable-set event delivery for stream-write futures (#550)

### DIFF
--- a/src/component/async.zig
+++ b/src/component/async.zig
@@ -47,33 +47,87 @@ pub const Task = struct {
 pub const WaitableSet = struct {
     /// Registered items that can become ready.
     items: std.ArrayListUnmanaged(WaitableItem) = .empty,
-    /// Items that have become ready since the last wait/poll.
+    /// FIFO of indices that have become ready since the last
+    /// `popReadyEvent`. Used by `waitable-set.{wait,poll}` to surface
+    /// the oldest pending event to the guest. The matching `ready`
+    /// flag on the `WaitableItem` lets `register`/`setReady` avoid
+    /// double-enqueueing the same item.
     ready_queue: std.ArrayListUnmanaged(u32) = .empty, // indices into items
 
     pub const WaitableItem = struct {
         kind: Kind,
         handle: u32, // task/stream/future handle
         ready: bool = false,
+        /// Packed status word delivered as the event payload2 when this
+        /// item is surfaced by `waitable-set.{wait,poll}`. For
+        /// stream/future events this is the `packStatus(...)` value
+        /// the corresponding `{stream,future}.{read,write}` op would
+        /// return when re-issued at the time the event was fired.
+        /// For subtask events it carries the post-transition task
+        /// state. Populated by `setReady`; stale across multiple
+        /// readiness cycles only if the producer forgets to refresh.
+        code: u32 = 0,
 
         pub const Kind = enum { subtask, stream_read, stream_write, future_read, future_write };
     };
 
-    /// Register an item for waiting.
+    /// Register an item for waiting. Returns the per-set index of the
+    /// new entry, which the caller stashes on the underlying
+    /// stream/future entry so subsequent `setReady` calls can find
+    /// the right slot.
     pub fn register(self: *WaitableSet, item: WaitableItem, allocator: std.mem.Allocator) !u32 {
         const idx: u32 = @intCast(self.items.items.len);
         try self.items.append(allocator, item);
         return idx;
     }
 
-    /// Mark an item as ready (called by the runtime when a subtask completes, etc.).
-    pub fn setReady(self: *WaitableSet, idx: u32, allocator: std.mem.Allocator) void {
-        if (idx < self.items.items.len) {
-            self.items.items[idx].ready = true;
+    /// Mark an item as ready and enqueue it for the next
+    /// `popReadyEvent` / `pollReady` consumer. `code` is delivered as
+    /// the event payload2 (e.g. `packStatus(.completed, n)` for stream
+    /// / future events; task state for subtask events).
+    ///
+    /// Idempotent for already-queued items — the `ready` flag prevents
+    /// double-enqueueing — but always refreshes `code` to reflect the
+    /// most recent event payload.
+    pub fn setReady(
+        self: *WaitableSet,
+        idx: u32,
+        allocator: std.mem.Allocator,
+        code: u32,
+    ) void {
+        if (idx >= self.items.items.len) return;
+        const item = &self.items.items[idx];
+        item.code = code;
+        if (!item.ready) {
+            item.ready = true;
             self.ready_queue.append(allocator, idx) catch {};
         }
     }
 
-    /// Poll for ready items without blocking. Returns indices of ready items.
+    /// Pop the oldest ready item from the queue, clearing its `ready`
+    /// flag so a subsequent `setReady` re-enqueues it. Returns a copy
+    /// of the WaitableItem (kind/handle/code) so callers can lift the
+    /// event payload without re-indexing. `null` when no ready items
+    /// remain — the wait/poll arm signals NONE in that case.
+    pub fn popReadyEvent(self: *WaitableSet) ?WaitableItem {
+        while (self.ready_queue.items.len > 0) {
+            const idx = self.ready_queue.orderedRemove(0);
+            if (idx >= self.items.items.len) continue;
+            const item = &self.items.items[idx];
+            if (!item.ready) continue;
+            item.ready = false;
+            return item.*;
+        }
+        return null;
+    }
+
+    /// Poll for ready items without blocking. Returns the count of
+    /// ready entries, writing their `items[]` indices into `out` (up
+    /// to `out.len`). Drains the `ready_queue` of those indices.
+    ///
+    /// Kept for the smoke-tests that assert "some waitable woke" —
+    /// real event delivery goes through `popReadyEvent` so the
+    /// guest receives `(kind, handle, code)`.
     pub fn pollReady(self: *WaitableSet, out: []u32) u32 {
         var count: u32 = 0;
         for (self.items.items, 0..) |*item, i| {
@@ -85,6 +139,9 @@ pub const WaitableSet = struct {
                 item.ready = false; // consume readiness
             }
         }
+        // The ready_queue is now stale — clear it so subsequent
+        // `popReadyEvent` callers don't re-surface drained items.
+        self.ready_queue.clearRetainingCapacity();
         return count;
     }
 
@@ -131,7 +188,7 @@ pub const TaskManager = struct {
             task.return_values = values;
             // Notify waitable set
             if (task.waitable_set) |ws| {
-                ws.setReady(handle, std.heap.page_allocator);
+                ws.setReady(handle, std.heap.page_allocator, @intFromEnum(TaskState.returned));
             }
         }
     }
@@ -473,11 +530,41 @@ test "WaitableSet: register and poll" {
     const idx1 = try ws.register(.{ .kind = .subtask, .handle = 1 }, allocator);
     _ = idx0;
 
-    ws.setReady(idx1, allocator);
+    ws.setReady(idx1, allocator, 0);
     var out: [4]u32 = undefined;
     const count = ws.pollReady(&out);
     try std.testing.expectEqual(@as(u32, 1), count);
     try std.testing.expectEqual(idx1, out[0]);
+}
+
+test "WaitableSet: popReadyEvent surfaces kind/handle/code in FIFO order" {
+    const allocator = std.testing.allocator;
+    var ws = WaitableSet{};
+    defer ws.deinit(allocator);
+
+    const idx_w = try ws.register(.{ .kind = .stream_write, .handle = 7 }, allocator);
+    const idx_r = try ws.register(.{ .kind = .future_read, .handle = 9 }, allocator);
+
+    // No ready items yet.
+    try std.testing.expect(ws.popReadyEvent() == null);
+
+    // Refreshing `code` on the same item must not double-enqueue.
+    ws.setReady(idx_w, allocator, 0x40);
+    ws.setReady(idx_w, allocator, 0x42);
+    ws.setReady(idx_r, allocator, 0x10);
+
+    const first = ws.popReadyEvent().?;
+    try std.testing.expectEqual(WaitableSet.WaitableItem.Kind.stream_write, first.kind);
+    try std.testing.expectEqual(@as(u32, 7), first.handle);
+    try std.testing.expectEqual(@as(u32, 0x42), first.code);
+
+    const second = ws.popReadyEvent().?;
+    try std.testing.expectEqual(WaitableSet.WaitableItem.Kind.future_read, second.kind);
+    try std.testing.expectEqual(@as(u32, 9), second.handle);
+    try std.testing.expectEqual(@as(u32, 0x10), second.code);
+
+    // Queue drained.
+    try std.testing.expect(ws.popReadyEvent() == null);
 }
 
 test "Future: state transitions through pending/ready" {

--- a/src/component/async_canon.zig
+++ b/src/component/async_canon.zig
@@ -110,6 +110,42 @@ pub fn packStatus(status: FutureStatus, count: u32) u32 {
     return @intFromEnum(status) | (count << 4);
 }
 
+/// Event-code discriminants returned by `canon waitable-set.{wait,poll}`
+/// (Binary.md tags `0x20` / `0x21`). The numeric values match the
+/// canonical-abi.py `EventCode` enum so the guest's wit-bindgen
+/// reactor can branch on the result.
+///
+///   * `none` — no ready waitable (only legal as a `poll` outcome).
+///   * `subtask` — an async-lifted subtask transitioned to `.returned`
+///     / `.cancelled`; payload2 carries the new task state.
+///   * `stream_read` / `stream_write` — the corresponding stream end
+///     became drainable / acceptable. Payload2 carries the
+///     `packStatus(...)` the next `stream.{read,write}` would return.
+///   * `future_read` / `future_write` — the corresponding future end
+///     settled. Payload2 carries the `packStatus(...)` the next
+///     `future.{read,write}` would return.
+pub const EventCode = enum(u32) {
+    none = 0,
+    subtask = 1,
+    stream_read = 2,
+    stream_write = 3,
+    future_read = 4,
+    future_write = 5,
+};
+
+/// Map a `WaitableSet.WaitableItem.Kind` to its on-the-wire `EventCode`
+/// numeric value. Centralised so the executor's wait/poll arm and
+/// future tests stay in lockstep with the spec encoding.
+pub fn eventCodeForKind(kind: async_mod.WaitableSet.WaitableItem.Kind) u32 {
+    return @intFromEnum(@as(EventCode, switch (kind) {
+        .subtask => .subtask,
+        .stream_read => .stream_read,
+        .stream_write => .stream_write,
+        .future_read => .future_read,
+        .future_write => .future_write,
+    }));
+}
+
 /// Execute `canon thread.yield cancel?` for the currently executing task.
 ///
 /// Single-threaded runtime semantics: a "yield" is the smallest possible

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -1190,7 +1190,7 @@ fn dispatchAsyncCanon(
 
                 s.pending_read = null;
                 if (s.waitable_set) |ws| if (s.read_waitable_idx) |idx|
-                    ws.setReady(idx, allocator);
+                    ws.setReady(idx, allocator, async_canon.packStatus(.completed, transfer_count));
                 env.pushI32(@bitCast(async_canon.packStatus(.completed, transfer_count))) catch
                     return error.StackOverflow;
                 return;
@@ -1229,7 +1229,7 @@ fn dispatchAsyncCanon(
             s.buffer.appendSlice(comp_inst.allocator, src) catch
                 return error.OutOfMemory;
             if (s.waitable_set) |ws| if (s.read_waitable_idx) |idx|
-                ws.setReady(idx, allocator);
+                ws.setReady(idx, allocator, async_canon.packStatus(.completed, count));
             env.pushI32(@bitCast(async_canon.packStatus(.completed, count))) catch
                 return error.StackOverflow;
         },
@@ -1264,7 +1264,7 @@ fn dispatchAsyncCanon(
                 s.read_closed = true;
                 // Wake a parked writer so it can observe CANCELLED.
                 if (s.waitable_set) |ws| if (s.write_waitable_idx) |idx|
-                    ws.setReady(idx, allocator);
+                    ws.setReady(idx, allocator, async_canon.packStatus(.dropped, 0));
                 if (s.read_closed and s.write_closed) {
                     if (s.host_handler) |h| if (h.on_destroy) |cb|
                         cb(h.ctx);
@@ -1292,7 +1292,7 @@ fn dispatchAsyncCanon(
                 };
                 // Wake a parked reader so it can observe CANCELLED.
                 if (s.waitable_set) |ws| if (s.read_waitable_idx) |idx|
-                    ws.setReady(idx, allocator);
+                    ws.setReady(idx, allocator, async_canon.packStatus(.dropped, 0));
                 if (s.read_closed and s.write_closed) {
                     if (s.host_handler) |h| if (h.on_destroy) |cb|
                         cb(h.ctx);
@@ -1351,7 +1351,7 @@ fn dispatchAsyncCanon(
             if (fut.state == .ready and fut.payload == null and !fut.write_closed) {
                 fut.state = .closed;
                 if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
-                    ws.setReady(idx, allocator);
+                    ws.setReady(idx, allocator, async_canon.packStatus(.completed, 0));
                 env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
@@ -1366,7 +1366,7 @@ fn dispatchAsyncCanon(
                 fut.payload = null;
                 fut.state = .ready;
                 if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
-                    ws.setReady(idx, allocator);
+                    ws.setReady(idx, allocator, async_canon.packStatus(.completed, 0));
                 env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
@@ -1423,7 +1423,7 @@ fn dispatchAsyncCanon(
                 fut.pending_read = null;
                 fut.state = .ready;
                 if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
-                    ws.setReady(idx, allocator);
+                    ws.setReady(idx, allocator, async_canon.packStatus(.completed, 0));
                 env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                     return error.StackOverflow;
                 return;
@@ -1437,7 +1437,7 @@ fn dispatchAsyncCanon(
             fut.payload = heap_buf;
             fut.state = .ready;
             if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
-                ws.setReady(idx, allocator);
+                ws.setReady(idx, allocator, async_canon.packStatus(.completed, 0));
             env.pushI32(@bitCast(async_canon.packStatus(.completed, 0))) catch
                 return error.StackOverflow;
         },
@@ -1491,7 +1491,7 @@ fn dispatchAsyncCanon(
                 fut.read_closed = true;
                 // Wake a parked writer so it can observe CANCELLED.
                 if (fut.waitable_set) |ws| if (fut.write_waitable_idx) |idx|
-                    ws.setReady(idx, allocator);
+                    ws.setReady(idx, allocator, async_canon.packStatus(.dropped, 0));
                 if (fut.read_closed and fut.write_closed) {
                     fut.deinit(comp_inst.allocator);
                     _ = comp_inst.futures.remove(handle);
@@ -1505,7 +1505,7 @@ fn dispatchAsyncCanon(
                 fut.write_closed = true;
                 // Wake a parked reader so it can observe CANCELLED.
                 if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
-                    ws.setReady(idx, allocator);
+                    ws.setReady(idx, allocator, async_canon.packStatus(.dropped, 0));
                 if (fut.read_closed and fut.write_closed) {
                     fut.deinit(comp_inst.allocator);
                     _ = comp_inst.futures.remove(handle);
@@ -1589,22 +1589,143 @@ fn dispatchAsyncCanon(
             }
         },
         .waitable_set_wait, .waitable_set_poll => {
-            // wait/poll expect a (ws_handle, out_ptr) and write a 2-tuple
-            // (event-kind, payload) into guest memory. Without
-            // guest-memory bridging we can't honour that contract — pop
-            // arguments and push a zero status to keep the core stack
-            // balanced for the conformance "load + don't crash" target.
-            _ = env.popI32() catch return error.StackUnderflow; // out ptr
-            _ = env.popI32() catch return error.StackUnderflow; // ws handle
-            env.pushI32(0) catch return error.StackOverflow;
+            // wait/poll surface the oldest ready item registered in the
+            // waitable-set as `(event-kind: i32, payload: (handle: u32, code: u32))`:
+            // the event-kind is returned on the operand stack and the
+            // (handle, code) pair is written at the guest out-pointer
+            // popped off the stack. Mirrors the canonical-abi.py
+            // `canon_waitable_set_{wait,poll}` semantics so wit-bindgen's
+            // wakeup loop can decode the result via `EventCode + ReturnCode`.
+            //
+            // Single-threaded runtime semantics:
+            //
+            //   * `poll` returns `none` (event-code 0) when the queue is
+            //     empty.
+            //   * `wait` returns `none` here as well — true blocking
+            //     would deadlock the single-fiber runtime. wit-bindgen
+            //     treats `none` as "no progress" and re-polls all
+            //     branches, which is what we want for fixtures like
+            //     `cli-stdio-roundtrip` where peer settlement happens
+            //     synchronously inside the same `futures::join!` arm.
+            const out_ptr: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            const ws_handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+
+            const ws = comp_inst.waitable_sets.getPtr(ws_handle) orelse {
+                env.pushI32(0) catch return error.StackOverflow;
+                return;
+            };
+
+            if (ws.popReadyEvent()) |item| {
+                const bytes = comp_inst.writableGuestBytes(out_ptr, 8) orelse
+                    return error.MemoryNotAvailable;
+                std.mem.writeInt(u32, bytes[0..4], item.handle, .little);
+                std.mem.writeInt(u32, bytes[4..8], item.code, .little);
+                env.pushI32(@bitCast(async_canon.eventCodeForKind(item.kind))) catch
+                    return error.StackOverflow;
+                return;
+            }
+
+            // No ready waitable — `none` event-code. Caller (wit-bindgen
+            // reactor) reschedules.
+            env.pushI32(@intFromEnum(async_canon.EventCode.none)) catch
+                return error.StackOverflow;
         },
 
         .waitable_join => {
-            // Pops (waitable_handle, ws_handle). We simply drop both —
-            // the join becomes a no-op until real WaitableItem-typed
-            // registration lands alongside the read/write canon ops.
-            _ = env.popI32() catch return error.StackUnderflow;
-            _ = env.popI32() catch return error.StackUnderflow;
+            // `canon waitable.join` — canonical-abi.py
+            // `canon_waitable_join(wi, si)` declares params in
+            // `(waitable, set)` order, so the runtime stack at call
+            // time is (bottom→top) `[waitable, set]`. We therefore
+            // pop **set** first (top) and **waitable** second
+            // (under). A zero `set` means "remove from any current
+            // set" — we currently no-op that because removal isn't
+            // observable until the waitable becomes ready, and the
+            // only producer of a zero-set join is wit-bindgen's drop
+            // path which shortly drops the waitable entirely.
+            const ws_handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+            const waitable_handle: u32 = @bitCast(env.popI32() catch return error.StackUnderflow);
+
+            if (ws_handle == 0) return;
+            const ws = comp_inst.waitable_sets.getPtr(ws_handle) orelse return;
+
+            // Determine kind by inspecting which end of the
+            // future/stream is currently parked. The guest calls
+            // `waitable.join` immediately after the corresponding
+            // `{future,stream}.{read,write}` returned `BLOCKED`, so
+            // exactly one of `pending_read` / `pending_write` is set
+            // (futures only park readers in our impl; streams can
+            // park either end). Fall back to `_read` for futures and
+            // `_write` for streams — the common case is a guest
+            // awaiting a host-produced future end (see #537
+            // `write-via-stream` / `read-via-stream`).
+            if (comp_inst.futures.getPtr(waitable_handle)) |fut| {
+                if (fut.waitable_set != null) return; // already joined
+                // Futures default to `future_read` because their only
+                // blocking arm is the reader (`future.read` parks via
+                // `pending_read`). A `pending_write` slot doesn't exist
+                // in our model — `future.write` always completes
+                // synchronously. We still treat `read_closed` as a
+                // hint that the join is for the write end so the
+                // dropped-peer wake fires the right slot.
+                const kind: async_mod.WaitableSet.WaitableItem.Kind =
+                    if (fut.read_closed) .future_write else .future_read;
+                const idx = ws.register(.{ .kind = kind, .handle = waitable_handle }, allocator) catch
+                    return error.OutOfMemory;
+                fut.waitable_set = ws;
+                if (kind == .future_read) {
+                    fut.read_waitable_idx = idx;
+                } else {
+                    fut.write_waitable_idx = idx;
+                }
+                // If the corresponding end is already settled (the
+                // peer fired its drop / write before the join arrived
+                // — common when stdout's `on_drop_writable` runs
+                // synchronously inside the same `futures::join!` arm),
+                // mark the slot ready immediately so the very next
+                // `waitable-set.{wait,poll}` surfaces the event.
+                if (kind == .future_read) {
+                    if (fut.payload != null or (fut.state == .ready and !fut.write_closed)) {
+                        ws.setReady(idx, allocator, async_canon.packStatus(.completed, 0));
+                    } else if (fut.write_closed and fut.payload == null) {
+                        ws.setReady(idx, allocator, async_canon.packStatus(.dropped, 0));
+                    }
+                } else { // future_write
+                    if (fut.read_closed) {
+                        ws.setReady(idx, allocator, async_canon.packStatus(.dropped, 0));
+                    }
+                }
+                return;
+            }
+
+            if (comp_inst.streams.getPtr(waitable_handle)) |s| {
+                if (s.waitable_set != null) return; // already joined
+                const kind: async_mod.WaitableSet.WaitableItem.Kind =
+                    if (s.pending_read != null) .stream_read else .stream_write;
+                const idx = ws.register(.{ .kind = kind, .handle = waitable_handle }, allocator) catch
+                    return error.OutOfMemory;
+                s.waitable_set = ws;
+                if (kind == .stream_read) {
+                    s.read_waitable_idx = idx;
+                    // Buffered bytes available or peer closed →
+                    // surface readiness immediately.
+                    if (s.buffer.items.len > 0) {
+                        ws.setReady(idx, allocator, async_canon.packStatus(.completed, 0));
+                    } else if (s.write_closed) {
+                        ws.setReady(idx, allocator, async_canon.packStatus(.dropped, 0));
+                    }
+                } else {
+                    s.write_waitable_idx = idx;
+                    if (s.read_closed) {
+                        ws.setReady(idx, allocator, async_canon.packStatus(.dropped, 0));
+                    }
+                }
+                return;
+            }
+
+            // Unknown waitable handle — silently no-op. Spec says trap,
+            // but the conformance suite occasionally joins a
+            // just-dropped handle on the cancellation path; matching
+            // wasmtime's tolerant behaviour avoids spurious traps.
         },
     }
 }
@@ -3439,6 +3560,240 @@ test "stream.drop-writable while buffer drained: subsequent read returns DROPPED
     );
     const status: u32 = @bitCast(try env.popI32());
     try testing.expectEqual(async_canon.packStatus(.dropped, 0), status);
+}
+
+// ── #550: waitable.join + waitable-set.{wait,poll} event delivery ─────────
+
+test "waitable.join + waitable-set.wait: stream-write event delivered to a parked write waitable (#550)" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    const inst = try newStreamU32Inst(testing.allocator);
+    defer destroyStreamInst(inst);
+
+    // Allocate a stream + a waitable-set.
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .stream_new = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const stream_handle: u32 = @truncate(@as(u64, @bitCast(try env.popI64())) >> 32);
+
+    try dispatchCanonBuiltin(inst, .{ .async_canon = .waitable_set_new }, env, null, testing.allocator);
+    const ws_handle: u32 = @bitCast(try env.popI32());
+
+    // Park a stream.write by pre-flagging `pending_write` so the
+    // join arm classifies the join as `stream_write` (matches the
+    // post-#541 BLOCKED-then-join sequence wit-bindgen emits when
+    // an out-of-band sink can't accept bytes immediately).
+    {
+        const s = inst.streams.getPtr(stream_handle).?;
+        s.pending_write = .{ .guest_ptr = 0, .count = 4 };
+    }
+
+    // `canon waitable.join : [waitable, set]` — wasm pop order is set
+    // (top), waitable (under), so push waitable first then set.
+    try env.pushI32(@bitCast(stream_handle));
+    try env.pushI32(@bitCast(ws_handle));
+    try dispatchCanonBuiltin(inst, .{ .async_canon = .waitable_join }, env, null, testing.allocator);
+
+    try testing.expectEqual(@as(usize, 1), inst.waitable_sets.getPtr(ws_handle).?.items.items.len);
+    try testing.expectEqual(
+        async_mod.WaitableSet.WaitableItem.Kind.stream_write,
+        inst.waitable_sets.getPtr(ws_handle).?.items.items[0].kind,
+    );
+    try testing.expectEqual(@as(u32, 0), inst.streams.getPtr(stream_handle).?.write_waitable_idx.?);
+
+    // Drop the readable end — the parked writer must wake with a
+    // `dropped` event so the guest can re-issue `stream.write` and
+    // observe the closed peer synchronously.
+    try env.pushI32(@bitCast(stream_handle));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .stream_drop_readable = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+
+    // `canon waitable-set.wait : [set, out_ptr] -> [event]` —
+    // out_ptr at top of stack.
+    const out_ptr: u32 = 0x100;
+    try env.pushI32(@bitCast(ws_handle));
+    try env.pushI32(@bitCast(out_ptr));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .waitable_set_wait = .{ .cancellable = false, .memory = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const event: u32 = @bitCast(try env.popI32());
+    try testing.expectEqual(@intFromEnum(async_canon.EventCode.stream_write), event);
+
+    // Payload at out_ptr: (handle, packed_status).
+    const ev_bytes = inst.writableGuestBytes(out_ptr, 8).?;
+    try testing.expectEqual(stream_handle, std.mem.readInt(u32, ev_bytes[0..4], .little));
+    try testing.expectEqual(async_canon.packStatus(.dropped, 0), std.mem.readInt(u32, ev_bytes[4..8], .little));
+}
+
+test "waitable-set.poll: settled future surfaces FUTURE_READ event with the right handle/code (#550)" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    const inst = try newFutureU32Inst(testing.allocator);
+    defer destroyFutureInst(inst);
+
+    // Allocate a future + waitable-set. The future stands in for the
+    // `future<result<_,error-code>>` returned by `write-via-stream`.
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_new = .{ .type_idx = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    const future_handle: u32 = @truncate(@as(u64, @bitCast(try env.popI64())) >> 32);
+
+    try dispatchCanonBuiltin(inst, .{ .async_canon = .waitable_set_new }, env, null, testing.allocator);
+    const ws_handle: u32 = @bitCast(try env.popI32());
+
+    // Park a reader via `future.read` — returns BLOCKED so the join
+    // arm can detect `pending_read != null` and classify as future_read.
+    const guest_ptr: u32 = 0x80;
+    try env.pushI32(@bitCast(future_handle));
+    try env.pushI32(@bitCast(guest_ptr));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .future_read = .{ .type_idx = 0, .opts = &.{} } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(async_canon.BLOCKED_STATUS, @as(u32, @bitCast(try env.popI32())));
+
+    // Join the parked future to the waitable-set.
+    try env.pushI32(@bitCast(future_handle));
+    try env.pushI32(@bitCast(ws_handle));
+    try dispatchCanonBuiltin(inst, .{ .async_canon = .waitable_join }, env, null, testing.allocator);
+
+    // poll before settlement → NONE.
+    const out_ptr: u32 = 0x200;
+    try env.pushI32(@bitCast(ws_handle));
+    try env.pushI32(@bitCast(out_ptr));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .waitable_set_poll = .{ .cancellable = false, .memory = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@intFromEnum(async_canon.EventCode.none), @as(u32, @bitCast(try env.popI32())));
+
+    // Simulate host settling the future the way
+    // `writeViaStreamOnDropWritable` does: directly populate the
+    // parked reader's destination + set state ready + fire setReady.
+    {
+        const fut = inst.futures.getPtr(future_handle).?;
+        const dst = inst.writableGuestBytes(fut.pending_read.?.guest_ptr, 1).?;
+        dst[0] = 0;
+        fut.pending_read = null;
+        fut.state = .ready;
+        fut.write_closed = true;
+        if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
+            ws.setReady(idx, testing.allocator, async_canon.packStatus(.completed, 0));
+    }
+
+    // poll after settlement → FUTURE_READ event with the future handle.
+    try env.pushI32(@bitCast(ws_handle));
+    try env.pushI32(@bitCast(out_ptr));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .waitable_set_poll = .{ .cancellable = false, .memory = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@intFromEnum(async_canon.EventCode.future_read), @as(u32, @bitCast(try env.popI32())));
+    const ev_bytes = inst.writableGuestBytes(out_ptr, 8).?;
+    try testing.expectEqual(future_handle, std.mem.readInt(u32, ev_bytes[0..4], .little));
+    try testing.expectEqual(async_canon.packStatus(.completed, 0), std.mem.readInt(u32, ev_bytes[4..8], .little));
+
+    // The lifted Ok discriminant is at `guest_ptr` already (written
+    // synchronously above) so wit-bindgen's lift-from-original-ptr
+    // contract is satisfied — no re-issued `future.read` needed.
+    try testing.expectEqual(@as(u8, 0), inst.writableGuestBytes(guest_ptr, 1).?[0]);
+}
+
+test "waitable.join on already-settled future: marks ready synchronously so the next wait surfaces it (#550)" {
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    const inst = try newFutureU32Inst(testing.allocator);
+    defer destroyFutureInst(inst);
+
+    // Allocate a future and pre-settle it (state=.ready, payload set)
+    // — this mirrors a `read-via-stream` companion future that the
+    // host creates already-Ok.
+    const future_handle = inst.allocAsyncHandle();
+    const payload = try testing.allocator.alloc(u8, 1);
+    payload[0] = 0;
+    try inst.futures.put(testing.allocator, future_handle, .{
+        .elem_type_idx = 0,
+        .state = .ready,
+        .payload = payload,
+    });
+
+    try dispatchCanonBuiltin(inst, .{ .async_canon = .waitable_set_new }, env, null, testing.allocator);
+    const ws_handle: u32 = @bitCast(try env.popI32());
+
+    // Join — the future is already ready, so `waitable.join` must
+    // synchronously mark the slot ready (otherwise the guest would
+    // wait forever for an event that's already past).
+    try env.pushI32(@bitCast(future_handle));
+    try env.pushI32(@bitCast(ws_handle));
+    try dispatchCanonBuiltin(inst, .{ .async_canon = .waitable_join }, env, null, testing.allocator);
+
+    const ws = inst.waitable_sets.getPtr(ws_handle).?;
+    try testing.expectEqual(@as(usize, 1), ws.ready_queue.items.len);
+
+    // Wait drains the event.
+    const out_ptr: u32 = 0x300;
+    try env.pushI32(@bitCast(ws_handle));
+    try env.pushI32(@bitCast(out_ptr));
+    try dispatchCanonBuiltin(
+        inst,
+        .{ .async_canon = .{ .waitable_set_wait = .{ .cancellable = false, .memory = 0 } } },
+        env,
+        null,
+        testing.allocator,
+    );
+    try testing.expectEqual(@intFromEnum(async_canon.EventCode.future_read), @as(u32, @bitCast(try env.popI32())));
+    const ev_bytes = inst.writableGuestBytes(out_ptr, 8).?;
+    try testing.expectEqual(future_handle, std.mem.readInt(u32, ev_bytes[0..4], .little));
 }
 
 test "dispatchCanonBuiltin: error-context.new + drop round-trip" {

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -41,6 +41,7 @@ const InterfaceValue = instance_mod.InterfaceValue;
 const ctypes = @import("types.zig");
 const abi = @import("canonical_abi.zig");
 const async_mod = @import("async.zig");
+const async_canon = @import("async_canon.zig");
 
 // ── Local TypeDef table for hand-lowered list<compound> shapes (#402) ───────
 //
@@ -3212,25 +3213,46 @@ pub const WasiCliAdapter = struct {
     fn writeViaStreamOnDropWritable(ctx_opaque: ?*anyopaque) void {
         const c: *WriteViaStreamCtx = @ptrCast(@alignCast(ctx_opaque.?));
         if (c.ci.futures.getPtr(c.future_handle)) |fut| {
-            // Settle as `Ok(())` (discriminant 0). Allocate a 1-byte
-            // payload — `future_read` copies `buf.len` bytes into the
-            // guest's destination, and `result<_, error-code>` only
-            // requires the leading discriminant byte to lift Ok.
-            if (fut.payload == null and !fut.write_closed) {
-                if (c.adapter.allocator.alloc(u8, 1)) |buf| {
-                    buf[0] = 0;
-                    fut.payload = buf;
-                } else |_| {
-                    // Out-of-memory fallback: mark ready with no payload.
-                    // The unit-type fast-path in `future_read` handles
-                    // this by returning COMPLETED(0) — a behaviourally
-                    // equivalent ok-result lift.
+            // Settle as `Ok(())` (discriminant 0). The companion
+            // `future<result<_,error-code>>` lift only inspects the
+            // leading 1-byte discriminant: 0 selects the Ok arm and
+            // the trailing payload bytes are unread.
+            if (!fut.write_closed) {
+                // If a reader already parked (the common case for
+                // `futures::join!` over a host-future-await + a
+                // stream writer), populate the parked destination
+                // **before** delivering the wakeup event. wit-bindgen's
+                // `WaitableOperation` lifts directly from the pointer
+                // it passed to `future.read` at `start_read` time —
+                // it does **not** re-call `future.read` after the
+                // event — so writing the payload into a side heap
+                // buffer would leave the guest's lift target
+                // uninitialised and trigger a Rust enum-discriminant
+                // panic (#550). Clear `pending_read` and skip the
+                // heap buffer in that case.
+                if (fut.pending_read) |pr| {
+                    if (c.ci.writableGuestBytes(pr.guest_ptr, 1)) |dst| {
+                        dst[0] = 0;
+                    }
+                    fut.pending_read = null;
+                } else if (fut.payload == null) {
+                    // No parked reader yet — buffer the discriminant so
+                    // a subsequent `future.read` can copy it out.
+                    if (c.adapter.allocator.alloc(u8, 1)) |buf| {
+                        buf[0] = 0;
+                        fut.payload = buf;
+                    } else |_| {
+                        // Out-of-memory fallback: leave payload null;
+                        // the unit-type fast-path in `future_read`
+                        // surfaces COMPLETED(0) which the guest's
+                        // `result<_, error-code>` lift treats as Ok.
+                    }
                 }
                 fut.state = .ready;
                 fut.write_closed = true;
             }
             if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
-                ws.setReady(idx, c.adapter.allocator);
+                ws.setReady(idx, c.adapter.allocator, async_canon.packStatus(.completed, 0));
         }
         // NB: the ctx is NOT freed here — `stream.drop-readable` /
         // `stream.drop-writable` fire `on_destroy` once the stream
@@ -4325,7 +4347,7 @@ pub const WasiCliAdapter = struct {
                 fut.pending_read = null;
                 fut.state = .ready;
                 if (fut.waitable_set) |ws| if (fut.read_waitable_idx) |idx|
-                    ws.setReady(idx, allocator);
+                    ws.setReady(idx, allocator, async_canon.packStatus(.completed, 0));
             }
             if (self.timer_future_ready.getPtr(tf.handle)) |slot| slot.* = true;
             _ = self.timer_futures.swapRemove(i);

--- a/tests/wasi-p3-testsuite-skip.json
+++ b/tests/wasi-p3-testsuite-skip.json
@@ -30,7 +30,6 @@
         "filesystem-set-size": "wasi:filesystem@0.3.0 host bindings wired in #484/#522; end-to-end run still blocked on wamr P3 CLI loader dispatch — tracking #520",
         "filesystem-stat": "wasi:filesystem@0.3.0 host bindings wired in #484/#522; end-to-end run still blocked on wamr P3 CLI loader dispatch — tracking #520",
         "filesystem-unlink-errors": "wasi:filesystem@0.3.0 host bindings wired in #484/#522; end-to-end run still blocked on wamr P3 CLI loader dispatch — tracking #520",
-        "cli-stdio-roundtrip": "P3 stdio works but `futures::join!` rendezvous needs waitable-set.{wait,poll} event delivery for stream-write futures — tracking #550",
         "monotonic-clock": "wasi:clocks@0.3.0 routing fixed in #534 / PR #546; `wait-for` / `wait-until` need canon-lower-of-async-func wiring — tracking #551",
         "multi-clock-wait": "wasi:clocks@0.3.0 routing fixed in #534 / PR #546; needs canon-lower-of-async-func + task.cancel-aware sleep cancellation — tracking #551"
     }


### PR DESCRIPTION
Closes #550.

## Summary


## What changed

1. **`async.zig`**: `WaitableSet.WaitableItem` gains a `code: u32` field (the `packStatus(...)` the corresponding canon op would return). `setReady` takes the code; `popReadyEvent` drains the FIFO and returns the full item.
2. **`async_canon.zig`**: adds the `EventCode` enum + `eventCodeForKind` helper matching the canonical-abi.py spec values.
3. **`executor.zig` — `canon waitable.join`**: looks up the handle in futures/streams, classifies the join side (future_read default; future_write when read end is closed; stream_read/stream_write per pending state), and stores the slot index. Already-settled handles are marked ready synchronously so the next wait surfaces them rather than blocking forever on a past event.
4. **`executor.zig` — `canon waitable-set.{wait,poll}`**: pops (set, out_ptr), calls `popReadyEvent`, writes `(handle, code)` at `out_ptr`, returns the spec event-code. Returns NONE when nothing's ready (true blocking would deadlock the single-fiber runtime; wit-bindgen treats NONE as "re-poll").
5. **`wasi_cli_adapter.zig` — `writeViaStreamOnDropWritable`**: writes the Ok discriminant directly into the parked reader's `pending_read.guest_ptr` instead of buffering a side heap payload. wit-bindgen's `WaitableOperation` lifts from the pointer it originally passed to `future.read` at start-time — it does **not** re-issue `future.read` after the wakeup event — so writing only to a side buffer left the lift target uninitialised.
6. All existing `ws.setReady(idx, alloc)` call sites updated to pass the appropriate `packStatus(...)` code.

## Tests added (3 new + 1 supporting)

In `src/component/executor.zig`:
- `waitable.join + waitable-set.wait: stream-write event delivered to a parked write waitable (#550)`
- `waitable-set.poll: settled future surfaces FUTURE_READ event with the right handle/code (#550)`
- `waitable.join on already-settled future: marks ready synchronously so the next wait surfaces it (#550)`

In `src/component/async.zig`:
- `WaitableSet: popReadyEvent surfaces kind/handle/code in FIFO order` (validates the idempotent `setReady` + FIFO drain)

## Verification

- `zig build` ✅
- `zig build test` ✅ (1677 pass / 2 skip / 0 fail in the component-level slice — full `zig build test` clean)
- Cross-compile sweep clean: `aarch64-macos`, `x86_64-windows`, `x86_64-linux` ✅
- `zig build wasi-p3-testsuite -Doptimize=ReleaseSafe`: `cli-stdio-roundtrip passed` ✅
- `cli-stdio-roundtrip` entry removed from `tests/wasi-p3-testsuite-skip.json` (1 entry).

## Scope

Localised to the waitable-set event delivery path: `async.zig`, `async_canon.zig`, `executor.zig` (waitable-set/join arms + setReady call-sites), `wasi_cli_adapter.zig` (`writeViaStreamOnDropWritable` parked-reader fast path). No changes to the broader canon dispatch, type registry, or scheduler.