### PR TITLE
feat(ir/verifier): operand-width sanity check (paranoid mode, #628)

### DIFF
--- a/src/compiler/ir/verifier.zig
+++ b/src/compiler/ir/verifier.zig
@@ -25,6 +25,16 @@
 //! instruction, not a block parameter — and is therefore omitted. It will be
 //! re-introduced if/when block-params land.
 //!
+//! Paranoid-mode checks (issue #624 stretch invariant 7, implemented in #628):
+//!
+//!   7. **Operand-type sanity.** Each VReg operand's recorded width matches
+//!      the producing instruction's result width. Catches an i32 producer
+//!      feeding an `add` whose other operand is i64, a v128 fed into a
+//!      scalar load `base`, an `f_neg` reading the result of an integer
+//!      op, etc. Only runs when `verify_mode == .paranoid` because it
+//!      walks every operand a second time and is intended for fuzz /
+//!      debug bring-up rather than steady-state CI.
+//!
 //! Wiring: `passes.runPassesWithOptions` calls `verifyFunction` after every
 //! pass invocation when `opts.verify_mode != .off`, and annotates the failure
 //! with the pass name before propagating.
@@ -38,9 +48,9 @@ pub const VerifyMode = enum {
     off,
     /// Run checks 1, 2, 4, 5, 6 after every pass.
     after_each_pass,
-    /// Reserved for future stricter checks (operand-width sanity, loop /
-    /// dom-tree freshness, live-range monotonicity). Behaves like
-    /// `after_each_pass` for now.
+    /// Additionally run check 7 (operand-width sanity). Future stricter
+    /// checks (loop / dom-tree freshness, live-range monotonicity) will
+    /// also land here.
     paranoid,
 };
 
@@ -64,6 +74,9 @@ pub const VerifyError = error{
     /// A block whose terminator targets another block is missing from the
     /// target's `predecessors` list (check 6).
     MissingPredecessor,
+    /// A VReg operand's recorded type does not match the type the
+    /// consuming instruction expects for that role (check 7, paranoid).
+    OperandTypeMismatch,
 } || std.mem.Allocator.Error;
 
 /// Information about the most-recent verifier failure. Populated as a
@@ -531,6 +544,9 @@ pub fn verifyFunction(
     try checkBlockRefs(func, func_index);
     try checkPredecessors(func, func_index, allocator);
     try checkSsaDominance(func, func_index, allocator);
+    if (mode == .paranoid) {
+        try checkOperandWidths(func, func_index, allocator);
+    }
 }
 
 // ── Check 2: def uniqueness ─────────────────────────────────────────────
@@ -832,6 +848,423 @@ fn checkSsaDominance(
     }
 }
 
