### PR TITLE
fix(ir): rewrite call_indirect.elem_idx / call_ref.func_ref on rename

### DIFF
--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -921,14 +921,14 @@ pub fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
                 if (arg.* == old) arg.* = new;
             }
         },
-        .call_indirect => |ci| {
-            if (ci.elem_idx == old) @constCast(&ci.elem_idx).* = new;
+        .call_indirect => |*ci| {
+            if (ci.elem_idx == old) ci.elem_idx = new;
             for (@constCast(ci.args)) |*arg| {
                 if (arg.* == old) arg.* = new;
             }
         },
-        .call_ref => |cr| {
-            if (cr.func_ref == old) @constCast(&cr.func_ref).* = new;
+        .call_ref => |*cr| {
+            if (cr.func_ref == old) cr.func_ref = new;
             for (@constCast(cr.args)) |*arg| {
                 if (arg.* == old) arg.* = new;
             }
@@ -5743,14 +5743,14 @@ pub fn promoteLocalsToSSA(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
                         .call => |cl| for (@constCast(cl.args)) |*a| {
                             if (rename_map.get(a.*)) |r| a.* = r;
                         },
-                        .call_indirect => |ci| {
-                            if (rename_map.get(ci.elem_idx)) |r| @constCast(&ci.elem_idx).* = r;
+                        .call_indirect => |*ci| {
+                            if (rename_map.get(ci.elem_idx)) |r| ci.elem_idx = r;
                             for (@constCast(ci.args)) |*a| {
                                 if (rename_map.get(a.*)) |r| a.* = r;
                             }
                         },
-                        .call_ref => |cr| {
-                            if (rename_map.get(cr.func_ref)) |r| @constCast(&cr.func_ref).* = r;
+                        .call_ref => |*cr| {
+                            if (rename_map.get(cr.func_ref)) |r| cr.func_ref = r;
                             for (@constCast(cr.args)) |*a| {
                                 if (rename_map.get(a.*)) |r| a.* = r;
                             }
@@ -11886,6 +11886,59 @@ test "foldLoadStoreOffset: adjusts checked_end when folding a widened access" {
     try std.testing.expectEqual(v_base, ld.base);
     try std.testing.expectEqual(@as(u32, 16), ld.offset);
     try std.testing.expectEqual(@as(u64, 32), ld.checked_end);
+}
+
+test "replaceInInst rewrites call_indirect.elem_idx" {
+    // Regression for #617: `.call_indirect => |ci|` captured the payload
+    // by value, so `@constCast(&ci.elem_idx).* = new` wrote into a stack
+    // copy and left the IR field unchanged. The same bug fired in
+    // `promoteLocalsToSSA`'s rename pass, leaving `elem_idx` referencing
+    // a vreg whose defining `local_get` had been rewritten away — which
+    // surfaced at codegen as `error.UnboundVReg`.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const v_old = func.newVReg();
+    const v_new = func.newVReg();
+    const args = try allocator.alloc(ir.VReg, 1);
+    args[0] = v_old;
+    try func.getBlock(b0).append(.{
+        .op = .{ .call_indirect = .{ .type_idx = 0, .elem_idx = v_old, .args = args } },
+        .dest = func.newVReg(),
+        .type = .i32,
+    });
+
+    replaceVReg(&func, v_old, v_new);
+
+    const ci = func.getBlock(b0).instructions.items[0].op.call_indirect;
+    try std.testing.expectEqual(v_new, ci.elem_idx);
+    try std.testing.expectEqual(v_new, ci.args[0]);
+}
+
+test "replaceInInst rewrites call_ref.func_ref" {
+    // Mirror of the call_indirect regression for `call_ref`.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const v_old = func.newVReg();
+    const v_new = func.newVReg();
+    const args = try allocator.alloc(ir.VReg, 1);
+    args[0] = v_old;
+    try func.getBlock(b0).append(.{
+        .op = .{ .call_ref = .{ .type_idx = 0, .func_ref = v_old, .args = args } },
+        .dest = func.newVReg(),
+        .type = .i32,
+    });
+
+    replaceVReg(&func, v_old, v_new);
+
+    const cr = func.getBlock(b0).instructions.items[0].op.call_ref;
+    try std.testing.expectEqual(v_new, cr.func_ref);
+    try std.testing.expectEqual(v_new, cr.args[0]);
 }
 
 test "promoteLocalsToSSA: simple countdown loop" {


### PR DESCRIPTION
Fixes #617.

## Root cause

Two switch arms in `src/compiler/ir/passes.zig` captured the `call_indirect` / `call_ref` payload **by value**:

```zig
.call_indirect => |ci| {                                  // ← stack copy of payload
    if (ci.elem_idx == old) @constCast(&ci.elem_idx).* = new;  // ← writes into the copy
```

`&ci.elem_idx` points into the stack copy, so the rewrite is silently discarded. The `args` slice happened to still mutate because the slice header copy aliases the same backing storage. Same shape for `.call_ref`.

This fired in two rewriters:

1. `replaceInInst` — generic vreg replacement used by every IR pass that rewrites operands
2. `promoteLocalsToSSA` rename pass — the unbounded-operand fallback that rewrites operands of `call`/`call_indirect`/`call_ref`/`ret_multi`

## How it manifested on #617

Every Rust `wasm32-wasip1` module that uses `call_indirect` on a parameter hit this:

```
v5 = local_get local[0]
call_indirect ..., elem_idx=v5
```

After mem2reg, `local_get` was rewritten to a dest-less placeholder and `(v5 → v10)` queued into the rename map. The rename fallback then wrote `v10` into a stack copy, leaving `elem_idx=v5`. DCE then dropped the dead `local_get`, and codegen later returned `error.UnboundVReg` on `v5`.

The 50-second compile time reported in #617 was a side-effect — with the IR permanently broken, the fixpoint loop never converged (`Optimization: 2569 passes made changes`).

## Fix

Switch both sites to `|*ci|` / `|*cr|` (by-pointer) captures and write directly into the payload field.

## Verification

| Metric | Before | After |
|---|---|---|
| `big_random_buf.wasm` compile | error.UnboundVReg @ ~50s | rc=0 @ 0.27s |
| All 46 Rust wasip1 fixture modules | many UnboundVReg | all compile |
| `zig build test` | 228 passing | **230** passing (+2 regression tests) |
| AOT-run `big_random_buf.cwasm` | n/a | rc=0 |

Note: `sched_yield.wasm` now compiles cleanly but segfaults at runtime — a separate downstream codegen bug exposed by the fix, not a regression.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>