### PR TITLE
ci(wasi-p3-testsuite): Wasmtime parity matrix (#583 C1)

### DIFF
--- a/.github/workflows/wasi-p3-parity.yml
+++ b/.github/workflows/wasi-p3-parity.yml
@@ -1,0 +1,105 @@
+name: WASI Preview 3 — wasmtime parity
+
+# Issue #583 C1 — runs the same `wasm32-wasip3` fixtures through both
+# `wamr` and upstream `wasmtime`, then diffs the JSON reports so a
+# wamr regression that wasmtime *also* exhibits surfaces as a fixture
+# bug rather than a wamr bug. PR #518 only landed the wamr-side gate;
+# this workflow closes the loop proposed in #489.
+#
+# Trigger policy:
+#   * push to `main` / `zig` — keeps the gate close to PRs without
+#     blocking individual PRs while the parity infra beds in. Per #583
+#     C1's "start with on-push to main and adjust" guidance.
+#   * nightly cron — catches drift between wamr and wasmtime even if
+#     no push lands in a 24h window.
+#   * `workflow_dispatch` — manual triage from the Actions UI.
+#
+# Wasmtime is pinned to v44.0.1 (the same pin used by the existing
+# `component-examples-wasmtime` job in `.github/workflows/ci.yml`).
+# v44.0.1 is the first stable release with `-Sp3` / wasm32-wasip3
+# support; older versions cannot run the corpus at all. The pin lives
+# in two places (`component-examples-wasmtime` and here); bump them
+# together.
+
+on:
+  push:
+    branches: [main, zig]
+  schedule:
+    - cron: "27 4 * * *" # 04:27 UTC nightly — outside CI peak.
+  workflow_dispatch:
+
+# Cancel superseded runs on the same branch so a sequence of pushes
+# only consumes one runner-slot worth of wall time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  wasi-p3-parity:
+    name: Wasmtime parity (wasm32-wasip3)
+    runs-on: ubuntu-22.04
+    # Informational while the parity infra beds in. Once the wasmtime
+    # baseline + wamr-side flake handling are nailed down, move this
+    # into the `ci-summary` blocking set in `.github/workflows/ci.yml`.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install wasi-testsuite runner deps
+        run: |
+          pip install --user -r tests/wasi-testsuite/test-runner/requirements.txt
+
+      # Wasmtime 44.0.1 is the first stable release that supports
+      # `wasm32-wasip3` via `-Sp3`. Matches the pin used by the
+      # `component-examples-wasmtime` job in `ci.yml`; bump them
+      # together. The official installer drops the binary into
+      # `~/.wasmtime/bin/`; appending it to `$GITHUB_PATH` lets the
+      # `WASMTIME` env var fall back to the unqualified `wasmtime`
+      # name resolved through `PATH`.
+      - name: Install wasmtime v44.0.1
+        run: |
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v44.0.1
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+
+      - name: Build wamr (ReleaseSafe)
+        # ReleaseSafe instead of Debug for the same reason as the
+        # `wasi-p3-testsuite` job: the `http-fields` fixture sweeps
+        # ≥1024 codepoints through the host adapter on every run,
+        # which the Debug interpreter cannot complete inside the
+        # 5-second per-`wait` timeout. Safety checks still fire so a
+        # real regression still trips the gate.
+        run: zig build -Doptimize=ReleaseSafe
+
+      - name: Run Wasmtime parity gate
+        run: zig build wasi-p3-parity -Doptimize=ReleaseSafe
+
+      - name: Upload parity JSON reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: wasi-p3-parity-reports
+          path: |
+            zig-out/test-reports/wamr-p3.json
+            zig-out/test-reports/wasmtime-p3.json
+            zig-out/test-reports/wasi-p3-parity.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ $ git submodule update --init tests/wasi-testsuite
 $ pip install -r tests/wasi-testsuite/test-runner/requirements.txt
 $ zig build wasi-testsuite      # WASI Preview 1 + Preview 2 — passing
 $ zig build wasi-p3-testsuite   # WASI Preview 3 (wasm32-wasip3) — 40 / 40 passing
+$ zig build wasi-p3-parity      # Same fixtures via wamr + wasmtime, diff the reports
 ```
 
 The upstream `do_wait` timeout is 5s; that matches GitHub Actions runner
@@ -83,6 +84,20 @@ and [`tests/wasi-p3-testsuite-skip.json`](tests/wasi-p3-testsuite-skip.json)
 in either skiplist must carry a one-line rationale and a follow-up issue number.
 When a previously-skipped test starts passing, delete the entry — the suite is
 the gate against regressions in already-shipped WASI host functions.
+
+`zig build wasi-p3-parity` is the cross-runtime gate ([#583
+C1](https://github.com/cataggar/wamr/issues/583)): it runs the same
+`wasm32-wasip3` corpus through wamr **and** upstream
+[Wasmtime](https://wasmtime.dev/) (CI pin `v44.0.1`, the first stable
+release with `-Sp3` support) and diffs the JSON reports via
+[`scripts/diff-testsuite-reports.py`](scripts/diff-testsuite-reports.py).
+The classifier exits non-zero only on *regressions* (wamr fails a
+fixture that Wasmtime still passes); deltas in the other direction
+(Wasmtime fails a fixture wamr passes) are downgraded to fixture /
+runtime-bug warnings so a wamr regression that Wasmtime also exhibits
+doesn't masquerade as a wamr bug. The CI workflow at
+[`.github/workflows/wasi-p3-parity.yml`](.github/workflows/wasi-p3-parity.yml)
+runs the gate on push to `main` and nightly.
 
 [wts]: https://github.com/WebAssembly/wasi-testsuite
 

--- a/build.zig
+++ b/build.zig
@@ -277,6 +277,65 @@ pub fn build(b: *std.Build) void {
     );
     wasi_p3_testsuite_step.dependOn(&wasi_p3_runner.step);
 
+    // ── Wasmtime parity gate (#583 C1, original #489 proposal) ────────
+    // Runs the *same* `wasm32-wasip3` fixtures through upstream Wasmtime
+    // (CI pin: v44.0.1, the first release with `-Sp3` support — see the
+    // `component-examples-wasmtime` job in `.github/workflows/ci.yml`).
+    // The wasm test corpus is identical, so a wamr regression that
+    // Wasmtime *also* exhibits flags as a fixture bug rather than a
+    // wamr bug (see `scripts/diff-testsuite-reports.py`).
+    //
+    // Resolves the Wasmtime binary from the `WASMTIME` env var (set by
+    // CI; defaults to `wasmtime` on `PATH`). The `WASMTIME` env var is
+    // intentionally not pinned in-tree so a developer can point the
+    // step at a locally-built wasmtime for triage. The CI workflow at
+    // `.github/workflows/wasi-p3-parity.yml` is the source of truth
+    // for the pinned version.
+    const wasi_p3_runner_wasmtime = b.addSystemCommand(&.{
+        "python3",
+        "tests/wasi-testsuite-runner-patch/wasi_test_runner.py",
+        "--test-suite",
+        "tests/wasi-testsuite/tests/rust/testsuite/wasm32-wasip3",
+        "--runtime-adapter",
+        "tests/wasi-testsuite-adapter/wasmtime.py",
+        "--exclude-filter",
+        "tests/wasi-p3-testsuite-skip.json",
+    });
+    // No `WAMR` env var needed here; the wasmtime adapter reads
+    // `WASMTIME` instead (the test binaries themselves are the same
+    // `*.wasm` files that the wamr-side gate exercises).
+    const wasi_p3_testsuite_wasmtime_step = b.step(
+        "wasi-p3-testsuite-wasmtime",
+        "Run the WASI Preview 3 fixtures through Wasmtime (#583 C1 parity gate)",
+    );
+    wasi_p3_testsuite_wasmtime_step.dependOn(&wasi_p3_runner_wasmtime.step);
+
+    // ── Wasmtime parity diff ──────────────────────────────────────────
+    // Convenience step that runs both runtimes through
+    // `scripts/wasi-p3-parity.py` (which writes JSON reports + a
+    // classifier summary, then forwards the diff exit code). The
+    // orchestrator is a Python script because Wasmtime can exit
+    // non-zero on its own (e.g. v44.0.1 fails 4 / 40 fixtures —
+    // `http-service`, `sockets-tcp-{connect,listen}`,
+    // `sockets-udp-send`); we need to keep going through the diff
+    // step to classify the deltas as regressions vs fixture/runtime
+    // bugs. Output JSONs live under `zig-out/test-reports/` so CI
+    // can upload them as artifacts on failure.
+    const reports_dir = b.pathJoin(&.{ b.install_path, "test-reports" });
+    const parity_orchestrator = b.addSystemCommand(&.{
+        "python3",
+        "scripts/wasi-p3-parity.py",
+        "--output-dir",
+        reports_dir,
+    });
+    parity_orchestrator.setEnvironmentVariable("WAMR", b.getInstallPath(.bin, "wamr"));
+    parity_orchestrator.step.dependOn(b.getInstallStep());
+    const wasi_p3_parity_step = b.step(
+        "wasi-p3-parity",
+        "Run wamr + Wasmtime against wasm32-wasip3 fixtures and diff (#583 C1)",
+    );
+    wasi_p3_parity_step.dependOn(&parity_orchestrator.step);
+
     // ── Tests ──────────────────────────────────────────────────────────
     const test_module = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),

--- a/scripts/diff-testsuite-reports.py
+++ b/scripts/diff-testsuite-reports.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Diff two `wasi-testsuite` JSON reports and classify the deltas as
+either *regressions* (wamr regressed on a fixture the parity runtime
+still passes — exit non-zero) or *fixture/runtime bugs* (the parity
+runtime fails a fixture wamr still passes — warn but exit zero).
+
+Closes the Wasmtime-parity gate of issue #583 C1: #489 originally
+proposed running the same wasm32-wasip3 fixtures through Wasmtime so
+a wamr regression that Wasmtime *also* exhibits surfaces as a fixture
+bug rather than a wamr bug. Only the wamr-side gate landed in PR
+#518; this script + the `wasi-p3-testsuite-wasmtime` step + the
+matching CI job close the loop.
+
+Usage
+-----
+
+    diff-testsuite-reports.py WAMR.json WASMTIME.json
+        [--label-a wamr]
+        [--label-b wasmtime]
+        [--strict]
+        [--json OUTPUT.json]
+
+Exit codes
+----------
+
+* 0 — no true regressions (parity-runtime failures on fixtures wamr
+  also fails, or parity-runtime failures on fixtures wamr passes,
+  are classified as *fixture/runtime bugs* and downgraded to
+  warnings on stderr).
+* 1 — at least one true regression detected: wamr fails a fixture
+  the parity runtime still passes.
+* 2 — usage / input error.
+
+`--strict` upgrades fixture/runtime-bug warnings to hard failures so
+the parity gate can also enforce wasmtime-side hygiene once the
+wasm32-wasip3 baseline ships its own conformance-runtime tests.
+
+The two reports must come from `wasi_test_runner --json-output-location
+<path>` against the *same* test-suite paths (the suite name is used
+as the join key). Mismatched suites are flagged and the join falls
+back to the intersection.
+
+The format produced by the upstream JSON reporter is
+documented in
+`tests/wasi-testsuite/test-runner/wasi_test_runner/reporters/json.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+# Mapping from join key (suite_name, test_name) → fixture metadata
+# extracted from a single wasi-testsuite JSON report.
+FixtureKey = Tuple[str, str]
+
+
+def _load_report(path: Path) -> Dict[FixtureKey, Dict]:
+    try:
+        with path.open(encoding="UTF-8") as fp:
+            doc = json.load(fp)
+    except OSError as exc:
+        print(f"error: cannot open {path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except json.JSONDecodeError as exc:
+        print(f"error: {path} is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    fixtures: Dict[FixtureKey, Dict] = {}
+    for suite in doc.get("results", []):
+        suite_name = suite.get("name", "<unnamed-suite>")
+        for test in suite.get("tests", []):
+            key = (suite_name, test["name"])
+            executed = bool(test.get("executed", True))
+            failures = list(test.get("failures") or [])
+            fixtures[key] = {
+                "executed": executed,
+                # A fixture *passes* iff it ran and produced no
+                # failures; skipped fixtures are *not* passes.
+                "passed": executed and not failures,
+                "failures": failures,
+            }
+    return fixtures
+
+
+def _runtime_label(path: Path) -> str:
+    """Best-effort label extracted from the report's first
+    suite — used when no `--label-*` override was supplied. Falls
+    back to the JSON path's stem.
+    """
+    try:
+        with path.open(encoding="UTF-8") as fp:
+            doc = json.load(fp)
+    except (OSError, json.JSONDecodeError):
+        return path.stem
+    suites = doc.get("results", [])
+    if suites and "runtime" in suites[0]:
+        name = suites[0]["runtime"].get("name") or path.stem
+        version = suites[0]["runtime"].get("version") or ""
+        return f"{name} {version}".strip()
+    return path.stem
+
+
+def _format_failures(failures: List[str], limit: int = 1) -> str:
+    if not failures:
+        return ""
+    head = failures[0].splitlines()[0]
+    if len(failures) > limit or "\n" in failures[0]:
+        head += " …"
+    return f" — {head}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Diff two wasi-testsuite JSON reports (wamr-side vs a "
+            "parity-runtime side) and classify deltas as regressions "
+            "(hard fail) or fixture/runtime bugs (warning)."
+        ),
+    )
+    parser.add_argument(
+        "report_a",
+        type=Path,
+        help="Path to the wamr-side JSON report (`zig build wasi-p3-testsuite`).",
+    )
+    parser.add_argument(
+        "report_b",
+        type=Path,
+        help=(
+            "Path to the parity-runtime JSON report "
+            "(`zig build wasi-p3-testsuite-wasmtime`)."
+        ),
+    )
+    parser.add_argument(
+        "--label-a",
+        help="Override the runtime label inferred from report_a.",
+    )
+    parser.add_argument(
+        "--label-b",
+        help="Override the runtime label inferred from report_b.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Treat fixture/runtime-bug-class deltas (parity runtime "
+            "fails a fixture wamr passes) as hard failures."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        type=Path,
+        help="Optional path to write a machine-readable diff summary.",
+    )
+    args = parser.parse_args()
+
+    fixtures_a = _load_report(args.report_a)
+    fixtures_b = _load_report(args.report_b)
+
+    label_a = args.label_a or _runtime_label(args.report_a)
+    label_b = args.label_b or _runtime_label(args.report_b)
+
+    keys_a = set(fixtures_a.keys())
+    keys_b = set(fixtures_b.keys())
+
+    only_in_a = sorted(keys_a - keys_b)
+    only_in_b = sorted(keys_b - keys_a)
+    common = sorted(keys_a & keys_b)
+
+    regressions: List[FixtureKey] = []
+    fixture_bugs: List[FixtureKey] = []
+    shared_failures: List[FixtureKey] = []
+
+    for key in common:
+        a = fixtures_a[key]
+        b = fixtures_b[key]
+        if a["passed"] and b["passed"]:
+            continue
+        if not a["passed"] and not b["passed"]:
+            shared_failures.append(key)
+            continue
+        if not a["passed"] and b["passed"]:
+            regressions.append(key)
+        else:  # a passed, b failed
+            fixture_bugs.append(key)
+
+    def _emit_section(title: str, items: List[FixtureKey], src) -> None:
+        if not items:
+            return
+        print(f"\n{title}", file=src)
+        for suite_name, test_name in items:
+            label = f"  • {suite_name} :: {test_name}"
+            failures = (
+                fixtures_a.get((suite_name, test_name), {}).get("failures") or []
+                if src is sys.stderr
+                else fixtures_b.get((suite_name, test_name), {}).get("failures") or []
+            )
+            print(label + _format_failures(failures), file=src)
+
+    print(f"Comparing {label_a} (A) vs {label_b} (B)", file=sys.stderr)
+    print(
+        (
+            f"  A only: {len(only_in_a)} fixtures, "
+            f"B only: {len(only_in_b)} fixtures, "
+            f"common: {len(common)} fixtures"
+        ),
+        file=sys.stderr,
+    )
+
+    if only_in_a or only_in_b:
+        print(
+            "warning: fixture sets are not identical — comparing the "
+            "intersection.",
+            file=sys.stderr,
+        )
+        if only_in_a:
+            print(f"  fixtures only in {label_a}:", file=sys.stderr)
+            for k in only_in_a:
+                print(f"    • {k[0]} :: {k[1]}", file=sys.stderr)
+        if only_in_b:
+            print(f"  fixtures only in {label_b}:", file=sys.stderr)
+            for k in only_in_b:
+                print(f"    • {k[0]} :: {k[1]}", file=sys.stderr)
+
+    if regressions:
+        print(
+            f"\nREGRESSIONS ({len(regressions)}): "
+            f"{label_a} fails but {label_b} passes — true wamr regressions:",
+            file=sys.stderr,
+        )
+        for suite_name, test_name in regressions:
+            failures = fixtures_a[(suite_name, test_name)]["failures"]
+            print(
+                f"  • {suite_name} :: {test_name}" + _format_failures(failures),
+                file=sys.stderr,
+            )
+
+    if fixture_bugs:
+        print(
+            f"\nfixture/runtime bugs ({len(fixture_bugs)}): "
+            f"{label_b} fails but {label_a} passes — likely fixture or "
+            f"parity-runtime bug, not a wamr issue:",
+            file=sys.stderr,
+        )
+        for suite_name, test_name in fixture_bugs:
+            failures = fixtures_b[(suite_name, test_name)]["failures"]
+            print(
+                f"  • {suite_name} :: {test_name}" + _format_failures(failures),
+                file=sys.stderr,
+            )
+
+    if shared_failures:
+        print(
+            f"\nshared failures ({len(shared_failures)}): both runtimes "
+            "fail — almost certainly a fixture bug:",
+            file=sys.stderr,
+        )
+        for suite_name, test_name in shared_failures:
+            print(f"  • {suite_name} :: {test_name}", file=sys.stderr)
+
+    summary = {
+        "labels": {"a": label_a, "b": label_b},
+        "only_in_a": [list(k) for k in only_in_a],
+        "only_in_b": [list(k) for k in only_in_b],
+        "regressions": [list(k) for k in regressions],
+        "fixture_bugs": [list(k) for k in fixture_bugs],
+        "shared_failures": [list(k) for k in shared_failures],
+    }
+    if args.json is not None:
+        with args.json.open("w", encoding="UTF-8") as fp:
+            json.dump(summary, fp, indent=2)
+            fp.write("\n")
+
+    # Decide exit code.
+    if regressions:
+        print(
+            f"\n::error::Wasmtime parity diff: {len(regressions)} wamr "
+            "regression(s) detected.",
+            file=sys.stderr,
+        )
+        return 1
+    if args.strict and fixture_bugs:
+        print(
+            f"\n::error::Wasmtime parity diff (strict): "
+            f"{len(fixture_bugs)} fixture/runtime bug(s) detected.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"\nWasmtime parity diff: 0 regressions, "
+        f"{len(fixture_bugs)} fixture/runtime-bug warning(s), "
+        f"{len(shared_failures)} shared failure(s).",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wasi-p3-parity.py
+++ b/scripts/wasi-p3-parity.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Run the wamr + Wasmtime sides of the `wasm32-wasip3` conformance
+suite and feed both JSON reports into `diff-testsuite-reports.py`.
+
+Wired into `build.zig`'s `wasi-p3-parity` step (issue #583 C1). The
+step needs an orchestrator because the standalone Wasmtime run can
+exit non-zero (Wasmtime fails 4 / 40 fixtures on the v44.0.1 pin —
+`http-service`, `sockets-tcp-{connect,listen}`, `sockets-udp-send`),
+which would otherwise abort the build before the diff script gets a
+chance to *classify* the deltas. The diff exit code is the step's
+exit code: 0 if no wamr regressions, 1 if wamr fails a fixture the
+parity runtime still passes.
+
+Resolves the `WAMR` / `WASMTIME` binaries from env vars (matching the
+upstream adapters). Defaults are the just-built `zig-out/bin/wamr`
+and `wasmtime` on `PATH`.
+
+Usage
+-----
+
+    wasi-p3-parity.py --output-dir <DIR>
+
+The script writes
+* `<DIR>/wamr-p3.json` — wamr-side wasi-testsuite report
+* `<DIR>/wasmtime-p3.json` — Wasmtime-side report
+* `<DIR>/wasi-p3-parity.json` — classifier summary
+
+and forwards the diff script's exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent
+_RUNNER = _REPO_ROOT / "tests" / "wasi-testsuite-runner-patch" / "wasi_test_runner.py"
+_SUITE = _REPO_ROOT / "tests" / "wasi-testsuite" / "tests" / "rust" / "testsuite" / "wasm32-wasip3"
+_WAMR_ADAPTER = _REPO_ROOT / "tests" / "wasi-testsuite-adapter" / "wamr-zig.py"
+_WASMTIME_ADAPTER = _REPO_ROOT / "tests" / "wasi-testsuite-adapter" / "wasmtime.py"
+_SKIPLIST = _REPO_ROOT / "tests" / "wasi-p3-testsuite-skip.json"
+_DIFF = _HERE / "diff-testsuite-reports.py"
+
+
+def _run_suite(label: str, adapter: Path, out: Path) -> int:
+    cmd = [
+        sys.executable,
+        str(_RUNNER),
+        "--test-suite",
+        str(_SUITE),
+        "--runtime-adapter",
+        str(adapter),
+        "--exclude-filter",
+        str(_SKIPLIST),
+        "--json-output-location",
+        str(out),
+    ]
+    print(f"\n=== {label} ===", flush=True)
+    print(" ".join(cmd), flush=True)
+    proc = subprocess.run(cmd, check=False)
+    # The Wasmtime run may exit non-zero when wasmtime fails fixtures
+    # that wamr passes — that's not a parity-gate failure, the diff
+    # step does the classification. Surface the actual exit code in
+    # the log but let the orchestrator carry on.
+    print(f"=== {label} exit={proc.returncode} ===", flush=True)
+    return proc.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Directory to write the two JSON reports + parity summary into.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Treat fixture/runtime-bug-class deltas as hard failures "
+            "(forwarded to diff-testsuite-reports.py)."
+        ),
+    )
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    wamr_out = args.output_dir / "wamr-p3.json"
+    wasmtime_out = args.output_dir / "wasmtime-p3.json"
+    summary_out = args.output_dir / "wasi-p3-parity.json"
+
+    wamr_rc = _run_suite("wamr", _WAMR_ADAPTER, wamr_out)
+    wasmtime_rc = _run_suite("wasmtime", _WASMTIME_ADAPTER, wasmtime_out)
+
+    if not wamr_out.exists():
+        print(
+            f"error: wamr report missing at {wamr_out} (runner exit "
+            f"{wamr_rc}); aborting parity diff.",
+            file=sys.stderr,
+        )
+        return wamr_rc or 2
+    if not wasmtime_out.exists():
+        print(
+            f"error: wasmtime report missing at {wasmtime_out} (runner "
+            f"exit {wasmtime_rc}); aborting parity diff.",
+            file=sys.stderr,
+        )
+        return wasmtime_rc or 2
+
+    diff_cmd = [
+        sys.executable,
+        str(_DIFF),
+        str(wamr_out),
+        str(wasmtime_out),
+        "--json",
+        str(summary_out),
+    ]
+    if args.strict:
+        diff_cmd.append("--strict")
+
+    print(f"\n=== diff ===\n{' '.join(diff_cmd)}", flush=True)
+    proc = subprocess.run(diff_cmd, check=False)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/wasi-testsuite-adapter/wasmtime.py
+++ b/tests/wasi-testsuite-adapter/wasmtime.py
@@ -1,0 +1,152 @@
+"""wasi-testsuite adapter for upstream Wasmtime — used by the parity
+gate (`zig build wasi-p3-testsuite-wasmtime`, CI job
+`wasi-p3-testsuite-wasmtime`).
+
+Drives the same `wasm32-wasip3` fixtures as `wamr-zig.py` through a
+`wasmtime` CLI binary so a wamr regression that Wasmtime *also*
+exhibits gets classified as a fixture bug rather than a wamr bug.
+See `scripts/diff-testsuite-reports.py` for the classifier.
+
+This file lives outside the vendored wasi-testsuite submodule
+(`tests/wasi-testsuite/adapters/wasmtime.py`) so the in-tree repo can
+edit it without forking the upstream — the upstream adapter is
+treated as a reference and tracked there. Keep this in sync with the
+upstream contract (`tests/wasi-testsuite/test-runner/wasi_test_runner/
+runtime_adapter.py`); any drift will silently break the runner.
+
+The runtime binary is resolved from the `WASMTIME` env var (set by
+`build.zig`) and defaults to `wasmtime` on `PATH`. Preopen
+directories are snapshotted into per-test tempdirs to match the
+isolation behaviour of `wamr-zig.py` (#564) so a filesystem fixture
+that mutates a preopen doesn't pollute state for subsequent tests in
+the same run.
+
+Tracks wamr issue #583 C1 (Wasmtime parity matrix).
+"""
+
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+# `shlex.split` so `WASMTIME="wasmtime --some-flag"` works — the user
+# (or `build.zig`) can supply additional flags ahead of our injected
+# ones. The upstream wasi-testsuite adapter uses the same pattern.
+WASMTIME = shlex.split(os.getenv("WASMTIME", "wasmtime"))
+
+
+def get_name() -> str:
+    return "wasmtime"
+
+
+def get_version() -> str:
+    # `wasmtime --version` prints `wasmtime <version> (<commit> <date>)`.
+    # The version-query path must not pick up any optional flags the
+    # caller bundled into `WASMTIME` (e.g. `-W…`) — drop them by
+    # slicing to the binary alone.
+    result = subprocess.run(
+        WASMTIME[0:1] + ["--version"],
+        encoding="UTF-8",
+        capture_output=True,
+        check=True,
+    )
+    output = result.stdout.splitlines()[0].split(" ")
+    return output[1]
+
+
+def get_wasi_versions() -> List[str]:
+    # Mirror `wamr-zig.py`: declare both Preview 1 (the legacy
+    # `zig build wasi-testsuite` corpus, exercised through Wasmtime
+    # only on demand) and Preview 3 (the parity gate's main target).
+    return ["wasm32-wasip1", "wasm32-wasip3"]
+
+
+def get_wasi_worlds() -> List[str]:
+    # Same world declarations as `wamr-zig.py`: cli/command for the
+    # default fixtures and http/service for `http-service`, which
+    # exports `wasi:http/incoming-handler@0.3.0.handle`.
+    return ["wasi:cli/command", "wasi:http/service"]
+
+
+def _isolate_preopens(dirs: List[Tuple[Path, str]]) -> List[Tuple[Path, str]]:
+    """Snapshot each preopen host directory into a fresh tempdir so a
+    filesystem test that mutates the mapped directory doesn't pollute
+    state for subsequent tests in the run. Matches the behaviour of
+    `wamr-zig.py._isolate_preopens` so a side-by-side parity diff
+    isn't perturbed by host-FS state drift. The tempdirs are leaked
+    intentionally — they're tiny and the per-suite TMPDIR is cleared
+    between CI invocations.
+    """
+    isolated: List[Tuple[Path, str]] = []
+    for host, guest in dirs:
+        host_path = Path(host)
+        if not host_path.is_dir():
+            isolated.append((host, guest))
+            continue
+        snapshot = Path(tempfile.mkdtemp(prefix="wasmtime-fs-"))
+        shutil.copytree(host_path, snapshot, dirs_exist_ok=True, symlinks=True)
+        isolated.append((snapshot, guest))
+    return isolated
+
+
+def compute_argv(
+    test_path: str,
+    args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
+    proposals: List[str],
+    wasi_world: str,
+    wasi_version: str,
+) -> List[str]:
+    argv: List[str] = []
+    argv += WASMTIME
+    args, env, dirs = args_env_dirs
+
+    for k, v in env.items():
+        argv += ["--env", f"{k}={v}"]
+
+    for host, guest in _isolate_preopens(dirs):
+        argv += ["--dir", f"{host}::{guest}"]
+
+    argv += [test_path]
+    argv += args
+    _add_wasi_version_options(argv, wasi_version, proposals, wasi_world)
+    return argv
+
+
+def _add_wasi_version_options(
+    argv: List[str],
+    wasi_version: str,
+    proposals: List[str],
+    wasi_world: str,
+) -> None:
+    """Insert the wasmtime-side WASI feature flags before the wasm
+    module path so the user's `WASMTIME=` overrides take precedence.
+
+    Mirrors `tests/wasi-testsuite/adapters/wasmtime.py` — Preview 3
+    requires `-Wcomponent-model-async -Sp3`, plus `,http` and
+    `,inherit-network` when the fixture declares the corresponding
+    proposals. `wasi:http/service` fixtures additionally need the
+    `serve` subcommand and an ephemeral bind so the testsuite
+    runner's URL-scrape can find the listener.
+    """
+    splice_pos = len(WASMTIME)
+    while splice_pos > 1 and argv[splice_pos - 1].startswith("-"):
+        splice_pos -= 1
+
+    if wasi_world == "wasi:http/service":
+        argv[splice_pos:splice_pos] = ["serve", "-Scli", "--addr=127.0.0.1:0"]
+        splice_pos += 1
+
+    if wasi_version == "wasm32-wasip3":
+        flags_from_proposals = ""
+        if "http" in proposals:
+            flags_from_proposals += ",http"
+        if "sockets" in proposals:
+            flags_from_proposals += ",inherit-network"
+        argv[splice_pos:splice_pos] = [
+            "-Wcomponent-model-async",
+            f"-Sp3{flags_from_proposals}",
+        ]