+// ── Check 7: operand-width sanity (paranoid only) ───────────────────────
+
+/// Thread-local scratch used to format dynamic detail strings (e.g.
+/// "operand %3 has type v128, expected i32"). The single-threaded
+/// verifier guarantees no two checks share this buffer concurrently.
+threadlocal var detail_buf: [160]u8 = undefined;
+
+/// Build a dense `[]?ir.IrType` keyed by VReg. Params (vregs
+/// `0..param_count`) get types from `func.local_types` when present;
+/// otherwise their slot stays `null` and operand checks against them
+/// are skipped. Defs from `Inst.dest` use `inst.type`; `parallel_copy`
+/// dsts use the per-pair `ParallelCopy.ty`.
+fn buildVRegTypeMap(
+    func: *const ir.IrFunction,
+    allocator: std.mem.Allocator,
+) std.mem.Allocator.Error![]?ir.IrType {
+    const n: usize = @intCast(func.next_vreg);
+    const types = try allocator.alloc(?ir.IrType, n);
+    @memset(types, null);
+
+    if (func.local_types) |lt| {
+        const np: usize = @intCast(func.param_count);
+        const lim = @min(np, n);
+        for (0..lim) |i| types[i] = lt[i];
+    }
+
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |inst| {
+            if (inst.dest) |d| {
+                if (@as(usize, @intCast(d)) < n) types[@intCast(d)] = inst.type;
+            }
+            switch (inst.op) {
+                .parallel_copy => |pairs| for (pairs) |p| {
+                    if (@as(usize, @intCast(p.dst)) < n) types[@intCast(p.dst)] = p.ty;
+                },
+                else => {},
+            }
+        }
+    }
+    return types;
+}
+
+const OperandCheckCtx = struct {
+    func: *const ir.IrFunction,
+    func_index: u32,
+    types: []const ?ir.IrType,
+    block: ir.BlockId,
+    inst_index: u32,
+
+    fn typeOf(self: OperandCheckCtx, v: ir.VReg) ?ir.IrType {
+        if (@as(usize, @intCast(v)) >= self.types.len) return null;
+        return self.types[@intCast(v)];
+    }
+
+    fn expect(
+        self: OperandCheckCtx,
+        v: ir.VReg,
+        expected: ir.IrType,
+        role: []const u8,
+    ) VerifyError!void {
+        const got = self.typeOf(v) orelse return; // unknown (param w/o local_types, or unbound — flagged by check 1)
+        if (got == expected) return;
+        const written = std.fmt.bufPrint(
+            &detail_buf,
+            "operand %{d} ({s}) has type {s}, expected {s}",
+            .{ v, role, @tagName(got), @tagName(expected) },
+        ) catch &detail_buf;
+        last_failure = .{
+            .kind = error.OperandTypeMismatch,
+            .func_index = self.func_index,
+            .block = self.block,
+            .inst_index = self.inst_index,
+            .vreg = v,
+            .detail = written,
+        };
+        return error.OperandTypeMismatch;
+    }
+
+    /// Both operands must share the same width as each other. Used for
+    /// binops/cmps where `inst.type` is the operand width (int cmps record
+    /// operand width in `Inst.type` even though the logical result is i32 —
+    /// see frontend.zig for the convention).
+    fn expectBin(
+        self: OperandCheckCtx,
+        lhs: ir.VReg,
+        rhs: ir.VReg,
+        expected: ir.IrType,
+    ) VerifyError!void {
+        try self.expect(lhs, expected, "lhs");
+        try self.expect(rhs, expected, "rhs");
+    }
+};
+
+fn checkOperandWidths(
+    func: *const ir.IrFunction,
+    func_index: u32,
+    allocator: std.mem.Allocator,
+) VerifyError!void {
+    const types = try buildVRegTypeMap(func, allocator);
+    defer allocator.free(types);
+
+    for (func.blocks.items) |block| {
+        for (block.instructions.items, 0..) |inst, ii| {
+            const ctx = OperandCheckCtx{
+                .func = func,
+                .func_index = func_index,
+                .types = types,
+                .block = block.id,
+                .inst_index = @intCast(ii),
+            };
+            try checkOneInst(ctx, inst);
+        }
+    }
+}
+
+fn checkOneInst(ctx: OperandCheckCtx, inst: ir.Inst) VerifyError!void {
+    switch (inst.op) {
+        // Nullary / constants — no operands.
+        .iconst_32,
+        .iconst_64,
+        .fconst_32,
+        .fconst_64,
+        .v128_const,
+        .local_get,
+        .global_get,
+        .br,
+        .@"unreachable",
+        .atomic_fence,
+        .memory_size,
+        .table_size,
+        .ref_func,
+        .data_drop,
+        .elem_drop,
+        .call_result,
+        => {},
+
+        // Integer + float binops. `inst.type` is the operand width.
+        .add,
+        .sub,
+        .mul,
+        .div_s,
+        .div_u,
+        .rem_s,
+        .rem_u,
+        .@"and",
+        .@"or",
+        .xor,
+        .shl,
+        .shr_s,
+        .shr_u,
+        .rotl,
+        .rotr,
+        .eq,
+        .ne,
+        .lt_s,
+        .lt_u,
+        .gt_s,
+        .gt_u,
+        .le_s,
+        .le_u,
+        .ge_s,
+        .ge_u,
+        .f_min,
+        .f_max,
+        .f_copysign,
+        .f_eq,
+        .f_ne,
+        .f_lt,
+        .f_gt,
+        .f_le,
+        .f_ge,
+        => |bin| try ctx.expectBin(bin.lhs, bin.rhs, inst.type),
+
+        // Single-operand integer/float unops where `inst.type` is the
+        // operand (and result) type.
+        .clz, .ctz, .popcnt, .eqz => |v| try ctx.expect(v, inst.type, "operand"),
+        .extend8_s, .extend16_s, .extend32_s => |v| try ctx.expect(v, inst.type, "operand"),
+        .f_neg, .f_abs, .f_sqrt, .f_ceil, .f_floor, .f_trunc, .f_nearest => |v|
+            try ctx.expect(v, inst.type, "operand"),
+
+        // Width-changing conversions: operand width fixed per-op, dest is
+        // `inst.type`.
+        .wrap_i64 => |v| try ctx.expect(v, .i64, "operand"),
+        .extend_i32_s, .extend_i32_u => |v| try ctx.expect(v, .i32, "operand"),
+        .trunc_f32_s, .trunc_f32_u, .trunc_sat_f32_s, .trunc_sat_f32_u => |v|
+            try ctx.expect(v, .f32, "operand"),
+        .trunc_f64_s, .trunc_f64_u, .trunc_sat_f64_s, .trunc_sat_f64_u => |v|
+            try ctx.expect(v, .f64, "operand"),
+        .convert_i32_s, .convert_i32_u => |v| try ctx.expect(v, .i32, "operand"),
+        .convert_i64_s, .convert_i64_u => |v| try ctx.expect(v, .i64, "operand"),
+        .demote_f64 => |v| try ctx.expect(v, .f64, "operand"),
+        .promote_f32 => |v| try ctx.expect(v, .f32, "operand"),
+        // `reinterpret`, `convert_s`, `convert_u` have ambiguous operand
+        // widths under the current IR (the op is reused across i32↔f32 /
+        // i64↔f64); skip rather than risk false positives.
+        .reinterpret, .convert_s, .convert_u => {},
+
+        // Locals / globals — value type isn't recorded on the op (only the
+        // local/global index), so we can't check here. Mem2reg / promotion
+        // passes elsewhere already enforce typed assignment.
+        .local_set, .global_set => {},
+
+        // Loads: `base` is the linear-memory pointer, always i32 in wasm32.
+        .load => |ld| try ctx.expect(ld.base, .i32, "base"),
+        .v128_load => |ld| try ctx.expect(ld.base, .i32, "base"),
+        .v128_load_splat => |ld| try ctx.expect(ld.base, .i32, "base"),
+        .v128_load_zero => |ld| try ctx.expect(ld.base, .i32, "base"),
+        .v128_load_extend => |ld| try ctx.expect(ld.base, .i32, "base"),
+        .v128_load_lane => |ld| {
+            try ctx.expect(ld.base, .i32, "base");
+            try ctx.expect(ld.vector, .v128, "vector");
+        },
+
+        // Stores: base is i32; value width is the store's `inst.type`.
+        .store => |st| {
+            try ctx.expect(st.base, .i32, "base");
+            try ctx.expect(st.val, inst.type, "val");
+        },
+        .v128_store => |st| {
+            try ctx.expect(st.base, .i32, "base");
+            try ctx.expect(st.val, .v128, "val");
+        },
+        .v128_store_lane => |st| {
+            try ctx.expect(st.base, .i32, "base");
+            try ctx.expect(st.vector, .v128, "vector");
+        },
+
+        // Control flow.
+        .br_if => |bi| try ctx.expect(bi.cond, .i32, "cond"),
+        .br_table => |bt| try ctx.expect(bt.index, .i32, "index"),
+
+        // Returns: would need the function signature to type-check; defer.
+        .ret, .ret_multi => {},
+
+        // Calls: arg types would need the module's `func_types`; defer to a
+        // follow-up. (`elem_idx`/`func_ref` are integer table/func indices,
+        // always i32 in wasm32 and worth checking.)
+        .call => {},
+        .call_indirect => |ci| try ctx.expect(ci.elem_idx, .i32, "elem_idx"),
+        .call_ref => |cr| try ctx.expect(cr.func_ref, .i32, "func_ref"),
+
+        // Select: cond i32, branches share `inst.type`.
+        .select => |sel| {
+            try ctx.expect(sel.cond, .i32, "cond");
+            try ctx.expect(sel.if_true, inst.type, "if_true");
+            try ctx.expect(sel.if_false, inst.type, "if_false");
+        },
+
+        // Atomics. base is i32; val/expected/replacement match the access
+        // width via `inst.type`. atomic_notify count is i32; atomic_wait
+        // timeout is always i64 (per spec) and `expected` matches inst.type.
+        .atomic_load => |al| try ctx.expect(al.base, .i32, "base"),
+        .atomic_store => |st| {
+            try ctx.expect(st.base, .i32, "base");
+            try ctx.expect(st.val, inst.type, "val");
+        },
+        .atomic_rmw => |ar| {
+            try ctx.expect(ar.base, .i32, "base");
+            try ctx.expect(ar.val, inst.type, "val");
+        },
+        .atomic_cmpxchg => |ac| {
+            try ctx.expect(ac.base, .i32, "base");
+            try ctx.expect(ac.expected, inst.type, "expected");
+            try ctx.expect(ac.replacement, inst.type, "replacement");
+        },
+        .atomic_notify => |an| {
+            try ctx.expect(an.base, .i32, "base");
+            try ctx.expect(an.count, .i32, "count");
+        },
+        .atomic_wait => |aw| {
+            try ctx.expect(aw.base, .i32, "base");
+            try ctx.expect(aw.expected, inst.type, "expected");
+            try ctx.expect(aw.timeout, .i64, "timeout");
+        },
+
+        // Bulk memory ops — all operands are i32 in wasm32.
+        .memory_copy => |mc| {
+            try ctx.expect(mc.dst, .i32, "dst");
+            try ctx.expect(mc.src, .i32, "src");
+            try ctx.expect(mc.len, .i32, "len");
+        },
+        .memory_fill => |mf| {
+            try ctx.expect(mf.dst, .i32, "dst");
+            try ctx.expect(mf.val, .i32, "val");
+            try ctx.expect(mf.len, .i32, "len");
+        },
+        .memory_init => |mi| {
+            try ctx.expect(mi.dst, .i32, "dst");
+            try ctx.expect(mi.src, .i32, "src");
+            try ctx.expect(mi.len, .i32, "len");
+        },
+        .memory_grow => |v| try ctx.expect(v, .i32, "delta"),
+
+        // Tables. Index always i32; element-type-dependent operands skipped.
+        .table_get => |tg| try ctx.expect(tg.idx, .i32, "idx"),
+        .table_set => |ts| try ctx.expect(ts.idx, .i32, "idx"),
+        .table_grow => |tg| try ctx.expect(tg.delta, .i32, "delta"),
+        .table_init => |ti| {
+            try ctx.expect(ti.dst, .i32, "dst");
+            try ctx.expect(ti.src, .i32, "src");
+            try ctx.expect(ti.len, .i32, "len");
+        },
+
+        // SIMD — vector operands are v128; scalar shift counts / splat
+        // values use the documented scalar width per opcode.
+        .v128_not => |v| try ctx.expect(v, .v128, "operand"),
+        .v128_any_true => |v| try ctx.expect(v, .v128, "operand"),
+        .v128_bitwise => |bin| try ctx.expectBin(bin.lhs, bin.rhs, .v128),
+        .v128_bitselect => |sel| {
+            try ctx.expect(sel.a, .v128, "a");
+            try ctx.expect(sel.b, .v128, "b");
+            try ctx.expect(sel.mask, .v128, "mask");
+        },
+        .simd_all_true => |op| try ctx.expect(op.vector, .v128, "vector"),
+        .simd_bitmask => |op| try ctx.expect(op.vector, .v128, "vector"),
+
+        .i32x4_binop => |bin| try ctx.expectBin(bin.lhs, bin.rhs, .v128),
+        .f32x4_binop => |bin| try ctx.expectBin(bin.lhs, bin.rhs, .v128),
+        .i8x16_binop => |bin| try ctx.expectBin(bin.lhs, bin.rhs, .v128),
+        .i16x8_binop => |bin| try ctx.expectBin(bin.lhs, bin.rhs, .v128),
+        .i64x2_binop => |bin| try ctx.expectBin(bin.lhs, bin.rhs, .v128),
+        .f64x2_binop => |bin| try ctx.expectBin(bin.lhs, bin.rhs, .v128),
+
+        .i32x4_unop => |un| try ctx.expect(un.vector, .v128, "vector"),
+        .f32x4_unop => |un| try ctx.expect(un.vector, .v128, "vector"),
+        .i8x16_unop => |un| try ctx.expect(un.vector, .v128, "vector"),
+        .i16x8_unop => |un| try ctx.expect(un.vector, .v128, "vector"),
+        .i64x2_unop => |un| try ctx.expect(un.vector, .v128, "vector"),
+        .f64x2_unop => |un| try ctx.expect(un.vector, .v128, "vector"),
+
+        .i32x4_extadd_pairwise_i16x8 => |op| try ctx.expect(op.vector, .v128, "vector"),
+        .i16x8_extadd_pairwise_i8x16 => |op| try ctx.expect(op.vector, .v128, "vector"),
+        .i32x4_extend_i16x8 => |op| try ctx.expect(op.vector, .v128, "vector"),
+        .i16x8_extend_i8x16 => |op| try ctx.expect(op.vector, .v128, "vector"),
+        .i64x2_extend_i32x4 => |op| try ctx.expect(op.vector, .v128, "vector"),
+        .i32x4_trunc_sat => |op| try ctx.expect(op.vector, .v128, "vector"),
+        .f32x4_convert_i32x4 => |op| try ctx.expect(op.vector, .v128, "vector"),
+        .f32x4_demote_f64x2_zero => |op| try ctx.expect(op.vector, .v128, "vector"),
+        .f64x2_convert_low_i32x4 => |op| try ctx.expect(op.vector, .v128, "vector"),
+        .f64x2_promote_low_f32x4 => |op| try ctx.expect(op.vector, .v128, "vector"),
+
+        .i32x4_dot_i16x8_s => |op| try ctx.expectBin(op.lhs, op.rhs, .v128),
+        .i32x4_extmul_i16x8 => |op| try ctx.expectBin(op.lhs, op.rhs, .v128),
+        .i16x8_extmul_i8x16 => |op| try ctx.expectBin(op.lhs, op.rhs, .v128),
+        .i64x2_extmul_i32x4 => |op| try ctx.expectBin(op.lhs, op.rhs, .v128),
+        .i8x16_shuffle => |op| try ctx.expectBin(op.lhs, op.rhs, .v128),
+        .i8x16_narrow_i16x8 => |op| try ctx.expectBin(op.lhs, op.rhs, .v128),
+        .i16x8_narrow_i32x4 => |op| try ctx.expectBin(op.lhs, op.rhs, .v128),
+
+        .i8x16_swizzle => |op| {
+            try ctx.expect(op.vector, .v128, "vector");
+            try ctx.expect(op.indices, .v128, "indices");
+        },
+
+        .i8x16_shift => |shift| {
+            try ctx.expect(shift.vector, .v128, "vector");
+            try ctx.expect(shift.count, .i32, "count");
+        },
+        .i16x8_shift => |shift| {
+            try ctx.expect(shift.vector, .v128, "vector");
+            try ctx.expect(shift.count, .i32, "count");
+        },
+        .i32x4_shift => |shift| {
+            try ctx.expect(shift.vector, .v128, "vector");
+            try ctx.expect(shift.count, .i32, "count");
+        },
+        .i64x2_shift => |shift| {
+            try ctx.expect(shift.vector, .v128, "vector");
+            try ctx.expect(shift.count, .i32, "count");
+        },
+
+        .i32x4_extract_lane => |lane| try ctx.expect(lane.vector, .v128, "vector"),
+        .f32x4_extract_lane => |lane| try ctx.expect(lane.vector, .v128, "vector"),
+        .i8x16_extract_lane => |lane| try ctx.expect(lane.vector, .v128, "vector"),
+        .i16x8_extract_lane => |lane| try ctx.expect(lane.vector, .v128, "vector"),
+        .i64x2_extract_lane => |lane| try ctx.expect(lane.vector, .v128, "vector"),
+        .f64x2_extract_lane => |lane| try ctx.expect(lane.vector, .v128, "vector"),
+        .i32x4_replace_lane => |lane| {
+            try ctx.expect(lane.vector, .v128, "vector");
+            try ctx.expect(lane.val, .i32, "val");
+        },
+        .f32x4_replace_lane => |lane| {
+            try ctx.expect(lane.vector, .v128, "vector");
+            try ctx.expect(lane.val, .f32, "val");
+        },
+        .i8x16_replace_lane => |lane| {
+            try ctx.expect(lane.vector, .v128, "vector");
+            try ctx.expect(lane.val, .i32, "val"); // i8 lifted to i32
+        },
+        .i16x8_replace_lane => |lane| {
+            try ctx.expect(lane.vector, .v128, "vector");
+            try ctx.expect(lane.val, .i32, "val"); // i16 lifted to i32
+        },
+        .i64x2_replace_lane => |lane| {
+            try ctx.expect(lane.vector, .v128, "vector");
+            try ctx.expect(lane.val, .i64, "val");
+        },
+        .f64x2_replace_lane => |lane| {
+            try ctx.expect(lane.vector, .v128, "vector");
+            try ctx.expect(lane.val, .f64, "val");
+        },
+
+        .i32x4_splat => |v| try ctx.expect(v, .i32, "scalar"),
+        .f32x4_splat => |v| try ctx.expect(v, .f32, "scalar"),
+        .i8x16_splat => |v| try ctx.expect(v, .i32, "scalar"), // i8 lifted to i32
+        .i16x8_splat => |v| try ctx.expect(v, .i32, "scalar"), // i16 lifted to i32
+        .i64x2_splat => |v| try ctx.expect(v, .i64, "scalar"),
+        .f64x2_splat => |v| try ctx.expect(v, .f64, "scalar"),
+
+        // Phi: every incoming edge must produce a value of the phi's type.
+        .phi => |edges| for (edges) |e| try ctx.expect(e.val, inst.type, "phi edge"),
+
+        // Parallel copy: each pair carries its own width.
+        .parallel_copy => |pairs| for (pairs) |p| try ctx.expect(p.src, p.ty, "src"),
+    }
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 const testing = std.testing;
@@ -984,4 +1417,143 @@ test "verifier: off mode is a no-op even on broken IR" {
     // Block with no terminator — would normally trip MissingTerminator.
     try func.getBlock(b).append(.{ .op = .{ .local_get = 0 } });
     try verifyFunction(&func, 0, .off, a);
+}
+
+// ── Check 7 (operand-width sanity, paranoid only) ─────────────────────
+
+test "verifier(paranoid): well-typed add i32 passes" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b = try func.newBlock();
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try func.getBlock(b).append(.{ .dest = v0, .type = .i32, .op = .{ .iconst_32 = 1 } });
+    try func.getBlock(b).append(.{ .dest = v1, .type = .i32, .op = .{ .iconst_32 = 2 } });
+    try func.getBlock(b).append(.{ .dest = v2, .type = .i32, .op = .{ .add = .{ .lhs = v0, .rhs = v1 } } });
+    try func.getBlock(b).append(.{ .op = .{ .ret = v2 } });
+    try verifyFunction(&func, 0, .paranoid, a);
+}
+
+test "verifier(paranoid): detects scalar bin-op width mismatch" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b = try func.newBlock();
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try func.getBlock(b).append(.{ .dest = v0, .type = .i32, .op = .{ .iconst_32 = 1 } });
+    try func.getBlock(b).append(.{ .dest = v1, .type = .i64, .op = .{ .iconst_64 = 2 } });
+    // i32 add reading an i64 operand.
+    try func.getBlock(b).append(.{ .dest = v2, .type = .i32, .op = .{ .add = .{ .lhs = v0, .rhs = v1 } } });
+    try func.getBlock(b).append(.{ .op = .{ .ret = v2 } });
+    try testing.expectError(error.OperandTypeMismatch, verifyFunction(&func, 0, .paranoid, a));
+    try testing.expectEqual(@as(?ir.VReg, v1), last_failure.vreg);
+}
+
+test "verifier(paranoid): detects load base wrong width" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b = try func.newBlock();
+    const v_base = func.newVReg();
+    const v_loaded = func.newVReg();
+    try func.getBlock(b).append(.{ .dest = v_base, .type = .i64, .op = .{ .iconst_64 = 0 } });
+    try func.getBlock(b).append(.{
+        .dest = v_loaded,
+        .type = .i32,
+        .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } },
+    });
+    try func.getBlock(b).append(.{ .op = .{ .ret = v_loaded } });
+    try testing.expectError(error.OperandTypeMismatch, verifyFunction(&func, 0, .paranoid, a));
+    try testing.expectEqual(@as(?ir.VReg, v_base), last_failure.vreg);
+}
+
+test "verifier(paranoid): detects simd swizzle indices not v128" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b = try func.newBlock();
+    const v_vec = func.newVReg();
+    const v_idx = func.newVReg();
+    const v_out = func.newVReg();
+    try func.getBlock(b).append(.{ .dest = v_vec, .type = .v128, .op = .{ .v128_const = 0 } });
+    try func.getBlock(b).append(.{ .dest = v_idx, .type = .i32, .op = .{ .iconst_32 = 0 } });
+    try func.getBlock(b).append(.{
+        .dest = v_out,
+        .type = .v128,
+        .op = .{ .i8x16_swizzle = .{ .vector = v_vec, .indices = v_idx } },
+    });
+    try func.getBlock(b).append(.{ .op = .{ .ret = v_out } });
+    try testing.expectError(error.OperandTypeMismatch, verifyFunction(&func, 0, .paranoid, a));
+    try testing.expectEqual(@as(?ir.VReg, v_idx), last_failure.vreg);
+}
+
+test "verifier(paranoid): detects f_neg on integer producer" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b = try func.newBlock();
+    const v_i = func.newVReg();
+    const v_out = func.newVReg();
+    try func.getBlock(b).append(.{ .dest = v_i, .type = .i32, .op = .{ .iconst_32 = 7 } });
+    // f_neg with inst.type = .f32, reading an i32-typed producer.
+    try func.getBlock(b).append(.{ .dest = v_out, .type = .f32, .op = .{ .f_neg = v_i } });
+    try func.getBlock(b).append(.{ .op = .{ .ret = v_out } });
+    try testing.expectError(error.OperandTypeMismatch, verifyFunction(&func, 0, .paranoid, a));
+    try testing.expectEqual(@as(?ir.VReg, v_i), last_failure.vreg);
+}
+
+test "verifier(paranoid): after_each_pass mode skips operand-width check" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b = try func.newBlock();
+    const v_i = func.newVReg();
+    const v_out = func.newVReg();
+    try func.getBlock(b).append(.{ .dest = v_i, .type = .i32, .op = .{ .iconst_32 = 7 } });
+    try func.getBlock(b).append(.{ .dest = v_out, .type = .f32, .op = .{ .f_neg = v_i } });
+    try func.getBlock(b).append(.{ .op = .{ .ret = v_out } });
+    // Same broken IR — paranoid trips, after_each_pass does not.
+    try verifyFunction(&func, 0, .after_each_pass, a);
+    try testing.expectError(error.OperandTypeMismatch, verifyFunction(&func, 0, .paranoid, a));
+}
+
+test "verifier(paranoid): parameter operand types respected via local_types" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 1, 1, 1);
+    defer func.deinit();
+    // Param 0 is vreg 0, typed i64 via local_types.
+    const lt = try a.alloc(ir.IrType, 1);
+    lt[0] = .i64;
+    func.local_types = lt;
+    _ = func.newVReg(); // reserve vreg 0 for the param
+    const v_other = func.newVReg();
+    const v_sum = func.newVReg();
+    const b = try func.newBlock();
+    try func.getBlock(b).append(.{ .dest = v_other, .type = .i32, .op = .{ .iconst_32 = 1 } });
+    // i32 add reading the i64 param.
+    try func.getBlock(b).append(.{ .dest = v_sum, .type = .i32, .op = .{ .add = .{ .lhs = 0, .rhs = v_other } } });
+    try func.getBlock(b).append(.{ .op = .{ .ret = v_sum } });
+    try testing.expectError(error.OperandTypeMismatch, verifyFunction(&func, 0, .paranoid, a));
+    try testing.expectEqual(@as(?ir.VReg, 0), last_failure.vreg);
+}
+
+test "verifier(paranoid): parallel_copy per-pair type checked" {
+    const a = testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const v_src = func.newVReg();
+    const v_dst = func.newVReg();
+    const b = try func.newBlock();
+    try func.getBlock(b).append(.{ .dest = v_src, .type = .i32, .op = .{ .iconst_32 = 1 } });
+    const pairs = try a.alloc(ir.Inst.ParallelCopy, 1);
+    // pair says ty=i64 but src is i32 — mismatch.
+    pairs[0] = .{ .dst = v_dst, .src = v_src, .ty = .i64 };
+    try func.getBlock(b).append(.{ .op = .{ .parallel_copy = pairs } });
+    try func.getBlock(b).append(.{ .op = .{ .ret = null } });
+    try testing.expectError(error.OperandTypeMismatch, verifyFunction(&func, 0, .paranoid, a));
+    try testing.expectEqual(@as(?ir.VReg, v_src), last_failure.vreg);
 }

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -630,8 +630,8 @@ const compile_usage =
     \\                                 after every pass that mutated the
     \\                                 function. Modes:
     \\                                   after-each-pass (default with --verify-ir)
