### PR TITLE
chore(wasi): configurable wasi-testsuite timeout + README refresh (#583 A7+D1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ $ zig build wasi-testsuite      # WASI Preview 1 + Preview 2 — passing
 $ zig build wasi-p3-testsuite   # WASI Preview 3 (wasm32-wasip3) — 40 / 40 passing
 ```
 
+The upstream `do_wait` timeout is 5s; that matches GitHub Actions runner
+timings but is tight on slow developer VMs (e.g. `http-fields` takes
+~11s on the project Azure dev VM). Set `WAMR_TESTSUITE_TIMEOUT=<seconds>`
+to override it — see
+[`tests/wasi-testsuite-runner-patch/`](tests/wasi-testsuite-runner-patch/wasi_test_runner.py)
+([#583](https://github.com/cataggar/wamr/issues/583) A7).
+
 The suite drives the freshly-built `wamr` CLI through the in-tree adapter at
 [`tests/wasi-testsuite-adapter/wamr-zig.py`](tests/wasi-testsuite-adapter/wamr-zig.py)
 and applies the curated skiplists at
@@ -102,8 +109,20 @@ are mapped onto specific `error-code` variants per the 0.3 WIT
 unclassified failures fall through to `error-code::internal-error`
 (see [#583](https://github.com/cataggar/wamr/issues/583) A3). Response
 headers are not yet surfaced (a `std.http.Client` limitation:
-`FetchResult` only exposes the status line) and incoming-handler
-server semantics remain a stub.
+`FetchResult` only exposes the status line). Incoming-handler dispatch
+(`wasi:http/handler@0.3.0`) is wired end-to-end against the TCP
+listener for HTTP/1.1
+([#580](https://github.com/cataggar/wamr/pull/580)) — `Connection: close`
+only; keep-alive, chunked transfer-encoding, and trailers are tracked
+under the post-Preview-3 follow-up
+[#583](https://github.com/cataggar/wamr/issues/583).
+
+The 0.3.0 interface surface shipped by `wamr` covers
+`wasi:cli`, `wasi:clocks`, `wasi:filesystem`, `wasi:http`, `wasi:random`,
+and `wasi:sockets`; the
+[`wasi-p3-testsuite`](tests/wasi-p3-testsuite-skip.json) gate passes
+40 / 40 `wasm32-wasip3` fixtures. Remaining hardening items are tracked
+under [#583](https://github.com/cataggar/wamr/issues/583).
 
 The earlier `error-code::HTTP_protocol_error` short-circuit on `https://`
 (introduced in [#477](https://github.com/cataggar/wamr/issues/477) /

--- a/build.zig
+++ b/build.zig
@@ -218,9 +218,17 @@ pub fn build(b: *std.Build) void {
     // `tests/wasi-testsuite-skip.json`. Not wired into the default `test`
     // aggregate (it requires Python 3 + the runner's deps), but the CI job
     // gates regressions on every PR. Run locally with `zig build wasi-testsuite`.
+    // The runner entry point is wrapped through
+    // `tests/wasi-testsuite-runner-patch/wasi_test_runner.py`, which
+    // imports the upstream package unmodified and monkey-patches
+    // `TestCaseRunner.do_wait` to honour the `WAMR_TESTSUITE_TIMEOUT`
+    // env var (seconds; defaults to upstream's hard-coded 5s when
+    // unset). Without that override, slow developer VMs flake on
+    // `http-fields` and other fixtures whose runtime drifts past 5s.
+    // See #583 A7 + the wrapper's module docstring for rationale.
     const wasi_runner = b.addSystemCommand(&.{
         "python3",
-        "tests/wasi-testsuite/test-runner/wasi_test_runner.py",
+        "tests/wasi-testsuite-runner-patch/wasi_test_runner.py",
         "--test-suite",
         "tests/wasi-testsuite/tests/c/testsuite/wasm32-wasip1",
         "tests/wasi-testsuite/tests/rust/testsuite/wasm32-wasip1",
@@ -253,7 +261,7 @@ pub fn build(b: *std.Build) void {
     // locally with `zig build wasi-p3-testsuite`.
     const wasi_p3_runner = b.addSystemCommand(&.{
         "python3",
-        "tests/wasi-testsuite/test-runner/wasi_test_runner.py",
+        "tests/wasi-testsuite-runner-patch/wasi_test_runner.py",
         "--test-suite",
         "tests/wasi-testsuite/tests/rust/testsuite/wasm32-wasip3",
         "--runtime-adapter",

--- a/tests/wasi-testsuite-runner-patch/wasi_test_runner.py
+++ b/tests/wasi-testsuite-runner-patch/wasi_test_runner.py
@@ -1,0 +1,102 @@
+"""Thin wrapper around the vendored `wasi_test_runner` package that
+makes the hard-coded 5s `do_wait` timeout configurable via the
+`WAMR_TESTSUITE_TIMEOUT` env var (seconds, defaults to the upstream
+5s when unset).
+
+Background — issue #583 A7:
+`tests/wasi-testsuite/test-runner/wasi_test_runner/test_suite_runner.py`
+hard-codes `self._wait(5)` inside `TestCaseRunner.do_wait`. That
+matches GitHub Actions runner timings (every `wasm32-wasip3` fixture
+exits in <5s on the CI hosts) but is tight on slow developer VMs
+(`http-fields.wasm` takes ~11s on the project Azure dev VM, which
+causes the upstream runner to mark the test as
+`timeout expired` even though the wamr subprocess would finish
+correctly a few seconds later).
+
+The adapter/runtime-adapter contract (see `runtime_adapter.py`) does
+not expose a timeout hook, so we cannot plumb the override through
+`tests/wasi-testsuite-adapter/wamr-zig.py`. Wrapping the wamr binary
+in `timeout(1)` also does not help — the wait is enforced by
+Python's `subprocess.communicate(timeout=...)`, not by the wamr
+binary's own runtime.
+
+Rather than vendor a forked copy of `test_suite_runner.py`, this
+wrapper imports the upstream package unmodified and monkey-patches
+`TestCaseRunner.do_wait` before delegating to the upstream `main()`.
+The override reads `WAMR_TESTSUITE_TIMEOUT` (parsed as a positive
+float, in seconds) and falls back to the upstream 5s default when
+the variable is unset or invalid. The submodule contents at
+`tests/wasi-testsuite/` are left untouched so the upstream pin can
+move forward without rebasing a vendored runner copy.
+
+This file is wired into `build.zig`'s `wasi-testsuite` /
+`wasi-p3-testsuite` steps. Run locally with e.g.
+`WAMR_TESTSUITE_TIMEOUT=30 zig build wasi-p3-testsuite`.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_THIS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _THIS_DIR.parent.parent
+_UPSTREAM_RUNNER_DIR = _REPO_ROOT / "tests" / "wasi-testsuite" / "test-runner"
+
+# Make the vendored `wasi_test_runner` package importable without
+# requiring the user to set PYTHONPATH manually.
+sys.path.insert(0, str(_UPSTREAM_RUNNER_DIR))
+
+from wasi_test_runner import __main__ as _upstream_main  # noqa: E402
+from wasi_test_runner.test_suite_runner import TestCaseRunner  # noqa: E402
+from wasi_test_runner.test_case import Wait  # noqa: E402
+
+
+_UPSTREAM_DO_WAIT_TIMEOUT_SECS = 5.0
+
+
+def _resolve_timeout() -> float:
+    raw = os.environ.get("WAMR_TESTSUITE_TIMEOUT")
+    if raw is None or raw == "":
+        return _UPSTREAM_DO_WAIT_TIMEOUT_SECS
+    try:
+        value = float(raw)
+    except ValueError:
+        print(
+            f"warning: ignoring non-numeric WAMR_TESTSUITE_TIMEOUT={raw!r}; "
+            f"falling back to upstream {_UPSTREAM_DO_WAIT_TIMEOUT_SECS}s",
+            file=sys.stderr,
+        )
+        return _UPSTREAM_DO_WAIT_TIMEOUT_SECS
+    if value <= 0:
+        print(
+            f"warning: ignoring non-positive WAMR_TESTSUITE_TIMEOUT={raw!r}; "
+            f"falling back to upstream {_UPSTREAM_DO_WAIT_TIMEOUT_SECS}s",
+            file=sys.stderr,
+        )
+        return _UPSTREAM_DO_WAIT_TIMEOUT_SECS
+    return value
+
+
+def _patched_do_wait(self: TestCaseRunner, wait: Wait) -> None:
+    timeout = _resolve_timeout()
+    try:
+        exit_code, out, err = self._wait(timeout)  # pylint: disable=protected-access
+        if wait.exit_code != exit_code:
+            from wasi_test_runner.test_suite_runner import (  # noqa: E402
+                _append_stdout_and_stderr,
+            )
+            msg = f"{wait} failed: expected {wait.exit_code}, got {exit_code}"
+            msg = _append_stdout_and_stderr(msg, out, err)
+            self.fail_expectation(msg)
+    except subprocess.TimeoutExpired:
+        self.fail_expectation(
+            f"{wait} failed: timeout expired after {timeout}s"
+        )
+
+
+TestCaseRunner.do_wait = _patched_do_wait  # type: ignore[assignment]
+
+
+if __name__ == "__main__":
+    sys.exit(_upstream_main.main())


### PR DESCRIPTION
chore(wasi): configurable wasi-testsuite timeout + README refresh (#583)

Closes #583 A7.
Closes #583 D1.

A7 — `tests/wasi-testsuite/test-runner/wasi_test_runner/test_suite_runner.py:241`
hard-codes the `do_wait` timeout to 5s. On slow workers (this dev VM
takes 11s on http-fields; CI stays <5s) the test errors with
`timeout expired` instead of running to completion. Adds a
`WAMR_TESTSUITE_TIMEOUT` env override consumed by a thin Python
wrapper (`tests/wasi-testsuite-runner-patch/wasi_test_runner.py`,
Plan C variant) that imports the upstream package unmodified and
monkey-patches `TestCaseRunner.do_wait`. The vendored submodule
contents are untouched. `build.zig`'s `wasi-testsuite` and
`wasi-p3-testsuite` steps now invoke the wrapper. When the env var
is unset the wrapper falls back to the upstream 5s default, so CI
behaviour is unchanged.

The adapter/runtime-adapter contract (`get_name`, `get_version`,
`get_wasi_versions`, `get_wasi_worlds`, `compute_argv`) exposes no
timeout hook, ruling out Plan A. Wrapping `wamr` in `timeout(1)`
(Plan B) doesn't help either: the limit is enforced by Python's
`subprocess.communicate(timeout=...)`, not by the wamr binary's
runtime.

D1 — README WASI section refresh: drops the line claiming
"incoming-handler server semantics remain a stub" (false since PR
#580) and replaces it with the truthful HTTP/1.1
`Connection: close` end-to-end description; summarises the shipped
0.3.0 interface surface (cli / clocks / filesystem / http / random /
sockets); links to #583 for post-Preview-3 follow-ups. Adds a
one-line `WAMR_TESTSUITE_TIMEOUT` callout under "Running tests".
The "outbound HTTP internal_error" paragraph is intentionally left
in place — W7-3 owns that refresh.

Verification:
* `zig build test` — green (2624/2626, 2 skipped).
* `WAMR_TESTSUITE_TIMEOUT=30 zig build wasi-p3-testsuite` — 40/40.
* default `zig build wasi-p3-testsuite` — unchanged on CI runners
  (only http-fields fails on slow VMs, with a clear
  `timeout expired after 5.0s` diagnostic).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

