### PR TITLE
fix(ir): free per-op slices in BasicBlock.deinit (call/ret_multi)

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -9247,7 +9247,6 @@ test "compileModule: direct v128 call stages q0" {
 
     var f1 = ir.IrFunction.init(allocator, 0, 1, 0);
     const args = try allocator.alloc(ir.VReg, 1);
-    defer allocator.free(args);
     {
         const b = try f1.newBlock();
         const v = f1.newVReg();
@@ -9291,7 +9290,6 @@ test "compileModule: mixed scalar and v128 direct call uses independent banks" {
 
     var f1 = ir.IrFunction.init(allocator, 0, 1, 0);
     const args = try allocator.alloc(ir.VReg, 3);
-    defer allocator.free(args);
     {
         const b = try f1.newBlock();
         const s0 = f1.newVReg();
@@ -9339,7 +9337,6 @@ test "compileModule: excess v128 args use outgoing stack" {
 
     var f1 = ir.IrFunction.init(allocator, 0, 1, 0);
     const args = try allocator.alloc(ir.VReg, 9);
-    defer allocator.free(args);
     {
         const b = try f1.newBlock();
         for (args, 0..) |*slot, idx| {
@@ -9368,7 +9365,6 @@ test "compileFunction: indirect v128 call stages q0 and emits BLR" {
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
     const args = try allocator.alloc(ir.VReg, 1);
-    defer allocator.free(args);
 
     const b = try func.newBlock();
     const v = func.newVReg();
@@ -9391,7 +9387,6 @@ test "compileFunction: call_ref v128 call stages q0 and emits BLR" {
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
     const args = try allocator.alloc(ir.VReg, 1);
-    defer allocator.free(args);
 
     const b = try func.newBlock();
     const v = func.newVReg();
@@ -9494,7 +9489,6 @@ test "compileModule: v128 primary and aligned v128 extra multi-result" {
 
     var f0 = ir.IrFunction.init(allocator, 0, 3, 0);
     const ret_vals = try allocator.alloc(ir.VReg, 3);
-    defer allocator.free(ret_vals);
     {
         const b = try f0.newBlock();
         const primary = f0.newVReg();
@@ -13052,7 +13046,6 @@ test "compileModule: direct tail call emits B (not BL) to target" {
     // f1: (i32) -> i32 that `return_call f0(x)` — a direct tail call.
     var f1 = ir.IrFunction.init(allocator, 1, 1, 1);
     const args = try allocator.alloc(ir.VReg, 1);
-    defer allocator.free(args);
     {
         const b = try f1.newBlock();
         const p = f1.newVReg();
@@ -13110,7 +13103,6 @@ test "compileModule: multi-result call (ret_multi + call_result)" {
     // f0: () -> (i32, i32, i32) returning (10, 20, 30)
     var f0 = ir.IrFunction.init(allocator, 0, 3, 0);
     const rets = try allocator.alloc(ir.VReg, 3);
-    defer allocator.free(rets);
     {
         const b = try f0.newBlock();
         const v0 = f0.newVReg();
@@ -13936,7 +13928,6 @@ test "compileModule: regalloc hints — leaf 2-arg call places args directly int
     try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = a0, .type = .i32 });
     try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 2 }, .dest = a1, .type = .i32 });
     const args = try allocator.alloc(ir.VReg, 2);
-    defer allocator.free(args);
     args[0] = a0;
     args[1] = a1;
     try caller.getBlock(0).append(.{

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -6239,7 +6239,6 @@ test "compileFunctionRA: caller passes >3 args via stack on Win64" {
     });
     try caller.getBlock(0).append(.{ .op = .{ .ret = r } });
     _ = try ir_module.addFunction(caller);
-    defer allocator.free(args);
 
     const result = try compileModule(&ir_module, allocator);
     defer allocator.free(result.code);
@@ -6462,7 +6461,6 @@ test "compileModule: regression #406 — vmctx → rdi setup deferred past arg m
     try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 2 }, .dest = a1, .type = .i32 });
     try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 3 }, .dest = a2, .type = .i32 });
     const args = try allocator.alloc(ir.VReg, 3);
-    defer allocator.free(args);
     args[0] = a0;
     args[1] = a1;
     args[2] = a2;
@@ -6684,7 +6682,6 @@ test "compileModule: regalloc hints — leaf 2-arg call emits no inter-vreg shuf
     try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = a0, .type = .i32 });
     try caller.getBlock(0).append(.{ .op = .{ .iconst_32 = 2 }, .dest = a1, .type = .i32 });
     const args = try allocator.alloc(ir.VReg, 2);
-    defer allocator.free(args);
     args[0] = a0;
     args[1] = a1;
     try caller.getBlock(0).append(.{

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -1806,7 +1806,6 @@ test "computeLiveRanges: call with explicit args" {
     const v1 = func.newVReg();
     const v2 = func.newVReg();
     const args = try allocator.alloc(ir.VReg, 2);
-    defer allocator.free(args);
     args[0] = v0;
     args[1] = v1;
     try block0.append(.{ .op = .{ .iconst_32 = 10 }, .dest = v0 }); // pos 0

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -892,6 +892,10 @@ pub const BasicBlock = struct {
             switch (inst.op) {
                 .phi => |edges| self.allocator.free(edges),
                 .parallel_copy => |pairs| self.allocator.free(pairs),
+                .call => |cl| if (cl.args.len > 0) self.allocator.free(cl.args),
+                .call_indirect => |ci| if (ci.args.len > 0) self.allocator.free(ci.args),
+                .call_ref => |cr| if (cr.args.len > 0) self.allocator.free(cr.args),
+                .ret_multi => |vregs| if (vregs.len > 0) self.allocator.free(vregs),
                 else => {},
             }
         }

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -5425,6 +5425,11 @@ fn inlineSmallFunctionsCount(module: *ir.IrModule, allocator: std.mem.Allocator)
                 }
             }
 
+            // The original call inst was dropped from caller via
+            // `shrinkRetainingCapacity(ci)` above, so BasicBlock.deinit
+            // can no longer free its args slice; release it here.
+            if (call_args.len > 0) caller.allocator.free(call_args);
+
             inlined_count += 1;
         }
     }
@@ -6928,7 +6933,6 @@ test "DCE: preserves call argument VRegs" {
     const arg0 = func.newVReg();
     const arg1 = func.newVReg();
     const args = try allocator.dupe(ir.VReg, &[_]ir.VReg{ arg0, arg1 });
-    defer allocator.free(args);
     try block.append(.{ .op = .{ .iconst_32 = 10 }, .dest = arg0 });
     try block.append(.{ .op = .{ .iconst_32 = 20 }, .dest = arg1 });
     try block.append(.{ .op = .{ .call = .{ .func_idx = 0, .args = args } } });
@@ -6949,7 +6953,6 @@ test "DCE: preserves call_indirect elem_idx and arg VRegs" {
     const elem = func.newVReg();
     const arg = func.newVReg();
     const call_args = try allocator.dupe(ir.VReg, &[_]ir.VReg{arg});
-    defer allocator.free(call_args);
     try block.append(.{ .op = .{ .iconst_32 = 3 }, .dest = elem });
     try block.append(.{ .op = .{ .iconst_32 = 7 }, .dest = arg });
     try block.append(.{ .op = .{ .call_indirect = .{ .type_idx = 0, .elem_idx = elem, .args = call_args } } });
@@ -6970,7 +6973,6 @@ test "DCE: preserves call_ref func_ref and arg VRegs" {
     const fref = func.newVReg();
     const arg = func.newVReg();
     const call_args = try allocator.dupe(ir.VReg, &[_]ir.VReg{arg});
-    defer allocator.free(call_args);
     try block.append(.{ .op = .{ .iconst_32 = 5 }, .dest = fref });
     try block.append(.{ .op = .{ .iconst_32 = 9 }, .dest = arg });
     try block.append(.{ .op = .{ .call_ref = .{ .type_idx = 0, .func_ref = fref, .args = call_args } } });
@@ -6991,7 +6993,6 @@ test "DCE: preserves ret_multi VRegs" {
     const v0 = func.newVReg();
     const v1 = func.newVReg();
     const ret_vals = try allocator.dupe(ir.VReg, &[_]ir.VReg{ v0, v1 });
-    defer allocator.free(ret_vals);
     try block.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0 });
     try block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = v1 });
     try block.append(.{ .op = .{ .ret_multi = ret_vals } });
@@ -9593,7 +9594,6 @@ test "inlineSmallFunctions: leaf with param-return is inlined" {
     // Caller: fn main() -> i32   { i32.const 42; call 0; return }
     try module.functions.append(allocator, ir.IrFunction.init(allocator, 0, 1, 0));
     const args = try allocator.alloc(ir.VReg, 1);
-    defer allocator.free(args);
     {
         const caller = &module.functions.items[1];
         const mb = try caller.newBlock();
@@ -9692,7 +9692,6 @@ test "inlineSmallFunctions: multi-block if/else callee is inlined" {
     // Caller: fn main(p, a, b) -> i32  { call 0(p, a, b); return }
     try module.functions.append(allocator, ir.IrFunction.init(allocator, 3, 1, 3));
     const args = try allocator.alloc(ir.VReg, 3);
-    defer allocator.free(args);
     {
         const caller = &module.functions.items[1];
         const mb = try caller.newBlock();
@@ -9750,7 +9749,6 @@ test "inlineSmallFunctions: local_set callee gets inlined with synthetic local r
     // Caller has one original local; the inlined callee must not reuse local 0.
     try module.functions.append(allocator, ir.IrFunction.init(allocator, 1, 1, 1));
     const args = try allocator.alloc(ir.VReg, 1);
-    defer allocator.free(args);
     const caller_original_locals = module.functions.items[1].local_count;
     {
         const caller = &module.functions.items[1];
@@ -9809,7 +9807,6 @@ test "inlineSmallFunctions: multi-block callee with declared locals zero-inits s
 
     try module.functions.append(allocator, ir.IrFunction.init(allocator, 1, 1, 1));
     const args = try allocator.alloc(ir.VReg, 1);
-    defer allocator.free(args);
     const caller_original_locals = module.functions.items[1].local_count;
     {
         const caller = &module.functions.items[1];
@@ -9875,7 +9872,6 @@ test "inlineSmallFunctions: br_table callee gets inlined with remapped targets" 
 
     try module.functions.append(allocator, ir.IrFunction.init(allocator, 1, 1, 1));
     const args = try allocator.alloc(ir.VReg, 1);
-    defer allocator.free(args);
     {
         const caller = &module.functions.items[1];
         const mb = try caller.newBlock();
@@ -9934,7 +9930,6 @@ test "runPasses: re-runs inlining after first per-function fixpoint" {
     // inlines f1 into f2.
     try module.functions.append(allocator, ir.IrFunction.init(allocator, 1, 1, 1));
     const f1_args = try allocator.alloc(ir.VReg, 1);
-    defer allocator.free(f1_args);
     {
         const f = &module.functions.items[1];
         const cb = try f.newBlock();
@@ -9950,7 +9945,6 @@ test "runPasses: re-runs inlining after first per-function fixpoint" {
     // f2 (caller): fn main() -> i32 { call middle(42); ret }.
     try module.functions.append(allocator, ir.IrFunction.init(allocator, 0, 1, 0));
     const f2_args = try allocator.alloc(ir.VReg, 1);
-    defer allocator.free(f2_args);
     {
         const f = &module.functions.items[2];
         const cb = try f.newBlock();


### PR DESCRIPTION
## Summary

Every `call` / `call_indirect` / `call_ref` / `ret_multi` op in the IR carries an owned `[]const VReg` operand slice (allocated by the frontend at `frontend.zig:735` and similar sites). `BasicBlock.deinit` was only freeing `phi` edges and `parallel_copy` pairs — every call/ret_multi slice leaked.

On `big_random_buf.wasm` (small Rust wasip1 module), wamrc emits hundreds of DebugAllocator leak reports at exit, all rooted at `frontend.zig:735`.

## Fix

* `BasicBlock.deinit` now also frees the slices on `call` / `call_indirect` / `call_ref` / `ret_multi` (guarded on `len > 0` so the default `&.{}` literal is left alone).
* The inliner's `shrinkRetainingCapacity(ci)` drops the rewritten call instruction from the block before `deinit` can see it, so the inliner now explicitly frees `call_args` after consuming it when an inline is applied.
* IR tests that previously deferred-freed `args`/`ret_vals` slices passed into ops now skip that free — the IR owns the slice. Without removing these, they'd double-free under `std.testing.allocator`.

## Verification

| | Before | After |
|---|---|---|
| `zig build test` | 1660+ passing | 1660+ passing |
| Smoke compile of every Rust `wasm32-wasip1` fixture (with PR #618 applied) | many leaks per module | 0 leaks across 46/46 |

## Dependencies

This fix is independent of #617/PR #618 but stacks cleanly on top: it is opened as a **draft** because the easiest end-to-end verification (`wamrc compile big_random_buf.wasm` shows the leaks) requires #618 to compile the module successfully. Once #618 merges, this PR can be marked ready.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>