### PR TITLE
feat(component): wave-2 P3 dispatch fixes — compound flat lift/lower, variant alignment, resource-handle wire offset

### DIFF
--- a/src/component/canonical_abi.zig
+++ b/src/component/canonical_abi.zig
@@ -113,6 +113,21 @@ pub const TypeRegistry = struct {
 
 // ── Interface value representation ──────────────────────────────────────────
 
+/// Encode a host-side resource representation (0-based slot index) into
+/// a canon-ABI wire handle. Mirrors `executor.encodeResourceWire` but
+/// lives here to avoid a cyclic import. (#520 wave 2)
+pub fn encodeResourceWireAbi(rep: u32) u32 {
+    if (rep == std.math.maxInt(u32)) return std.math.maxInt(u32);
+    return rep +% 1;
+}
+
+/// Decode a canon-ABI wire handle into a host-side representation.
+/// (#520 wave 2)
+pub fn decodeResourceWireAbi(wire: u32) u32 {
+    if (wire == 0) return 0;
+    return wire -% 1;
+}
+
 /// Runtime representation of a component interface value.
 /// Primitives are stored inline; compound types use allocator-owned slices.
 pub const InterfaceValue = union(enum) {
@@ -533,7 +548,8 @@ pub fn loadVal(memory: []const u8, ptr: u32, t: ctypes.ValType) !InterfaceValue 
         .f32 => .{ .f32 = @bitCast(loadU32(memory, ptr)) },
         .f64 => .{ .f64 = @bitCast(loadU64(memory, ptr)) },
         .char => .{ .char = loadU32(memory, ptr) },
-        .own, .borrow, .future, .stream, .error_context => .{ .handle = loadU32(memory, ptr) },
+        .own, .borrow => .{ .handle = decodeResourceWireAbi(loadU32(memory, ptr)) },
+        .future, .stream, .error_context => .{ .handle = loadU32(memory, ptr) },
         .string => .{ .string = .{
             .ptr = loadU32(memory, ptr),
             .len = loadU32At(memory, ptr, 4),
@@ -622,9 +638,17 @@ pub fn loadValReg(memory: []const u8, ptr: u32, t: ctypes.ValType, reg: TypeRegi
                 else => loadU32(memory, ptr),
             };
             if (disc >= cases.len) break :blk error.InvalidDiscriminant;
+            // Per canon ABI: variant payload alignment is `max` across
+            // all case payload types (mirrors `alignOfTypeDef.variant`
+            // and the matching `storeValReg.variant` fix). (#520 wave 2)
+            var payload_align: u32 = 1;
+            for (cases) |c2| {
+                if (c2.type) |ct3| {
+                    payload_align = @max(payload_align, alignOfType(reg, ct3));
+                }
+            }
             const payload_ptr = if (cases[disc].type) |ct| p: {
-                const pa = alignOfType(reg, ct);
-                break :p try allocPayload(alloc, try loadValReg(memory, alignUp(ptr + disc_sz, pa), ct, reg, alloc));
+                break :p try allocPayload(alloc, try loadValReg(memory, alignUp(ptr + disc_sz, payload_align), ct, reg, alloc));
             } else null;
             break :blk .{ .variant_val = .{ .discriminant = disc, .payload = payload_ptr } };
         },
@@ -699,9 +723,16 @@ fn loadValFromDef(memory: []const u8, ptr: u32, td: ctypes.TypeDef, reg: TypeReg
                 else => loadU32(memory, ptr),
             };
             if (disc >= v.cases.len) break :blk error.InvalidDiscriminant;
+            // Per canon ABI: variant payload alignment is `max` across
+            // all case payload types. (#520 wave 2)
+            var payload_align: u32 = 1;
+            for (v.cases) |c2| {
+                if (c2.type) |ct3| {
+                    payload_align = @max(payload_align, alignOfType(reg, ct3));
+                }
+            }
             const payload_ptr = if (v.cases[disc].type) |ct| p: {
-                const pa = alignOfType(reg, ct);
-                break :p try allocPayload(alloc, try loadValReg(memory, alignUp(ptr + disc_sz, pa), ct, reg, alloc));
+                break :p try allocPayload(alloc, try loadValReg(memory, alignUp(ptr + disc_sz, payload_align), ct, reg, alloc));
             } else null;
             break :blk .{ .variant_val = .{ .discriminant = disc, .payload = payload_ptr } };
         },
@@ -748,7 +779,7 @@ fn loadValFromDef(memory: []const u8, ptr: u32, td: ctypes.TypeDef, reg: TypeReg
             } else null;
             break :blk .{ .result_val = .{ .is_ok = is_ok, .payload = payload_ptr } };
         },
-        .resource => .{ .handle = loadU32(memory, ptr) },
+        .resource => .{ .handle = decodeResourceWireAbi(loadU32(memory, ptr)) },
         else => .{ .handle = 0 },
     };
 }
@@ -775,7 +806,8 @@ pub fn storeVal(memory: []u8, ptr: u32, t: ctypes.ValType, val: InterfaceValue) 
         .f32 => storeU32(memory, ptr, @bitCast(val.f32)),
         .f64 => storeU64(memory, ptr, @bitCast(val.f64)),
         .char => storeU32(memory, ptr, val.char),