### PR DESCRIPTION
ci(wasi-p3-testsuite): Wasmtime parity matrix (#583)

Closes #583 C1.

Adds a CI job that runs the same `wasm32-wasip3` fixtures through
Wasmtime v44.0.1 alongside wamr, and diffs the test reports so a
wamr regression that wasmtime also exhibits flags as a fixture bug
rather than a wamr bug.

* `build.zig` — new `wasi-p3-testsuite-wasmtime` informational step
  (runs the corpus through wasmtime alone) + `wasi-p3-parity` gate
  step (runs both runtimes and applies the diff classifier).
* `tests/wasi-testsuite-adapter/wasmtime.py` — runtime adapter for
  upstream Wasmtime; mirrors the upstream
  `tests/wasi-testsuite/adapters/wasmtime.py` so it stays in sync
  with the runtime-adapter contract, while adding the same
  preopen-isolation behaviour as `wamr-zig.py` so the side-by-side
  parity diff isn't perturbed by host-FS state drift.
* `scripts/diff-testsuite-reports.py` — wamr vs wasmtime diff with
  *regression* (hard fail) / *fixture-bug* (warn) classification;
  emits a machine-readable summary alongside the human report.
* `scripts/wasi-p3-parity.py` — orchestrator used by the
  `wasi-p3-parity` build step. Needed because wasmtime can exit
  non-zero on its own (v44.0.1 fails 4 / 40 fixtures —
  `http-service`, `sockets-tcp-{connect,listen}`,
  `sockets-udp-send`), which would otherwise abort the build
  before the diff step gets to classify.
* `.github/workflows/wasi-p3-parity.yml` — new workflow, runs on
  push to `main`/`zig` + nightly + manual dispatch; pinned to
  Wasmtime v44.0.1 (matches the existing
  `component-examples-wasmtime` job pin). Marked
  `continue-on-error: true` until the wasmtime baseline + wamr-side
  flake handling are nailed down, then it can join the blocking
  set in `ci-summary`.
* `README.md` — adds `zig build wasi-p3-parity` to the Running
  tests section + a paragraph explaining the regression /
  fixture-bug classification.

Verification on the dev VM:
* `zig build wasi-p3-testsuite` — 40 / 40 wamr-side pass.
* `zig build wasi-p3-testsuite-wasmtime` — Wasmtime 44.0.1 passes
  36 / 40 (`http-service`, `sockets-tcp-connect`,
  `sockets-tcp-listen`, `sockets-udp-send` fail — these are
  Wasmtime / fixture issues, not wamr bugs).
* `zig build wasi-p3-parity` — green for the post-wave-7 state:
  0 regressions, 4 fixture/runtime-bug warnings, 0 shared
  failures.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