-    \\                                   paranoid        (reserved; same as
-    \\                                                    after-each-pass today)
+    \\                                   paranoid        (adds operand-width
+    \\                                                    sanity check, #628)
     \\                                 Default: on for safety builds, off
     \\                                 for release builds.
     \\  --no-verify-ir                Disable the IR verifier (overrides


### PR DESCRIPTION
Closes #628. Follow-up to #626 (Phase 1 verifier).

Implements **stretch invariant 7** from #624 — every `VReg` operand's recorded width must match the producing instruction's result width.

## What

- New `VerifyError.OperandTypeMismatch` with a dynamic `LastFailure.detail` like `operand %3 (lhs) has type i64, expected i32`.
- New `checkOperandWidths` pass gated on `verify_mode == .paranoid`, so `--verify-ir=after-each-pass` (the default safe-build mode) keeps its cost profile.
- Per-pass `VReg → IrType` map built once from `Inst.dest`+`Inst.type` and `parallel_copy` per-pair `ty`. Param widths are sourced from `func.local_types` when present; otherwise the operand check is skipped for params.
- Per-opcode switch mirrors `forEachOperand` and asserts expected operand widths (e.g. load `base` = i32, simd shift `count` = i32, splat scalar = i32/i64/f32/f64 per lane, phi edges = `inst.type`, `parallel_copy` `src` = pair `ty`).

### Skipped to avoid false positives

| Op family | Why | Follow-up |
|---|---|---|
| `reinterpret`, `convert_s`, `convert_u` | Reused across i32↔f32 / i64↔f64; operand width ambiguous from the op alone | Would need an explicit operand-type field on the IR op |
| `call` args, `ret` value | Need module `func_types` to know expected widths; verifier today only sees one `IrFunction` | Plumb `*const ir.IrModule` into `verifyFunction` |
| `local_set` / `global_set` | Only the index is on the op | Already enforced upstream by mem2reg / type-check |

`call_indirect.elem_idx` and `call_ref.func_ref` are still checked as i32.

## Tests

8 new cases in `verifier.zig`:

1. Well-typed `add i32` passes.
2. Scalar bin-op width mismatch (`add` lhs=i32, rhs=i64) → `OperandTypeMismatch`.
3. Load `base` produced by `iconst_64` → mismatch.
4. `i8x16_swizzle.indices` produced by `iconst_32` → mismatch.
5. `f_neg` reading an i32 producer → mismatch.
6. Paranoid-vs-`after_each_pass` gating: same broken IR passes the older mode, trips paranoid.
7. Parameter operand widths picked up from `func.local_types` (i64 param fed to i32 add → mismatch).
8. `parallel_copy` per-pair `ty` mismatch.

## CLI

`wamrc --verify-ir=paranoid` was already accepted but previously behaved identically to `after-each-pass`. The help text is updated to reflect that paranoid now actually adds a check.

## Verification

- `zig build test`: **2856 / 2856 pass**, 7 skipped (parity with main).
- `wamrc compile --verify-ir=paranoid tests/coldstart/noop.wasm`: clean.
- `wamrc compile --verify-ir=paranoid tests/benchmarks/coremark/coremark_wasi.wasm`: trips `MultipleTerminators` (check 4, pre-existing on `main` — unrelated to this PR).

Refs: #624, #626