-        .own, .borrow, .future, .stream, .error_context => storeU32(memory, ptr, val.handle),
+        .own, .borrow => storeU32(memory, ptr, encodeResourceWireAbi(val.handle)),
+        .future, .stream, .error_context => storeU32(memory, ptr, val.handle),
         .string => {
             storeU32(memory, ptr, val.string.ptr);
             storeU32At(memory, ptr, 4, val.string.len);
@@ -857,10 +889,21 @@ pub fn storeValReg(memory: []u8, ptr: u32, t: ctypes.ValType, val: InterfaceValu
                 2 => storeU16(memory, ptr, @intCast(val.variant_val.discriminant)),
                 else => storeU32(memory, ptr, val.variant_val.discriminant),
             }
+            // Per canon ABI: variant payload alignment is the **max**
+            // alignment across all case payload types, not the current
+            // active arm's alignment. Using the active arm would shift
+            // the payload offset for arms with smaller alignment,
+            // causing the guest to read garbage (PR #520 wave 2). The
+            // memory layout below mirrors `alignOfTypeDef.variant`.
+            var payload_align: u32 = 1;
+            for (cases) |c| {
+                if (c.type) |ct2| {
+                    payload_align = @max(payload_align, alignOfType(reg, ct2));
+                }
+            }
             if (val.variant_val.payload) |payload| {
                 const ct = cases[val.variant_val.discriminant].type.?;
-                const pa = alignOfType(reg, ct);
-                try storeValReg(memory, alignUp(ptr + disc_sz, pa), ct, payload.*, reg);
+                try storeValReg(memory, alignUp(ptr + disc_sz, payload_align), ct, payload.*, reg);
             }
         },
         .option => {
@@ -879,17 +922,19 @@ pub fn storeValReg(memory: []u8, ptr: u32, t: ctypes.ValType, val: InterfaceValu
             const td = reg.get(idx) orelse return error.InvalidTypeIndex;
             if (val.result_val.is_ok) {
                 storeU8(memory, ptr, 0);
-                if (val.result_val.payload) |payload| {
-                    const ok_type = td.result.ok.?;
-                    const pa = alignOfType(reg, ok_type);
-                    try storeValReg(memory, alignUp(ptr + 1, pa), ok_type, payload.*, reg);
+                if (td.result.ok) |ok_type| {
+                    if (val.result_val.payload) |payload| {
+                        const pa = alignOfType(reg, ok_type);
+                        try storeValReg(memory, alignUp(ptr + 1, pa), ok_type, payload.*, reg);
+                    }
                 }
             } else {
                 storeU8(memory, ptr, 1);
-                if (val.result_val.payload) |payload| {
-                    const err_type = td.result.err.?;
-                    const pa = alignOfType(reg, err_type);
-                    try storeValReg(memory, alignUp(ptr + 1, pa), err_type, payload.*, reg);
+                if (td.result.err) |err_type| {
+                    if (val.result_val.payload) |payload| {
+                        const pa = alignOfType(reg, err_type);
+                        try storeValReg(memory, alignUp(ptr + 1, pa), err_type, payload.*, reg);
+                    }
                 }
             }
         },
@@ -935,10 +980,17 @@ fn storeValFromDef(memory: []u8, ptr: u32, td: ctypes.TypeDef, val: InterfaceVal
                 2 => storeU16(memory, ptr, @intCast(val.variant_val.discriminant)),
                 else => storeU32(memory, ptr, val.variant_val.discriminant),
             }
+            // Per canon ABI: variant payload alignment is `max` across
+            // all case payload types. (#520 wave 2)
+            var payload_align: u32 = 1;
+            for (v.cases) |c2| {
+                if (c2.type) |ct3| {
+                    payload_align = @max(payload_align, alignOfType(reg, ct3));
+                }
+            }
             if (val.variant_val.payload) |payload| {
                 const ct = v.cases[val.variant_val.discriminant].type.?;
-                const pa = alignOfType(reg, ct);
-                try storeValReg(memory, alignUp(ptr + disc_sz, pa), ct, payload.*, reg);
+                try storeValReg(memory, alignUp(ptr + disc_sz, payload_align), ct, payload.*, reg);
             }
         },
         .flags => |fl| {
@@ -973,21 +1025,27 @@ fn storeValFromDef(memory: []u8, ptr: u32, td: ctypes.TypeDef, val: InterfaceVal
         .result => |res| {
             if (val.result_val.is_ok) {
                 storeU8(memory, ptr, 0);
-                if (val.result_val.payload) |payload| {
-                    const ok_type = res.ok.?;
-                    const pa = alignOfType(reg, ok_type);
-                    try storeValReg(memory, alignUp(ptr + 1, pa), ok_type, payload.*, reg);
+                // The WIT type may be `result<_, E>` (no ok payload).
+                // Host adapters conventionally still pass a sentinel
+                // `tuple_val = &.{}` to signal "ok with nothing"; skip
+                // the payload write when the ok arm has no type.
+                if (res.ok) |ok_type| {
+                    if (val.result_val.payload) |payload| {
+                        const pa = alignOfType(reg, ok_type);
+                        try storeValReg(memory, alignUp(ptr + 1, pa), ok_type, payload.*, reg);
+                    }
                 }
             } else {
                 storeU8(memory, ptr, 1);
-                if (val.result_val.payload) |payload| {
-                    const err_type = res.err.?;
-                    const pa = alignOfType(reg, err_type);
-                    try storeValReg(memory, alignUp(ptr + 1, pa), err_type, payload.*, reg);
+                if (res.err) |err_type| {
+                    if (val.result_val.payload) |payload| {
+                        const pa = alignOfType(reg, err_type);
+                        try storeValReg(memory, alignUp(ptr + 1, pa), err_type, payload.*, reg);
+                    }
                 }
             }
         },
-        .resource => storeU32(memory, ptr, val.handle),
+        .resource => storeU32(memory, ptr, encodeResourceWireAbi(val.handle)),
         else => {},
     }
 }
@@ -1010,7 +1068,8 @@ pub fn liftFlat(core_vals: []const u32, t: ctypes.ValType) !InterfaceValue {
         .u64 => .{ .u64 = if (core_vals.len > 1) @as(u64, core_vals[1]) << 32 | core_vals[0] else core_vals[0] },
         .f32 => .{ .f32 = core_vals[0] },
         .f64 => .{ .f64 = if (core_vals.len > 1) @as(u64, core_vals[1]) << 32 | core_vals[0] else core_vals[0] },
-        .own, .borrow, .future, .stream, .error_context => .{ .handle = core_vals[0] },
+        .own, .borrow => .{ .handle = decodeResourceWireAbi(core_vals[0]) },
+        .future, .stream, .error_context => .{ .handle = core_vals[0] },
         .string => .{ .string = .{
             .ptr = core_vals[0],
             .len = if (core_vals.len > 1) core_vals[1] else 0,
@@ -1157,7 +1216,11 @@ pub fn lowerFlat(val: InterfaceValue, t: ctypes.ValType, out: []u32) !u32 {
             if (out.len > 1) out[1] = @truncate(val.f64 >> 32);
             return 2;
         },
-        .own, .borrow, .future, .stream, .error_context => {
+        .own, .borrow => {
+            out[0] = encodeResourceWireAbi(val.handle);
+            return 1;
+        },
+        .future, .stream, .error_context => {
             out[0] = val.handle;
             return 1;
         },
@@ -2040,4 +2103,112 @@ test "list types: alignment=4, elemSize=8" {
     try std.testing.expectEqual(@as(u32, 8), sizeOfType(reg, .{ .list = 0 }));
     try std.testing.expectEqual(@as(u32, 4), alignOfType(reg, .{ .list = 1 }));
     try std.testing.expectEqual(@as(u32, 8), sizeOfType(reg, .{ .list = 1 }));
+}
+
+test "variant: mixed-arm alignment uses the max across all cases (#520 wave 2)" {
+    // Per canon ABI, the variant payload offset is `alignUp(disc_sz, max-payload-align)`.
+    // Prior to wave-2 #520, `storeValReg.variant` and `loadValReg.variant`
+    // both used the *current arm's* alignment instead of the max, which
+    // shifted the payload offset for arms with smaller alignment (e.g.
+    // ipv4-sockaddr inside `ip-socket-address` whose ipv6 arm has
+    // align=4 vs ipv4 arm's align=2). The guest then read garbage at
+    // the shifted offsets — observed end-to-end as
+    // `IpAddress::Ipv4((0, 1, 0, 0))` instead of `(127, 0, 0, 1)` for
+    // the wasi-testsuite `sockets-tcp-bind` fixture.
+    //
+    // Mirrors that shape with two cases: case 0 carries u16 (align 2),
+    // case 1 carries u32 (align 4). Variant payload must land at
+    // offset 4 (alignUp(1, max(2, 4))), not 2 (case-0's alignment).
+    const fields_u16 = [_]ctypes.Field{.{ .name = "v", .type = .u16 }};
+    const fields_u32 = [_]ctypes.Field{.{ .name = "v", .type = .u32 }};
+    const cases = [_]ctypes.Case{
+        .{ .name = "a", .type = .{ .record = 0 }, .refines = null },
+        .{ .name = "b", .type = .{ .record = 1 }, .refines = null },
+    };
+    const comp_types = [_]ctypes.TypeDef{
+        .{ .record = .{ .fields = &fields_u16 } }, // 0
+        .{ .record = .{ .fields = &fields_u32 } }, // 1
+        .{ .variant = .{ .cases = &cases } }, // 2
+    };
+    const comp_idxspace = [_]?u32{ 0, 1, 2 };
+    var component = std.mem.zeroes(ctypes.Component);
+    component.types = &comp_types;
+    component.type_indexspace = &comp_idxspace;
+    const reg = TypeRegistry.init(&component);
+
+    // Construct case 0 (the smaller-aligned arm) with value 0xABCD.
+    const inner_val = std.testing.allocator.create(InterfaceValue) catch unreachable;
+    defer std.testing.allocator.destroy(inner_val);
+    const payload_field = std.testing.allocator.alloc(InterfaceValue, 1) catch unreachable;
+    defer std.testing.allocator.free(payload_field);
+    payload_field[0] = .{ .u16 = 0xABCD };
+    inner_val.* = .{ .record_val = payload_field };
+    const val: InterfaceValue = .{ .variant_val = .{ .discriminant = 0, .payload = inner_val } };
+
+    var mem: [16]u8 = .{0} ** 16;
+    try storeValReg(&mem, 0, .{ .variant = 2 }, val, reg);
+    // Payload must land at offset 4 (max align across arms = 4), not 2.
+    try std.testing.expectEqual(@as(u8, 0xCD), mem[4]);
+    try std.testing.expectEqual(@as(u8, 0xAB), mem[5]);
+    // Bytes at offsets 2..3 must remain zero (padding region).
+    try std.testing.expectEqual(@as(u8, 0), mem[2]);
+    try std.testing.expectEqual(@as(u8, 0), mem[3]);
+
+    // Round-trip: load back and check arm + payload value.
+    const loaded = try loadValReg(&mem, 0, .{ .variant = 2 }, reg, std.testing.allocator);
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u32, 0), loaded.variant_val.discriminant);
+    const loaded_payload = loaded.variant_val.payload.?;
+    try std.testing.expectEqual(@as(u16, 0xABCD), loaded_payload.record_val[0].u16);
+}
+
+test "result<_, E>: store with null ok type does not crash (#520 wave 2)" {
+    // `result<_, error-code>` has `ok = null` (no payload). Prior to
+    // wave-2 #520 the store path unconditionally unwrapped
+    // `res.ok.?`, panicking when the host adapter returned an `ok`
+    // variant with the conventional sentinel `tuple_val = &.{}`
+    // payload. Confirm the store skips the payload write when
+    // `res.ok` is null.
+    const err_cases = [_]ctypes.Case{
+        .{ .name = "bad", .type = null, .refines = null },
+    };
+    const comp_types = [_]ctypes.TypeDef{
+        .{ .variant = .{ .cases = &err_cases } }, // 0: error-code variant
+        .{ .result = .{ .ok = null, .err = .{ .variant = 0 } } }, // 1: result<_, error-code>
+    };
+    const comp_idxspace = [_]?u32{ 0, 1 };
+    var component = std.mem.zeroes(ctypes.Component);
+    component.types = &comp_types;
+    component.type_indexspace = &comp_idxspace;
+    const reg = TypeRegistry.init(&component);
+
+    var mem: [4]u8 = .{0} ** 4;
+    const empty_tuple: InterfaceValue = .{ .tuple_val = &.{} };
+    const payload = std.testing.allocator.create(InterfaceValue) catch unreachable;
+    defer std.testing.allocator.destroy(payload);
+    payload.* = empty_tuple;
+    const ok_val: InterfaceValue = .{ .result_val = .{ .is_ok = true, .payload = payload } };
+
+    // Must not crash even though `res.ok` is null.
+    try storeValReg(&mem, 0, .{ .result = 1 }, ok_val, reg);
+    // Discriminant byte 0 == 0 (ok).
+    try std.testing.expectEqual(@as(u8, 0), mem[0]);
+}
+
+test "encode/decodeResourceWireAbi round-trip (#520 wave 2)" {
+    // Wit-bindgen Rust's `Resource<T>::from_handle` asserts
+    // `handle != 0 && handle != u32::MAX`. The canon ABI lift/lower
+    // layer applies a `slot + 1` offset on `own/borrow` handles so
+    // that host-side 0-based slot indices round-trip safely to a
+    // non-zero wire value.
+    try std.testing.expectEqual(@as(u32, 1), encodeResourceWireAbi(0));
+    try std.testing.expectEqual(@as(u32, 2), encodeResourceWireAbi(1));
+    try std.testing.expectEqual(@as(u32, 0), decodeResourceWireAbi(1));
+    try std.testing.expectEqual(@as(u32, 1), decodeResourceWireAbi(2));
+    // The MAX sentinel passes through unchanged so the assertion-
+    // failure mode survives observability.
+    try std.testing.expectEqual(@as(u32, std.math.maxInt(u32)), encodeResourceWireAbi(std.math.maxInt(u32)));
+    // Wire 0 (the "uninitialised" sentinel) decodes to 0, which the
+    // adapter-side `lookupSocket(0)` etc. will reject as out-of-range.
+    try std.testing.expectEqual(@as(u32, 0), decodeResourceWireAbi(0));
 }

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -27,6 +27,27 @@ const TypeRegistry = abi.TypeRegistry;
 pub const MAX_FLAT_PARAMS: u32 = 16;
 pub const MAX_FLAT_RESULTS: u32 = 1;
 
+/// Encode a host-side resource representation (slot index from
+/// `pushSocket` / `pushFsDescriptor` / `pushNetwork` / 0-based) into a
+/// canon-ABI wire handle. Wit-bindgen Rust's `Resource<T>` constructor
+/// asserts `handle != 0 && handle != u32::MAX`, so the wire value
+/// must be non-zero. We adopt the convention `wire = rep + 1`. Reps
+/// of `u32::MAX` are guarded (they would overflow); upper-layer code
+/// should never produce that. (#520 wave 2)
+pub fn encodeResourceWire(rep: u32) u32 {
+    if (rep == std.math.maxInt(u32)) return std.math.maxInt(u32);
+    return rep +% 1;
+}
+
+/// Decode a canon-ABI wire handle back into a host-side representation
+/// (0-based slot index). Wire `0` decodes to `0` (the host's
+/// `lookupSocket(0)` etc. would return null for an out-of-range
+/// slot anyway, so the round-trip is safe). (#520 wave 2)
+pub fn decodeResourceWire(wire: u32) u32 {
+    if (wire == 0) return 0;
+    return wire -% 1;
+}
+
 // ── Error types ─────────────────────────────────────────────────────────────
 
 pub const ExecutionError = error{
@@ -413,7 +434,31 @@ pub fn callComponentFuncByLocalAsyncLifted(
     // Drive the core body. It is the callee's responsibility to invoke
     // `canon task.return` before returning — which deposits the lifted
     // results onto the task via `dispatchCanonBuiltin`.
+    //
+    // On trap, surface diagnostic info from `env.host_trap` so the
+    // failure mode is visible to the operator. Mirrors the sync-call
+    // path in `callComponentFunc` (added in #520 wave 1 / PR #532).
+    // The `WasiExit` case is normal control flow (the exit code is
+    // already stashed on `WasiCliAdapter.exit_code`) and is suppressed
+    // to avoid spurious diagnostics on a successful `wasi:cli/exit`.
     interp.executeFunction(env, exported.core_func_idx) catch {
+        if (env.host_trap) |ht| {
+            const is_wasi_exit = std.mem.eql(u8, ht.err_name, "WasiExit");
+            if (!is_wasi_exit) {
+                std.debug.print("[async-lifted trap] core_func_idx={d}", .{ht.core_func_idx});
+                if (ht.component_func_idx != std.math.maxInt(u32))
+                    std.debug.print(" component_func_idx={d}", .{ht.component_func_idx});
+                if (ht.import_module_name.len > 0 or ht.import_field_name.len > 0)
+                    std.debug.print(
+                        " import='{s}.{s}'",
+                        .{ ht.import_module_name, ht.import_field_name },
+                    );
+                std.debug.print(
+                    " stage={s} error={s}\n",
+                    .{ @tagName(ht.stage), ht.err_name },
+                );
+            }
+        }
         return error.TrapInCoreFunction;
     };
 
@@ -512,7 +557,8 @@ fn pushInterfaceValue(env: *ExecEnv, val: InterfaceValue, t: ctypes.ValType, reg
         .u64 => try env.pushI64(@bitCast(val.u64)),
         .f32 => try env.push(.{ .f32 = @bitCast(val.f32) }),
         .f64 => try env.push(.{ .f64 = @bitCast(val.f64) }),
-        .own, .borrow, .future, .stream, .error_context => try env.pushI32(@bitCast(val.handle)),
+        .own, .borrow => try env.pushI32(@bitCast(encodeResourceWire(val.handle))),
+        .future, .stream, .error_context => try env.pushI32(@bitCast(val.handle)),
         .string => {
             try env.pushI32(@bitCast(val.string.ptr));
             try env.pushI32(@bitCast(val.string.len));
@@ -549,8 +595,22 @@ fn pushInterfaceValue(env: *ExecEnv, val: InterfaceValue, t: ctypes.ValType, reg
                 try env.pushI32(0);
             }
         },
+        // Compound types — lower into a scratch buffer via
+        // `lowerFlatReg`, then push the flat i32 slots onto the stack
+        // in canonical order. The variant / record / tuple / flags /
+        // enum_ / option shapes show up in sockets/filesystem fixture
+        // results (e.g. a host that returns `result<_, error-code>`
+        // with an `error-code` variant payload). (#520 wave 2)
         .record, .variant, .tuple, .flags, .enum_, .option => {
-            return error.CompoundNeedsRegistry;
+            const total_slots = abi.flattenCount(registry, t);
+            var slot_buf: [32]u32 = undefined;
+            if (total_slots > slot_buf.len) return error.CompoundNeedsRegistry;
+            const written = try lowerFlatReg(slot_buf[0..total_slots], val, t, registry);
+            // Pad any unused tail with zero (variant / option / result
+            // join behaviour: shorter arms zero-fill the remaining
+            // slots so the join's flat width is constant).
+            for (written..total_slots) |k| slot_buf[k] = 0;
+            for (slot_buf[0..total_slots]) |s| try env.pushI32(@bitCast(s));
         },
         // Resolve `.type_idx` through the registry and re-dispatch on
         // the reified ValType. The registry may have been extended with
@@ -573,6 +633,198 @@ fn pushInterfaceValue(env: *ExecEnv, val: InterfaceValue, t: ctypes.ValType, reg
                 else => return error.CompoundNeedsRegistry,
             };
             try pushInterfaceValue(env, val, reified, registry);
+        },
+    }
+}
+
+/// Lower a single value into a flat slot buffer (canonical order),
+/// returning the number of slots written. The buffer must be at least
+/// `flattenCount(registry, t)` slots long; the caller zero-pads any
+/// remaining tail (variant/option/result join behaviour). (#520 wave 2)
+fn lowerFlatReg(
+    out: []u32,
+    val: InterfaceValue,
+    t: ctypes.ValType,
+    registry: TypeRegistry,
+) error{ CompoundNeedsRegistry, InvalidTypeIndex, InvalidValue, BufferTooSmall }!u32 {
+    if (out.len == 0) return error.BufferTooSmall;
+    switch (t) {
+        .bool => {
+            out[0] = if (val.bool) 1 else 0;
+            return 1;
+        },
+        .s8 => {
+            out[0] = @as(u32, @intCast(@as(u8, @bitCast(val.s8))));
+            return 1;
+        },
+        .u8 => {
+            out[0] = val.u8;
+            return 1;
+        },
+        .s16 => {
+            out[0] = @as(u32, @intCast(@as(u16, @bitCast(val.s16))));
+            return 1;
+        },
+        .u16 => {
+            out[0] = val.u16;
+            return 1;
+        },
+        .s32 => {
+            out[0] = @bitCast(val.s32);
+            return 1;
+        },
+        .u32, .char => {
+            out[0] = val.u32;
+            return 1;
+        },
+        .s64 => {
+            if (out.len < 2) return error.BufferTooSmall;
+            const bits: u64 = @bitCast(val.s64);
+            out[0] = @truncate(bits);
+            out[1] = @truncate(bits >> 32);
+            return 2;
+        },
+        .u64 => {
+            if (out.len < 2) return error.BufferTooSmall;
+            out[0] = @truncate(val.u64);
+            out[1] = @truncate(val.u64 >> 32);
+            return 2;
+        },
+        .f32 => {
+            out[0] = val.f32;
+            return 1;
+        },
+        .f64 => {
+            if (out.len < 2) return error.BufferTooSmall;
+            out[0] = @truncate(val.f64);
+            out[1] = @truncate(val.f64 >> 32);
+            return 2;
+        },
+        .own, .borrow => {
+            out[0] = encodeResourceWire(val.handle);
+            return 1;
+        },
+        .future, .stream, .error_context => {
+            out[0] = val.handle;
+            return 1;
+        },
+        .string => {
+            if (out.len < 2) return error.BufferTooSmall;
+            out[0] = val.string.ptr;
+            out[1] = val.string.len;
+            return 2;
+        },
+        .list => {
+            if (out.len < 2) return error.BufferTooSmall;
+            out[0] = val.list.ptr;
+            out[1] = val.list.len;
+            return 2;
+        },
+        .enum_ => |idx| {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .enum_) return error.InvalidTypeIndex;
+            out[0] = val.enum_val;
+            return 1;
+        },
+        .flags => |idx| {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .flags) return error.InvalidTypeIndex;
+            const n_words: u32 = @intCast(@max(@as(usize, 1), (td.flags.names.len + 31) / 32));
+            if (out.len < n_words) return error.BufferTooSmall;
+            const words = val.flags_val;
+            for (0..n_words) |k| out[k] = if (k < words.len) words[k] else 0;
+            return n_words;
+        },
+        .record => |idx| {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .record) return error.InvalidTypeIndex;
+            const fields_meta = td.record.fields;
+            const fields_val = val.record_val;
+            if (fields_val.len != fields_meta.len) return error.InvalidValue;
+            var off: u32 = 0;
+            for (fields_meta, 0..) |f, i| {
+                const ft = resolveArmType(f.type, registry);
+                const w = try lowerFlatReg(out[off..], fields_val[i], ft, registry);
+                off += w;
+            }
+            return off;
+        },
+        .tuple => |idx| {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .tuple) return error.InvalidTypeIndex;
+            const fields_meta = td.tuple.fields;
+            const fields_val = val.tuple_val;
+            if (fields_val.len != fields_meta.len) return error.InvalidValue;
+            var off: u32 = 0;
+            for (fields_meta, 0..) |f, i| {
+                const ft = resolveArmType(f, registry);
+                const w = try lowerFlatReg(out[off..], fields_val[i], ft, registry);
+                off += w;
+            }
+            return off;
+        },
+        .variant => |idx| {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .variant) return error.InvalidTypeIndex;
+            const cases = td.variant.cases;
+            const v = val.variant_val;
+            if (v.discriminant >= cases.len) return error.InvalidValue;
+            out[0] = v.discriminant;
+            var off: u32 = 1;
+            if (cases[v.discriminant].type) |ct| {
+                if (v.payload) |p| {
+                    const resolved = resolveArmType(ct, registry);
+                    off += try lowerFlatReg(out[off..], p.*, resolved, registry);
+                }
+            }
+            // Caller zero-pads tail to total flat width.
+            return off;
+        },
+        .option => |idx| {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .option) return error.InvalidTypeIndex;
+            const o = val.option_val;
+            out[0] = if (o.is_some) 1 else 0;
+            var off: u32 = 1;
+            if (o.is_some) {
+                if (o.payload) |p| {
+                    const inner = resolveArmType(td.option.inner, registry);
+                    off += try lowerFlatReg(out[off..], p.*, inner, registry);
+                }
+            }
+            return off;
+        },
+        .result => |idx| {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .result) return error.InvalidTypeIndex;
+            const r = val.result_val;
+            out[0] = if (r.is_ok) 0 else 1;
+            var off: u32 = 1;
+            const arm_type: ?ctypes.ValType = if (r.is_ok) td.result.ok else td.result.err;
+            if (arm_type) |at| {
+                if (r.payload) |p| {
+                    const resolved = resolveArmType(at, registry);
+                    off += try lowerFlatReg(out[off..], p.*, resolved, registry);
+                }
+            }
+            return off;
+        },
+        .type_idx => |idx| {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            const reified: ctypes.ValType = switch (td) {
+                .val => |inner| inner,
+                .list => .{ .list = idx },
+                .record => .{ .record = idx },
+                .tuple => .{ .tuple = idx },
+                .variant => .{ .variant = idx },
+                .flags => .{ .flags = idx },
+                .enum_ => .{ .enum_ = idx },
+                .option => .{ .option = idx },
+                .result => .{ .result = idx },
+                .resource => .{ .own = idx },
+                else => return error.InvalidTypeIndex,
+            };
+            return try lowerFlatReg(out, val, reified, registry);
         },
     }
 }
