### PR TITLE
feat(wasi:filesystem@0.3.0): filesystem-stat fixture detail (#571)

### DIFF
--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -2445,12 +2445,20 @@ fn canResolveOuterTypeAlias(a: ctypes.Alias, component: *const ctypes.Component)
 /// Resolve a single-hop `.alias outer 1 M (type)` against the parent
 /// component's `type_indexspace`. Returns the parent's `TypeDef` or
 /// `null` when the alias shape is unsupported (multi-level outer,
-/// non-type sort, target slot still unresolved). The returned TypeDef
-/// is structurally shared with the parent — callers MUST NOT deep-free
-/// it when tearing the extension down. Limited to `TypeDef.val` for
-/// now (#534 scope; primitives like `type duration = u64` cover the
-/// clock fixtures). A future slice may extend this to record / variant
-/// payloads with proper deep-copy + type_idx rewriting.
+/// non-type sort, target slot still unresolved).
+///
+/// `#534` originally limited the return shape to `TypeDef.val` because
+/// that covers `type duration = u64` (the clock fixtures). `#571`
+/// (filesystem-stat) requires the same path for `.record` / `.variant`
+/// / `.tuple` / `.flags` / `.enum_` / `.option` / `.result` / `.list`
+/// because wit-bindgen emits the `wasi:filesystem/types` instance-type
+/// body with `(alias outer 1 M (type))` decls pointing at top-level
+/// records (`datetime`) and variants (`new-timestamp` references
+/// `datetime` via this alias). The returned `TypeDef` is structurally
+/// shared with the parent — `buildInstanceTypeExtension` deep-copies
+/// it through `rewriteTypeDefAbsolute(allocator, 0, ...)` so the
+/// extension owns its own field/case/tuple slice and `deinit` can free
+/// safely without double-freeing the parent's slices.
 fn resolveOuterTypeAliasToParent(
     a: ctypes.Alias,
     component: *const ctypes.Component,
@@ -2468,7 +2476,7 @@ fn resolveOuterTypeAliasToParent(
     if (local >= component.types.len) return null;
     const td = component.types[local];
     return switch (td) {
-        .val => td,
+        .val, .record, .variant, .tuple, .flags, .enum_, .option, .result, .list => td,
         else => null,
     };
 }
@@ -2539,14 +2547,31 @@ fn buildInstanceTypeExtension(
             // `.alias outer count=1 idx=M (type)` — when M points at a
             // parent type-indexspace slot that has been resolved (e.g.
             // by the loader's #534 top-level type-alias resolution),
-            // copy that TypeDef into the extension so canon-ABI
-            // lift/lower of values whose declared type goes through this
-            // slot can look up the concrete shape. Deep-copy is not
-            // needed for the `TypeDef.val` case currently handled by
-            // the loader resolver; nested type_idx refs would require
-            // rewriting and are out of scope here.
+            // materialize the parent's TypeDef in the extension so
+            // canon-ABI lift/lower of values whose declared type goes
+            // through this slot can look up the concrete shape.
+            //
+            // For `.record` / `.tuple` / `.variant` we deep-copy via
+            // `rewriteTypeDefAbsolute(allocator, 0, ...)` so the
+            // extension owns its own fields/cases slice (`deinit`
+            // would otherwise double-free shared parent slices). The
+            // `base=0` argument leaves nested `.type_idx` refs at the
+            // parent's absolute index, which is correct: those refs
+            // are < `ext_base`, so the registry's `get()` falls into
+            // the parent-component lookup path. (`#571`.)
+            //
+            // For leaf shapes (`.val` / `.flags` / `.enum_` / `.list`
+            // / `.option` / `.result`) deinit doesn't free heap
+            // payload, so shallow sharing is safe.
             if (resolveOuterTypeAliasToParent(a, component)) |parent_td| {
-                types_buf[type_i] = parent_td;
+                const copied: ctypes.TypeDef = switch (parent_td) {
+                    .record, .tuple, .variant => rewriteTypeDefAbsolute(allocator, 0, parent_td) catch {
+                        rewrite_failed = true;
+                        break;
+                    },
+                    else => parent_td,
+                };
+                types_buf[type_i] = copied;
                 idxspace_buf[slot_i] = type_i;
                 type_i += 1;
             } else {

--- a/src/component/loader.zig
+++ b/src/component/loader.zig
@@ -420,11 +420,33 @@ fn resolveTopLevelTypeAliases(
             ) orelse continue;
 
             // Materialize the resolved TypeDef in the parent's type
-            // pool. For primitive `TypeDef.val` we can copy directly;
-            // any compound shape would require deep-copy + type_idx
-            // rewriting, which this pass leaves for a future slice.
+            // pool. Primitive `TypeDef.val` can be copied directly.
+            //
+            // For structural compounds (`.record` / `.variant` / etc.)
+            // we accept only the "safe" subset where every nested
+            // ValType is a primitive — no `.type_idx` / `.record` /
+            // `.variant` / `.list` / ... references whose meaning is
+            // local to the source instance-type body. This covers
+            // `wasi:clocks/wall-clock` `datetime = record { seconds:
+            // u64, nanoseconds: u32 }` (the 0.2 shape) and
+            // `wasi:clocks/system-clock` `record instant { seconds:
+            // s64, nanoseconds: u32 }` (the 0.3 shape), which
+            // `wasi:filesystem` aliases via `(alias outer 1 K (type))`
+            // for `new-timestamp`'s `timestamp(datetime)` case
+            // payload. (`#571`.)
+            //
+            // Compound types whose nested references would need
+            // remapping into the parent indexspace are still skipped —
+            // that remains future work.
             switch (resolved) {
                 .val => {
+                    const new_idx: u32 = @intCast(type_defs.items.len);
+                    try type_defs.append(allocator, resolved);
+                    type_indexspace[slot] = new_idx;
+                    any_change = true;
+                },
+                .record, .variant, .tuple, .flags, .enum_, .option, .result, .list => {
+                    if (!typeDefHasOnlyPrimitiveRefs(resolved)) continue;
                     const new_idx: u32 = @intCast(type_defs.items.len);
                     try type_defs.append(allocator, resolved);
                     type_indexspace[slot] = new_idx;
@@ -435,6 +457,63 @@ fn resolveTopLevelTypeAliases(
         }
         if (!any_change) return;
     }
+}
+
+/// True iff `td` references only primitive ValTypes (no `.type_idx`
+/// indirection into another indexspace, no nested `.record` / `.variant`
+/// / `.list` / etc. structural refs). Used by `resolveTopLevelTypeAliases`
+/// (#571) to gate which structural typedefs are safe to materialize
+/// across instance-type-body boundaries without a remap pass — typically
+/// `wasi:clocks/wall-clock` `datetime = record { seconds: u64,
+/// nanoseconds: u32 }` and similar primitive-only records.
+fn typeDefHasOnlyPrimitiveRefs(td: ctypes.TypeDef) bool {
+    return switch (td) {
+        .val => |v| isPrimitiveValType(v),
+        .record => |r| blk: {
+            for (r.fields) |f| if (!isPrimitiveValType(f.type)) break :blk false;
+            break :blk true;
+        },
+        .tuple => |t| blk: {
+            for (t.fields) |f| if (!isPrimitiveValType(f)) break :blk false;
+            break :blk true;
+        },
+        .variant => |v| blk: {
+            for (v.cases) |c| if (c.type) |ct| {
+                if (!isPrimitiveValType(ct)) break :blk false;
+            };
+            break :blk true;
+        },
+        .option => |o| isPrimitiveValType(o.inner),
+        .result => |r| blk: {
+            if (r.ok) |t| if (!isPrimitiveValType(t)) break :blk false;
+            if (r.err) |t| if (!isPrimitiveValType(t)) break :blk false;
+            break :blk true;
+        },
+        .list => |l| isPrimitiveValType(l.element),
+        // `.flags` / `.enum_` carry only name lists — always safe.
+        .flags, .enum_ => true,
+        else => false,
+    };
+}
+
+fn isPrimitiveValType(vt: ctypes.ValType) bool {
+    return switch (vt) {
+        .bool,
+        .s8,
+        .u8,
+        .s16,
+        .u16,
+        .s32,
+        .u32,
+        .s64,
+        .u64,
+        .f32,
+        .f64,
+        .char,
+        .string,
+        => true,
+        else => false,
+    };
 }
 
 /// Resolve `(alias <inst_ci_idx> "<name>" (type …))` to the exported
@@ -1747,4 +1826,76 @@ test "load: real wasm32-wasip2 Rust component (stdio-echo)" {
             return err;
         };
     }
+}
+
+test "loader #571: typeDefHasOnlyPrimitiveRefs accepts primitive-only compounds" {
+    const testing = std.testing;
+
+    // `datetime` from `wasi:clocks/wall-clock` / `system-clock.instant`:
+    // record { seconds: s64, nanoseconds: u32 } — primitives only.
+    const datetime_fields = [_]ctypes.Field{
+        .{ .name = "seconds", .type = .s64 },
+        .{ .name = "nanoseconds", .type = .u32 },
+    };
+    const datetime_td: ctypes.TypeDef = .{ .record = .{ .fields = &datetime_fields } };
+    try testing.expect(typeDefHasOnlyPrimitiveRefs(datetime_td));
+
+    // Flags / enum — always safe (name lists, no nested ValType refs).
+    const flags_names = [_][]const u8{ "a", "b" };
+    const flags_td: ctypes.TypeDef = .{ .flags = .{ .names = &flags_names } };
+    try testing.expect(typeDefHasOnlyPrimitiveRefs(flags_td));
+
+    const enum_names = [_][]const u8{ "x", "y" };
+    const enum_td: ctypes.TypeDef = .{ .enum_ = .{ .names = &enum_names } };
+    try testing.expect(typeDefHasOnlyPrimitiveRefs(enum_td));
+
+    // option<u64> and result<u32, string> are primitive-only.
+    const opt_td: ctypes.TypeDef = .{ .option = .{ .inner = .u64 } };
+    try testing.expect(typeDefHasOnlyPrimitiveRefs(opt_td));
+
+    const res_td: ctypes.TypeDef = .{ .result = .{ .ok = .u32, .err = .string } };
+    try testing.expect(typeDefHasOnlyPrimitiveRefs(res_td));
+}
+
+test "loader #571: typeDefHasOnlyPrimitiveRefs rejects records with structural ref fields" {
+    const testing = std.testing;
+
+    // Record whose field is `.type_idx = 7` — a parent indexspace
+    // reference. `resolveTopLevelTypeAliases` must NOT auto-materialize
+    // these because the index is local to the source instance-type body
+    // and would mean nothing in the parent's pool.
+    const fields = [_]ctypes.Field{
+        .{ .name = "inner", .type = .{ .type_idx = 7 } },
+    };
+    const td: ctypes.TypeDef = .{ .record = .{ .fields = &fields } };
+    try testing.expect(!typeDefHasOnlyPrimitiveRefs(td));
+
+    // Record whose field is a structural `.record` ref by index — also
+    // unsafe to direct-materialize without remapping.
+    const fields2 = [_]ctypes.Field{
+        .{ .name = "nested", .type = .{ .record = 3 } },
+    };
+    const td2: ctypes.TypeDef = .{ .record = .{ .fields = &fields2 } };
+    try testing.expect(!typeDefHasOnlyPrimitiveRefs(td2));
+}
+
+test "loader #571: isPrimitiveValType discriminates primitives vs compound refs" {
+    const testing = std.testing;
+
+    try testing.expect(isPrimitiveValType(.bool));
+    try testing.expect(isPrimitiveValType(.u8));
+    try testing.expect(isPrimitiveValType(.s8));
+    try testing.expect(isPrimitiveValType(.u32));
+    try testing.expect(isPrimitiveValType(.s64));
+    try testing.expect(isPrimitiveValType(.u64));
+    try testing.expect(isPrimitiveValType(.f32));
+    try testing.expect(isPrimitiveValType(.f64));
+    try testing.expect(isPrimitiveValType(.char));
+    try testing.expect(isPrimitiveValType(.string));
+
+    try testing.expect(!isPrimitiveValType(.{ .record = 0 }));
+    try testing.expect(!isPrimitiveValType(.{ .variant = 0 }));
+    try testing.expect(!isPrimitiveValType(.{ .type_idx = 0 }));
+    try testing.expect(!isPrimitiveValType(.{ .list = 0 }));
+    try testing.expect(!isPrimitiveValType(.{ .own = 0 }));
 }

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -6247,6 +6247,16 @@ pub const WasiCliAdapter = struct {
         }
 
         const io = std.Io.Threaded.global_single_threaded.io();
+        // Pre-check path existence: Zig stdlib's `Dir.setTimestamps`
+        // error set has no `FileNotFound` variant, so the kernel
+        // `ENOENT` on `utimensat` falls into `error.Unexpected` and
+        // we'd return `.io` instead of the spec-required `.no_entry`.
+        // Probe with `statFile` (which does have `FileNotFound`) and
+        // map kernel errors here. (#571.)
+        _ = base_dir.statFile(io, path_bytes, .{ .follow_symlinks = follow_symlinks }) catch |err| {
+            results[0] = try fsResultErr(allocator, mapFsError(err));
+            return;
+        };
         base_dir.setTimestamps(io, path_bytes, .{
             .follow_symlinks = follow_symlinks,
             .access_timestamp = ats,
@@ -17056,16 +17066,23 @@ fn liftNewTimestamp(arg: InterfaceValue) !std.Io.File.SetTimestamp {
                 else => return error.InvalidArgs,
             };
             if (record.len < 2) return error.InvalidArgs;
-            const secs_u64: u64 = switch (record[0]) {
-                .u64 => |x| x,
+            // `seconds` is `s64` in `wasi:clocks@0.3.0-rc-2026-03-15`
+            // `system-clock.instant` (negative pre-epoch instants are
+            // representable); the older 0.2 `wall-clock.datetime` shape
+            // declared it as `u64`. Accept either tag so the lift works
+            // regardless of which wit-bindgen vintage produced the
+            // component (the wasi-testsuite `filesystem-stat` fixture
+            // builds against the 0.3 shape, exercising `.s64`). (`#571`.)
+            const secs_i96: i96 = switch (record[0]) {
+                .s64 => |x| @intCast(x),
+                .u64 => |x| @intCast(x),
                 else => return error.InvalidArgs,
             };
             const nsec_u32: u32 = switch (record[1]) {
                 .u32 => |x| x,
+                .s32 => |x| @bitCast(x),
                 else => return error.InvalidArgs,
             };
-            // Clamp seconds into i96 range — i96 easily holds u64.
-            const secs_i96: i96 = @intCast(secs_u64);
             const nsec_i96: i96 = @intCast(nsec_u32);
             return .{ .new = .{ .nanoseconds = secs_i96 * 1_000_000_000 + nsec_i96 } };
         },
@@ -20331,6 +20348,46 @@ test "filesystem: liftNewTimestamp covers all three variants (#177)" {
     try testing.expectError(error.InvalidArgs, liftNewTimestamp(.{ .variant_val = .{ .discriminant = 7, .payload = null } }));
 }
 
+test "filesystem #571: liftNewTimestamp accepts s64-encoded seconds (system-clock.instant)" {
+    // The wit-bindgen-emitted component encodes
+    // `wasi:clocks/system-clock.instant.seconds` as `s64` (signed —
+    // pre-epoch instants are representable). The 0.2 `wall-clock.datetime`
+    // shape used `u64`. liftNewTimestamp must accept either tag so the
+    // wasi-testsuite `filesystem-stat` fixture's `set-times-at` call
+    // lifts correctly regardless of which wit-bindgen vintage the
+    // component was built with.
+    const testing = std.testing;
+
+    var dt_fields_s64 = [_]InterfaceValue{
+        .{ .s64 = 42 },
+        .{ .u32 = 0 },
+    };
+    const dt_iv_s64 = InterfaceValue{ .record_val = &dt_fields_s64 };
+    const ts_s64 = try liftNewTimestamp(.{ .variant_val = .{ .discriminant = 2, .payload = &dt_iv_s64 } });
+    try testing.expect(ts_s64 == .new);
+    try testing.expectEqual(@as(i96, 42 * 1_000_000_000), ts_s64.new.nanoseconds);
+
+    // Negative pre-epoch seconds round-trip correctly through i96.
+    var dt_fields_neg = [_]InterfaceValue{
+        .{ .s64 = -3 },
+        .{ .u32 = 250_000_000 },
+    };
+    const dt_iv_neg = InterfaceValue{ .record_val = &dt_fields_neg };
+    const ts_neg = try liftNewTimestamp(.{ .variant_val = .{ .discriminant = 2, .payload = &dt_iv_neg } });
+    try testing.expect(ts_neg == .new);
+    try testing.expectEqual(@as(i96, -3 * 1_000_000_000 + 250_000_000), ts_neg.new.nanoseconds);
+
+    // u64 seconds still work (back-compat with 0.2 wall-clock.datetime).
+    var dt_fields_u64 = [_]InterfaceValue{
+        .{ .u64 = 99 },
+        .{ .u32 = 0 },
+    };
+    const dt_iv_u64 = InterfaceValue{ .record_val = &dt_fields_u64 };
+    const ts_u64 = try liftNewTimestamp(.{ .variant_val = .{ .discriminant = 2, .payload = &dt_iv_u64 } });
+    try testing.expect(ts_u64 == .new);
+    try testing.expectEqual(@as(i96, 99 * 1_000_000_000), ts_u64.new.nanoseconds);
+}
+
 test "filesystem: stat returns mtime/ctime as option::some (#177)" {
     const testing = std.testing;
     var adapter = WasiCliAdapter.init(testing.allocator);
@@ -20445,6 +20502,62 @@ test "filesystem: set-times on dir descriptor returns not_permitted (#177)" {
     try testing.expect(!results[0].result_val.is_ok);
     try testing.expectEqual(
         @as(u32, @intFromEnum(FsErrorCode.not_permitted)),
+        results[0].result_val.payload.?.*.variant_val.discriminant,
+    );
+}
+
+test "filesystem #571: set-times-at on missing path returns no-entry" {
+    // Before #571 the host adapter called `Dir.setTimestamps` directly
+    // and surfaced the kernel `ENOENT` as `error.Unexpected`, which
+    // `mapFsError` collapsed to `.io`. The wasi-testsuite
+    // `filesystem-stat` fixture asserts that
+    // `set_times_at(no_flags, "z.txt", atime, mtime)` returns
+    // `Err(NoEntry)`. Pre-check via `statFile` (which has a
+    // `FileNotFound` error in its set) and map cleanly.
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const handle = try adapter.addPreopen("/sb", tmp.dir);
+    adapter.fs_descriptor_table.items[handle] = null;
+    const reused = try adapter.pushFsDescriptor(.{ .preopen = .{ .dir = tmp.dir, .flags = .{ .read = true, .write = true, .mutate_directory = true } } });
+
+    // Build the new-timestamp arg — s64 seconds (the
+    // wit-bindgen-emitted system-clock.instant encoding).
+    var dt_fields = [_]InterfaceValue{
+        .{ .s64 = 42 },
+        .{ .u32 = 0 },
+    };
+    const dt_iv = InterfaceValue{ .record_val = &dt_fields };
+    const ts_arg = InterfaceValue{ .variant_val = .{ .discriminant = 2, .payload = &dt_iv } };
+
+    var ci: ComponentInstance = undefined;
+    try ci.enableTestMem(testing.allocator, 64);
+    defer ci.disableTestMem();
+    const path_ptr = ci.hostAllocAndWrite("z.txt") orelse return error.OutOfMemory;
+
+    var empty_flags = [_]u32{0};
+    var args = [_]InterfaceValue{
+        .{ .handle = reused },
+        .{ .flags_val = &empty_flags },
+        .{ .string = .{ .ptr = path_ptr, .len = 5 } },
+        ts_arg,
+        ts_arg,
+    };
+    var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+    try WasiCliAdapter.fsDescriptorSetTimesAt(&adapter, &ci, &args, &results, testing.allocator);
+    defer results[0].deinit(testing.allocator);
+
+    // Hand the slot back so adapter.deinit doesn't re-close tmp.dir.
+    adapter.fs_descriptor_table.items[reused] = null;
+
+    try testing.expect(results[0] == .result_val);
+    try testing.expect(!results[0].result_val.is_ok);
+    try testing.expectEqual(
+        @as(u32, @intFromEnum(FsErrorCode.no_entry)),
         results[0].result_val.payload.?.*.variant_val.discriminant,
     );
 }

--- a/tests/wasi-p3-testsuite-skip.json
+++ b/tests/wasi-p3-testsuite-skip.json
@@ -3,7 +3,6 @@
     "WASI Rust tests [wasm32-wasip3]": {
         "http-service": "wasi:http@0.3.0 incoming-handler trampoline + async-lower + wire offset all merged; needs the dispatch glue (TCP listener \u2192 guest export \u2192 response writeback) \u2014 tracking #570",
         "sockets-tcp-bind": "wasi:sockets@0.3.0 sockets-tcp-bind: most subtests pass; test_reuseaddr (line 231) fails because Linux SO_REUSEADDR semantics conflict with test_explicit_bind_addrinuse \u2014 rebind to TIME_WAIT port without REUSEADDR returns EADDRINUSE. Needs SO_LINGER tuning or kernel-state inspection \u2014 tracking wave-6 follow-up #569",
-        "sockets-udp-receive": "wasi:sockets@0.3.0 sockets-udp-receive: test_not_bound passes (#569 fixed err-future encoding); test_receive_data needs a host-driver poll mechanism on Future so that an unsettled receive future can be re-polled after the peer send writes to the kernel queue \u2014 tracking wave-6 async-future-driver follow-up #569",
-        "filesystem-stat": "wasi:filesystem@0.3.0 stat-at flow passes the cross-sandbox / `..` / absolute path matrix added in #571; the fixture still trips later on `set-times-at` lift_args trapping `InvalidTypeIndex` for the `new-timestamp` variant param \u2014 a separate canon-abi type-registry plumbing gap for cross-instance variant args. Remaining filesystem follow-up \u2014 tracking #571"
+        "sockets-udp-receive": "wasi:sockets@0.3.0 sockets-udp-receive: test_not_bound passes (#569 fixed err-future encoding); test_receive_data needs a host-driver poll mechanism on Future so that an unsettled receive future can be re-polled after the peer send writes to the kernel queue \u2014 tracking wave-6 async-future-driver follow-up #569"
     }
 }


### PR DESCRIPTION
feat(wasi:filesystem@0.3.0): filesystem-stat fixture detail (#571)

Partial close of #571 — addresses the filesystem-stat residual after
PR #573 landed the path-validation matrix and PR #577 landed the
filesystem-io write-via-stream driver.

Root cause: the fixture's `set-times-at` call passes two `new-timestamp`
variant args (where the `timestamp(datetime)` arm payload is the
`datetime` / `instant` record from `wasi:clocks`). Cross-interface
type resolution failed on three independent layers:

1. **Loader** (`resolveTopLevelTypeAliases`) only materialized
   `TypeDef.val` shapes when resolving a top-level
   `(alias instance_export N "datetime" (type))` chain. The `datetime`
   record was structurally `.record` (not `.val`), so the parent
   `type_indexspace[K]` stayed null. Extended to handle every primitive-
   only structural shape (`.record` / `.variant` / `.tuple` / `.flags` /
   `.enum_` / `.option` / `.result` / `.list`) gated by a new
   `typeDefHasOnlyPrimitiveRefs` helper that defends against accidentally
   materializing compounds whose nested refs would need remapping into
   the parent indexspace.

2. **Instance** (`resolveOuterTypeAliasToParent` +
   `buildInstanceTypeExtension`) only accepted `TypeDef.val` for outer-
   type aliases when materializing the per-trampoline type-extension
   covering a `wasi:filesystem/types` instance-type body. The body's
   `(alias outer 1 K (type))` for `datetime` resolved to a `.record`
   that got rejected, so `new-timestamp`'s `timestamp(datetime)` case
   payload couldn't be lifted (registry returned null → `InvalidTypeIndex`
   trap during canon-lower `lift_args`). Extended to accept any structural
   typedef and deep-copy `.record` / `.tuple` / `.variant` shapes via
   `rewriteTypeDefAbsolute(allocator, 0, ...)` so the extension owns its
   own fields/cases slice (the `base=0` argument leaves nested
   `.type_idx` refs at the parent's absolute index, which is correct
   because those refs are `< ext_base`).

3. **Adapter** (`liftNewTimestamp`) only accepted `.u64` for the
   `seconds` field. `wasi:clocks@0.3.0-rc-2026-03-15`'s
   `system-clock.instant` declares `seconds: s64` (the 0.2
   `wall-clock.datetime` used `u64`) — the binary primvaltype byte is
   `0x78` (`s64`) not `0x77` (`u64`). Now accepts either tag.

Additionally, `Dir.setTimestamps` for a missing path returns
`error.Unexpected` (Zig stdlib's `SetTimestampsError` set has no
`FileNotFound` variant — kernel `ENOENT` falls into
`unexpectedErrno`), which `mapFsError` collapsed to `.io`. The
fixture asserts `Err(NoEntry)` for `set-times-at(no_flags, "z.txt",
…)`. Pre-check via `statFile` (whose error set does have
`FileNotFound`) so the spec-required `.no_entry` reaches the guest.

Tests (≥3 per the task spec):

* `loader #571: typeDefHasOnlyPrimitiveRefs accepts primitive-only compounds`
* `loader #571: typeDefHasOnlyPrimitiveRefs rejects records with structural ref fields`
* `loader #571: isPrimitiveValType discriminates primitives vs compound refs`
* `filesystem #571: liftNewTimestamp accepts s64-encoded seconds (system-clock.instant)`
* `filesystem #571: set-times-at on missing path returns no-entry`

Verification:

* `zig build test` — clean
* `zig build wasi-p3-testsuite` — `filesystem-stat` moves from
  skipped → passed; 37/37 tests now accounted for; 3 skipped
  (http-service, sockets-tcp-bind, sockets-udp-receive — none
  filesystem-related)
* skip-list: 4 → 3

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

