### PR TITLE
fix(ir): close out remaining inlineSmallFunctions verifier failures (#631, #632)

### DIFF
--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -469,7 +469,21 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                 if (vreg_stack.items.len > frame.stack_depth) {
                     vreg_stack.items.len = frame.stack_depth;
                 }
-                try ir_func.getBlock(current_block).append(.{ .op = .{ .br = frame.end_block } });
+                // Only emit the fall-through `br frame.end_block` when
+                // current_block doesn't already end with a terminator.
+                // Inside dead code (after `br`/`return`/`unreachable`), the
+                // block was already closed by that terminator; emitting a
+                // second `br` here produces a block with two terminators,
+                // which trips the IR verifier (issue #631
+                // `MultipleTerminators`) and confuses the inliner.
+                const cur_insts = ir_func.getBlock(current_block).instructions.items;
+                const already_terminated = cur_insts.len != 0 and switch (cur_insts[cur_insts.len - 1].op) {
+                    .br, .br_if, .br_table, .ret, .ret_multi, .@"unreachable" => true,
+                    else => false,
+                };
+                if (!already_terminated) {
+                    try ir_func.getBlock(current_block).append(.{ .op = .{ .br = frame.end_block } });
+                }
                 current_block = frame.end_block;
                 // Re-push the N results as fresh vregs loaded from the
                 // result_locals, preserving stack order (results[0] deepest).

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -5253,6 +5253,11 @@ fn inlineSmallFunctionsCount(module: *ir.IrModule, allocator: std.mem.Allocator)
                 var i: usize = 0;
                 while (i < block.instructions.items.len) : (i += 1) {
                     const inst = block.instructions.items[i];
+                    // Stop scanning at the block's terminator. Anything past
+                    // it is dead code — splitting at a call there would
+                    // leave the original terminator stranded as a non-final
+                    // terminator (issue #631 MultipleTerminators).
+                    if (verifier.isTerminator(inst.op)) break;
                     const call = switch (inst.op) {
                         .call => |c| c,
                         else => continue,
@@ -5381,6 +5386,15 @@ fn inlineSmallFunctionsCount(module: *ir.IrModule, allocator: std.mem.Allocator)
                                 caller.allocator,
                                 .{ .op = .{ .br = b_after_id } },
                             );
+                            // Drop any unreachable code that followed the `ret`
+                            // in the callee block. Leaving it would produce a
+                            // clone with multiple terminators (or a clone whose
+                            // *last* instruction is a non-terminator, which
+                            // hides the true successor edge from
+                            // `forEachSuccessor` and surfaces later as
+                            // `MissingPredecessor` once `promoteLocalsToSSA`
+                            // strips the trailing junk). See issue #631.
+                            break;
                         },
                         else => {
                             var cloned = citem;
@@ -5403,7 +5417,19 @@ fn inlineSmallFunctionsCount(module: *ir.IrModule, allocator: std.mem.Allocator)
                             } else {
                                 shiftBlockIdsInInst(&cloned, clone_offset);
                             }
+                            const is_terminator = switch (cloned.op) {
+                                .br, .br_if, .br_table, .ret_multi, .@"unreachable" => true,
+                                else => false,
+                            };
                             try caller.blocks.items[clone_id].instructions.append(caller.allocator, cloned);
+                            if (is_terminator) {
+                                // Same reasoning as the `.ret` arm above: drop
+                                // any callee instructions that followed a
+                                // terminator so the clone has exactly one
+                                // terminator and it is the block's last
+                                // instruction. See issue #631.
+                                break;
+                            }
                         },
                     }
                 }
@@ -5936,6 +5962,17 @@ pub fn promoteLocalsToSSA(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
             });
         }
     }
+
+    // The dead-code-after-terminator strip above changed the LAST
+    // instruction of any block that had post-terminator junk (e.g.
+    // `br loop_header; <orphan ops>` left by an earlier pass or by the
+    // frontend before its own dead-code guard). `forEachSuccessor` only
+    // looks at the last instruction, so trimming flips the successor
+    // set — recorded `BasicBlock.predecessors` of the previously-implied
+    // successor become stale, and the actual terminator's targets gain
+    // a missing predecessor entry. Rebuild the on-block lists now so
+    // the IR verifier's check 6 sees a consistent view. See issue #632.
+    try analysis.refreshBlockPredecessors(func, allocator);
 
     return changed;
 }


### PR DESCRIPTION
Follow-up to #636 (which fixed #630). Three triage failures remained under `zig build test -Dverify-ir-triage`:

* `MultipleTerminators after pass 'inlineSmallFunctions' func #1 block #4` on `differential: two-function linked list (build + traverse)` (issue #631)
* `MissingPredecessor after pass 'promoteLocalsToSSA' func #0 block #1` on `differential: linked list traversal in memory` and `crcu8 … CoreMark CRC kernel` (issue #632)

## Root causes

### #631 root cause #1 — frontend
`lowerFunction` always appended `br frame.end_block` at every wasm `end`, even when `current_block` was already closed by a `br` / `ret` / `unreachable` inside the dead-code region of the block (e.g. a loop body whose final `br 0` continues the loop and leaves the implicit end-of-loop fallthrough unreachable). That produced a block with two terminators that subsequent passes mis-saw via `forEachSuccessor` (which only looks at the last inst).

**Fix**: guard the append with an `already_terminated` check.

### #631 root cause #2 — inliner robustness
Even with the frontend fix, the inliner could re-introduce the same shape if it ever encountered (or someday produces) a callee block with code after its terminator. Two defensive guards:
* The call-finding scan now `break`s at the block's first terminator so it never picks up a call living in dead code and splits the block there.
* The clone loop now `break`s after appending any terminator (`ret` rewritten to `br b_after_id`, or `br` / `br_if` / `br_table` / `ret_multi` / `unreachable` from the callee) so the clone has exactly one terminator, at the end.

### #632 root cause — promoteLocalsToSSA
`promoteLocalsToSSA` strips post-terminator dead code on entry, which flips a block's effective successor set when the previous "last" was a non-terminator. Recorded `BasicBlock.predecessors` then go stale (or missing) and trip the IR verifier.

**Fix**: refresh the on-block pred lists at end of the pass via `analysis.refreshBlockPredecessors`, matching the pattern already used by `inlineSmallFunctionsCount`.

## Verified
* `zig build test -Dverify-ir-triage` → all green (was 3 failing).
* `zig build test` → all green.

Closes #631
Closes #632
Refs #624, #626, #627, #630