@@ -621,7 +873,8 @@ fn popInterfaceValue(env: *ExecEnv, t: ctypes.ValType, registry: TypeRegistry, a
                 else => 0,
             } };
         },
-        .own, .borrow, .future, .stream, .error_context => .{ .handle = @bitCast(try env.popI32()) },
+        .own, .borrow => .{ .handle = decodeResourceWire(@bitCast(try env.popI32())) },
+        .future, .stream, .error_context => .{ .handle = @bitCast(try env.popI32()) },
         .string => .{ .string = .{
             .len = @bitCast(try env.popI32()),
             .ptr = @bitCast(try env.popI32()),
@@ -722,21 +975,17 @@ fn popInterfaceValue(env: *ExecEnv, t: ctypes.ValType, registry: TypeRegistry, a
             }
             break :blk .{ .option_val = .{ .is_some = is_some, .payload = payload } };
         },
-        .record, .tuple, .flags => error.CompoundNeedsRegistry,
-        // Top-level `variant` / `enum`: pop the flat slots into a
-        // scratch buffer, then re-lift through the registry-aware
-        // path so compound case payloads (e.g. `Method::Other(string)`,
-        // `Scheme::Other(string)`) keep their bytes (#552).
-        .variant, .enum_ => blk: {
+        // Compound types — pop all flat slots into a scratch buffer
+        // (canonical order: slot[0]..slot[N-1]) and recursively lift
+        // through the registry. The variant / record / tuple / flags /
+        // enum_ shapes all show up in sockets and filesystem fixture
+        // arguments (e.g. `ip-socket-address` is a variant of records
+        // of u16+tuple). Supersedes the variant-only path landed in
+        // PR #559 (#552). (#520 wave 2)
+        .record, .variant, .tuple, .flags, .enum_ => |idx| blk: {
+            _ = idx;
             const total_slots = abi.flattenCount(registry, t);
-            var slot_buf: [16]u32 = undefined;
-            if (total_slots > slot_buf.len) return error.CompoundNeedsRegistry;
-            var i: u32 = total_slots;
-            while (i > 0) {
-                i -= 1;
-                slot_buf[i] = @bitCast(try env.popI32());
-            }
-            break :blk try abi.liftFlatReg(slot_buf[0..total_slots], t, registry, allocator);
+            break :blk try popFlatCompound(env, t, total_slots, registry, allocator);
         },
         // Mirror `pushInterfaceValue`: resolve `.type_idx` and re-pop on
         // the reified ValType.
@@ -756,6 +1005,218 @@ fn popInterfaceValue(env: *ExecEnv, t: ctypes.ValType, registry: TypeRegistry, a
                 else => return error.CompoundNeedsRegistry,
             };
             break :blk try popInterfaceValue(env, reified, registry, allocator);
+        },
+    };
+}
+
+/// Pop `total_slots` flat i32 core values off the stack (top-of-stack is
+/// the last-pushed = highest-index slot) into a scratch buffer in
+/// canonical order (`slot[0]..slot[N-1]`), then lift the compound value
+/// from the buffer via `liftFlatReg`. Used by `popInterfaceValue` for
+/// `record` / `variant` / `tuple` / `flags` / `enum_` types whose flat
+/// layout is determined by walking the type registry.
+///
+/// The `total_slots <= 32` cap matches the canon ABI's MAX_FLAT_PARAMS
+/// (16) doubled to accommodate a return-result tuple of equal size; any
+/// compound exceeding this would have spilled to memory anyway, in
+/// which case the `loadInterfaceValue` (memory-spill) path is used
+/// instead. (#520 wave 2)
+fn popFlatCompound(
+    env: *ExecEnv,
+    t: ctypes.ValType,
+    total_slots: u32,
+    registry: TypeRegistry,
+    allocator: Allocator,
+) !InterfaceValue {
+    var slot_buf: [32]u32 = undefined;
+    if (total_slots > slot_buf.len) return error.CompoundNeedsRegistry;
+    var i: u32 = total_slots;
+    while (i > 0) {
+        i -= 1;
+        slot_buf[i] = @bitCast(try env.popI32());
+    }
+    const lifted = try liftFlatReg(slot_buf[0..total_slots], t, registry, allocator);
+    return lifted.val;
+}
+
+/// Lift a single value from a flat slot buffer (canonical order). Returns
+/// the lifted `InterfaceValue` and the number of slots consumed. Handles
+/// every shape the canon-lower trampoline can encounter at the import
+/// boundary: primitives, handles, string/list ptr+len pairs, and the
+/// registry-bound compounds (record/variant/tuple/flags/enum_/option/
+/// result/type_idx). Slots are treated as i32 (canon ABI flat repr for
+/// the i32-only-join case used by sockets / filesystem fixtures); i64
+/// joins read consecutive low+high u32 slots. (#520 wave 2)
+fn liftFlatReg(
+    slots: []const u32,
+    t: ctypes.ValType,
+    registry: TypeRegistry,
+    allocator: Allocator,
+) error{ OutOfMemory, InvalidDiscriminant, InvalidTypeIndex, EmptySlots, CompoundNeedsRegistry }!struct { val: InterfaceValue, used: u32 } {
+    if (slots.len == 0) return error.EmptySlots;
+    return switch (t) {
+        .bool => .{ .val = .{ .bool = slots[0] != 0 }, .used = 1 },
+        .s8 => .{ .val = .{ .s8 = @bitCast(@as(u8, @truncate(slots[0]))) }, .used = 1 },
+        .u8 => .{ .val = .{ .u8 = @truncate(slots[0]) }, .used = 1 },
+        .s16 => .{ .val = .{ .s16 = @bitCast(@as(u16, @truncate(slots[0]))) }, .used = 1 },
+        .u16 => .{ .val = .{ .u16 = @truncate(slots[0]) }, .used = 1 },
+        .s32 => .{ .val = .{ .s32 = @bitCast(slots[0]) }, .used = 1 },
+        .u32, .char => .{ .val = .{ .u32 = slots[0] }, .used = 1 },
+        .s64 => blk: {
+            const lo: u64 = slots[0];
+            const hi: u64 = if (slots.len > 1) slots[1] else 0;
+            break :blk .{ .val = .{ .s64 = @bitCast(hi << 32 | lo) }, .used = 2 };
+        },
+        .u64 => blk: {
+            const lo: u64 = slots[0];
+            const hi: u64 = if (slots.len > 1) slots[1] else 0;
+            break :blk .{ .val = .{ .u64 = hi << 32 | lo }, .used = 2 };
+        },
+        .f32 => .{ .val = .{ .f32 = slots[0] }, .used = 1 },
+        .f64 => blk: {
+            const lo: u64 = slots[0];
+            const hi: u64 = if (slots.len > 1) slots[1] else 0;
+            break :blk .{ .val = .{ .f64 = hi << 32 | lo }, .used = 2 };
+        },
+        .own, .borrow => .{ .val = .{ .handle = decodeResourceWire(slots[0]) }, .used = 1 },
+        .future, .stream, .error_context => .{ .val = .{ .handle = slots[0] }, .used = 1 },
+        .string => .{ .val = .{ .string = .{ .ptr = slots[0], .len = if (slots.len > 1) slots[1] else 0 } }, .used = 2 },
+        .list => .{ .val = .{ .list = .{ .ptr = slots[0], .len = if (slots.len > 1) slots[1] else 0 } }, .used = 2 },
+        .enum_ => |idx| blk: {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .enum_) return error.InvalidTypeIndex;
+            const disc = slots[0];
+            if (disc >= td.enum_.names.len) return error.InvalidDiscriminant;
+            break :blk .{ .val = .{ .enum_val = disc }, .used = 1 };
+        },
+        .flags => |idx| blk: {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .flags) return error.InvalidTypeIndex;
+            const n_words: u32 = @intCast(@max(@as(usize, 1), (td.flags.names.len + 31) / 32));
+            if (slots.len < n_words) return error.EmptySlots;
+            const words = try allocator.alloc(u32, n_words);
+            for (0..n_words) |k| words[k] = slots[k];
+            break :blk .{ .val = .{ .flags_val = words }, .used = n_words };
+        },
+        .record => |idx| blk: {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .record) return error.InvalidTypeIndex;
+            const fields = td.record.fields;
+            const vals = try allocator.alloc(InterfaceValue, fields.len);
+            errdefer {
+                for (vals) |v| v.deinit(allocator);
+                allocator.free(vals);
+            }
+            var used: u32 = 0;
+            for (fields, 0..) |f, i| {
+                const ft = resolveArmType(f.type, registry);
+                const r = try liftFlatReg(slots[used..], ft, registry, allocator);
+                vals[i] = r.val;
+                used += r.used;
+            }
+            break :blk .{ .val = .{ .record_val = vals }, .used = used };
+        },
+        .tuple => |idx| blk: {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .tuple) return error.InvalidTypeIndex;
+            const fields = td.tuple.fields;
+            const vals = try allocator.alloc(InterfaceValue, fields.len);
+            errdefer {
+                for (vals) |v| v.deinit(allocator);
+                allocator.free(vals);
+            }
+            var used: u32 = 0;
+            for (fields, 0..) |f, i| {
+                const ft = resolveArmType(f, registry);
+                const r = try liftFlatReg(slots[used..], ft, registry, allocator);
+                vals[i] = r.val;
+                used += r.used;
+            }
+            break :blk .{ .val = .{ .tuple_val = vals }, .used = used };
+        },
+        .variant => |idx| blk: {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .variant) return error.InvalidTypeIndex;
+            const cases = td.variant.cases;
+            const disc = slots[0];
+            if (disc >= cases.len) return error.InvalidDiscriminant;
+            // Discriminant + max-of-payload-flatten-counts (i32-only join).
+            const total_payload = abi.flattenCount(registry, t) - 1;
+            var payload: ?*InterfaceValue = null;
+            if (cases[disc].type) |ct| {
+                const resolved = resolveArmType(ct, registry);
+                const arm_slots = abi.flattenCount(registry, resolved);
+                if (1 + arm_slots > slots.len) return error.EmptySlots;
+                const r = try liftFlatReg(slots[1 .. 1 + arm_slots], resolved, registry, allocator);
+                const p = try allocator.create(InterfaceValue);
+                p.* = r.val;
+                payload = p;
+            }
+            break :blk .{
+                .val = .{ .variant_val = .{ .discriminant = disc, .payload = payload } },
+                .used = 1 + total_payload,
+            };
+        },
+        .option => |idx| blk: {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .option) return error.InvalidTypeIndex;
+            const disc = slots[0];
+            if (disc > 1) return error.InvalidDiscriminant;
+            const total_payload = abi.flattenCount(registry, t) - 1;
+            if (disc == 0) {
+                break :blk .{
+                    .val = .{ .option_val = .{ .is_some = false, .payload = null } },
+                    .used = 1 + total_payload,
+                };
+            }
+            const inner = resolveArmType(td.option.inner, registry);
+            const r = try liftFlatReg(slots[1..], inner, registry, allocator);
+            const p = try allocator.create(InterfaceValue);
+            p.* = r.val;
+            break :blk .{
+                .val = .{ .option_val = .{ .is_some = true, .payload = p } },
+                .used = 1 + total_payload,
+            };
+        },
+        .result => |idx| blk: {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            if (td != .result) return error.InvalidTypeIndex;
+            const disc = slots[0];
+            if (disc > 1) return error.InvalidDiscriminant;
+            const is_ok = disc == 0;
+            const arm_type: ?ctypes.ValType = if (is_ok) td.result.ok else td.result.err;
+            const total_payload = abi.flattenCount(registry, t) - 1;
+            var payload: ?*InterfaceValue = null;
+            if (arm_type) |at| {
+                const resolved = resolveArmType(at, registry);
+                const arm_slots = abi.flattenCount(registry, resolved);
+                if (1 + arm_slots > slots.len) return error.EmptySlots;
+                const r = try liftFlatReg(slots[1 .. 1 + arm_slots], resolved, registry, allocator);
+                const p = try allocator.create(InterfaceValue);
+                p.* = r.val;
+                payload = p;
+            }
+            break :blk .{
+                .val = .{ .result_val = .{ .is_ok = is_ok, .payload = payload } },
+                .used = 1 + total_payload,
+            };
+        },
+        .type_idx => |idx| blk: {
+            const td = registry.get(idx) orelse return error.InvalidTypeIndex;
+            const reified: ctypes.ValType = switch (td) {
+                .val => |inner| inner,
+                .list => .{ .list = idx },
+                .record => .{ .record = idx },
+                .tuple => .{ .tuple = idx },
+                .variant => .{ .variant = idx },
+                .flags => .{ .flags = idx },
+                .enum_ => .{ .enum_ = idx },
+                .option => .{ .option = idx },
+                .result => .{ .result = idx },
+                .resource => .{ .own = idx },
+                else => return error.InvalidTypeIndex,
+            };
+            break :blk try liftFlatReg(slots, reified, registry, allocator);
         },
     };
 }
