### PR TITLE
feat(ir): add Cranelift-style invariant verifier between passes (#624)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -468,6 +468,18 @@ pub fn build(b: *std.Build) void {
     const run_ir_print_tests = b.addRunArtifact(ir_print_tests);
     test_step.dependOn(&run_ir_print_tests.step);
 
+    // IR verifier tests (#624).
+    const verifier_test_module = b.createModule(.{
+        .root_source_file = b.path("src/compiler/ir/verifier.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const verifier_tests = b.addTest(.{
+        .root_module = verifier_test_module,
+    });
+    const run_verifier_tests = b.addRunArtifact(verifier_tests);
+    test_step.dependOn(&run_verifier_tests.step);
+
     // Dominator-aware redundant-load forwarder tests (#391).
     const dom_frl_test_module = b.createModule(.{
         .root_source_file = b.path("src/compiler/ir/forward_redundant_loads_dominator.zig"),

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -9,6 +9,7 @@ const ir = @import("ir.zig");
 const analysis = @import("analysis.zig");
 const alias_class = @import("alias_class.zig");
 const deadStoreElimination = @import("dead_store_elimination.zig").deadStoreElimination;
+const verifier = @import("verifier.zig");
 
 const LoadKey = alias_class.LoadKey;
 
@@ -2534,6 +2535,10 @@ pub const RunOptions = struct {
     /// `lowerPhisToLocals` (first outer iteration) and once-per-function
     /// after every successful round of `inlineSmallFunctions`.
     dump_hook: ?DumpHook = null,
+    /// Run the IR verifier between passes (#624). Off by default so
+    /// release builds pay nothing. Callers in debug / fuzz contexts
+    /// should set this to `.after_each_pass`.
+    verify_mode: verifier.VerifyMode = .off,
 };
 
 const PassNameEntry = struct { fn_ptr: PassFn, name: []const u8 };
@@ -6392,6 +6397,24 @@ pub fn runPassesWithOptions(
 ) !u32 {
     var total_changes: u32 = 0;
 
+    // Local helper: run the verifier and stamp the pass name on the
+    // surfaced failure record. A no-op when `verify_mode == .off`.
+    const Verify = struct {
+        fn check(
+            mode: verifier.VerifyMode,
+            pass_label: []const u8,
+            func: *const ir.IrFunction,
+            func_idx: u32,
+            alloc: std.mem.Allocator,
+        ) verifier.VerifyError!void {
+            if (mode == .off) return;
+            verifier.verifyFunction(func, func_idx, mode, alloc) catch |e| {
+                verifier.last_failure.pass_name = pass_label;
+                return e;
+            };
+        }
+    };
+
     // Outer loop: alternate between module-level inlining and per-function
     // fixpoint passes. The first per-function round constant-folds
     // arguments at call sites (e.g. via `forwardLocalGet` + `constantFold`),
@@ -6415,6 +6438,12 @@ pub fn runPassesWithOptions(
             if (iter_inlined == 0) break;
             inlined_count += iter_inlined;
             total_changes += 1;
+
+            if (opts.verify_mode != .off) {
+                for (module.functions.items, 0..) |*f, fi| {
+                    try Verify.check(opts.verify_mode, "inlineSmallFunctions", f, @intCast(fi), allocator);
+                }
+            }
 
             if (opts.dump_hook) |hook| {
                 for (module.functions.items, 0..) |*f, fi| {
@@ -6450,6 +6479,7 @@ pub fn runPassesWithOptions(
             if (outer_iter == 0) {
                 if (try promoteLocalsToSSA(func, allocator)) {
                     total_changes += 1;
+                    try Verify.check(opts.verify_mode, "promoteLocalsToSSA", func, func_idx, allocator);
                     if (opts.dump_hook) |hook| {
                         try hook.callback(hook.ctx, .{
                             .pass_name = "promoteLocalsToSSA",
@@ -6462,6 +6492,7 @@ pub fn runPassesWithOptions(
                     }
                     if (try lowerPhisToLocals(func, allocator)) {
                         total_changes += 1;
+                        try Verify.check(opts.verify_mode, "lowerPhisToLocals", func, func_idx, allocator);
                         if (opts.dump_hook) |hook| {
                             try hook.callback(hook.ctx, .{
                                 .pass_name = "lowerPhisToLocals",
@@ -6489,6 +6520,9 @@ pub fn runPassesWithOptions(
                         any_changed = true;
                         total_changes += 1;
                     }
+                    if (changed) {
+                        try Verify.check(opts.verify_mode, passName(pass), func, func_idx, allocator);
+                    }
                     if (opts.dump_hook) |hook| {
                         try hook.callback(hook.ctx, .{
                             .pass_name = passName(pass),
@@ -6513,6 +6547,7 @@ pub fn runPassesWithOptions(
             // (issue #620).
             if (try scrubUnreachableBlocks(func, allocator)) {
                 total_changes += 1;
+                try Verify.check(opts.verify_mode, "scrubUnreachableBlocks", func, func_idx, allocator);
             }
         }
     }

--- a/src/compiler/ir/verifier.zig
+++ b/src/compiler/ir/verifier.zig
@@ -1,0 +1,987 @@
+//! IR invariant checker (Cranelift-style "verifier") run between IR passes.
+//!
+//! Detects SSA / CFG breakage at the *producing pass* instead of letting the
+//! symptom surface deep inside aarch64 lowering as `error.UnboundVReg`. See
+//! issue #624.
+//!
+//! Checks implemented (Phase 1 — issue #624 invariants 1, 2, 4, 5, 6):
+//!
+//!   1. **SSA def-before-use.** Every `VReg` operand read by an instruction
+//!      must be either (a) a function parameter (vregs `0..param_count`),
+//!      (b) defined by an earlier instruction in the same block, or
+//!      (c) defined in a strictly-dominating block.
+//!   2. **Def uniqueness.** Each `VReg` has at most one defining instruction.
+//!   4. **Terminator legality.** Every reachable block ends in exactly one
+//!      terminator (`br`, `br_if`, `br_table`, `ret`, `ret_multi`,
+//!      `unreachable`, or a tail-call). Non-last instructions must not be
+//!      terminators.
+//!   5. **No dangling block refs.** Every `BlockId` named by a terminator
+//!      refers to an existing block in `func.blocks`.
+//!   6. **Predecessor consistency.** `BasicBlock.predecessors` matches the
+//!      set of blocks whose terminator targets it (both directions — no
+//!      stale preds and no missing preds).
+//!
+//! Check 3 (block-parameter arity) is vacuous on the current IR — phi is an
+//! instruction, not a block parameter — and is therefore omitted. It will be
+//! re-introduced if/when block-params land.
+//!
+//! Wiring: `passes.runPassesWithOptions` calls `verifyFunction` after every
+//! pass invocation when `opts.verify_mode != .off`, and annotates the failure
+//! with the pass name before propagating.
+
+const std = @import("std");
+const ir = @import("ir.zig");
+const analysis = @import("analysis.zig");
+
+pub const VerifyMode = enum {
+    /// Skip verification entirely (no-op, zero cost).
+    off,
+    /// Run checks 1, 2, 4, 5, 6 after every pass.
+    after_each_pass,
+    /// Reserved for future stricter checks (operand-width sanity, loop /
+    /// dom-tree freshness, live-range monotonicity). Behaves like
+    /// `after_each_pass` for now.
+    paranoid,
+};
+
+pub const VerifyError = error{
+    /// An instruction reads a VReg that has no dominating definition
+    /// (check 1).
+    UnboundVRegUse,
+    /// A VReg appears as the `dest` of more than one instruction
+    /// (check 2).
+    VRegDefinedTwice,
+    /// A reachable block has no terminator at its end (check 4).
+    MissingTerminator,
+    /// A block contains a terminator before its final instruction (check 4).
+    MultipleTerminators,
+    /// A terminator references a `BlockId` that doesn't exist in the
+    /// function (check 5).
+    DanglingBlockRef,
+    /// `BasicBlock.predecessors` lists a block whose terminator does not
+    /// target this block (check 6).
+    StalePredecessor,
+    /// A block whose terminator targets another block is missing from the
+    /// target's `predecessors` list (check 6).
+    MissingPredecessor,
+} || std.mem.Allocator.Error;
+
+/// Information about the most-recent verifier failure. Populated as a
+/// best-effort companion to the returned `VerifyError` so callers (the
+/// `runPasses` wrapper + the `wamrc` CLI) can produce a meaningful
+/// "pass X broke invariant Y in func #N block #B" diagnostic without
+/// hand-decoding the error.
+///
+/// Thread-local — the verifier is single-threaded (one IR module at a
+/// time inside `runPasses`).
+pub const LastFailure = struct {
+    kind: VerifyError = error.OutOfMemory, // sentinel, overwritten on real failure
+    func_index: ?u32 = null,
+    block: ?ir.BlockId = null,
+    inst_index: ?u32 = null,
+    vreg: ?ir.VReg = null,
+    pass_name: []const u8 = "",
+    detail: []const u8 = "",
+
+    pub fn reset(self: *LastFailure) void {
+        self.* = .{};
+    }
+
+    pub fn format(self: LastFailure, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        try writer.print("IR verifier: {s}", .{@errorName(self.kind)});
+        if (self.pass_name.len > 0) try writer.print(" after pass '{s}'", .{self.pass_name});
+        if (self.func_index) |fi| try writer.print(" func #{d}", .{fi});
+        if (self.block) |b| try writer.print(" block #{d}", .{b});
+        if (self.inst_index) |i| try writer.print(" inst #{d}", .{i});
+        if (self.vreg) |v| try writer.print(" vreg %{d}", .{v});
+        if (self.detail.len > 0) try writer.print(" — {s}", .{self.detail});
+    }
+};
+
+/// Reset before each `runPasses` invocation, populated on the first failing
+/// check. Accessed by `passes.runPassesWithOptions` to surface a diagnostic.
+pub threadlocal var last_failure: LastFailure = .{};
+
+// ── Operand / successor iteration ───────────────────────────────────────
+
+/// Invoke `cb(ctx, vreg)` for every `VReg` *read* by `inst` (operands,
+/// not the `dest`). Comptime-exhaustive over every `Inst.Op` variant.
+pub fn forEachOperand(
+    inst: ir.Inst,
+    ctx: anytype,
+    comptime cb: fn (@TypeOf(ctx), ir.VReg) void,
+) void {
+    switch (inst.op) {
+        // Pure constants / nullary ops — no VReg operands.
+        .iconst_32,
+        .iconst_64,
+        .fconst_32,
+        .fconst_64,
+        .v128_const,
+        .local_get,
+        .global_get,
+        .br,
+        .@"unreachable",
+        .atomic_fence,
+        .memory_size,
+        .table_size,
+        .ref_func,
+        .data_drop,
+        .elem_drop,
+        .call_result,
+        => {},
+
+        // BinOp shape (lhs, rhs).
+        .add,
+        .sub,
+        .mul,
+        .div_s,
+        .div_u,
+        .rem_s,
+        .rem_u,
+        .@"and",
+        .@"or",
+        .xor,
+        .shl,
+        .shr_s,
+        .shr_u,
+        .rotl,
+        .rotr,
+        .eq,
+        .ne,
+        .lt_s,
+        .lt_u,
+        .gt_s,
+        .gt_u,
+        .le_s,
+        .le_u,
+        .ge_s,
+        .ge_u,
+        .f_min,
+        .f_max,
+        .f_copysign,
+        .f_eq,
+        .f_ne,
+        .f_lt,
+        .f_gt,
+        .f_le,
+        .f_ge,
+        => |bin| {
+            cb(ctx, bin.lhs);
+            cb(ctx, bin.rhs);
+        },
+
+        // SIMD bin/un/lane shapes. Each opcode's payload is a distinct type
+        // so we can't combine them in one match arm — list them out instead.
+        .v128_bitwise => |bin| {
+            cb(ctx, bin.lhs);
+            cb(ctx, bin.rhs);
+        },
+        .v128_bitselect => |sel| {
+            cb(ctx, sel.a);
+            cb(ctx, sel.b);
+            cb(ctx, sel.mask);
+        },
+        .i32x4_binop => |bin| {
+            cb(ctx, bin.lhs);
+            cb(ctx, bin.rhs);
+        },
+        .f32x4_binop => |bin| {
+            cb(ctx, bin.lhs);
+            cb(ctx, bin.rhs);
+        },
+        .i8x16_binop => |bin| {
+            cb(ctx, bin.lhs);
+            cb(ctx, bin.rhs);
+        },
+        .i16x8_binop => |bin| {
+            cb(ctx, bin.lhs);
+            cb(ctx, bin.rhs);
+        },
+        .i64x2_binop => |bin| {
+            cb(ctx, bin.lhs);
+            cb(ctx, bin.rhs);
+        },
+        .f64x2_binop => |bin| {
+            cb(ctx, bin.lhs);
+            cb(ctx, bin.rhs);
+        },
+        .i32x4_unop => |un| cb(ctx, un.vector),
+        .f32x4_unop => |un| cb(ctx, un.vector),
+        .i8x16_unop => |un| cb(ctx, un.vector),
+        .i16x8_unop => |un| cb(ctx, un.vector),
+        .i64x2_unop => |un| cb(ctx, un.vector),
+        .f64x2_unop => |un| cb(ctx, un.vector),
+        .i32x4_extadd_pairwise_i16x8 => |op| cb(ctx, op.vector),
+        .i16x8_extadd_pairwise_i8x16 => |op| cb(ctx, op.vector),
+        .i32x4_extend_i16x8 => |op| cb(ctx, op.vector),
+        .i16x8_extend_i8x16 => |op| cb(ctx, op.vector),
+        .i64x2_extend_i32x4 => |op| cb(ctx, op.vector),
+        .i32x4_trunc_sat => |op| cb(ctx, op.vector),
+        .f32x4_convert_i32x4 => |op| cb(ctx, op.vector),
+        .f32x4_demote_f64x2_zero => |op| cb(ctx, op.vector),
+        .f64x2_convert_low_i32x4 => |op| cb(ctx, op.vector),
+        .f64x2_promote_low_f32x4 => |op| cb(ctx, op.vector),
+        .i32x4_dot_i16x8_s => |op| {
+            cb(ctx, op.lhs);
+            cb(ctx, op.rhs);
+        },
+        .i32x4_extmul_i16x8 => |op| {
+            cb(ctx, op.lhs);
+            cb(ctx, op.rhs);
+        },
+        .i16x8_extmul_i8x16 => |op| {
+            cb(ctx, op.lhs);
+            cb(ctx, op.rhs);
+        },
+        .i64x2_extmul_i32x4 => |op| {
+            cb(ctx, op.lhs);
+            cb(ctx, op.rhs);
+        },
+        .i8x16_shuffle => |op| {
+            cb(ctx, op.lhs);
+            cb(ctx, op.rhs);
+        },
+        .i8x16_narrow_i16x8 => |op| {
+            cb(ctx, op.lhs);
+            cb(ctx, op.rhs);
+        },
+        .i16x8_narrow_i32x4 => |op| {
+            cb(ctx, op.lhs);
+            cb(ctx, op.rhs);
+        },
+        .i8x16_swizzle => |op| {
+            cb(ctx, op.vector);
+            cb(ctx, op.indices);
+        },
+        .i8x16_shift => |shift| {
+            cb(ctx, shift.vector);
+            cb(ctx, shift.count);
+        },
+        .i16x8_shift => |shift| {
+            cb(ctx, shift.vector);
+            cb(ctx, shift.count);
+        },
+        .i32x4_shift => |shift| {
+            cb(ctx, shift.vector);
+            cb(ctx, shift.count);
+        },
+        .i64x2_shift => |shift| {
+            cb(ctx, shift.vector);
+            cb(ctx, shift.count);
+        },
+        .simd_all_true => |op| cb(ctx, op.vector),
+        .simd_bitmask => |op| cb(ctx, op.vector),
+        .i32x4_extract_lane => |lane| cb(ctx, lane.vector),
+        .f32x4_extract_lane => |lane| cb(ctx, lane.vector),
+        .i8x16_extract_lane => |lane| cb(ctx, lane.vector),
+        .i16x8_extract_lane => |lane| cb(ctx, lane.vector),
+        .i64x2_extract_lane => |lane| cb(ctx, lane.vector),
+        .f64x2_extract_lane => |lane| cb(ctx, lane.vector),
+        .i32x4_replace_lane => |lane| {
+            cb(ctx, lane.vector);
+            cb(ctx, lane.val);
+        },
+        .f32x4_replace_lane => |lane| {
+            cb(ctx, lane.vector);
+            cb(ctx, lane.val);
+        },
+        .i8x16_replace_lane => |lane| {
+            cb(ctx, lane.vector);
+            cb(ctx, lane.val);
+        },
+        .i16x8_replace_lane => |lane| {
+            cb(ctx, lane.vector);
+            cb(ctx, lane.val);
+        },
+        .i64x2_replace_lane => |lane| {
+            cb(ctx, lane.vector);
+            cb(ctx, lane.val);
+        },
+        .f64x2_replace_lane => |lane| {
+            cb(ctx, lane.vector);
+            cb(ctx, lane.val);
+        },
+
+        // Single-operand unary ops (where the variant payload is a bare VReg).
+        .clz,
+        .ctz,
+        .popcnt,
+        .eqz,
+        .wrap_i64,
+        .extend_i32_s,
+        .extend_i32_u,
+        .extend8_s,
+        .extend16_s,
+        .extend32_s,
+        .f_neg,
+        .f_abs,
+        .f_sqrt,
+        .f_ceil,
+        .f_floor,
+        .f_trunc,
+        .f_nearest,
+        .trunc_f32_s,
+        .trunc_f32_u,
+        .trunc_f64_s,
+        .trunc_f64_u,
+        .convert_s,
+        .convert_u,
+        .convert_i32_s,
+        .convert_i64_s,
+        .convert_i32_u,
+        .convert_i64_u,
+        .demote_f64,
+        .promote_f32,
+        .reinterpret,
+        .trunc_sat_f32_s,
+        .trunc_sat_f32_u,
+        .trunc_sat_f64_s,
+        .trunc_sat_f64_u,
+        .v128_not,
+        .v128_any_true,
+        .i32x4_splat,
+        .f32x4_splat,
+        .i8x16_splat,
+        .i16x8_splat,
+        .i64x2_splat,
+        .f64x2_splat,
+        .memory_grow,
+        => |vreg| cb(ctx, vreg),
+
+        .local_set => |ls| cb(ctx, ls.val),
+        .global_set => |gs| cb(ctx, gs.val),
+
+        .load => |ld| cb(ctx, ld.base),
+        .v128_load => |ld| cb(ctx, ld.base),
+        .v128_load_splat => |ld| cb(ctx, ld.base),
+        .v128_load_zero => |ld| cb(ctx, ld.base),
+        .v128_load_extend => |ld| cb(ctx, ld.base),
+        .v128_load_lane => |ld| {
+            cb(ctx, ld.base);
+            cb(ctx, ld.vector);
+        },
+        .store => |st| {
+            cb(ctx, st.base);
+            cb(ctx, st.val);
+        },
+        .v128_store => |st| {
+            cb(ctx, st.base);
+            cb(ctx, st.val);
+        },
+        .v128_store_lane => |st| {
+            cb(ctx, st.base);
+            cb(ctx, st.vector);
+        },
+
+        .br_if => |bi| cb(ctx, bi.cond),
+        .br_table => |bt| cb(ctx, bt.index),
+
+        .ret => |maybe| if (maybe) |v| cb(ctx, v),
+        .ret_multi => |vregs| {
+            for (vregs) |v| cb(ctx, v);
+        },
+
+        .call => |cl| {
+            for (cl.args) |a| cb(ctx, a);
+        },
+        .call_indirect => |ci| {
+            cb(ctx, ci.elem_idx);
+            for (ci.args) |a| cb(ctx, a);
+        },
+        .call_ref => |cr| {
+            cb(ctx, cr.func_ref);
+            for (cr.args) |a| cb(ctx, a);
+        },
+        .select => |sel| {
+            cb(ctx, sel.cond);
+            cb(ctx, sel.if_true);
+            cb(ctx, sel.if_false);
+        },
+
+        .atomic_load => |al| cb(ctx, al.base),
+        .atomic_store => |ast| {
+            cb(ctx, ast.base);
+            cb(ctx, ast.val);
+        },
+        .atomic_rmw => |ar| {
+            cb(ctx, ar.base);
+            cb(ctx, ar.val);
+        },
+        .atomic_cmpxchg => |ac| {
+            cb(ctx, ac.base);
+            cb(ctx, ac.expected);
+            cb(ctx, ac.replacement);
+        },
+        .atomic_notify => |an| {
+            cb(ctx, an.base);
+            cb(ctx, an.count);
+        },
+        .atomic_wait => |aw| {
+            cb(ctx, aw.base);
+            cb(ctx, aw.expected);
+            cb(ctx, aw.timeout);
+        },
+
+        .memory_copy => |mc| {
+            cb(ctx, mc.dst);
+            cb(ctx, mc.src);
+            cb(ctx, mc.len);
+        },
+        .memory_fill => |mf| {
+            cb(ctx, mf.dst);
+            cb(ctx, mf.val);
+            cb(ctx, mf.len);
+        },
+        .memory_init => |mi| {
+            cb(ctx, mi.dst);
+            cb(ctx, mi.src);
+            cb(ctx, mi.len);
+        },
+        .table_get => |tg| cb(ctx, tg.idx),
+        .table_set => |ts| {
+            cb(ctx, ts.idx);
+            cb(ctx, ts.val);
+        },
+        .table_grow => |tg| {
+            cb(ctx, tg.init);
+            cb(ctx, tg.delta);
+        },
+        .table_init => |ti| {
+            cb(ctx, ti.dst);
+            cb(ctx, ti.src);
+            cb(ctx, ti.len);
+        },
+
+        .phi => |edges| {
+            for (edges) |e| cb(ctx, e.val);
+        },
+        .parallel_copy => |pairs| {
+            for (pairs) |p| cb(ctx, p.src);
+        },
+    }
+}
+
+/// True iff `op` transfers control out of the current block.
+pub fn isTerminator(op: ir.Inst.Op) bool {
+    return switch (op) {
+        .br,
+        .br_if,
+        .br_table,
+        .ret,
+        .ret_multi,
+        .@"unreachable",
+        => true,
+        .call => |c| c.tail,
+        .call_indirect => |c| c.tail,
+        .call_ref => |c| c.tail,
+        else => false,
+    };
+}
+
+/// Invoke `cb(ctx, target)` for every successor `BlockId` named by `op`.
+/// Non-terminators contribute no successors. Tail-calls have no in-function
+/// successors.
+pub fn forEachSuccessor(
+    op: ir.Inst.Op,
+    ctx: anytype,
+    comptime cb: fn (@TypeOf(ctx), ir.BlockId) void,
+) void {
+    switch (op) {
+        .br => |t| cb(ctx, t),
+        .br_if => |bi| {
+            cb(ctx, bi.then_block);
+            cb(ctx, bi.else_block);
+        },
+        .br_table => |bt| {
+            for (bt.targets) |t| cb(ctx, t);
+            cb(ctx, bt.default);
+        },
+        else => {},
+    }
+}
+
+// ── Module / function entry points ──────────────────────────────────────
+
+pub fn verifyModule(
+    module: *const ir.IrModule,
+    mode: VerifyMode,
+    allocator: std.mem.Allocator,
+) VerifyError!void {
+    if (mode == .off) return;
+    for (module.functions.items, 0..) |*func, fi| {
+        try verifyFunction(func, @intCast(fi), mode, allocator);
+    }
+}
+
+pub fn verifyFunction(
+    func: *const ir.IrFunction,
+    func_index: u32,
+    mode: VerifyMode,
+    allocator: std.mem.Allocator,
+) VerifyError!void {
+    if (mode == .off) return;
+    last_failure.reset();
+    last_failure.func_index = func_index;
+
+    if (func.blocks.items.len == 0) return;
+
+    try checkDefUniqueness(func, func_index);
+    try checkTerminators(func, func_index);
+    try checkBlockRefs(func, func_index);
+    try checkPredecessors(func, func_index, allocator);
+    try checkSsaDominance(func, func_index, allocator);
+}
+
+// ── Check 2: def uniqueness ─────────────────────────────────────────────
+
+fn checkDefUniqueness(func: *const ir.IrFunction, func_index: u32) VerifyError!void {
+    var seen = std.AutoHashMap(ir.VReg, void).init(std.heap.page_allocator);
+    defer seen.deinit();
+    for (func.blocks.items) |block| {
+        for (block.instructions.items, 0..) |inst, ii| {
+            if (inst.dest) |d| {
+                const gop = try seen.getOrPut(d);
+                if (gop.found_existing) {
+                    last_failure = .{
+                        .kind = error.VRegDefinedTwice,
+                        .func_index = func_index,
+                        .block = block.id,
+                        .inst_index = @intCast(ii),
+                        .vreg = d,
+                        .detail = "VReg has a second defining instruction",
+                    };
+                    return error.VRegDefinedTwice;
+                }
+            }
+            // phi result is encoded as `dest`; parallel_copy multi-dests are
+            // tracked separately.
+            switch (inst.op) {
+                .parallel_copy => |pairs| for (pairs) |p| {
+                    const gop = try seen.getOrPut(p.dst);
+                    if (gop.found_existing) {
+                        last_failure = .{
+                            .kind = error.VRegDefinedTwice,
+                            .func_index = func_index,
+                            .block = block.id,
+                            .inst_index = @intCast(ii),
+                            .vreg = p.dst,
+                            .detail = "parallel_copy dst has a second definition",
+                        };
+                        return error.VRegDefinedTwice;
+                    }
+                },
+                else => {},
+            }
+        }
+    }
+}
+
+// ── Check 4: terminator legality ────────────────────────────────────────
+
+fn checkTerminators(func: *const ir.IrFunction, func_index: u32) VerifyError!void {
+    for (func.blocks.items) |block| {
+        if (block.instructions.items.len == 0) {
+            last_failure = .{
+                .kind = error.MissingTerminator,
+                .func_index = func_index,
+                .block = block.id,
+                .detail = "block has no instructions",
+            };
+            return error.MissingTerminator;
+        }
+        const last_idx = block.instructions.items.len - 1;
+        for (block.instructions.items, 0..) |inst, ii| {
+            const is_term = isTerminator(inst.op);
+            if (is_term and ii != last_idx) {
+                last_failure = .{
+                    .kind = error.MultipleTerminators,
+                    .func_index = func_index,
+                    .block = block.id,
+                    .inst_index = @intCast(ii),
+                    .detail = "terminator before end of block",
+                };
+                return error.MultipleTerminators;
+            }
+            if (!is_term and ii == last_idx) {
+                last_failure = .{
+                    .kind = error.MissingTerminator,
+                    .func_index = func_index,
+                    .block = block.id,
+                    .inst_index = @intCast(ii),
+                    .detail = "last instruction is not a terminator",
+                };
+                return error.MissingTerminator;
+            }
+        }
+    }
+}
+
+// ── Check 5: dangling block refs ────────────────────────────────────────
+
+fn checkBlockRefs(func: *const ir.IrFunction, func_index: u32) VerifyError!void {
+    const nblocks: u32 = @intCast(func.blocks.items.len);
+    for (func.blocks.items) |block| {
+        for (block.instructions.items, 0..) |inst, ii| {
+            const Ctx = struct {
+                ok: bool = true,
+                bad: ir.BlockId = 0,
+                nblocks: u32,
+            };
+            var c = Ctx{ .nblocks = nblocks };
+            forEachSuccessor(inst.op, &c, struct {
+                fn cb(ptr: *Ctx, target: ir.BlockId) void {
+                    if (!ptr.ok) return;
+                    if (target >= ptr.nblocks) {
+                        ptr.ok = false;
+                        ptr.bad = target;
+                    }
+                }
+            }.cb);
+            if (!c.ok) {
+                last_failure = .{
+                    .kind = error.DanglingBlockRef,
+                    .func_index = func_index,
+                    .block = block.id,
+                    .inst_index = @intCast(ii),
+                    .detail = "terminator targets a nonexistent block",
+                };
+                return error.DanglingBlockRef;
+            }
+        }
+    }
+}
+
+// ── Check 6: predecessor consistency ────────────────────────────────────
+
+fn checkPredecessors(
+    func: *const ir.IrFunction,
+    func_index: u32,
+    allocator: std.mem.Allocator,
+) VerifyError!void {
+    const nblocks: u32 = @intCast(func.blocks.items.len);
+    // Derive the canonical pred set from successor edges.
+    var derived = try allocator.alloc(std.AutoHashMap(ir.BlockId, void), nblocks);
+    defer {
+        for (derived) |*s| s.deinit();
+        allocator.free(derived);
+    }
+    for (derived) |*s| s.* = std.AutoHashMap(ir.BlockId, void).init(allocator);
+
+    for (func.blocks.items) |block| {
+        const last = block.instructions.items[block.instructions.items.len - 1];
+        const Ctx = struct {
+            derived: []std.AutoHashMap(ir.BlockId, void),
+            src: ir.BlockId,
+            err: ?std.mem.Allocator.Error = null,
+        };
+        var c = Ctx{ .derived = derived, .src = block.id };
+        forEachSuccessor(last.op, &c, struct {
+            fn cb(ptr: *Ctx, target: ir.BlockId) void {
+                if (ptr.err != null) return;
+                ptr.derived[target].put(ptr.src, {}) catch |e| {
+                    ptr.err = e;
+                };
+            }
+        }.cb);
+        if (c.err) |e| return e;
+    }
+
+    // Compare each block's recorded preds to the derived set.
+    for (func.blocks.items) |block| {
+        var recorded = std.AutoHashMap(ir.BlockId, void).init(allocator);
+        defer recorded.deinit();
+        for (block.predecessors.items) |p| try recorded.put(p, {});
+
+        // Stale: in `recorded` but not derived.
+        var rit = recorded.iterator();
+        while (rit.next()) |entry| {
+            if (!derived[block.id].contains(entry.key_ptr.*)) {
+                last_failure = .{
+                    .kind = error.StalePredecessor,
+                    .func_index = func_index,
+                    .block = block.id,
+                    .detail = "predecessor list contains a block whose terminator does not target this block",
+                };
+                return error.StalePredecessor;
+            }
+        }
+        // Missing: in derived but not recorded.
+        var dit = derived[block.id].iterator();
+        while (dit.next()) |entry| {
+            if (!recorded.contains(entry.key_ptr.*)) {
+                last_failure = .{
+                    .kind = error.MissingPredecessor,
+                    .func_index = func_index,
+                    .block = block.id,
+                    .detail = "predecessor list omits a block whose terminator targets this block",
+                };
+                return error.MissingPredecessor;
+            }
+        }
+    }
+}
+
+// ── Check 1: SSA def-before-use ─────────────────────────────────────────
+
+fn checkSsaDominance(
+    func: *const ir.IrFunction,
+    func_index: u32,
+    allocator: std.mem.Allocator,
+) VerifyError!void {
+    var dom = try analysis.computeDominators(func, allocator);
+    defer dom.deinit();
+
+    const nblocks = func.blocks.items.len;
+    // For each VReg, record (block, inst_index) of its definition.
+    var def_loc = std.AutoHashMap(ir.VReg, struct { block: ir.BlockId, idx: u32 }).init(allocator);
+    defer def_loc.deinit();
+
+    for (func.blocks.items) |block| {
+        for (block.instructions.items, 0..) |inst, ii| {
+            if (inst.dest) |d| {
+                try def_loc.put(d, .{ .block = block.id, .idx = @intCast(ii) });
+            }
+            switch (inst.op) {
+                .parallel_copy => |pairs| for (pairs) |p| {
+                    try def_loc.put(p.dst, .{ .block = block.id, .idx = @intCast(ii) });
+                },
+                else => {},
+            }
+        }
+    }
+
+    const param_count = func.param_count;
+
+    // Pre-collect predecessors per block (canonical from edges, since
+    // checkPredecessors has already passed if we got here).
+    for (func.blocks.items) |block| {
+        // Only verify reachable blocks. `scrubUnreachableBlocks` is run by
+        // `runPasses` and turns unreachable bodies into a single
+        // `unreachable` op anyway, so an unreachable block with stale uses
+        // would already fail check 4 / 5 first.
+        if (block.id != 0 and dom.idom[block.id] == null) continue;
+
+        for (block.instructions.items, 0..) |inst, ii| {
+            const Ctx = struct {
+                bad: ?ir.VReg = null,
+                param_count: u32,
+                def_loc: *const @TypeOf(def_loc),
+                dom: *const analysis.DomTree,
+                cur_block: ir.BlockId,
+                cur_idx: u32,
+                cur_op: ir.Inst.Op,
+                nblocks: usize,
+            };
+            var c = Ctx{
+                .param_count = param_count,
+                .def_loc = &def_loc,
+                .dom = &dom,
+                .cur_block = block.id,
+                .cur_idx = @intCast(ii),
+                .cur_op = inst.op,
+                .nblocks = nblocks,
+            };
+            forEachOperand(inst, &c, struct {
+                fn cb(ptr: *Ctx, v: ir.VReg) void {
+                    if (ptr.bad != null) return;
+                    if (v < ptr.param_count) return; // function parameter
+                    const def = ptr.def_loc.get(v) orelse {
+                        ptr.bad = v;
+                        return;
+                    };
+                    // For phi: the operand for edge `block = B` must dominate
+                    // the END of B, not the phi's own block.
+                    if (ptr.cur_op == .phi) {
+                        // Find the matching edge to determine the predecessor.
+                        // We re-scan since forEachOperand doesn't pass the
+                        // edge metadata; phi edges are small in practice.
+                        for (ptr.cur_op.phi) |edge| {
+                            if (edge.val != v) continue;
+                            if (def.block == edge.block) return; // same block: OK
+                            if (ptr.dom.dominates(def.block, edge.block)) return;
+                            ptr.bad = v;
+                            return;
+                        }
+                        // Operand isn't on any edge — fall through to default
+                        // dom check, which will likely fail.
+                    }
+                    if (def.block == ptr.cur_block) {
+                        if (def.idx < ptr.cur_idx) return;
+                        ptr.bad = v;
+                        return;
+                    }
+                    if (!ptr.dom.dominates(def.block, ptr.cur_block)) {
+                        ptr.bad = v;
+                        return;
+                    }
+                }
+            }.cb);
+            if (c.bad) |v| {
+                last_failure = .{
+                    .kind = error.UnboundVRegUse,
+                    .func_index = func_index,
+                    .block = block.id,
+                    .inst_index = @intCast(ii),
+                    .vreg = v,
+                    .detail = "use is not dominated by a definition",
+                };
+                return error.UnboundVRegUse;
+            }
+        }
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+fn newReturnBlock(func: *ir.IrFunction, ret_v: ?ir.VReg) !ir.BlockId {
+    const b = try func.newBlock();
+    try func.getBlock(b).append(.{ .op = .{ .ret = ret_v } });
+    return b;
+}
+
+test "verifier: empty function passes" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    try verifyFunction(&func, 0, .after_each_pass, a);
+}
+
+test "verifier: minimal ret-only block passes" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    _ = try newReturnBlock(&func, null);
+    try verifyFunction(&func, 0, .after_each_pass, a);
+}
+
+test "verifier: detects missing terminator" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b = try func.newBlock();
+    const v = func.newVReg();
+    try func.getBlock(b).append(.{ .dest = v, .type = .i32, .op = .{ .iconst_32 = 7 } });
+    try testing.expectError(error.MissingTerminator, verifyFunction(&func, 0, .after_each_pass, a));
+    try testing.expectEqual(@as(?ir.BlockId, b), last_failure.block);
+}
+
+test "verifier: detects multiple terminators" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+    try func.getBlock(b0).append(.{ .op = .{ .@"unreachable" = {} } });
+    try func.getBlock(b1).append(.{ .op = .{ .ret = null } });
+    try func.getBlock(b1).addPredecessor(b0);
+    try testing.expectError(error.MultipleTerminators, verifyFunction(&func, 0, .after_each_pass, a));
+}
+
+test "verifier: detects dangling block ref" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    try func.getBlock(b0).append(.{ .op = .{ .br = 99 } });
+    try testing.expectError(error.DanglingBlockRef, verifyFunction(&func, 0, .after_each_pass, a));
+}
+
+test "verifier: detects stale predecessor" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    try func.getBlock(b0).append(.{ .op = .{ .ret = null } });
+    try func.getBlock(b1).append(.{ .op = .{ .ret = null } });
+    // b1 falsely claims b0 as a predecessor.
+    try func.getBlock(b1).addPredecessor(b0);
+    try testing.expectError(error.StalePredecessor, verifyFunction(&func, 0, .after_each_pass, a));
+}
+
+test "verifier: detects missing predecessor" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+    try func.getBlock(b1).append(.{ .op = .{ .ret = null } });
+    // Deliberately omit b1.addPredecessor(b0).
+    try testing.expectError(error.MissingPredecessor, verifyFunction(&func, 0, .after_each_pass, a));
+}
+
+test "verifier: detects def uniqueness violation" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b = try func.newBlock();
+    const v = func.newVReg();
+    try func.getBlock(b).append(.{ .dest = v, .type = .i32, .op = .{ .iconst_32 = 1 } });
+    try func.getBlock(b).append(.{ .dest = v, .type = .i32, .op = .{ .iconst_32 = 2 } });
+    try func.getBlock(b).append(.{ .op = .{ .ret = v } });
+    try testing.expectError(error.VRegDefinedTwice, verifyFunction(&func, 0, .after_each_pass, a));
+    try testing.expectEqual(@as(?ir.VReg, v), last_failure.vreg);
+}
+
+test "verifier: detects unbound vreg use (non-dominating def)" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    // CFG:
+    //   b0 -> {b1, b2}; b1 defines v; b2 reads v (NOT dominated by b1).
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const cond = func.newVReg();
+    const v = func.newVReg();
+    try func.getBlock(b0).append(.{ .dest = cond, .type = .i32, .op = .{ .iconst_32 = 0 } });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = b1, .else_block = b2 } } });
+    try func.getBlock(b1).append(.{ .dest = v, .type = .i32, .op = .{ .iconst_32 = 1 } });
+    try func.getBlock(b1).append(.{ .op = .{ .ret = v } });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v } }); // bad: v not defined here
+    try func.getBlock(b1).addPredecessor(b0);
+    try func.getBlock(b2).addPredecessor(b0);
+    try testing.expectError(error.UnboundVRegUse, verifyFunction(&func, 0, .after_each_pass, a));
+    try testing.expectEqual(@as(?ir.VReg, v), last_failure.vreg);
+}
+
+test "verifier: dominating def across blocks passes" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    // b0 defines v; b0 -> b1 returns v (b0 dominates b1).
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const v = func.newVReg();
+    try func.getBlock(b0).append(.{ .dest = v, .type = .i32, .op = .{ .iconst_32 = 42 } });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+    try func.getBlock(b1).append(.{ .op = .{ .ret = v } });
+    try func.getBlock(b1).addPredecessor(b0);
+    try verifyFunction(&func, 0, .after_each_pass, a);
+}
+
+test "verifier: function parameter use without def is OK" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 1, 1, 1);
+    defer func.deinit();
+    // Param 0 is vreg 0 (no defining instruction); return it.
+    _ = func.newVReg(); // reserve vreg 0 for the param
+    const b = try func.newBlock();
+    try func.getBlock(b).append(.{ .op = .{ .ret = 0 } });
+    try verifyFunction(&func, 0, .after_each_pass, a);
+}
+
+test "verifier: off mode is a no-op even on broken IR" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b = try func.newBlock();
+    // Block with no terminator — would normally trip MissingTerminator.
+    try func.getBlock(b).append(.{ .op = .{ .local_get = 0 } });
+    try verifyFunction(&func, 0, .off, a);
+}

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -80,6 +80,13 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
     var dump_func_globs: std.ArrayList([]const u8) = .empty;
     var dump_out_dir: ?[]const u8 = null;
 
+    // Default to `.after_each_pass` in safe builds (Debug / ReleaseSafe)
+    // and `.off` in release builds, matching the cost-vs-diagnostic
+    // tradeoff documented in #624. The user can override with
+    // `--verify-ir[=…]` or `--no-verify-ir`.
+    var verify_mode: wamr.ir_verifier.VerifyMode =
+        if (std.debug.runtime_safety) .after_each_pass else .off;
+
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
         const a = sub_args[i];
@@ -118,6 +125,14 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
             try dump_func_globs.append(dump_alloc, a["--dump-ir-functions=".len..]);
         } else if (std.mem.startsWith(u8, a, "--dump-ir-out=")) {
             dump_out_dir = a["--dump-ir-out=".len..];
+        } else if (std.mem.eql(u8, a, "--verify-ir")) {
+            verify_mode = .after_each_pass;
+        } else if (std.mem.eql(u8, a, "--verify-ir=after-each-pass")) {
+            verify_mode = .after_each_pass;
+        } else if (std.mem.eql(u8, a, "--verify-ir=paranoid")) {
+            verify_mode = .paranoid;
+        } else if (std.mem.eql(u8, a, "--no-verify-ir")) {
+            verify_mode = .off;
         } else if (a.len > 0 and a[0] == '-') {
             std.debug.print("error: unknown option '{s}' — try `wamrc compile help`\n", .{a});
             std.process.exit(1);
@@ -240,14 +255,41 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
 
     // 4. Optimize IR (unless -O0)
     if (optimize) {
-        const run_opts: passes.RunOptions = if (dumper.pass_names.len == 0) .{} else .{
-            .dump_hook = .{ .ctx = @ptrCast(&dumper), .callback = Dumper.callback },
+        const run_opts: passes.RunOptions = .{
+            .dump_hook = if (dumper.pass_names.len == 0) null else .{
+                .ctx = @ptrCast(&dumper),
+                .callback = Dumper.callback,
+            },
+            .verify_mode = verify_mode,
         };
         const opt_changes = passes.runPassesWithOptions(&ir_module, passes.defaultPassesForTarget(target_arch), allocator, run_opts) catch |err| {
+            // If the IR verifier tripped, surface its diagnostic before
+            // the generic "Error optimizing IR" line so the user sees the
+            // pass name + block/inst/vreg coordinates.
+            switch (err) {
+                error.UnboundVRegUse,
+                error.VRegDefinedTwice,
+                error.MissingTerminator,
+                error.MultipleTerminators,
+                error.DanglingBlockRef,
+                error.StalePredecessor,
+                error.MissingPredecessor,
+                => {
+                    const f = wamr.ir_verifier.last_failure;
+                    var buf: [256]u8 = undefined;
+                    var w = std.Io.Writer.fixed(&buf);
+                    f.format(&w) catch {};
+                    std.debug.print("{s}\n", .{w.buffered()});
+                },
+                else => {},
+            }
             std.debug.print("Error optimizing IR: {}\n", .{err});
             std.process.exit(1);
         };
         std.debug.print("Optimization: {d} passes made changes\n", .{opt_changes});
+        if (verify_mode != .off) {
+            std.debug.print("IR verifier: enabled ({s})\n", .{@tagName(verify_mode)});
+        }
     }
 
     // #540: Route phi-resolution through register MOV instead of frame
@@ -584,6 +626,16 @@ const compile_usage =
     \\                                 stdout, one snapshot per pass per
     \\                                 function preceded by a header
     \\                                 comment.
+    \\  --verify-ir[=<mode>]          Run the IR invariant checker (#624)
+    \\                                 after every pass that mutated the
+    \\                                 function. Modes:
+    \\                                   after-each-pass (default with --verify-ir)
+    \\                                   paranoid        (reserved; same as
+    \\                                                    after-each-pass today)
+    \\                                 Default: on for safety builds, off
+    \\                                 for release builds.
+    \\  --no-verify-ir                Disable the IR verifier (overrides
+    \\                                 the safety-build default).
     \\
 ;
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -84,6 +84,9 @@ pub const aarch64_peephole = @import("compiler/codegen/aarch64/peephole.zig");
 /// AOT compiler optimization passes.
 pub const passes = @import("compiler/ir/passes.zig");
 
+/// IR invariant checker run between passes (#624).
+pub const ir_verifier = @import("compiler/ir/verifier.zig");
+
 // Testing
 /// Spec test runner infrastructure.
 pub const spec_runner = @import("tests/spec_runner.zig");

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -244,6 +244,11 @@ pub const Harness = struct {
         /// after wiring imports. The spec runner and the differential
         /// tests need this. Fuzz targets should pass `false`.
         invoke_start: bool = true,
+        /// Run the IR verifier (#624) between optimisation passes. Off
+        /// by default so the differential-test corpus (which exercises
+        /// pre-existing IR shapes the verifier has not yet been
+        /// audited against) keeps working. Fuzz targets opt in.
+        verify_ir: bool = false,
     };
 
     /// Compile `wasm_bytes` through the full AOT pipeline and instantiate it.
@@ -298,7 +303,7 @@ pub const Harness = struct {
             return error.CompileFailed;
         };
 
-        const aot_bin = compileToAot(allocator, arena, &wasm_module, registry) catch |err| {
+        const aot_bin = compileToAot(allocator, arena, &wasm_module, registry, options.verify_ir) catch |err| {
             std.debug.print("aot_harness: compile failed: {}\n", .{err});
             return error.CompileFailed;
         };
@@ -1002,16 +1007,26 @@ fn compileToAot(
     arena: *std.heap.ArenaAllocator,
     module: *const types.WasmModule,
     registry: ?*const ImportRegistry,
+    verify_ir: bool,
 ) ![]u8 {
     const a = arena.allocator();
 
     var ir_module = try frontend.lowerModule(module, a);
     defer ir_module.deinit();
 
-    _ = try passes.runPasses(&ir_module, passes.defaultPassesForTarget(switch (builtin.cpu.arch) {
-        .aarch64 => .aarch64,
-        else => .x86_64,
-    }), a);
+    // Opt-in IR verifier (#624). Fuzz / differential harness callers can
+    // toggle this via `InitOptions.verify_ir`; default `false` to avoid
+    // regressing pre-existing differential tests whose IR shapes have not
+    // yet been audited against the invariants.
+    _ = try passes.runPassesWithOptions(
+        &ir_module,
+        passes.defaultPassesForTarget(switch (builtin.cpu.arch) {
+            .aarch64 => .aarch64,
+            else => .x86_64,
+        }),
+        a,
+        .{ .verify_mode = if (verify_ir) .after_each_pass else .off },
+    );
 
     const code: []const u8, const offsets: []const u32 = switch (builtin.cpu.arch) {
         .aarch64 => blk: {

--- a/src/tests/fuzz/aot.zig
+++ b/src/tests/fuzz/aot.zig
@@ -51,6 +51,6 @@ fn runOnce(allocator: std.mem.Allocator, bytes: []const u8) !void {
     // arbitrary wasm bytecode can SEGV on OOB memory/table access, and
     // the runtime does not sandbox those faults. Compile + instantiate
     // only.
-    const h = aot_harness.Harness.initWithOptions(allocator, bytes, null, .{ .invoke_start = false }) catch return;
+    const h = aot_harness.Harness.initWithOptions(allocator, bytes, null, .{ .invoke_start = false, .verify_ir = true }) catch return;
     defer h.deinit();
 }

--- a/src/tests/fuzz/diff.zig
+++ b/src/tests/fuzz/diff.zig
@@ -66,7 +66,7 @@ fn runOnce(allocator: std.mem.Allocator, io: std.Io, crashes_dir: []const u8, by
 
     // Full AOT compile + instantiate, but do NOT invoke start. Native AOT
     // invocation below is limited to the statically safe subset selected above.
-    const h = aot_harness.Harness.initWithOptions(allocator, bytes, null, .{ .invoke_start = false }) catch return;
+    const h = aot_harness.Harness.initWithOptions(allocator, bytes, null, .{ .invoke_start = false, .verify_ir = true }) catch return;
     defer h.deinit();
 
     for (targets[0..target_count]) |target| {


### PR DESCRIPTION
Closes #624 (Phase 1).

## What

Adds `src/compiler/ir/verifier.zig` — a Cranelift-style IR invariant
checker that runs between IR passes and pins the **producing pass** as
the culprit when SSA/CFG breakage occurs, instead of letting the
symptom surface deep in aarch64 lowering as `error.UnboundVReg`.

## Phase 1 invariants (issue checks 1, 2, 4, 5, 6)

| # | Invariant | Catches |
|---|-----------|---------|
| 1 | SSA def-before-use (dominator-aware; phi edges checked against their pred block) | #617 / #618 / #622 |
| 2 | Def uniqueness (incl. `parallel_copy` multi-dests) | mis-renamed clones |
| 4 | Exactly one terminator at end of block; none before | #620 / #622 stale-block class |
| 5 | Dangling block refs in `br` / `br_if` / `br_table` | post-CFG-rewrite slips |
| 6 | `BasicBlock.predecessors` matches the canonical pred set in both directions | #620 / #622 directly |

Invariant 3 (block-parameter arity) is vacuous on the current IR (phi is an
instruction, not a block param) and is stubbed for future use.

A single comptime-exhaustive `forEachOperand` switch covers every `Inst.Op`
variant, modelled on `passes.replaceInInst` so coverage tracks the already-audited
rename pass.

## Wiring

* **`passes.RunOptions.verify_mode`** — verifier runs after every mutation
  point (`inlineSmallFunctions`, `promoteLocalsToSSA`, `lowerPhisToLocals`,
  every per-function fixpoint pass, `scrubUnreachableBlocks`). Failures are
  stamped with the producing pass name.
* **wamrc CLI** gains `--verify-ir[=after-each-pass|paranoid]` and
  `--no-verify-ir`. **Default**: on for safety builds
  (`std.debug.runtime_safety`), off for release. Diagnostics print
  `IR verifier: <kind> after pass '<name>' func #N block #B inst #J vreg %V`
  before the generic compile error.
* **Fuzz harnesses** (`src/tests/fuzz/aot.zig`, `src/tests/fuzz/diff.zig`)
  opt in via `InitOptions.verify_ir = true`. Differential tests keep the
  previous behaviour for now — the verifier surfaces real failures on some
  pre-existing IR shapes that haven't been audited yet; per #624's rollout
  plan, file those as follow-ups rather than blocking this PR.

## Tests

12 new unit tests in `verifier.zig` cover each invariant negatively plus a
happy-path cross-block dominating def, a function-parameter case, and `off`
mode no-op behaviour. Wired into `build.zig` as a dedicated test module.

`zig build test --summary all`: **2824 / 2831 pass, 7 skipped, 0 failures.**
The coldstart noop test exercises the verifier end-to-end in Debug mode
(`IR verifier: enabled (after_each_pass)` appears in its trace).

## Out of scope (follow-ups under #624)

* Checks 7-11 (operand widths, loop info, dom freshness, live-range monotonicity).
* Audit of differential-test IR shapes the verifier flags.
* Post-regalloc machine-code verifier.
* ISLE-style lowering rule exhaustiveness.