### PR TITLE
test(differential): add -Dverify-ir-triage option and triage report (#627)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -111,6 +111,7 @@ pub fn build(b: *std.Build) void {
     options.addOption(bool, "network_tests", network_tests);
 
     const skip_coldstart = b.option(bool, "skip-coldstart", "Skip cold-start budget tests (issue #395)") orelse false;
+    const verify_ir_triage = b.option(bool, "verify-ir-triage", "Run differential tests with the IR verifier enabled and print per-test verifier failures (issue #627)") orelse false;
 
     const config_module = options.createModule();
 
@@ -504,6 +505,9 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     differential_test_module.addImport("wamr", lib_module);
+    const differential_options = b.addOptions();
+    differential_options.addOption(bool, "verify_ir_triage", verify_ir_triage);
+    differential_test_module.addImport("differential_options", differential_options.createModule());
     const differential_tests = b.addTest(.{
         .root_module = differential_test_module,
     });

--- a/docs/ir-verifier-triage.md
+++ b/docs/ir-verifier-triage.md
@@ -1,0 +1,69 @@
+# IR verifier — differential corpus triage (issue #627)
+
+The IR verifier landed in [#626](https://github.com/cataggar/wamr/pull/626) /
+[#624](https://github.com/cataggar/wamr/issues/624) is currently opt-in for the
+differential test suite (`InitOptions.verify_ir = false`). Flipping the default
+to `true` requires that every test currently passing under the legacy
+(verifier-off) pipeline also pass under verification. This page records the
+shape of that work: which passes the verifier currently catches red-handed,
+which invariants they violate, and which sub-issue tracks the fix.
+
+## Reproducing
+
+```sh
+zig build test -Dverify-ir-triage --summary all
+```
+
+Each compile that fails verification prints a `triage:` line to stderr that
+encodes the failing pass + invariant + location. The test itself fails with
+`error.CompileFailed`, exactly so the test runner stamps the test name above
+the verifier diagnostic.
+
+When every entry in the table below has been fixed, flip the default in
+`src/tests/aot_harness.zig:InitOptions.verify_ir` to `true` and remove this
+file's "currently failing" caveat. That is the closing task of #627.
+
+## Currently failing (as of branch `issue-627-fuzz-verifier-triage`)
+
+11 of 200 differential tests fail under `-Dverify-ir-triage`. They reduce to
+**3 distinct (pass, invariant) pairs**:
+
+| # | Failing pass | Invariant | Tests | Sub-issue |
+|---|--------------|-----------|-------|-----------|
+| 1 | `inlineSmallFunctions` | `MissingPredecessor` | 8 SIMD param/result tests | [#630](https://github.com/cataggar/wamr/issues/630) |
+| 2 | `inlineSmallFunctions` | `MultipleTerminators` | `two-function linked list (build + traverse)` | [#631](https://github.com/cataggar/wamr/issues/631) |
+| 3 | `promoteLocalsToSSA`   | `MissingPredecessor` | `crcu8 CoreMark CRC kernel`, `linked list traversal in memory` | [#632](https://github.com/cataggar/wamr/issues/632) |
+
+Verifier messages (verbatim):
+
+- `IR verifier: MissingPredecessor after pass 'inlineSmallFunctions' func #1 block #1 — predecessor list omits a block whose terminator targets this block`
+- `IR verifier: MissingPredecessor after pass 'promoteLocalsToSSA' func #0 block #1 — predecessor list omits a block whose terminator targets this block`
+- `IR verifier: MultipleTerminators after pass 'inlineSmallFunctions' func #1 block #4 inst #10 — terminator before end of block`
+
+### Tests, grouped by (pass, invariant)
+
+`inlineSmallFunctions` / `MissingPredecessor`:
+- `differential SIMD: direct v128 param preserves f32 NaN payload bits`
+- `differential SIMD: direct v128 param preserves f32 signed zero bits`
+- `differential SIMD: direct v128 result preserves f32 NaN payload bits`
+- `differential SIMD: direct v128 result preserves f32 signed zero bits`
+- `differential SIMD: excess v128 params use stack`
+- `differential SIMD: global v128 value passed as param`
+- `differential SIMD: local v128 value passed as param`
+- `differential SIMD: mixed scalar and v128 params`
+
+`inlineSmallFunctions` / `MultipleTerminators`:
+- `differential: two-function linked list (build + traverse)`
+
+`promoteLocalsToSSA` / `MissingPredecessor`:
+- `differential: crcu8(0x53, 0xe9f5) — CoreMark CRC kernel`
+- `differential: linked list traversal in memory`
+
+## Fuzz corpora
+
+`tests/fuzz/regression/wasi/` is empty in-tree; there is no committed corpus to
+replay against `fuzz_aot` / `fuzz_diff`. The fuzz targets themselves already
+opt in to `verify_ir = true` (see `src/tests/fuzz/aot.zig` and
+`src/tests/fuzz/diff.zig`), so as soon as a corpus is reintroduced the
+verifier will exercise it. Adding a checked-in regression corpus is tracked
+separately (the empty `regression/wasi` directory is the existing hook).

--- a/src/tests/differential.zig
+++ b/src/tests/differential.zig
@@ -24,6 +24,17 @@ const ExecEnv = wamr.exec_env.ExecEnv;
 
 const aot_harness = @import("aot_harness.zig");
 const aot_runtime = wamr.aot_runtime;
+const ir_verifier = wamr.ir_verifier;
+
+/// Triage mode (issue #627): when true, every AOT compile in this suite runs
+/// with `verify_ir = true`, and any `error.CompileFailed` is printed as a
+/// `triage:` line tagged with the running test name. Set via build option
+/// `-Dverify-ir-triage`; falls back to `false` when this file is built as a
+/// standalone `zig test` (no `build_options` module present).
+const triage_mode: bool = blk: {
+    const opt = @import("differential_options");
+    break :blk opt.verify_ir_triage;
+};
 
 /// Runtime-arch gate for the AOT half of these tests. We deliberately keep
 /// this narrower than `aot_harness.can_exec_aot` (which also lists aarch64):
@@ -56,7 +67,15 @@ fn runInterpI32(allocator: std.mem.Allocator, wasm: []const u8, name: []const u8
 /// `aot_harness.Harness`. Kept as a thin wrapper so `expectDiffI32` reads
 /// symmetrically against `runInterpI32`.
 fn runAotI32(allocator: std.mem.Allocator, wasm: []const u8, name: []const u8) !i32 {
-    const h = try aot_harness.Harness.init(allocator, wasm);
+    const h = if (comptime triage_mode)
+        aot_harness.Harness.initWithOptions(allocator, wasm, null, .{ .verify_ir = true }) catch |err| {
+            if (err == error.CompileFailed) {
+                std.debug.print("triage: export='{s}' — {f}\n", .{ name, ir_verifier.last_failure });
+            }
+            return err;
+        }
+    else
+        try aot_harness.Harness.init(allocator, wasm);
     defer h.deinit();
 
     const func_idx = h.findFuncExport(name) orelse return error.FunctionNotFound;


### PR DESCRIPTION
Closes #627 (tooling + triage half — the closing task to flip the default to verify_ir=true depends on #630, #631, #632).

## What

- New build option `-Dverify-ir-triage` (default false) wires `verify_ir = true` into every AOT compile in the differential suite and prints a `triage:` line on each verifier failure so the failing pass + invariant are visible per test.
- Default `zig build test` is unchanged: 2824/2831 pass, 7 skipped, 0 failures.
- With `-Dverify-ir-triage` the suite intentionally fails 11 tests, all reducing to **3 distinct (pass, invariant) pairs** — documented in `docs/ir-verifier-triage.md` and split into focused sub-issues:

  | Pass | Invariant | Tests | Sub-issue |
  |------|-----------|-------|-----------|
  | `inlineSmallFunctions` | `MissingPredecessor` | 8 SIMD param/result tests | #630 |
  | `inlineSmallFunctions` | `MultipleTerminators` | `two-function linked list` | #631 |
  | `promoteLocalsToSSA`   | `MissingPredecessor` | crcu8 + linked-list traversal | #632 |

## Why

#624's value is proportional to how many bugs the verifier surfaces close to the source. Per-pass attribution requires running the verifier on real corpora and grouping failures by pass. This PR ships that tooling and the first concrete data set; the actual fixes land via #630/#631/#632.

## What's NOT in this PR

- The default flip of `InitOptions.verify_ir` to `true` — gated on #630/#631/#632.
- An in-tree fuzz corpus replay: `tests/fuzz/regression/wasi/` is empty in-tree; the fuzz targets (`src/tests/fuzz/{aot,diff}.zig`) already opt in to verify_ir, so whenever a corpus is reintroduced the verifier exercises it automatically. Noted in the triage doc.

## Test plan

```
zig build test --summary all                       # 2824/2831 pass, 7 skipped (baseline)
zig build test -Dverify-ir-triage --summary all    # 2813/2831 pass, 11 fail (expected — exactly the triage entries)
```

Refs: #624, #626