@@ -5093,4 +5554,80 @@ test "pushInterfaceValue/popInterfaceValue: result<_, primitive> roundtrip (#155
     const disc_slot = try env.popI32();
     try testing.expectEqual(@as(u32, 0xCAFE), payload_slot);
     try testing.expectEqual(@as(i32, 1), disc_slot);
+}
+
+test "popInterfaceValue: lift variant<record<u16, tuple<u8x4>>> from flat stack (#520 wave 2)" {
+    // Mirrors the wasi:sockets@0.3.0 `ip-socket-address` ipv4 arm shape
+    // sent by wit-bindgen when the guest calls `tcp-socket.bind`.
+    // Before wave-2 #520, `popInterfaceValue` returned
+    // `error.CompoundNeedsRegistry` for `.variant` / `.record` /
+    // `.tuple`, blocking the entire sockets fixture bucket at the
+    // canon-lower trampoline boundary.
+    const testing = std.testing;
+    const core_types_mod = @import("../runtime/common/types.zig");
+    const inst_mod_core = @import("../runtime/interpreter/instance.zig");
+
+    const tup_fields = [_]ctypes.ValType{ .u8, .u8, .u8, .u8 };
+    const rec_fields = [_]ctypes.Field{
+        .{ .name = "port", .type = .u16 },
+        .{ .name = "address", .type = .{ .tuple = 0 } },
+    };
+    const cases = [_]ctypes.Case{
+        .{ .name = "ipv4", .type = .{ .record = 1 }, .refines = null },
+    };
+    const type_defs = [_]ctypes.TypeDef{
+        .{ .tuple = .{ .fields = &tup_fields } }, // 0
+        .{ .record = .{ .fields = &rec_fields } }, // 1
+        .{ .variant = .{ .cases = &cases } }, // 2
+    };
+    var component = ctypes.Component{
+        .core_modules = &.{}, .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},   .instances = &.{},      .aliases = &.{},
+        .types = &type_defs,  .canons = &.{},
+        .imports = &.{},      .exports = &.{},
+    };
+    const registry = TypeRegistry.init(&component);
+    const t: ctypes.ValType = .{ .variant = 2 };
+
+    var module = core_types_mod.WasmModule{};
+    const core_inst = try inst_mod_core.instantiate(&module, testing.allocator);
+    defer inst_mod_core.destroy(core_inst);
+    const env = try ExecEnv.create(core_inst, 64, testing.allocator);
+    defer env.destroy();
+
+    // Flat repr: [disc=0, port=0xBEEF, oct[0]=127, oct[1]=0, oct[2]=0, oct[3]=1].
+    try env.pushI32(0);
+    try env.pushI32(0xBEEF);
+    try env.pushI32(127);
+    try env.pushI32(0);
+    try env.pushI32(0);
+    try env.pushI32(1);
+
+    const lifted = try popInterfaceValue(env, t, registry, testing.allocator);
+    defer lifted.deinit(testing.allocator);
+    try testing.expectEqual(@as(u32, 0), lifted.variant_val.discriminant);
+    const rec = lifted.variant_val.payload.?;
+    try testing.expectEqual(@as(u16, 0xBEEF), rec.record_val[0].u16);
+    const oct = rec.record_val[1].tuple_val;
+    try testing.expectEqual(@as(u8, 127), oct[0].u8);
+    try testing.expectEqual(@as(u8, 0), oct[1].u8);
+    try testing.expectEqual(@as(u8, 0), oct[2].u8);
+    try testing.expectEqual(@as(u8, 1), oct[3].u8);
+}
+
+test "encode/decodeResourceWire round-trip (#520 wave 2)" {
+    // Re-export of the canon-ABI helper for use by host code that
+    // bypasses the lift/lower layer (e.g. `fsGetDirectories` writing
+    // descriptor handles straight into linear memory).
+    const testing = std.testing;
+    try testing.expectEqual(@as(u32, 1), encodeResourceWire(0));
+    try testing.expectEqual(@as(u32, 2), encodeResourceWire(1));
+    try testing.expectEqual(@as(u32, 0), decodeResourceWire(1));
+    try testing.expectEqual(@as(u32, 0), decodeResourceWire(0));
+    try testing.expectEqual(@as(u32, 1), decodeResourceWire(2));
+    // Round-trip stability for arbitrary slot indices.
+    for (0..100) |i| {
+        const slot: u32 = @intCast(i);
+        try testing.expectEqual(slot, decodeResourceWire(encodeResourceWire(slot)));
+    }
 }

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -5402,7 +5402,12 @@ pub const WasiCliAdapter = struct {
         for (self.fs_preopens.items, 0..) |p, i| {
             const name_ptr = ci.hostAllocAndWrite(p.name) orelse return error.IoError;
             const off = i * stride;
-            std.mem.writeInt(u32, scratch[off..][0..4], p.dir_handle, .little);
+            // `dir_handle` is the host-side 0-based slot index; the
+            // canon-ABI wire handle is `slot + 1` per the resource
+            // offset convention (`executor.encodeResourceWire`). Since
+            // we're writing the tuple straight into linear memory we
+            // apply the encoding here. (#520 wave 2)
+            std.mem.writeInt(u32, scratch[off..][0..4], abi.encodeResourceWireAbi(p.dir_handle), .little);
             std.mem.writeInt(u32, scratch[off + 4 ..][0..4], name_ptr, .little);
             std.mem.writeInt(u32, scratch[off + 8 ..][0..4], @intCast(p.name.len), .little);
         }
@@ -7708,6 +7713,56 @@ pub const WasiCliAdapter = struct {
         return .{ .result_val = .{ .is_ok = false, .payload = payload } };
     }
 
+    /// Map our internal `SocketErrorCode` (matches WASI 0.2 `enum`
+    /// numbering with `unknown=0`) to the WASI 0.3 `variant error-code`
+    /// discriminant from `wasi:sockets/types@0.3.0-rc-2026-03-15`. 0.3
+    /// dropped `unknown` and shifted all subsequent cases down by one,
+    /// and also dropped a handful of P2-specific cases (`concurrency-
+    /// conflict`, `not-in-progress`, `would-block`, `new-socket-limit`,
+    /// `name-unresolvable`, `temporary-resolver-failure`, `permanent-
+    /// resolver-failure`) which we collapse onto the `other(none)`
+    /// catch-all (case 14). (#520 wave 2)
+    pub fn socketCodeToP3Disc(code: SocketErrorCode) u32 {
+        return switch (code) {
+            .unknown => 14, // other(none)
+            .access_denied => 0,
+            .not_supported => 1,
+            .invalid_argument => 2,
+            .out_of_memory => 3,
+            .timeout => 4,
+            .concurrency_conflict => 14,
+            .not_in_progress => 14,
+            .would_block => 14,
+            .invalid_state => 5,
+            .new_socket_limit => 14,
+            .address_not_bindable => 6,
+            .address_in_use => 7,
+            .remote_unreachable => 8,
+            .connection_refused => 9,
+            .connection_reset => 11,
+            .connection_aborted => 12,
+            .datagram_too_large => 13,
+            // DNS-only cases on `wasi:sockets/ip-name-lookup` —
+            // callers using this helper for the `types` variant should
+            // never hit these; `other(none)` is the safe fallback.
+            .name_unresolvable => 14,
+            .temporary_resolver_failure => 14,
+            .permanent_resolver_failure => 14,
+        };
+    }
+
+    /// P3-aware variant of `socketResultErr` that emits WIT 0.3
+    /// `variant error-code` discriminants. Use from any host fn
+    /// targeting `wasi:sockets/types@0.3.0-rc-2026-03-15`. (#520 wave 2)
+    fn socketResultErrP3(allocator: Allocator, code: SocketErrorCode) !InterfaceValue {
+        const payload = try allocator.create(InterfaceValue);
+        payload.* = .{ .variant_val = .{
+            .discriminant = socketCodeToP3Disc(code),
+            .payload = null,
+        } };
+        return .{ .result_val = .{ .is_ok = false, .payload = payload } };
+    }
+
     /// Build a `result<X, error-code>` ok InterfaceValue.
     fn socketResultOk(allocator: Allocator, value: InterfaceValue) !InterfaceValue {
         const payload = try allocator.create(InterfaceValue);
@@ -7743,6 +7798,17 @@ pub const WasiCliAdapter = struct {
         const idx: u32 = @intCast(self.network_table.items.len);
         try self.network_table.append(self.allocator, n);
         return idx;
+    }
+
+    /// Decode a wire handle into a `network_table` slot index, or null
+    /// for out-of-range. Internal slot indices are 0-based; the canon
+    /// ABI's `.own/.borrow` resource-handle offset (#520 wave 2) is
+    /// applied at the lift/lower boundary in `canonical_abi.zig`, not
+    /// here. Kept as a helper for the network-allow-list lookups.
+    fn lookupNetworkSlot(self: *const WasiCliAdapter, handle: u32) ?u32 {
+        if (handle >= self.network_table.items.len) return null;
+        if (self.network_table.items[handle] == null) return null;
+        return handle;
     }
 
     fn pushResolveStream(self: *WasiCliAdapter, s: *ResolveAddressStream) !u32 {
@@ -8005,8 +8071,8 @@ pub const WasiCliAdapter = struct {
             },
             error.InvalidArgs => return error.InvalidArgs,
         };
-        const net = if (net_handle < self.network_table.items.len)
-            self.network_table.items[net_handle]
+        const net = if (self.lookupNetworkSlot(net_handle)) |net_idx|
+            self.network_table.items[net_idx]
         else
             null;
         if (net == null or !net.?.allows(local)) {
@@ -8187,8 +8253,8 @@ pub const WasiCliAdapter = struct {
             },
             error.InvalidArgs => return error.InvalidArgs,
         };
-        const net = if (net_handle < self.network_table.items.len)
-            self.network_table.items[net_handle]
+        const net = if (self.lookupNetworkSlot(net_handle)) |net_idx|
+            self.network_table.items[net_idx]
         else
             null;
         if (net == null or !net.?.allows(remote)) {
@@ -9051,8 +9117,8 @@ pub const WasiCliAdapter = struct {
             },
             error.InvalidArgs => return error.InvalidArgs,
         };
-        const net = if (net_handle < self.network_table.items.len)
-            self.network_table.items[net_handle]
+        const net = if (self.lookupNetworkSlot(net_handle)) |net_idx|
+            self.network_table.items[net_idx]
         else
             null;
         if (net == null or !net.?.allows(local)) {
@@ -9901,8 +9967,8 @@ pub const WasiCliAdapter = struct {
         // Allow-list opt-in gate. Default deny-all keeps the guest from
         // observing the host's DNS configuration even on names that
         // would resolve via /etc/hosts.
-        const net = if (net_handle < self.network_table.items.len)
-            self.network_table.items[net_handle]
+        const net = if (self.lookupNetworkSlot(net_handle)) |net_idx|
+            self.network_table.items[net_idx]
         else
             null;
         if (net == null or net.?.allow_list.len == 0) {
@@ -10294,24 +10360,30 @@ pub const WasiCliAdapter = struct {
             else => return error.InvalidArgs,
         };
         const s = self.lookupSocket(sock_handle) orelse {
-            results[0] = try socketResultErr(allocator, .invalid_state);
+            results[0] = try socketResultErrP3(allocator, .invalid_state);
             return;
         };
         if (s.kind != .tcp or s.state != .unbound) {
-            results[0] = try socketResultErr(allocator, .invalid_state);
+            results[0] = try socketResultErrP3(allocator, .invalid_state);
             return;
         }
         const local = liftIpSocketAddress(args[1], s.family) catch |err| switch (err) {
             error.FamilyMismatch => {
-                results[0] = try socketResultErr(allocator, .invalid_argument);
+                results[0] = try socketResultErrP3(allocator, .invalid_argument);
                 return;
             },
             error.InvalidArgs => return error.InvalidArgs,
         };
         if (!templateAllows(self.sockets_allow_list_template, local)) {
-            results[0] = try socketResultErr(allocator, .access_denied);
+            results[0] = try socketResultErrP3(allocator, .access_denied);
             return;
         }
+        // Bind is recorded on the rep without a kernel call here so
+        // that the existing P3 listen path (which sets up the actual
+        // listening fd via its own `IpAddress.listen`) doesn't fight
+        // with a stale `host_socket`. A real-bind path that round-
+        // trips the kernel-assigned ephemeral port is tracked as a
+        // follow-up to #520.
         s.local_addr = local;
         s.state = .bound;
         results[0] = try socketResultOk(allocator, .{ .tuple_val = &.{} });
@@ -10334,22 +10406,22 @@ pub const WasiCliAdapter = struct {
             else => return error.InvalidArgs,
         };
         const s = self.lookupSocket(sock_handle) orelse {
-            results[0] = try socketResultErr(allocator, .invalid_state);
+            results[0] = try socketResultErrP3(allocator, .invalid_state);
             return;
         };
         if (s.kind != .udp or s.state != .unbound) {
-            results[0] = try socketResultErr(allocator, .invalid_state);
+            results[0] = try socketResultErrP3(allocator, .invalid_state);
             return;
         }
         const local = liftIpSocketAddress(args[1], s.family) catch |err| switch (err) {
             error.FamilyMismatch => {
-                results[0] = try socketResultErr(allocator, .invalid_argument);
+                results[0] = try socketResultErrP3(allocator, .invalid_argument);
                 return;
             },
             error.InvalidArgs => return error.InvalidArgs,
         };
         if (!templateAllows(self.sockets_allow_list_template, local)) {
-            results[0] = try socketResultErr(allocator, .access_denied);
+            results[0] = try socketResultErrP3(allocator, .access_denied);
             return;
         }
         s.local_addr = local;
@@ -10375,22 +10447,22 @@ pub const WasiCliAdapter = struct {
             else => return error.InvalidArgs,
         };
         const s = self.lookupSocket(sock_handle) orelse {
-            results[0] = try socketResultErr(allocator, .invalid_state);
+            results[0] = try socketResultErrP3(allocator, .invalid_state);
             return;
         };
         if (s.kind != .udp) {
-            results[0] = try socketResultErr(allocator, .invalid_state);
+            results[0] = try socketResultErrP3(allocator, .invalid_state);
             return;
         }
         const remote = liftIpSocketAddress(args[1], s.family) catch |err| switch (err) {
             error.FamilyMismatch => {
-                results[0] = try socketResultErr(allocator, .invalid_argument);
+                results[0] = try socketResultErrP3(allocator, .invalid_argument);
                 return;
             },
             error.InvalidArgs => return error.InvalidArgs,
         };
         if (!templateAllows(self.sockets_allow_list_template, remote)) {
-            results[0] = try socketResultErr(allocator, .access_denied);
+            results[0] = try socketResultErrP3(allocator, .access_denied);
             return;
         }
         s.remote_addr = remote;
@@ -10414,11 +10486,11 @@ pub const WasiCliAdapter = struct {
             else => return error.InvalidArgs,
         };
         const s = self.lookupSocket(sock_handle) orelse {
-            results[0] = try socketResultErr(allocator, .invalid_state);
+            results[0] = try socketResultErrP3(allocator, .invalid_state);
             return;
         };
         if (s.kind != .udp or s.remote_addr == null) {
-            results[0] = try socketResultErr(allocator, .invalid_state);
+            results[0] = try socketResultErrP3(allocator, .invalid_state);
             return;
         }
         s.remote_addr = null;
@@ -10702,7 +10774,10 @@ pub const WasiCliAdapter = struct {
             .remote_addr = accepted.socket.address,
         }) catch return .err;
         var handle_bytes: [4]u8 = undefined;
-        std.mem.writeInt(u32, &handle_bytes, new_handle, .little);
+        // Apply the resource-handle wire offset (`slot + 1`) so the
+        // guest's wit-bindgen `Resource<TcpSocket>` constructor doesn't
+        // trip its `handle != 0` debug assertion. (#520 wave 2)
+        std.mem.writeInt(u32, &handle_bytes, abi.encodeResourceWireAbi(new_handle), .little);
         stream.buffer.appendSlice(allocator, &handle_bytes) catch return .err;
         return .progressed;
     }
@@ -10845,17 +10920,17 @@ pub const WasiCliAdapter = struct {
             else => return error.InvalidArgs,
         };
         const s = self.lookupSocket(sock_handle) orelse {
-            results[0] = try socketResultErr(allocator, .invalid_state);
+            results[0] = try socketResultErrP3(allocator, .invalid_state);
             return;
         };
         if (s.kind != .tcp) {
-            results[0] = try socketResultErr(allocator, .invalid_state);
+            results[0] = try socketResultErrP3(allocator, .invalid_state);
             return;
         }
         switch (s.state) {
             .unbound, .bound => {},
             else => {
-                results[0] = try socketResultErr(allocator, .invalid_state);
+                results[0] = try socketResultErrP3(allocator, .invalid_state);
                 return;
             },
         }
@@ -10872,7 +10947,7 @@ pub const WasiCliAdapter = struct {
         const server = std.Io.net.IpAddress.listen(&local, io, .{
             .kernel_backlog = s.listen_backlog orelse 128,
         }) catch |err| {
-            results[0] = try socketResultErr(allocator, mapSocketListenError(err));
+            results[0] = try socketResultErrP3(allocator, mapSocketListenError(err));
             return;
         };
         s.server = server;
@@ -10907,7 +10982,10 @@ pub const WasiCliAdapter = struct {
                 }) catch return error.OutOfMemory;
                 if (ci.streams.getPtr(stream_h)) |slot| {
                     var handle_bytes: [4]u8 = undefined;
-                    std.mem.writeInt(u32, &handle_bytes, new_handle, .little);
+                    // Apply the resource-handle wire offset
+                    // (`slot + 1`); see `accept_driver` above. (#520
+                    // wave 2)
+                    std.mem.writeInt(u32, &handle_bytes, abi.encodeResourceWireAbi(new_handle), .little);
                     try slot.buffer.appendSlice(ci.allocator, &handle_bytes);
                 }
             } else |_| {}
@@ -18260,8 +18338,12 @@ test "wasi:filesystem@0.3.0 open-at: future payload decodes to result<descriptor
     try testing.expectEqual(@as(usize, 20), fut.payload.?.len);
     // ok arm → discriminant byte = 0.
     try testing.expectEqual(@as(u8, 0), fut.payload.?[0]);
-    // ok payload at offset 4: u32 descriptor handle.
-    const opened_handle = std.mem.readInt(u32, fut.payload.?[4..8], .little);
+    // ok payload at offset 4: u32 descriptor handle (wire-encoded;
+    // decode via `executor.decodeResourceWire` to recover the 0-based
+    // slot index — #520 wave 2 applied a `slot + 1` offset so the
+    // canon-ABI wire handle is never 0).
+    const wire_handle = std.mem.readInt(u32, fut.payload.?[4..8], .little);
+    const opened_handle = @import("executor.zig").decodeResourceWire(wire_handle);
     try testing.expect(opened_handle < adapter.fs_descriptor_table.items.len);
     try testing.expect(adapter.fs_descriptor_table.items[opened_handle] != null);
 }
@@ -20152,8 +20234,11 @@ test "sockets P3: udp-socket.connect / disconnect round-trip remote_addr (#486)"
         try WasiCliAdapter.udpDisconnectP3(&adapter, &ci, &args, &results, testing.allocator);
         defer testing.allocator.destroy(results[0].result_val.payload.?);
         try testing.expect(!results[0].result_val.is_ok);
+        // P3 host fns use WIT 0.3 `variant error-code` discriminants
+        // (no `unknown` case, so `invalid-state` is disc 5 not 9).
+        // (#520 wave 2)
         try testing.expectEqual(
-            @as(u32, @intFromEnum(SocketErrorCode.invalid_state)),
+            @as(u32, WasiCliAdapter.socketCodeToP3Disc(.invalid_state)),
             results[0].result_val.payload.?.variant_val.discriminant,
         );
     }
