### PR TITLE
chore(wasi): reach Preview 3 — 40 / 40 wasm32-wasip3 fixtures pass (#451, #520)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,17 @@ WASI conformance ([WebAssembly/wasi-testsuite][wts]):
 ```console
 $ git submodule update --init tests/wasi-testsuite
 $ pip install -r tests/wasi-testsuite/test-runner/requirements.txt
-$ zig build wasi-testsuite
+$ zig build wasi-testsuite      # WASI Preview 1 + Preview 2 — passing
+$ zig build wasi-p3-testsuite   # WASI Preview 3 (wasm32-wasip3) — 40 / 40 passing
 ```
 
 The suite drives the freshly-built `wamr` CLI through the in-tree adapter at
 [`tests/wasi-testsuite-adapter/wamr-zig.py`](tests/wasi-testsuite-adapter/wamr-zig.py)
-and applies the curated skiplist at
-[`tests/wasi-testsuite-skip.json`](tests/wasi-testsuite-skip.json). Every entry
-in the skiplist must carry a one-line rationale and a follow-up issue number.
+and applies the curated skiplists at
+[`tests/wasi-testsuite-skip.json`](tests/wasi-testsuite-skip.json) (Preview 1 / 2)
+and [`tests/wasi-p3-testsuite-skip.json`](tests/wasi-p3-testsuite-skip.json)
+(Preview 3 — currently empty: every `wasm32-wasip3` fixture passes). Every entry
+in either skiplist must carry a one-line rationale and a follow-up issue number.
 When a previously-skipped test starts passing, delete the entry — the suite is
 the gate against regressions in already-shipped WASI host functions.
 

--- a/tests/wasi-p3-testsuite-skip.json
+++ b/tests/wasi-p3-testsuite-skip.json
@@ -1,4 +1,4 @@
 {
-    "_comment": "Skip-list for `zig build wasi-p3-testsuite` (issue #489). Mirrors the format of `tests/wasi-testsuite-skip.json` consumed by `wasi-testsuite/test-runner/wasi_test_runner.py`. Each entry MUST carry a rationale + tracking issue. Remove entries as the corresponding P3 adapter PRs land. Suite key matches `tests/wasi-testsuite/tests/rust/testsuite/wasm32-wasip3/manifest.json` `name`.",
+    "_comment": "Skip-list for `zig build wasi-p3-testsuite` (issue #489). Currently empty — all 40 `wasm32-wasip3` fixtures pass. Re-add an entry only with a one-line rationale and a tracking issue. Mirrors the format of `tests/wasi-testsuite-skip.json` consumed by `wasi-testsuite/test-runner/wasi_test_runner.py`. Suite key matches `tests/wasi-testsuite/tests/rust/testsuite/wasm32-wasip3/manifest.json` `name`.",
     "WASI Rust tests [wasm32-wasip3]": {}
 }


### PR DESCRIPTION
chore(wasi): reach Preview 3 — 40 / 40 wasm32-wasip3 fixtures pass (#451, #520)

Closes #520.
Closes #451.

Wave-6 brought `zig build wasi-p3-testsuite` from 5 skipped fixtures
on `dfb9e2aa` to 0 skipped on `bdac949e`. All 40 `wasm32-wasip3`
fixtures in `tests/wasi-testsuite/tests/rust/testsuite/wasm32-wasip3`
now pass against the in-tree `wamr` CLI on linux-x64, linux-arm64,
macos-arm64, and windows-x64 CI runners.

## Wave-6 PRs

| PR     | Issue                | Fixture(s) unblocked            |
|--------|----------------------|----------------------------------|
| #577   | #571 (residual)      | `filesystem-io`                 |
| #578   | #576                 | `sockets-udp-receive`           |
| #579   | #571 (residual)      | `filesystem-stat`               |
| #580   | #570                 | `http-service`                  |
| #581   | #575                 | `sockets-tcp-bind`              |

## Cumulative wave summary

| Wave | Net fixtures unblocked |
|------|------------------------|
| 1–3  | +13 (initial P3 adapters, async ABI, hybrid 0.2/0.3 routing) |
| 4    | +5  (sockets kernel-port, tcp-properties, async-lower trampoline, http wire offset) |
| 5    | +17 (sockets 0.3 async-future encoding, filesystem completeness, http-fields perf, clocks canon-lower) |
| 6    | +5  (http-service dispatch, tcp-bind reuseaddr, udp-receive driver, fs-stat type registry, fs-io write-via-stream) |
| **Total** | **40 / 40** |

## Changes in this PR

* `README.md` — declares `zig build wasi-p3-testsuite` at 40 / 40 and
  documents both skiplists.
* `tests/wasi-p3-testsuite-skip.json` — `_comment` updated to reflect
  that the map is intentionally empty; the gate is now a regression
  detector, not a parking lot.

No source changes.

## Verification

* GitHub CI on main `dfb9e2aa..bdac949e` — `Build & Test (wasi-p3-testsuite)` green on every commit (linux-x64, linux-arm64, macos-arm64, windows-x64).
* `zig build test` — unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
