### PR TITLE
fix(ir/inline): refresh BasicBlock.predecessors after inlining (#630)

### DIFF
--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -1139,6 +1139,37 @@ pub fn buildPredecessors(
     return result;
 }
 
+/// Recompute each block's on-block `predecessors` field from the
+/// canonical pred set derived from terminators.
+///
+/// Most analysis passes use `buildPredecessors` (which returns a fresh
+/// map) and never touch `BasicBlock.predecessors`. The on-block field is
+/// only consumed by the IR pretty-printer and the IR verifier
+/// (check 6, `MissingPredecessor` / `StalePredecessor`). Passes that
+/// mutate the CFG without rebuilding the on-block field will trip the
+/// verifier; call this helper after such a pass to restore the
+/// invariant.
+///
+/// Deduplicates within each pred list, matching `buildPredecessors`'
+/// semantics for `br_table` targets that list the same block twice.
+pub fn refreshBlockPredecessors(
+    func: *ir.IrFunction,
+    allocator: std.mem.Allocator,
+) !void {
+    var preds = try buildPredecessors(func, allocator);
+    defer {
+        var it = preds.iterator();
+        while (it.next()) |entry| allocator.free(entry.value_ptr.*);
+        preds.deinit();
+    }
+
+    for (func.blocks.items, 0..) |*block, idx| {
+        block.predecessors.clearRetainingCapacity();
+        const list = preds.get(@intCast(idx)) orelse continue;
+        try block.predecessors.appendSlice(block.allocator, list);
+    }
+}
+
 /// Compute the dominator tree for `func` rooted at block 0.
 pub fn computeDominators(
     func: *const ir.IrFunction,

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -5233,6 +5233,10 @@ fn inlineSmallFunctionsCount(module: *ir.IrModule, allocator: std.mem.Allocator)
     defer allocator.free(eligible);
     for (module.functions.items, 0..) |*f, i| eligible[i] = isInlinable(f, inline_small_max_insts, inline_small_max_blocks);
 
+    var caller_changed = try allocator.alloc(bool, module.functions.items.len);
+    defer allocator.free(caller_changed);
+    @memset(caller_changed, false);
+
     var inlined_count: u32 = 0;
     for (module.functions.items, 0..) |*caller, caller_idx| {
         // Only scan blocks that existed at the start of this pass. Newly
@@ -5435,8 +5439,20 @@ fn inlineSmallFunctionsCount(module: *ir.IrModule, allocator: std.mem.Allocator)
             // can no longer free its args slice; release it here.
             if (call_args.len > 0) caller.allocator.free(call_args);
 
+            caller_changed[caller_idx] = true;
             inlined_count += 1;
         }
+    }
+
+    // The inliner mutates the CFG (new `br` terminators on caller blocks,
+    // cloned callee terminators referencing shifted block ids, post-call
+    // IR moved into `b_after_id` whose successors now have `b_after_id`
+    // as a predecessor instead of `b`) without updating the on-block
+    // `BasicBlock.predecessors` field. Refresh it for every caller we
+    // touched so the IR verifier (check 6, `MissingPredecessor` /
+    // `StalePredecessor`) sees a consistent view. See issue #630.
+    for (module.functions.items, 0..) |*f, i| {
+        if (caller_changed[i]) try analysis.refreshBlockPredecessors(f, allocator);
     }
     return inlined_count;
 }


### PR DESCRIPTION
inlineSmallFunctionsCount splices callee blocks into the caller and
creates several new CFG edges:

  * B → clone_offset (new `br` terminator on the truncated caller block)
  * clone → b_after_id (each callee `ret` rewritten to `br b_after_id`)
  * clone → clone (intra-callee br/br_if/br_table shifted by clone_offset)
  * b_after_id → X (post-call IR moved into b_after_id retains its
    original successors, which previously had `b` as their predecessor)

The on-block `BasicBlock.predecessors` field is not updated for any of
these. Analysis passes don't notice (they call analysis.buildPredecessors
themselves), but the IR verifier's check 6 does — flagging
`MissingPredecessor` after inlineSmallFunctions on the differential
SIMD corpus under `-Dverify-ir-triage` (8 failing tests, all with the
same diagnostic).

Fix:

  * Add `analysis.refreshBlockPredecessors(func, allocator)` that
    rebuilds each block's on-block pred list from the canonical
    successor-derived set (deduping like buildPredecessors does for
    br_table).
  * In inlineSmallFunctionsCount, track which callers had at least one
    successful inline and refresh their pred lists once at end of pass,
    before runPassesWithOptions invokes the verifier.

Verified: `zig build test -Dverify-ir-triage` no longer reports
MissingPredecessor for inlineSmallFunctions; the 8 SIMD tests pass.
The remaining MultipleTerminators (#631) and promoteLocalsToSSA
MissingPredecessor (#632) failures are tracked separately.

Refs: #624, #626, #627

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