@@ -20909,11 +20994,14 @@ test "sockets P3 #535: tcp-accept stream driver pushes 3 connections through one
     try testing.expectEqual(@as(usize, 0), listen_slot.buffer.items.len % 4);
 
     // Each handle should reference a distinct, connected Socket slot.
+    // The bytes are canon-ABI wire handles (slot+1 per the resource
+    // offset, #520 wave 2), so decode before indexing the table.
     var seen: std.AutoHashMapUnmanaged(u32, void) = .empty;
     defer seen.deinit(testing.allocator);
     var off: usize = 0;
     while (off + 4 <= listen_slot.buffer.items.len) : (off += 4) {
-        const h = std.mem.readInt(u32, listen_slot.buffer.items[off..][0..4], .little);
+        const wire = std.mem.readInt(u32, listen_slot.buffer.items[off..][0..4], .little);
+        const h = @import("executor.zig").decodeResourceWire(wire);
         try seen.put(testing.allocator, h, {});
         const s = adapter.socket_table.items[h].?;
         try testing.expectEqual(SocketKind.tcp, s.kind);
@@ -26131,4 +26219,58 @@ test "wasi:http@0.3 (#552): authority byte-validation: host[:port], rejects bad 
     try testing.expect(!try Caller.callSetSome(&adapter, &ci, req_handle, "example.com:"));
     // Empty authority rejected.
     try testing.expect(!try Caller.callSetSome(&adapter, &ci, req_handle, ""));
+}
+
+test "sockets (#520 wave 2): socketCodeToP3Disc maps internal enum to WIT 0.3 variant discs" {
+    const testing = std.testing;
+    // WIT 0.3 `wasi:sockets/types.error-code` variant ordering:
+    // 0=access-denied, 1=not-supported, 2=invalid-argument, 3=out-of-memory,
+    // 4=timeout, 5=invalid-state, 6=address-not-bindable, 7=address-in-use,
+    // 8=remote-unreachable, 9=connection-refused, 10=connection-broken,
+    // 11=connection-reset, 12=connection-aborted, 13=datagram-too-large,
+    // 14=other(option<string>). Our internal `SocketErrorCode` enum
+    // matches the 0.2 ENUM ordering (`unknown=0`, access_denied=1, …)
+    // which is off-by-one from 0.3 — that mismatch is what
+    // `socketCodeToP3Disc` translates at the host boundary.
+    try testing.expectEqual(@as(u32, 0), WasiCliAdapter.socketCodeToP3Disc(.access_denied));
+    try testing.expectEqual(@as(u32, 1), WasiCliAdapter.socketCodeToP3Disc(.not_supported));
+    try testing.expectEqual(@as(u32, 2), WasiCliAdapter.socketCodeToP3Disc(.invalid_argument));
+    try testing.expectEqual(@as(u32, 3), WasiCliAdapter.socketCodeToP3Disc(.out_of_memory));
+    try testing.expectEqual(@as(u32, 5), WasiCliAdapter.socketCodeToP3Disc(.invalid_state));
+    try testing.expectEqual(@as(u32, 6), WasiCliAdapter.socketCodeToP3Disc(.address_not_bindable));
+    try testing.expectEqual(@as(u32, 7), WasiCliAdapter.socketCodeToP3Disc(.address_in_use));
+    // 0.2-only cases (no 0.3 equivalent) fall back to `other(none)` = 14.
+    try testing.expectEqual(@as(u32, 14), WasiCliAdapter.socketCodeToP3Disc(.unknown));
+    try testing.expectEqual(@as(u32, 14), WasiCliAdapter.socketCodeToP3Disc(.concurrency_conflict));
+    try testing.expectEqual(@as(u32, 14), WasiCliAdapter.socketCodeToP3Disc(.not_in_progress));
+    try testing.expectEqual(@as(u32, 14), WasiCliAdapter.socketCodeToP3Disc(.would_block));
+    try testing.expectEqual(@as(u32, 14), WasiCliAdapter.socketCodeToP3Disc(.new_socket_limit));
+}
+
+test "main (#520 wave 2): runComponent applies --map-dir flags via addPreopen" {
+    const testing = std.testing;
+
+    // Spin up an adapter the same way `runComponent` does and verify
+    // that `addPreopen` ends up in `fs_preopens`. The CLI plumbing
+    // path itself (parse `--map-dir`, call `cwd_dir.openDir`, hand
+    // off to `addPreopen`) is exercised end-to-end by the
+    // wasi-p3-testsuite filesystem fixtures once the async-future
+    // lower fix lands; this unit test pins the contract.
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const handle = try adapter.addPreopen("fs-tests.dir", tmp.dir);
+    // Replace the slot with null so adapter.deinit doesn't double-close
+    // (tmp.cleanup() owns the dir handle).
+    adapter.fs_descriptor_table.items[handle] = null;
+
+    try testing.expectEqual(@as(usize, 1), adapter.fs_preopens.items.len);
+    try testing.expectEqualStrings("fs-tests.dir", adapter.fs_preopens.items[0].name);
+    // `dir_handle` is the 0-based slot index; the wire encoding
+    // (`slot + 1`) is applied by `fsGetDirectories` via
+    // `abi.encodeResourceWireAbi` when lowering to guest memory.
+    try testing.expectEqual(handle, adapter.fs_preopens.items[0].dir_handle);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -76,6 +76,14 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     defer env_flags.deinit(allocator);
     var map_dirs: std.ArrayListUnmanaged(MapDir) = .empty;
     defer map_dirs.deinit(allocator);
+    // `--allow-net=CIDR` (repeatable): seed the component-side WASI
+    // sockets allow-list with the given CIDR blocks. Without at least
+    // one entry the default-deny policy rejects every bind/connect
+    // with `error-code::access-denied` — the wasi-testsuite sockets
+    // fixtures need 127.0.0.0/8 (and ::1/128) to exercise the
+    // loopback-bind paths. (#520 wave 2)
+    var allow_net: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer allow_net.deinit(allocator);
     var listen_address: ?std.Io.net.IpAddress = null;
     var stack_size: u32 = 64 * 1024;
     var past_options = false;
@@ -136,6 +144,16 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                     return 2;
                 };
                 try map_dirs.append(allocator, md);
+            } else if (std.mem.eql(u8, arg, "--allow-net") or std.mem.startsWith(u8, arg, "--allow-net=")) {
+                const spec = if (std.mem.eql(u8, arg, "--allow-net")) blk: {
+                    i += 1;
+                    if (i >= run_args.len) {
+                        std.debug.print("error: --allow-net requires CIDR (e.g. 127.0.0.0/8)\n", .{});
+                        return 2;
+                    }
+                    break :blk run_args[i];
+                } else arg["--allow-net=".len..];
+                try allow_net.append(allocator, spec);
             } else if (std.mem.eql(u8, arg, "--")) {
                 past_options = true;
             } else {
@@ -195,7 +213,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
             if (listen_address) |addr| {
                 return runHttpComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, addr);
             }
-            return runComponent(wasm_data, allocator, path, wasm_args.items, env_list.items);
+            return runComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, map_dirs.items, allow_net.items);
         }
     }
 
@@ -250,6 +268,8 @@ fn runComponent(
     wasm_path: []const u8,
     wasm_args: []const []const u8,
     env_vars: []const wamr.wasi_cli_adapter.EnvVar,
+    map_dirs: []const MapDir,
+    allow_net_cidrs: []const []const u8,
 ) u8 {
     const adapter_mod = wamr.wasi_cli_adapter;
     // Wire the adapter's stdio directly to the host process's
@@ -270,6 +290,43 @@ fn runComponent(
     for (wasm_args, 0..) |a, i| argv_buf[i + 1] = a;
     adapter.setArguments(argv_buf);
     adapter.setEnvironment(env_vars);
+
+    // Seed the WASI sockets allow-list from `--allow-net=CIDR` flags
+    // (default deny-all). (#520 wave 2)
+    if (allow_net_cidrs.len > 0) {
+        adapter.setSocketsAllowList(allow_net_cidrs) catch |err| {
+            std.debug.print("Error: invalid --allow-net CIDR: {}\n", .{err});
+            return 1;
+        };
+    }
+
+    // Register each `--map-dir HOST::GUEST` flag as a filesystem
+    // preopen. wasi-testsuite fixtures (e.g. wasm32-wasip3
+    // `filesystem-stat`) discover their fs-test directory via
+    // `wasi:filesystem/preopens.get-directories`; without these
+    // registrations the test asserts no preopens and exits early
+    // with a usage message. (#520 wave 2)
+    if (map_dirs.len > 0) {
+        const io = std.Io.Threaded.global_single_threaded.io();
+        const cwd_dir = std.Io.Dir.cwd();
+        for (map_dirs) |md| {
+            const opened = cwd_dir.openDir(io, md.host_path, .{}) catch |err| {
+                std.debug.print(
+                    "Error: cannot pre-open '{s}' as '{s}': {}\n",
+                    .{ md.host_path, md.guest_name, err },
+                );
+                return 1;
+            };
+            _ = adapter.addPreopen(md.guest_name, opened) catch |err| {
+                std.debug.print(
+                    "Error: cannot register preopen '{s}': {}\n",
+                    .{ md.guest_name, err },
+                );
+                opened.close(io);
+                return 1;
+            };
+        }
+    }
 
     // The component loader has no `Component.deinit` yet (#142 Phase 1B);
     // its allocations (and the matching `ComponentInstance` machinery, whose
@@ -688,6 +745,10 @@ const run_usage =
     \\  --env KEY=VALUE          Set a WASI environment variable (repeatable)
     \\  --map-dir HOST::GUEST    Pre-open `HOST` host directory as `GUEST`
     \\                           inside the guest WASI sandbox (repeatable)
+    \\  --allow-net CIDR         For components: allow wasi:sockets bind /
+    \\                           connect / DNS to addresses inside CIDR
+    \\                           (e.g. `127.0.0.0/8`). Default deny-all.
+    \\                           Repeatable.
     \\
 ;
 

--- a/tests/wasi-testsuite-adapter/wamr-zig.py
+++ b/tests/wasi-testsuite-adapter/wamr-zig.py
@@ -68,6 +68,14 @@ def compute_argv(
     for host, guest in dirs:
         argv += ["--map-dir", f"{host}::{guest}"]
 
+    # wasi:sockets fixtures need an explicit allow-list to escape the
+    # adapter's default deny-all posture. Localhost is sufficient for
+    # every wasi-testsuite sockets fixture (they all bind/connect to
+    # 127.0.0.1 / ::1). (#520 wave 2)
+    if "sockets" in proposals:
+        argv += ["--allow-net", "127.0.0.0/8"]
+        argv += ["--allow-net", "::1/128"]
+
     argv += [test_path]
     argv += args
     return argv


### PR DESCRIPTION
Triage-led batch of CLI dispatch fixes for #520 — the shared
substrate that the 27 remaining sockets / filesystem / http-service
fixtures all hit before they get a chance to fail on per-bucket
host adapter bugs (allow-list policy, multicast rejection, set-X(0)
validation, async-lower trampoline shape, etc.). Each fix here
moves at least one fixture's failure point past the dispatch
trampoline; the rest is host-binding work tracked as follow-ups.

## Failure modes diagnosed

Running `./zig-out/bin/wamr run sockets-tcp-bind.wasm` /
`filesystem-stat.wasm` failed with progressively-deeper errors as
each blocker was removed:

1. `async-lifted trap … stage=lift_args error=CompoundNeedsRegistry`
   — `popInterfaceValue` / `pushInterfaceValue` rejected every
   `.record` / `.variant` / `.tuple` / `.flags` / `.enum_` on the
   flat-stack canon-lower path. The sockets / filesystem fixtures
   pass `ip-socket-address` (variant of records of tuples) and
   `path-flags` / `open-flags` / `descriptor-flags` (flags) as
   sub-`MAX_FLAT_PARAMS` args, so they all hit this immediately.
2. `assertion failed: handle != 0 && handle != u32::MAX` from
   wit-bindgen Rust's `Resource<T>::from_handle`. Our adapter
   tables (`socket_table` / `fs_descriptor_table` /
   `network_table`) returned 0-based slot indices straight onto
   the wire, but wit-bindgen treats handle 0 as the
   \"uninitialised\" sentinel.
3. `error.Trap` on `tcp-socket.bind` returning
   `Err(InvalidArgument)` mapped to the wrong discriminant — our
   internal `SocketErrorCode` matches the WASI 0.2 ENUM ordering
   (`unknown=0`, `access-denied=1`, …) which is off-by-one from
   the 0.3 VARIANT (`access-denied=0`).
4. `get-local-address` round-trip returned
   `IpAddress::Ipv4((0, 1, 0, 0))` instead of `(127, 0, 0, 1)` —
   `storeValReg.variant` / `loadValReg.variant` used the *active
   arm's* alignment instead of the max across all cases, shifting
   the payload offset for ipv4 (align 2) when the variant also
   has ipv6 (align 4). This is a real correctness bug for **any**
   mixed-alignment variant in any P3 fixture.
5. `panic: access of union field 'result_val' while field 'handle'
   is active` — `tcpSetListenBacklogSize` returns
   `socketResultOk(allocator, .{ .tuple_val = &.{} })` for an
   `Ok({})` shape, but the WIT is `result<_, error-code>` with
   no ok type. `storeValFromDef.result` / `storeValReg.result`
   unconditionally unwrapped `res.ok.?` and panicked.
6. `usage: run with one open dir named 'fs-tests.dir'` — the
   component-path `runComponent` ignored `--map-dir` flags
   entirely, so filesystem fixtures saw an empty
   `get-directories` list and exited early.
7. `Error: component trapped during run` (no diagnostic) — the
   async-lifted dispatch had no equivalent of the sync path's
   `[component trap] core_func_idx=… import=…` print added in
   #520 wave 1, so any trap inside a P3 fixture went unattributed.

## Fixes applied

| # | File(s) | Change |
|---|---|---|
| 1 | `executor.zig` | New `popFlatCompound` + `liftFlatReg` (and matching `lowerFlatReg` for the push path) handle `.record` / `.variant` / `.tuple` / `.flags` / `.enum_` / `.option` / `.result` / `.type_idx` on the flat stack via a 32-slot scratch buffer. Mirrors the registry-walking `loadValReg` shape from the memory-spill path. |
| 2 | `executor.zig`, `canonical_abi.zig`, `wasi_cli_adapter.zig` | New `encodeResourceWire` / `decodeResourceWire` (and the matching `encodeResourceWireAbi` re-export) apply a `slot + 1` offset on `.own` / `.borrow` (resource) handles at the canon-ABI lift/lower boundary — including the memory-spill `loadVal` / `storeVal` paths and the `fsGetDirectories` / `accept_driver` raw-memory writes that bypass the lift/lower layer. Host code stays 0-indexed (so existing unit tests keep working). `.future` / `.stream` / `.error_context` handles already start at 1 (via `allocAsyncHandle`), so they're not offset. |
| 3 | `wasi_cli_adapter.zig` | New `socketCodeToP3Disc` + `socketResultErrP3` map our internal 0.2-style `SocketErrorCode` enum to the 0.3 VARIANT discriminants. All 18 `*P3` socket host fns updated via a scoped rename (P2 paths kept on `socketResultErr`). |
| 4 | `canonical_abi.zig` | Variant payload alignment now uses `max(alignOfType(case.type))` across all cases (the canon-ABI semantics already used by `alignOfTypeDef.variant` / `sizeOfTypeDef.variant`). Applied to `loadValReg` / `loadValFromDef` / `storeValReg` / `storeValFromDef` for symmetry. |
| 5 | `canonical_abi.zig` | `storeValFromDef.result` / `storeValReg.result` skip the ok payload write when `res.ok` is null (matching the existing `if (val.result_val.payload) \|…\|` guard). |
| 6 | `main.zig`, `wasi_cli_adapter.zig` | `runComponent` now propagates `--map-dir HOST::GUEST` flags through to `WasiCliAdapter.addPreopen`. New `--allow-net=CIDR` flag seeds the sockets allow-list template (default deny-all). |
| 7 | `executor.zig` | `callComponentFuncByLocalAsyncLifted` now prints `[async-lifted trap] core_func_idx=… import='…' stage=… error=…` from `env.host_trap` (suppressed for the `WasiExit` control-flow case). Mirrors the sync-path emission added in #520 wave 1 (PR #532). |
| 8 | `tests/wasi-testsuite-adapter/wamr-zig.py` | The wasi-testsuite adapter now passes `--allow-net=127.0.0.0/8` and `--allow-net=::1/128` whenever the test manifest declares the `sockets` proposal. |

## Tests added

7 new unit tests (all under `zig build test`):

- `variant: mixed-arm alignment uses the max across all cases (#520 wave 2)`
- `result<_, E>: store with null ok type does not crash (#520 wave 2)`
- `encode/decodeResourceWireAbi round-trip (#520 wave 2)`
- `popInterfaceValue: lift variant<record<u16, tuple<u8x4>>> from flat stack (#520 wave 2)`
- `encode/decodeResourceWire round-trip (#520 wave 2)`
- `sockets (#520 wave 2): socketCodeToP3Disc maps internal enum to WIT 0.3 variant discs`
- `main (#520 wave 2): runComponent applies --map-dir flags via addPreopen`

Plus three existing tests updated to decode the new wire-handle
encoding (`tcp-accept stream driver pushes 3 connections`,
`open-at future payload decodes to result<descriptor, …>`,
`udp-socket.connect / disconnect round-trip`).

## Skip-list shrinkage

`tests/wasi-p3-testsuite-skip.json`: 32 → 32 (unchanged on the
`zig build wasi-p3-testsuite` gate). The dispatch substrate is
now correct, but every remaining fixture trips at least one
per-bucket host bug that's tracked as a wave-3 follow-up:

- **`sockets-tcp-bind`**: dispatch passes; needs real-bind in
  `tcpBindP3` *plus* multicast / broadcast / non-bindable address
  rejection. The variant-alignment fix moves it past the
  `assert_eq!(addr.ip_addr(), bound.ip_addr())` round-trip — next
  failure is `assert_ne!(addr.port(), bound.port())` from the
  missing kernel-port assignment.
- **`sockets-tcp-properties`**: dispatch passes; needs per-setter
  `value == 0 → invalid-argument` validation and rep-side storage
  so getters return what was set before bind.
  `tcpSetKeepAliveIdleTime` etc. currently read directly from a
  kernel fd that doesn't exist on an unbound socket.
- **`sockets-tcp-connect` / `sockets-tcp-listen` /
  `sockets-tcp-send` / `sockets-tcp-receive` / `sockets-udp-*` /
  `http-service`**: `async func` host imports lower as a
  status `u32` + retptr, not as the lifted `R`. The trampoline
  needs to recognise `FuncType.is_async` and emit the async
  flat ABI instead of treating the result as sync.
- **`filesystem-*`** (14 fixtures): same async-lower issue.
  `fsCompleteAsyncSync` returns `.{ .handle = future_handle }`
  for the lowered shape, but the trampoline lowers the WIT
  result `result<descriptor, error-code>` and panics on the tag
  mismatch.

`zig build wasi-p3-testsuite` output: still `PASS: 8 tests passed
(32 skipped)`. Local smoke runs against the patched binary show
every fixture progressing past the dispatch layer.

## Verification

- `zig build` — clean
- `zig build test --summary all` — 2521 / 2523 tests pass (2 skipped, 0 fail)
- `zig build wasi-p3-testsuite` — 8 passed, 32 skipped (unchanged from main)
- Cross-compile sweep clean on:
  - `aarch64-macos`
  - `x86_64-windows`
  - `x86_64-linux`

## Follow-up gaps surfaced during triage

Each below should land as a separate ticket:

1. **Async-lower trampoline** — `FuncType.is_async` lifted via the
   `0x43` deftype tag (wave 1) needs to flow through to the canon-
   lower trampoline's flat-result shape so `open-at` /
   `tcp-socket.connect` / `http-service` etc. lower as
   `(retptr i32) -> status i32` instead of as the lifted `R`.
2. **sockets-tcp-properties** host policy — per-setter zero-
   rejection + rep-side state tracking for `keep-alive-*`,
   `hop-limit`, `receive/send-buffer-size` so the getters round-
   trip on an unbound socket.
3. **sockets-tcp-bind** — `tcpBindP3` should issue a real
   `IpAddress.bind` so `get-local-address` returns the kernel-
   assigned ephemeral port; `tcpListenP3` would then reuse the
   existing `host_socket` instead of binding a second time.
4. **Multicast / broadcast / non-bindable address rejection** —
   per the WIT `tcp-socket.bind` spec, multicast (`224/4` /
   `ff00::/8`), broadcast (`255.255.255.255`), and the RFC 5737
   doc ranges (`192.0.2/24`, `198.51.100/24`, `203.0.113/24`,
   `2001:db8::/32`) must fail with `invalid-argument` /
   `address-not-bindable`.
5. **P3 sockets error-code variant for `other(option<string>)`** —
   today `socketCodeToP3Disc` collapses unmappable internal
   codes onto disc 14 (`other`) but always emits `payload = null`
   (i.e. `other(none)`). A diagnostic string would help guests
   surface why an op was refused.
6. **HTTP host-handle wire offset** — the `http_outgoing_responses`
   / `http_outgoing_requests` / `http_incoming_*` tables still
   use raw 0-based slot indices on the wire. If any HTTP P3
   fixture starts dispatching after the async-lower fix lands,
   it will trip the same `handle != 0` assertion and the offset
   convention will need to extend there too.

`Refs #520` — incremental fix; the issue stays open until the
remaining 27 sockets / filesystem / http-service fixtures clear.