### PR TITLE
component: AOT-backed core instances (#625)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -530,6 +530,21 @@ pub fn build(b: *std.Build) void {
     const run_component_aot_smoke_tests = b.addRunArtifact(component_aot_smoke_tests);
     test_step.dependOn(&run_component_aot_smoke_tests.step);
 
+    // Phase 2: precompile → manifest → loadManifest → instantiate
+    // round-trip test (#625). Uses the same separate-module pattern
+    // as the phase 1 smoke test above.
+    const component_precompile_module = b.createModule(.{
+        .root_source_file = b.path("src/tests/component_precompile_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    component_precompile_module.addImport("wamr", lib_module);
+    const component_precompile_tests = b.addTest(.{
+        .root_module = component_precompile_module,
+    });
+    const run_component_precompile_tests = b.addRunArtifact(component_precompile_tests);
+    test_step.dependOn(&run_component_precompile_tests.step);
+
     // Cold-start budget tests (issue #395). In-process timing companion
     // to the subprocess harness in #394. Compile a 36-byte noop wasm
     // through the just-built `wamrc` to produce a `.cwasm` fixture, then

--- a/build.zig
+++ b/build.zig
@@ -545,6 +545,19 @@ pub fn build(b: *std.Build) void {
     const run_component_precompile_tests = b.addRunArtifact(component_precompile_tests);
     test_step.dependOn(&run_component_precompile_tests.step);
 
+    // Phase 3: canon.lift dispatches onto AOT cores (#625).
+    const component_aot_canonlift_module = b.createModule(.{
+        .root_source_file = b.path("src/tests/component_aot_canonlift_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    component_aot_canonlift_module.addImport("wamr", lib_module);
+    const component_aot_canonlift_tests = b.addTest(.{
+        .root_module = component_aot_canonlift_module,
+    });
+    const run_component_aot_canonlift_tests = b.addRunArtifact(component_aot_canonlift_tests);
+    test_step.dependOn(&run_component_aot_canonlift_tests.step);
+
     // Cold-start budget tests (issue #395). In-process timing companion
     // to the subprocess harness in #394. Compile a 36-byte noop wasm
     // through the just-built `wamrc` to produce a `.cwasm` fixture, then

--- a/build.zig
+++ b/build.zig
@@ -514,6 +514,22 @@ pub fn build(b: *std.Build) void {
     const run_differential_tests = b.addRunArtifact(differential_tests);
     test_step.dependOn(&run_differential_tests.step);
 
+    // #625 phase 1: AOT-backed component-core smoke test. Lives in its
+    // own test step for the same reason `differential.zig` does:
+    // `aot_harness.zig` cannot be pulled into the `wamr` lib module
+    // (it's already owned by the test runners that route through it).
+    const component_aot_smoke_module = b.createModule(.{
+        .root_source_file = b.path("src/tests/component_aot_smoke_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    component_aot_smoke_module.addImport("wamr", lib_module);
+    const component_aot_smoke_tests = b.addTest(.{
+        .root_module = component_aot_smoke_module,
+    });
+    const run_component_aot_smoke_tests = b.addRunArtifact(component_aot_smoke_tests);
+    test_step.dependOn(&run_component_aot_smoke_tests.step);
+
     // Cold-start budget tests (issue #395). In-process timing companion
     // to the subprocess harness in #394. Compile a 36-byte noop wasm
     // through the just-built `wamrc` to produce a `.cwasm` fixture, then

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -15,10 +15,11 @@ const ir = wamr.ir;
 
 const TargetArch = passes.TargetArch;
 
-const Subcommand = enum { compile, version, help };
+const Subcommand = enum { compile, compile_component, version, help };
 
 fn parseSubcommand(s: []const u8) ?Subcommand {
     if (std.mem.eql(u8, s, "compile")) return .compile;
+    if (std.mem.eql(u8, s, "compile-component")) return .compile_component;
     if (std.mem.eql(u8, s, "version")) return .version;
     if (std.mem.eql(u8, s, "help")) return .help;
     return null;
@@ -42,6 +43,7 @@ pub fn main(init: std.process.Init) !void {
         .version => try runVersion(init.io, args[2..]),
         .help => runHelp(init.io, args[2..]),
         .compile => try runCompile(init, allocator, args[2..]),
+        .compile_component => try runCompileComponent(init, allocator, args[2..]),
     }
 }
 
@@ -570,15 +572,102 @@ fn writeStdout(io: std.Io, text: []const u8) void {
     stdout_file.writeStreamingAll(io, text) catch {};
 }
 
+fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
+    if (sub_args.len == 1 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, compile_component_usage);
+        return;
+    }
+    var input_path: ?[]const u8 = null;
+    var output_dir: ?[]const u8 = null;
+    var target_arch: TargetArch = switch (builtin.cpu.arch) {
+        .aarch64 => .aarch64,
+        else => .x86_64,
+    };
+
+    var i: usize = 0;
+    while (i < sub_args.len) : (i += 1) {
+        const a = sub_args[i];
+        if (std.mem.eql(u8, a, "-o")) {
+            i += 1;
+            if (i >= sub_args.len) {
+                std.debug.print("error: -o requires an argument\n", .{});
+                std.process.exit(1);
+            }
+            output_dir = sub_args[i];
+        } else if (std.mem.startsWith(u8, a, "--target=")) {
+            const v = a["--target=".len..];
+            if (std.mem.eql(u8, v, "x86_64") or std.mem.eql(u8, v, "x86-64")) {
+                target_arch = .x86_64;
+            } else if (std.mem.eql(u8, v, "aarch64")) {
+                target_arch = .aarch64;
+            } else {
+                std.debug.print("error: unknown target '{s}'\n", .{v});
+                std.process.exit(1);
+            }
+        } else if (std.mem.startsWith(u8, a, "-")) {
+            std.debug.print("error: unknown option '{s}'\n", .{a});
+            std.process.exit(1);
+        } else if (input_path == null) {
+            input_path = a;
+        } else {
+            std.debug.print("error: unexpected argument '{s}'\n", .{a});
+            std.process.exit(1);
+        }
+    }
+
+    const in_path = input_path orelse {
+        std.debug.print("error: missing input component path\n", .{});
+        std.process.exit(1);
+    };
+    const out_dir = output_dir orelse blk: {
+        const stem = if (std.mem.endsWith(u8, in_path, ".wasm"))
+            in_path[0 .. in_path.len - ".wasm".len]
+        else
+            in_path;
+        break :blk try std.mem.concat(allocator, u8, &.{ stem, ".cwasm.d" });
+    };
+
+    const io = init.io;
+    const cwd = std.Io.Dir.cwd();
+    const component_data = cwd.readFileAlloc(io, in_path, allocator, @enumFromInt(256 * 1024 * 1024)) catch |err| {
+        wamr.utils.read_file.dieReadFileError(in_path, err);
+    };
+    defer allocator.free(component_data);
+
+    std.debug.print("Loaded component {s} ({d} bytes)\n", .{ in_path, component_data.len });
+
+    const is_comp = wamr.component_aot.isComponent(component_data) catch {
+        std.debug.print("error: input is not a valid wasm module or component\n", .{});
+        std.process.exit(1);
+    };
+    if (!is_comp) {
+        std.debug.print("error: input is a core wasm module, not a component — use `wamrc compile`\n", .{});
+        std.process.exit(1);
+    }
+
+    var result = wamr.component_aot.precompileComponent(allocator, component_data, out_dir, .{
+        .target_arch = target_arch,
+    }) catch |err| {
+        std.debug.print("error: precompile failed: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+    defer result.deinit();
+
+    std.debug.print("Wrote {d} core module(s) + manifest.json to {s}\n", .{
+        result.manifest.modules.len, out_dir,
+    });
+}
+
 const top_usage =
     \\wamrc - WebAssembly AOT Compiler
     \\
     \\Usage: wamrc <subcommand> [args...]
     \\
     \\Subcommands:
-    \\  compile   Compile a .wasm module to a .cwasm AOT binary
-    \\  version   Print version and exit
-    \\  help      Print this help
+    \\  compile             Compile a .wasm module to a .cwasm AOT binary
+    \\  compile-component   Precompile every embedded core of a component
+    \\  version             Print version and exit
+    \\  help                Print this help
     \\
     \\Run `wamrc <subcommand> help` to show help for a specific subcommand.
     \\
@@ -636,6 +725,21 @@ const compile_usage =
     \\                                 for release builds.
     \\  --no-verify-ir                Disable the IR verifier (overrides
     \\                                 the safety-build default).
+    \\
+;
+
+const compile_component_usage =
+    \\Usage: wamrc compile-component [options] <component.wasm> [-o <out_dir>]
+    \\
+    \\Precompile every embedded core module of a component into a directory
+    \\containing one `module<N>.cwasm` per core plus a `manifest.json`
+    \\(versioned, with build-id and component-hash, rejected on mismatch).
+    \\If `-o` is omitted, the directory is derived from the input path with
+    \\suffix `.cwasm.d`.
+    \\
+    \\Options:
+    \\  -o <dir>                      Output directory (default: <input>.cwasm.d)
+    \\  --target=<x86_64|aarch64>     Target architecture (default: host)
     \\
 ;
 

--- a/src/component/aot.zig
+++ b/src/component/aot.zig
@@ -1,0 +1,481 @@
+//! Component-level AOT precompilation (#625 phase 2).
+//!
+//! Walks every embedded core module in a parsed `Component` and AOT-
+//! compiles it via the existing `src/compiler` pipeline, writing each
+//! result to `<out_dir>/module<N>.cwasm` alongside a versioned
+//! `manifest.json`. The manifest records the component's sha256 and
+//! the wamr build id so a stale or wrong-component artifact is
+//! rejected on load.
+//!
+//! Mirrors `wasmtime::Engine::precompile_component`. The on-disk
+//! layout is:
+//!
+//! ```text
+//! <out_dir>/manifest.json
+//! <out_dir>/module0.cwasm
+//! <out_dir>/module1.cwasm
+//! …
+//! ```
+//!
+//! `loadManifest` is the inverse: parse `manifest.json`, mmap each
+//! referenced `.cwasm`, verify the embedded sha256s, and return a
+//! `LoadedManifest` whose `precompiledCores()` hands the slice
+//! directly to `instance.instantiateWithOptions`.
+//!
+//! Out of scope (per issue #625):
+//!   * Cross-process mmap sharing — every load reads its own copy.
+//!   * Cache invalidation beyond build-id + content-hash comparison.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const ctypes = @import("types.zig");
+const component_loader = @import("loader.zig");
+const core_backend = @import("core_backend.zig");
+const core_loader = @import("../runtime/interpreter/loader.zig");
+const frontend = @import("../compiler/frontend.zig");
+const passes = @import("../compiler/ir/passes.zig");
+const x86_64_compile = @import("../compiler/codegen/x86_64/compile.zig");
+const aarch64_compile = @import("../compiler/codegen/aarch64/compile.zig");
+const emit_aot = @import("../compiler/emit_aot.zig");
+const core_types = @import("../runtime/common/types.zig");
+const instance_mod = @import("instance.zig");
+const config = @import("../config.zig");
+
+pub const PrecompileError = error{
+    InvalidComponent,
+    CoreCompileFailed,
+    WriteFailed,
+    OutOfMemory,
+    OpenDirFailed,
+    JsonSerializationFailed,
+};
+
+pub const LoadError = error{
+    ManifestNotFound,
+    ManifestParseFailed,
+    ManifestVersionMismatch,
+    ManifestBuildIdMismatch,
+    ManifestComponentMismatch,
+    CwasmReadFailed,
+    CwasmHashMismatch,
+    OutOfMemory,
+};
+
+/// Manifest schema version. Bump when the on-disk layout or
+/// serialization changes in a way that older loaders cannot read.
+pub const manifest_format_version: u32 = 1;
+
+/// Per-core entry in the manifest.
+pub const ManifestModuleEntry = struct {
+    /// Index into `component.core_modules` this artifact precompiles.
+    idx: u32,
+    /// Relative path under the manifest's directory (e.g. `module3.cwasm`).
+    path: []const u8,
+    /// Hex sha256 of the `.cwasm` bytes, used to detect tampering
+    /// or partial writes on load.
+    sha256: []const u8,
+};
+
+/// Top-level manifest. Serialized to / parsed from `manifest.json`.
+pub const Manifest = struct {
+    /// `manifest_format_version` at write time. Refused on load when
+    /// it doesn't match the current loader's expected value.
+    version: u32 = manifest_format_version,
+    /// wamr build id (`config.version`) at precompile time. Refused
+    /// on load when the runtime's build id is different — AOT codegen
+    /// is not stable across wamr versions.
+    wamr_build_id: []const u8,
+    /// Hex sha256 of the **original component binary** that was fed
+    /// to `precompileComponent`. Cross-checked on load against the
+    /// component bytes the caller hands to `loadManifest`.
+    component_sha256: []const u8,
+    modules: []const ManifestModuleEntry,
+};
+
+/// The result of `loadManifest`: parsed manifest + a per-core buffer
+/// owned by the `LoadedManifest`. Callers turn it into the form
+/// `instance.instantiateWithOptions` consumes via `precompiledCores`.
+pub const LoadedManifest = struct {
+    manifest: Manifest,
+    /// One owned `.cwasm` buffer per `manifest.modules[]` entry, in
+    /// the same order. Freed by `deinit`.
+    cwasm_buffers: []const []u8,
+    /// Pre-built slice ready to pass as `Options.precompiled_cores`.
+    /// Borrows from `manifest.modules[]` (idx) and `cwasm_buffers`
+    /// (bytes); valid for the lifetime of this `LoadedManifest`.
+    pcs: []const core_backend.PrecompiledCore,
+    allocator: std.mem.Allocator,
+    /// Backing storage for `manifest` strings + entries. The JSON
+    /// parser allocates into this arena; `deinit` tears it down.
+    arena: *std.heap.ArenaAllocator,
+
+    pub fn precompiledCores(self: *const LoadedManifest) []const core_backend.PrecompiledCore {
+        return self.pcs;
+    }
+
+    pub fn deinit(self: *LoadedManifest) void {
+        for (self.cwasm_buffers) |buf| self.allocator.free(buf);
+        self.allocator.free(self.cwasm_buffers);
+        self.allocator.free(self.pcs);
+        self.arena.deinit();
+        self.allocator.destroy(self.arena);
+    }
+};
+
+/// Options controlling `precompileComponent`. Today only the target
+/// arch is exposed; future options (opt level, dump-ir hooks, …) slot
+/// in here without breaking the API.
+pub const PrecompileOptions = struct {
+    target_arch: passes.TargetArch = switch (builtin.cpu.arch) {
+        .aarch64 => .aarch64,
+        else => .x86_64,
+    },
+};
+
+/// AOT-compile a single core wasm module. Returns freshly-allocated
+/// `.cwasm` bytes owned by the caller (free with `allocator.free`).
+///
+/// Pure data in / data out — no filesystem I/O — so the same helper
+/// services both `precompileComponent` and any future programmatic
+/// caller that wants per-core artifacts in memory.
+pub fn compileCoreWasm(
+    allocator: std.mem.Allocator,
+    wasm_bytes: []const u8,
+    opts: PrecompileOptions,
+) PrecompileError![]u8 {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const owned_wasm = a.dupe(u8, wasm_bytes) catch return error.OutOfMemory;
+    const module = core_loader.load(owned_wasm, a) catch return error.CoreCompileFailed;
+
+    var ir_module = frontend.lowerModule(&module, a) catch return error.CoreCompileFailed;
+    defer ir_module.deinit();
+
+    _ = passes.runPassesWithOptions(
+        &ir_module,
+        passes.defaultPassesForTarget(opts.target_arch),
+        a,
+        .{ .verify_mode = .off },
+    ) catch return error.CoreCompileFailed;
+
+    const code: []const u8, const offsets: []const u32 = switch (opts.target_arch) {
+        .aarch64 => blk: {
+            const r = aarch64_compile.compileModule(&ir_module, a) catch return error.CoreCompileFailed;
+            break :blk .{ r.code, r.offsets };
+        },
+        .x86_64 => blk: {
+            const r = x86_64_compile.compileModule(&ir_module, a) catch return error.CoreCompileFailed;
+            break :blk .{ r.code, r.offsets };
+        },
+    };
+
+    var exports: std.ArrayList(emit_aot.ExportEntry) = .empty;
+    for (module.exports) |exp| {
+        if (exp.kind == .tag) continue;
+        exports.append(a, .{
+            .name = exp.name,
+            .kind = @enumFromInt(@intFromEnum(exp.kind)),
+            .index = exp.index,
+        }) catch return error.OutOfMemory;
+    }
+
+    var imports: std.ArrayList(emit_aot.ImportEntry) = .empty;
+    for (module.imports) |imp| {
+        if (imp.kind == .function) {
+            imports.append(a, .{
+                .module_name = imp.module_name,
+                .field_name = imp.field_name,
+                .kind = .function,
+                .func_type_idx = imp.func_type_idx orelse 0,
+            }) catch return error.OutOfMemory;
+        }
+    }
+
+    var mem_entries: std.ArrayList(emit_aot.MemoryEntry) = .empty;
+    for (module.memories) |mem| {
+        mem_entries.append(a, .{
+            .min_pages = @intCast(mem.limits.min),
+            .max_pages = if (mem.limits.max) |m| @as(?u32, @intCast(m)) else null,
+        }) catch return error.OutOfMemory;
+    }
+
+    var data_segs: std.ArrayList(emit_aot.DataSegmentEntry) = .empty;
+    for (module.data_segments) |seg| {
+        if (seg.is_passive) continue;
+        const offset: u32 = switch (seg.offset) {
+            .i32_const => |v| @bitCast(v),
+            else => continue,
+        };
+        data_segs.append(a, .{
+            .memory_idx = seg.memory_idx,
+            .offset = offset,
+            .data = seg.data,
+        }) catch return error.OutOfMemory;
+    }
+
+    var func_type_entries: std.ArrayList(emit_aot.FuncTypeEntry) = .empty;
+    for (module.types) |ft| {
+        if (ft.kind != .func) {
+            func_type_entries.append(a, .{ .params = &.{}, .results = &.{} }) catch return error.OutOfMemory;
+            continue;
+        }
+        const params_bytes = a.alloc(u8, ft.params.len) catch return error.OutOfMemory;
+        for (ft.params, 0..) |p, j| params_bytes[j] = @intFromEnum(p);
+        const results_bytes = a.alloc(u8, ft.results.len) catch return error.OutOfMemory;
+        for (ft.results, 0..) |r, j| results_bytes[j] = @intFromEnum(r);
+        func_type_entries.append(a, .{ .params = params_bytes, .results = results_bytes }) catch return error.OutOfMemory;
+    }
+
+    var local_func_tidx_list: std.ArrayList(u32) = .empty;
+    for (module.functions) |f| {
+        local_func_tidx_list.append(a, f.type_idx) catch return error.OutOfMemory;
+    }
+
+    var arch_name = std.mem.zeroes([16]u8);
+    switch (opts.target_arch) {
+        .x86_64 => @memcpy(arch_name[0..6], "x86-64"),
+        .aarch64 => @memcpy(arch_name[0..7], "aarch64"),
+    }
+
+    return emit_aot.emit(
+        allocator,
+        code,
+        offsets,
+        exports.items,
+        .{ .arch = arch_name },
+        if (data_segs.items.len > 0) data_segs.items else null,
+        if (imports.items.len > 0) imports.items else null,
+        if (mem_entries.items.len > 0) mem_entries.items else null,
+        // Globals + elems are not yet populated by this helper. The
+        // motivating workload (componentize-js cores) initialises its
+        // own globals through data segments + start code, and the
+        // existing AOT loader tolerates empty global/elem sections
+        // (it allocates from `module.memories.len`/`module.globals.len`
+        // = 0 just fine, then runs `start` which re-derives state).
+        // Wired in fully when phase 3 lights up canon-lift onto AOT
+        // exports for components that exercise top-level globals.
+        null,
+        null,
+        module.start_function,
+        if (func_type_entries.items.len > 0) func_type_entries.items else null,
+        if (local_func_tidx_list.items.len > 0) local_func_tidx_list.items else null,
+    ) catch return error.CoreCompileFailed;
+}
+
+/// Hex-encode a sha256 digest into a fresh allocator-owned string.
+fn hexSha256(allocator: std.mem.Allocator, bytes: []const u8) ![]u8 {
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    const hex = try allocator.alloc(u8, digest.len * 2);
+    const hex_chars = "0123456789abcdef";
+    for (digest, 0..) |b, i| {
+        hex[i * 2] = hex_chars[b >> 4];
+        hex[i * 2 + 1] = hex_chars[b & 0x0f];
+    }
+    return hex;
+}
+
+/// Result of `precompileComponent`. The returned `Manifest`'s strings
+/// are arena-allocated and freed by `deinit` together with the arena.
+pub const PrecompileResult = struct {
+    manifest: Manifest,
+    arena: *std.heap.ArenaAllocator,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *PrecompileResult) void {
+        self.arena.deinit();
+        self.allocator.destroy(self.arena);
+    }
+};
+
+/// Precompile every embedded core module of `component_bytes` to
+/// `<out_dir>/module<N>.cwasm` and write `<out_dir>/manifest.json`.
+///
+/// `out_dir` is created if it doesn't exist. Existing files at the
+/// target paths are overwritten — callers responsible for stale-cache
+/// management beyond the manifest's build-id check.
+pub fn precompileComponent(
+    allocator: std.mem.Allocator,
+    component_bytes: []const u8,
+    out_dir: []const u8,
+    opts: PrecompileOptions,
+) PrecompileError!PrecompileResult {
+    var load_arena = std.heap.ArenaAllocator.init(allocator);
+    defer load_arena.deinit();
+    const component = component_loader.load(component_bytes, load_arena.allocator()) catch
+        return error.InvalidComponent;
+
+    // Result-owned arena holds all strings the caller might read off
+    // the returned Manifest (paths, hex hashes, build id).
+    const result_arena = allocator.create(std.heap.ArenaAllocator) catch return error.OutOfMemory;
+    errdefer allocator.destroy(result_arena);
+    result_arena.* = std.heap.ArenaAllocator.init(allocator);
+    errdefer result_arena.deinit();
+    const ra = result_arena.allocator();
+
+    const cwd = std.Io.Dir.cwd();
+    const io = std.Io.Threaded.global_single_threaded.io();
+    cwd.createDirPath(io, out_dir) catch return error.OpenDirFailed;
+    var dir = cwd.openDir(io, out_dir, .{}) catch return error.OpenDirFailed;
+    defer dir.close(io);
+
+    var entries: std.ArrayList(ManifestModuleEntry) = .empty;
+    entries.ensureTotalCapacity(ra, component.core_modules.len) catch return error.OutOfMemory;
+
+    for (component.core_modules, 0..) |core_mod, idx| {
+        const cwasm = compileCoreWasm(allocator, core_mod.data, opts) catch |err| {
+            std.log.err("precompileComponent: core {d} compile failed: {s}", .{ idx, @errorName(err) });
+            return err;
+        };
+        defer allocator.free(cwasm);
+
+        const rel_path = std.fmt.allocPrint(ra, "module{d}.cwasm", .{idx}) catch return error.OutOfMemory;
+
+        dir.writeFile(io, .{ .sub_path = rel_path, .data = cwasm }) catch |err| {
+            std.log.err("precompileComponent: write {s}/{s} failed: {s}", .{ out_dir, rel_path, @errorName(err) });
+            return error.WriteFailed;
+        };
+
+        const hex = hexSha256(ra, cwasm) catch return error.OutOfMemory;
+        entries.append(ra, .{
+            .idx = @intCast(idx),
+            .path = rel_path,
+            .sha256 = hex,
+        }) catch return error.OutOfMemory;
+    }
+
+    const component_hex = hexSha256(ra, component_bytes) catch return error.OutOfMemory;
+    const build_id = ra.dupe(u8, config.version) catch return error.OutOfMemory;
+
+    const manifest = Manifest{
+        .version = manifest_format_version,
+        .wamr_build_id = build_id,
+        .component_sha256 = component_hex,
+        .modules = entries.items,
+    };
+
+    // Serialize manifest.json.
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    var stringify: std.json.Stringify = .{ .writer = &aw.writer, .options = .{ .whitespace = .indent_2 } };
+    stringify.write(manifest) catch return error.JsonSerializationFailed;
+    dir.writeFile(io, .{ .sub_path = "manifest.json", .data = aw.written() }) catch return error.WriteFailed;
+
+    return .{
+        .manifest = manifest,
+        .arena = result_arena,
+        .allocator = allocator,
+    };
+}
+
+/// Read + validate a `manifest.json` and its referenced `.cwasm`
+/// artifacts from `manifest_dir`, cross-checking the recorded
+/// `component_sha256` against `expected_component_bytes`.
+///
+/// The returned `LoadedManifest.precompiledCores()` slice can be
+/// handed straight to `instance.instantiateWithOptions`.
+pub fn loadManifest(
+    allocator: std.mem.Allocator,
+    manifest_dir: []const u8,
+    expected_component_bytes: []const u8,
+) LoadError!LoadedManifest {
+    const cwd = std.Io.Dir.cwd();
+    const io = std.Io.Threaded.global_single_threaded.io();
+    var dir = cwd.openDir(io, manifest_dir, .{}) catch return error.ManifestNotFound;
+    defer dir.close(io);
+
+    const json_bytes = dir.readFileAlloc(io, "manifest.json", allocator, @enumFromInt(4 * 1024 * 1024)) catch
+        return error.ManifestNotFound;
+    defer allocator.free(json_bytes);
+
+    const arena = allocator.create(std.heap.ArenaAllocator) catch return error.OutOfMemory;
+    errdefer allocator.destroy(arena);
+    arena.* = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+
+    const parsed = std.json.parseFromSliceLeaky(
+        Manifest,
+        arena.allocator(),
+        json_bytes,
+        .{ .ignore_unknown_fields = true },
+    ) catch return error.ManifestParseFailed;
+
+    if (parsed.version != manifest_format_version) return error.ManifestVersionMismatch;
+    if (!std.mem.eql(u8, parsed.wamr_build_id, config.version)) return error.ManifestBuildIdMismatch;
+
+    // Verify the manifest was produced from the component the caller
+    // is about to instantiate.
+    var expected_hex_buf: [64]u8 = undefined;
+    var expected_digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(expected_component_bytes, &expected_digest, .{});
+    const hex_chars = "0123456789abcdef";
+    for (expected_digest, 0..) |b, i| {
+        expected_hex_buf[i * 2] = hex_chars[b >> 4];
+        expected_hex_buf[i * 2 + 1] = hex_chars[b & 0x0f];
+    }
+    if (!std.mem.eql(u8, &expected_hex_buf, parsed.component_sha256)) return error.ManifestComponentMismatch;
+
+    const cwasm_buffers = allocator.alloc([]u8, parsed.modules.len) catch return error.OutOfMemory;
+    var loaded: usize = 0;
+    errdefer {
+        for (cwasm_buffers[0..loaded]) |b| allocator.free(b);
+        allocator.free(cwasm_buffers);
+    }
+
+    for (parsed.modules, 0..) |mod, i| {
+        const buf = dir.readFileAlloc(io, mod.path, allocator, @enumFromInt(256 * 1024 * 1024)) catch
+            return error.CwasmReadFailed;
+        cwasm_buffers[i] = buf;
+        loaded += 1;
+
+        // Verify content hash.
+        var hex_buf: [64]u8 = undefined;
+        var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(buf, &digest, .{});
+        for (digest, 0..) |b, j| {
+            hex_buf[j * 2] = hex_chars[b >> 4];
+            hex_buf[j * 2 + 1] = hex_chars[b & 0x0f];
+        }
+        if (!std.mem.eql(u8, &hex_buf, mod.sha256)) return error.CwasmHashMismatch;
+    }
+
+    const pcs = allocator.alloc(core_backend.PrecompiledCore, parsed.modules.len) catch return error.OutOfMemory;
+    for (parsed.modules, 0..) |mod, i| {
+        pcs[i] = .{ .module_idx = mod.idx, .cwasm_bytes = cwasm_buffers[i] };
+    }
+
+    return .{
+        .manifest = parsed,
+        .cwasm_buffers = cwasm_buffers,
+        .pcs = pcs,
+        .allocator = allocator,
+        .arena = arena,
+    };
+}
+
+/// Sniff the first 8 bytes of `data` for the component magic +
+/// version pair. Returns `true` for a component, `false` for a core
+/// module, `error.InvalidMagic` for anything else.
+pub fn isComponent(data: []const u8) error{InvalidMagic}!bool {
+    if (data.len < 8) return error.InvalidMagic;
+    const magic = std.mem.readInt(u32, data[0..4], .little);
+    if (magic != core_types.wasm_magic) return error.InvalidMagic;
+    const version = std.mem.readInt(u32, data[4..8], .little);
+    if (version == core_types.component_version) return true;
+    if (version == core_types.wasm_version) return false;
+    return error.InvalidMagic;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+test "isComponent: core module vs component" {
+    const core = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 };
+    const comp = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00 };
+    const bad = [_]u8{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    try std.testing.expectEqual(false, try isComponent(&core));
+    try std.testing.expectEqual(true, try isComponent(&comp));
+    try std.testing.expectError(error.InvalidMagic, isComponent(&bad));
+    try std.testing.expectError(error.InvalidMagic, isComponent(&.{}));
+}

--- a/src/component/core_backend.zig
+++ b/src/component/core_backend.zig
@@ -1,0 +1,160 @@
+//! Backend abstraction for a component's core-module instances.
+//!
+//! A `ComponentInstance` historically held one `*core_types.ModuleInstance`
+//! per `core_instances[…]` slot — every embedded core module was loaded
+//! by `runtime/interpreter/loader.zig` and executed by the interpreter.
+//! Issue #625 introduces an alternate AOT path so a precompiled
+//! `.cwasm` artifact for a core module can be instantiated and executed
+//! by `runtime/aot/runtime.zig`.
+//!
+//! This module defines the two unions that bridge the two backends:
+//!
+//!   * `CoreModuleBackend` — the parsed module form
+//!     (`*WasmModule` or `*AotModule`)
+//!   * `CoreInstanceBackend` — the runnable form
+//!     (`*ModuleInstance` or `*AotInstance`)
+//!
+//! Backend-agnostic adapter helpers (`memory`, `findExportFunc`, …)
+//! let callers in `instance.zig` and `executor.zig` resolve cross-
+//! instance memory/table/global sharing and export lookup without
+//! caring which backend produced the instance — the underlying
+//! `MemoryInstance`, `TableInstance` and `GlobalInstance` types
+//! already live in `runtime/common` and are shared between
+//! interp and AOT.
+//!
+//! Rollout (see issue #625):
+//!   * Phase 1 (this commit): types + `Options.precompiled_cores`
+//!     plumbing + `firstBackendMemory` lookup. AOT-backed cores can be
+//!     loaded and exposed for memory/table/global sharing but their
+//!     exported functions are not yet callable from the canon-ABI
+//!     lift path (phase 3).
+//!   * Phase 2: `wamrc compile-component` + manifest format.
+//!   * Phase 3: canon-ABI dispatch onto `*AotInstance` (executor.zig
+//!     `callComponentFuncByLocal`) + cross-instance canon-lower into
+//!     an AOT core via per-import native arg-marshalling stubs.
+
+const std = @import("std");
+const core_types = @import("../runtime/common/types.zig");
+const aot_loader = @import("../runtime/aot/loader.zig");
+const aot_runtime = @import("../runtime/aot/runtime.zig");
+
+/// The parsed-but-not-yet-runnable form of a core module.
+///
+/// Kept on `ComponentInstance.module_arena` next to whatever produced
+/// it (the interpreter loader or the AOT loader). The lifetime is the
+/// `ComponentInstance`'s.
+pub const CoreModuleBackend = union(enum) {
+    interp: *core_types.WasmModule,
+    aot: *aot_loader.AotModule,
+};
+
+/// The runnable form of a core module.
+///
+/// Sibling to (not replacement of) `CoreInstanceEntry.module_inst` in
+/// phase 1: existing call sites continue to read `module_inst` and the
+/// vast majority of paths stay interp-only. New AOT-aware lookups
+/// (`firstBackendMemory`, the executor's memory resolver) consult both.
+pub const CoreInstanceBackend = union(enum) {
+    interp: *core_types.ModuleInstance,
+    aot: *aot_runtime.AotInstance,
+
+    /// Return the `MemoryInstance` at `mem_idx` (0 is the canonical
+    /// memory) on this backend, or null if the backend has no memory
+    /// at that index.
+    pub fn memory(self: CoreInstanceBackend, mem_idx: u32) ?*core_types.MemoryInstance {
+        switch (self) {
+            .interp => |mi| return mi.getMemory(mem_idx),
+            .aot => |ai| {
+                if (mem_idx >= ai.memories.len) return null;
+                return ai.memories[mem_idx];
+            },
+        }
+    }
+
+    /// Return the `TableInstance` at `tbl_idx` on this backend.
+    pub fn table(self: CoreInstanceBackend, tbl_idx: u32) ?*core_types.TableInstance {
+        switch (self) {
+            .interp => |mi| {
+                if (tbl_idx >= mi.tables.len) return null;
+                return mi.tables[tbl_idx];
+            },
+            .aot => |ai| {
+                if (tbl_idx >= ai.tables.len) return null;
+                return ai.tables[tbl_idx];
+            },
+        }
+    }
+
+    /// Return the `GlobalInstance` at `glob_idx` on this backend.
+    pub fn global(self: CoreInstanceBackend, glob_idx: u32) ?*core_types.GlobalInstance {
+        switch (self) {
+            .interp => |mi| {
+                if (glob_idx >= mi.globals.len) return null;
+                return mi.globals[glob_idx];
+            },
+            .aot => |ai| {
+                if (glob_idx >= ai.globals.len) return null;
+                return ai.globals[glob_idx];
+            },
+        }
+    }
+
+    /// Look up an exported function by name. Returns the local funcidx
+    /// (imports + locals — same convention both backends use).
+    pub fn findExportFunc(self: CoreInstanceBackend, name: []const u8) ?u32 {
+        switch (self) {
+            .interp => |mi| {
+                for (mi.module.exports) |exp| {
+                    if (exp.kind == .function and std.mem.eql(u8, exp.name, name)) {
+                        return exp.index;
+                    }
+                }
+                return null;
+            },
+            .aot => |ai| return aot_runtime.findExportFunc(ai, name),
+        }
+    }
+};
+
+/// A caller-supplied precompiled-core artifact, used to opt a single
+/// `core_modules[module_idx]` into the AOT backend at instantiate time.
+///
+/// `cwasm_bytes` must outlive the resulting `ComponentInstance` —
+/// `AotModule` parsing is zero-copy on data sections, so the bytes are
+/// borrowed.
+pub const PrecompiledCore = struct {
+    module_idx: u32,
+    cwasm_bytes: []const u8,
+};
+
+/// Caller-supplied instantiation options. Today only `precompiled_cores`
+/// is wired; the struct exists so future opts (verbose load logging,
+/// custom AOT host imports, …) can be added without breaking the API.
+pub const Options = struct {
+    precompiled_cores: []const PrecompiledCore = &.{},
+
+    /// Find a precompiled artifact for a given core-module index.
+    pub fn findPrecompiled(self: Options, module_idx: u32) ?[]const u8 {
+        for (self.precompiled_cores) |pc| {
+            if (pc.module_idx == module_idx) return pc.cwasm_bytes;
+        }
+        return null;
+    }
+};
+
+test "Options.findPrecompiled hits + misses" {
+    const bytes_a = [_]u8{ 1, 2, 3 };
+    const bytes_b = [_]u8{ 4, 5 };
+    const pcs = [_]PrecompiledCore{
+        .{ .module_idx = 0, .cwasm_bytes = &bytes_a },
+        .{ .module_idx = 2, .cwasm_bytes = &bytes_b },
+    };
+    const opts = Options{ .precompiled_cores = &pcs };
+    try std.testing.expectEqualSlices(u8, &bytes_a, opts.findPrecompiled(0).?);
+    try std.testing.expectEqualSlices(u8, &bytes_b, opts.findPrecompiled(2).?);
+    try std.testing.expectEqual(@as(?[]const u8, null), opts.findPrecompiled(1));
+    try std.testing.expectEqual(@as(?[]const u8, null), opts.findPrecompiled(99));
+
+    const empty_opts = Options{};
+    try std.testing.expectEqual(@as(?[]const u8, null), empty_opts.findPrecompiled(0));
+}

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -18,6 +18,7 @@ const ExecEnv = @import("../runtime/common/exec_env.zig").ExecEnv;
 const HostTrapInfo = @import("../runtime/common/exec_env.zig").HostTrapInfo;
 const interp = @import("../runtime/interpreter/interp.zig");
 const indexspace = @import("indexspace.zig");
+const aot_runtime = @import("../runtime/aot/runtime.zig");
 const Allocator = std.mem.Allocator;
 
 const ComponentInstance = instance_mod.ComponentInstance;
@@ -75,6 +76,12 @@ pub const ExecutionError = error{
     PostReturnFailed,
     LiftError,
     LowerError,
+    /// AOT-backed core hit a canon-ABI shape this PR doesn't yet
+    /// support — only scalar primitive params and a single scalar
+    /// result land on the fast path; compound types, memory-spilled
+    /// params, and post-return on AOT cores are deferred to a
+    /// follow-up (see issue #625 phase 3 notes).
+    AotPathUnsupported,
 };
 
 // ── Lift options parsed from CanonOpt array ─────────────────────────────────
@@ -240,7 +247,30 @@ pub fn callComponentFuncByLocal(
     if (exported.core_instance_idx >= owner_inst.core_instances.len)
         return error.CoreInstanceNotAvailable;
     const core_entry = owner_inst.core_instances[exported.core_instance_idx];
-    const module_inst = core_entry.module_inst orelse return error.CoreInstanceNotAvailable;
+
+    // AOT fast path: when the core is AOT-backed and the canon-ABI
+    // shape is scalar-only, dispatch through `aot_runtime.callFuncScalar`
+    // directly. This is the phase-3 minimum: it proves the end-to-end
+    // canon.lift → AOT path works for primitive-typed exports
+    // (componentize-js's TCGC `compile()` ABI is mostly i32/string,
+    // and string is not yet on this path). More complex shapes —
+    // compound types, memory-spilled params, post-return — fall
+    // through to the interpreter path, which then traps if the
+    // backend is AOT-only. (#625 phase 3.)
+    if (core_entry.module_inst == null) {
+        if (core_entry.aot_inst) |ai| {
+            return callComponentFuncByLocalAot(
+                owner_inst,
+                ai,
+                exported,
+                args,
+                out_results,
+                allocator,
+            );
+        }
+        return error.CoreInstanceNotAvailable;
+    }
+    const module_inst = core_entry.module_inst.?;
 
     // Parse canonical options
     const lift_opts = LiftOptions.fromOpts(exported.opts);
@@ -369,6 +399,133 @@ pub fn callComponentFuncByLocal(
         }
         interp.executeFunction(env, pr_idx) catch {};
     }
+}
+
+/// AOT-backed canon.lift dispatch. Scalar-primitive-only fast path for
+/// `callComponentFuncByLocal` (issue #625 phase 3 minimum). Lowers
+/// `args` into a packed `[]Value` and dispatches via
+/// `aot_runtime.callFuncScalar`. Returns `error.AotPathUnsupported`
+/// for any shape outside the supported subset:
+///   * params and result must each be a primitive scalar (`bool`,
+///     `s8/u8/s16/u16/s32/u32/char/s64/u64/f32/f64`),
+///   * no memory-spilled params (covered automatically — primitives
+///     flatten 1:1),
+///   * at most one result (matches `MAX_FLAT_RESULTS`),
+///   * no `post_return` (AOT doesn't go through `ExecEnv` so the
+///     interp re-push trick from the standard path doesn't apply yet).
+///
+/// Compound types, strings, lists, resources, futures/streams, and
+/// post-return are deferred to a follow-up — the canon-ABI lower/lift
+/// helpers in this file are tightly coupled to `ExecEnv`'s stack
+/// machine, so a clean refactor that lets both backends share them
+/// belongs in its own PR.
+fn callComponentFuncByLocalAot(
+    owner_inst: *const ComponentInstance,
+    ai: *aot_runtime.AotInstance,
+    exported: ComponentInstance.ExportedFunc.Local,
+    args: []const InterfaceValue,
+    out_results: []InterfaceValue,
+    allocator: Allocator,
+) ExecutionError!void {
+    const lift_opts = LiftOptions.fromOpts(exported.opts);
+    if (lift_opts.is_async) return error.AotPathUnsupported;
+    if (lift_opts.post_return_idx != null) return error.AotPathUnsupported;
+
+    const registry = TypeRegistry.init(owner_inst.component);
+
+    const func_type = blk: {
+        const td = registry.get(exported.func_type_idx) orelse return error.InvalidFuncType;
+        switch (td) {
+            .func => |ft| break :blk ft,
+            else => return error.InvalidFuncType,
+        }
+    };
+
+    const param_types = getParamValTypes(func_type, allocator) catch return error.OutOfMemory;
+    defer allocator.free(param_types);
+    const result_types = getResultValTypes(func_type, allocator) catch return error.OutOfMemory;
+    defer allocator.free(result_types);
+
+    if (result_types.len > MAX_FLAT_RESULTS) return error.AotPathUnsupported;
+
+    // Lower each arg into a single core Value. We only accept shapes
+    // that flatten to one slot; everything else routes to the
+    // compound-types follow-up.
+    var arg_buf: [16]core_types.Value = undefined;
+    if (args.len > arg_buf.len) return error.AotPathUnsupported;
+    var core_param_types: [16]core_types.ValType = undefined;
+    var core_result_types: [1]core_types.ValType = undefined;
+
+    for (args, param_types, 0..) |val, pt, i| {
+        const cv = lowerScalarArg(val, pt) catch return error.AotPathUnsupported;
+        arg_buf[i] = cv.value;
+        core_param_types[i] = cv.ty;
+    }
+
+    if (result_types.len == 1) {
+        core_result_types[0] = scalarValType(result_types[0]) catch return error.AotPathUnsupported;
+    }
+
+    var results_buf: [1]aot_runtime.ScalarResult = .{.{ .i32 = 0 }};
+    const results = aot_runtime.callFuncScalar(
+        ai,
+        exported.core_func_idx,
+        core_param_types[0..args.len],
+        core_result_types[0..result_types.len],
+        arg_buf[0..args.len],
+        &results_buf,
+    ) catch return error.TrapInCoreFunction;
+
+    if (result_types.len == 1) {
+        out_results[0] = liftScalarResult(results[0], result_types[0]) catch
+            return error.AotPathUnsupported;
+    }
+}
+
+const LoweredScalar = struct { ty: core_types.ValType, value: core_types.Value };
+
+fn lowerScalarArg(val: InterfaceValue, t: ctypes.ValType) !LoweredScalar {
+    return switch (t) {
+        .bool => .{ .ty = .i32, .value = .{ .i32 = if (val.bool) 1 else 0 } },
+        .s8 => .{ .ty = .i32, .value = .{ .i32 = @as(i32, val.s8) } },
+        .u8 => .{ .ty = .i32, .value = .{ .i32 = @as(i32, @intCast(val.u8)) } },
+        .s16 => .{ .ty = .i32, .value = .{ .i32 = @as(i32, val.s16) } },
+        .u16 => .{ .ty = .i32, .value = .{ .i32 = @as(i32, @intCast(val.u16)) } },
+        .s32 => .{ .ty = .i32, .value = .{ .i32 = val.s32 } },
+        .u32, .char => .{ .ty = .i32, .value = .{ .i32 = @bitCast(val.u32) } },
+        .s64 => .{ .ty = .i64, .value = .{ .i64 = val.s64 } },
+        .u64 => .{ .ty = .i64, .value = .{ .i64 = @bitCast(val.u64) } },
+        .f32 => .{ .ty = .f32, .value = .{ .f32 = @bitCast(val.f32) } },
+        .f64 => .{ .ty = .f64, .value = .{ .f64 = @bitCast(val.f64) } },
+        else => error.AotPathUnsupported,
+    };
+}
+
+fn scalarValType(t: ctypes.ValType) !core_types.ValType {
+    return switch (t) {
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .char => .i32,
+        .s64, .u64 => .i64,
+        .f32 => .f32,
+        .f64 => .f64,
+        else => error.AotPathUnsupported,
+    };
+}
+
+fn liftScalarResult(r: aot_runtime.ScalarResult, t: ctypes.ValType) !InterfaceValue {
+    return switch (t) {
+        .bool => .{ .bool = (r.i32 != 0) },
+        .s8 => .{ .s8 = @truncate(r.i32) },
+        .u8 => .{ .u8 = @truncate(@as(u32, @bitCast(r.i32))) },
+        .s16 => .{ .s16 = @truncate(r.i32) },
+        .u16 => .{ .u16 = @truncate(@as(u32, @bitCast(r.i32))) },
+        .s32 => .{ .s32 = r.i32 },
+        .u32, .char => .{ .u32 = @bitCast(r.i32) },
+        .s64 => .{ .s64 = r.i64 },
+        .u64 => .{ .u64 = @bitCast(r.i64) },
+        .f32 => .{ .f32 = @bitCast(r.f32) },
+        .f64 => .{ .f64 = @bitCast(r.f64) },
+        else => error.AotPathUnsupported,
+    };
 }
 
 /// Async-lifted variant of `callComponentFuncByLocal`. Lifts args and

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -9,6 +9,13 @@ const core_types = @import("../runtime/common/types.zig");
 const executor_mod = @import("executor.zig");
 const indexspace = @import("indexspace.zig");
 const async_mod = @import("async.zig");
+const core_backend = @import("core_backend.zig");
+const aot_loader = @import("../runtime/aot/loader.zig");
+const aot_runtime = @import("../runtime/aot/runtime.zig");
+
+pub const Options = core_backend.Options;
+pub const PrecompiledCore = core_backend.PrecompiledCore;
+pub const CoreInstanceBackend = core_backend.CoreInstanceBackend;
 
 // ── Resource Table ──────────────────────────────────────────────────────────
 
@@ -245,6 +252,12 @@ pub const ComponentInstance = struct {
     pending_core_starts: std.ArrayListUnmanaged(*core_types.ModuleInstance) = .empty,
     /// Whether the start function has been executed.
     started: bool = false,
+    /// Caller-supplied instantiation options (e.g. precompiled-core
+    /// artifacts). Captured at instantiate-time and consulted by the
+    /// section-aware loop when it reaches each `.instantiate` expr
+    /// (#625). Default `.{}` matches the pre-#625 behaviour: every
+    /// core is loaded via `runtime/interpreter/loader.zig`.
+    options: Options = .{},
     /// Allocator for instance lifetime.
     allocator: std.mem.Allocator,
     /// Child component instances created when the parent component
@@ -402,11 +415,32 @@ pub const ComponentInstance = struct {
 
     pub const CoreInstanceEntry = struct {
         module_inst: ?*core_types.ModuleInstance = null,
+        /// AOT-backed runnable form of this core instance. Mutually
+        /// exclusive with `module_inst` — set only when `instantiate`
+        /// found a `PrecompiledCore` artifact for this slot's
+        /// `module_idx` in `Options.precompiled_cores` (#625).
+        ///
+        /// Phase 1: AOT instances are loaded + own memory/tables/
+        /// globals (visible to cross-instance import wiring via the
+        /// shared `MemoryInstance`/`TableInstance`/`GlobalInstance`
+        /// types), but the canon-ABI lift call path still requires
+        /// `module_inst`; lift against an AOT-only core errors out
+        /// until phase 3 wires `aot_runtime.callFunc` into
+        /// `executor.callComponentFuncByLocal`.
+        aot_inst: ?*aot_runtime.AotInstance = null,
         /// When this entry corresponds to a `CoreInstanceExpr.exports` (an
         /// inline instance bundling named core items rather than an actual
         /// core-module instantiation), the named items live here. `module_inst`
         /// is null in that case.
         inline_exports: []const ctypes.CoreInlineExport = &.{},
+
+        /// Phase-1 helper: return whichever backend is populated. Null
+        /// for inline-exports-only entries.
+        pub fn backend(self: CoreInstanceEntry) ?CoreInstanceBackend {
+            if (self.module_inst) |mi| return .{ .interp = mi };
+            if (self.aot_inst) |ai| return .{ .aot = ai };
+            return null;
+        }
     };
 
     /// An exported component function. Two flavours:
@@ -470,6 +504,25 @@ pub const ComponentInstance = struct {
     pub fn firstModuleInst(self: *const ComponentInstance) ?*core_types.ModuleInstance {
         for (self.core_instances) |entry| {
             if (entry.module_inst) |mi| return mi;
+        }
+        return null;
+    }
+
+    /// Backend-agnostic variant of `firstModuleInst` for callers that
+    /// only need a `*MemoryInstance` and don't care whether the core
+    /// runs on the interpreter or the AOT runtime. Searches each
+    /// `core_instances[]` entry in order and returns memory index 0 on
+    /// the first backend that exposes one (#625).
+    ///
+    /// Phase 1: callers that genuinely need a `*ModuleInstance` (e.g.
+    /// to drive interp-only execution paths) keep using
+    /// `firstModuleInst`; only the read-only memory probe paths
+    /// (`readGuestBytes`, `componentTrampoline` memory lookup) should
+    /// migrate to this helper.
+    pub fn firstBackendMemory(self: *const ComponentInstance) ?*core_types.MemoryInstance {
+        for (self.core_instances) |entry| {
+            const be = entry.backend() orelse continue;
+            if (be.memory(0)) |m| return m;
         }
         return null;
     }
@@ -1265,6 +1318,7 @@ pub const ComponentInstance = struct {
             const inst_mod = @import("../runtime/interpreter/instance.zig");
             for (self.core_instances) |entry| {
                 if (entry.module_inst) |mi| inst_mod.destroy(mi);
+                if (entry.aot_inst) |ai| aot_runtime.destroy(ai);
             }
             self.allocator.free(self.core_instances);
         }
@@ -1331,6 +1385,21 @@ pub fn instantiate(
     component: *const ctypes.Component,
     allocator: std.mem.Allocator,
 ) InstantiationError!*ComponentInstance {
+    return instantiateWithOptions(component, allocator, .{});
+}
+
+/// `instantiate` variant that accepts caller-supplied options (#625).
+///
+/// Today's only option is `precompiled_cores` — a slice of
+/// `(module_idx, cwasm_bytes)` pairs that opt individual embedded
+/// core modules into the AOT runtime. Cores not covered by the slice
+/// continue to load through `runtime/interpreter/loader.zig`. Bytes
+/// are borrowed and must outlive the returned `ComponentInstance`.
+pub fn instantiateWithOptions(
+    component: *const ctypes.Component,
+    allocator: std.mem.Allocator,
+    options: Options,
+) InstantiationError!*ComponentInstance {
     const inst = allocator.create(ComponentInstance) catch return error.OutOfMemory;
 
     inst.* = .{
@@ -1340,6 +1409,7 @@ pub fn instantiate(
         .resource_tables = .empty,
         .exported_funcs = .{},
         .imports = .{},
+        .options = options,
         .allocator = allocator,
     };
     // From here on, `inst.deinit()` is the single owner of partial-init
@@ -1365,6 +1435,43 @@ pub fn instantiate(
                 .instantiate => |ie| {
                     if (ie.module_idx >= component.core_modules.len) continue;
                     const core_mod = component.core_modules[ie.module_idx];
+
+                    // #625: AOT fast-path. If the caller supplied a
+                    // precompiled artifact for this `module_idx`, load
+                    // it via `runtime/aot/loader.zig` and instantiate
+                    // it via `runtime/aot/runtime.zig`. Phase 1 only
+                    // wires up the load — cross-instance memory/table/
+                    // global sharing is structurally compatible (the
+                    // shared `runtime/common` types), but the canon-ABI
+                    // lift call path still requires `module_inst` and
+                    // errors out against an AOT-only export until
+                    // phase 3.
+                    if (inst.options.findPrecompiled(ie.module_idx)) |cwasm_bytes| {
+                        const mod_alloc = inst.module_arena.allocator();
+                        const aot_module_ptr = mod_alloc.create(aot_loader.AotModule) catch continue;
+                        aot_module_ptr.* = aot_loader.load(cwasm_bytes, mod_alloc) catch |err| {
+                            std.log.warn("aot core load failed for module {d}: {s}", .{ ie.module_idx, @errorName(err) });
+                            continue;
+                        };
+                        const aot_inst_ptr = aot_runtime.instantiate(aot_module_ptr, inst.allocator) catch |err| {
+                            std.log.warn("aot core instantiate failed for module {d}: {s}", .{ ie.module_idx, @errorName(err) });
+                            continue;
+                        };
+                        aot_runtime.mapCodeExecutable(aot_inst_ptr) catch |err| {
+                            std.log.warn("aot core code-map failed for module {d}: {s}", .{ ie.module_idx, @errorName(err) });
+                            aot_runtime.destroy(aot_inst_ptr);
+                            continue;
+                        };
+                        cis[ci_idx] = .{ .aot_inst = aot_inst_ptr };
+                        // Phase 1: AOT cores skip cross-instance import
+                        // wiring / canon-lower trampoline plumbing
+                        // (handled by the interp path below for interp
+                        // cores). The big-core workload that motivates
+                        // #625 has its imports satisfied by the AOT
+                        // host bridge / WASI; richer wiring lands in
+                        // phase 3.
+                        continue;
+                    }
 
                     const mod_alloc = inst.module_arena.allocator();
                     const loaded = loader.load(core_mod.data, mod_alloc) catch continue;
@@ -4172,3 +4279,12 @@ test "instantiate: dropping component frees shared canon-builtin ctx exactly onc
     inst.deinit();
 }
 
+
+// ─── #625 phase 1: AOT-backed core instance load smoke test ────────────────
+// (See `src/tests/component_aot_smoke_test.zig`. The test lives in its
+// own module/test step rather than here because `aot_harness.zig` is
+// owned by the test-runner module and Zig 0.16 rejects a file existing
+// in two modules; importing it from `instance.zig` would pull
+// `aot_harness.zig` into the `wamr` lib module and break the
+// `differential.zig` and `run_spec_tests.zig` test runners that also
+// import it.)

--- a/src/root.zig
+++ b/src/root.zig
@@ -127,6 +127,7 @@ pub const component_indexspace = @import("component/indexspace.zig");
 
 /// Component Model instance and resource store.
 pub const component_instance = @import("component/instance.zig");
+pub const component_core_backend = @import("component/core_backend.zig");
 
 /// Component Model async ABI (tasks, futures, streams).
 pub const component_async = @import("component/async.zig");

--- a/src/root.zig
+++ b/src/root.zig
@@ -128,6 +128,7 @@ pub const component_indexspace = @import("component/indexspace.zig");
 /// Component Model instance and resource store.
 pub const component_instance = @import("component/instance.zig");
 pub const component_core_backend = @import("component/core_backend.zig");
+pub const component_aot = @import("component/aot.zig");
 
 /// Component Model async ABI (tasks, futures, streams).
 pub const component_async = @import("component/async.zig");

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -1002,6 +1002,22 @@ fn patchImportedFuncrefElems(
     }
 }
 
+/// Compile a raw wasm-1.0 binary to AOT cwasm bytes using the same
+/// pipeline `Harness.init` uses (frontend → IR passes → arch codegen →
+/// emit_aot). Returns a freshly-allocated cwasm buffer owned by the
+/// caller — free with `allocator.free`.
+///
+/// Exposed for tests that want to drive the AOT path without standing
+/// up a full `Harness` (e.g. the component AOT smoke test, #625).
+pub fn compileWasmToAot(allocator: std.mem.Allocator, wasm_bytes: []const u8) ![]u8 {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const owned_wasm = try a.dupe(u8, wasm_bytes);
+    const wasm_module = try loader_mod.load(owned_wasm, a);
+    return compileToAot(allocator, &arena, &wasm_module, null, false);
+}
+
 fn compileToAot(
     allocator: std.mem.Allocator,
     arena: *std.heap.ArenaAllocator,

--- a/src/tests/component_aot_canonlift_test.zig
+++ b/src/tests/component_aot_canonlift_test.zig
@@ -1,0 +1,165 @@
+//! #625 phase 3 — AOT canon.lift dispatch smoke test.
+//!
+//! Builds a component literal with one core module (the same
+//! `add42` AOT smoke fixture used in phase 1/2), a `canon.lift` of
+//! its `add42` export typed as `(func (param "x" s32) (result s32))`,
+//! and a top-level `.func` export pointing at that canon. Drives the
+//! exported function through `callComponentFuncByLocal`, asserting
+//! the dispatch flows through the new AOT scalar fast path in
+//! `executor.zig`.
+//!
+//! Pre-phase-3, the same call would hit
+//! `error.CoreInstanceNotAvailable` because the executor's
+//! `module_inst orelse` guard refused AOT-only cores.
+
+const std = @import("std");
+const wamr = @import("wamr");
+const aot_harness = @import("aot_harness.zig");
+
+const instance = wamr.component_instance;
+const ctypes = wamr.component_types;
+const executor = wamr.component_executor;
+const abi = wamr.canonical_abi;
+
+const core_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    0x03, 0x02, 0x01, 0x00,
+    0x05, 0x03, 0x01, 0x00, 0x01,
+    0x07, 0x12, 0x02,
+    0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
+    0x05, 'a', 'd', 'd', '4', '2', 0x00, 0x00,
+    0x0a, 0x09, 0x01, 0x07, 0x00,
+    0x20, 0x00,
+    0x41, 0x2a,
+    0x6a,
+    0x0b,
+};
+
+test "#625 phase 3: canon.lift dispatches onto AOT core" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, &core_wasm);
+    defer allocator.free(cwasm_bytes);
+
+    const core_modules = [_]ctypes.CoreModule{.{ .data = &core_wasm }};
+    const core_insts = [_]ctypes.CoreInstanceExpr{
+        .{ .instantiate = .{ .module_idx = 0, .args = &.{} } },
+    };
+
+    // Component-level types: one func type `(s32) -> s32`.
+    const params = [_]ctypes.NamedValType{.{ .name = "x", .type = .s32 }};
+    const types = [_]ctypes.TypeDef{
+        .{ .func = .{ .params = &params, .results = .{ .unnamed = .s32 } } },
+    };
+
+    // canon.lift of core_func 0 inside core_inst 0 → component func 0,
+    // typed by component type 0.
+    const lift_opts = [_]ctypes.CanonOpt{};
+    const canons = [_]ctypes.Canon{
+        .{ .lift = .{ .core_func_idx = 0, .type_idx = 0, .opts = &lift_opts } },
+    };
+
+    // Export the lifted func as "add42" on the component.
+    const exports = [_]ctypes.ExportDecl{
+        .{ .name = "add42", .desc = .{ .func = 0 }, .sort_idx = .{ .sort = .func, .idx = 0 } },
+    };
+
+    const component = ctypes.Component{
+        .core_modules = &core_modules,
+        .core_instances = &core_insts,
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &types,
+        .canons = &canons,
+        .imports = &.{},
+        .exports = &exports,
+    };
+
+    const pcs = [_]instance.PrecompiledCore{
+        .{ .module_idx = 0, .cwasm_bytes = cwasm_bytes },
+    };
+    const inst = try instance.instantiateWithOptions(&component, allocator, .{
+        .precompiled_cores = &pcs,
+    });
+    defer inst.deinit();
+
+    // Confirm the AOT branch was actually chosen.
+    try std.testing.expect(inst.core_instances[0].module_inst == null);
+    try std.testing.expect(inst.core_instances[0].aot_inst != null);
+
+    const ef = inst.getExport("add42") orelse return error.TestFailed;
+    const local = switch (ef) {
+        .local => |l| l,
+        else => return error.TestFailed,
+    };
+
+    const args = [_]abi.InterfaceValue{.{ .s32 = 100 }};
+    var results: [1]abi.InterfaceValue = .{.{ .s32 = 0 }};
+    try executor.callComponentFuncByLocal(inst, local, &args, &results, allocator);
+    try std.testing.expectEqual(@as(i32, 142), results[0].s32);
+}
+
+test "#625 phase 3: AOT path rejects unsupported shapes cleanly" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, &core_wasm);
+    defer allocator.free(cwasm_bytes);
+
+    const core_modules = [_]ctypes.CoreModule{.{ .data = &core_wasm }};
+    const core_insts = [_]ctypes.CoreInstanceExpr{
+        .{ .instantiate = .{ .module_idx = 0, .args = &.{} } },
+    };
+
+    // Declare the lift as taking a `string` param (which flattens to
+    // 2 i32 slots + needs memory) so the scalar fast path bails with
+    // AotPathUnsupported rather than producing wrong results.
+    const params = [_]ctypes.NamedValType{.{ .name = "s", .type = .string }};
+    const types = [_]ctypes.TypeDef{
+        .{ .func = .{ .params = &params, .results = .{ .unnamed = .s32 } } },
+    };
+    const lift_opts = [_]ctypes.CanonOpt{};
+    const canons = [_]ctypes.Canon{
+        .{ .lift = .{ .core_func_idx = 0, .type_idx = 0, .opts = &lift_opts } },
+    };
+    const exports = [_]ctypes.ExportDecl{
+        .{ .name = "go", .desc = .{ .func = 0 }, .sort_idx = .{ .sort = .func, .idx = 0 } },
+    };
+    const component = ctypes.Component{
+        .core_modules = &core_modules,
+        .core_instances = &core_insts,
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &types,
+        .canons = &canons,
+        .imports = &.{},
+        .exports = &exports,
+    };
+
+    const pcs = [_]instance.PrecompiledCore{
+        .{ .module_idx = 0, .cwasm_bytes = cwasm_bytes },
+    };
+    const inst = try instance.instantiateWithOptions(&component, allocator, .{
+        .precompiled_cores = &pcs,
+    });
+    defer inst.deinit();
+
+    const ef = inst.getExport("go") orelse return error.TestFailed;
+    const local = switch (ef) {
+        .local => |l| l,
+        else => return error.TestFailed,
+    };
+
+    const args = [_]abi.InterfaceValue{.{ .string = .{ .ptr = 0, .len = 0 } }};
+    var results: [1]abi.InterfaceValue = .{.{ .s32 = 0 }};
+    try std.testing.expectError(
+        error.AotPathUnsupported,
+        executor.callComponentFuncByLocal(inst, local, &args, &results, allocator),
+    );
+}

--- a/src/tests/component_aot_smoke_test.zig
+++ b/src/tests/component_aot_smoke_test.zig
@@ -1,0 +1,109 @@
+//! #625 phase 1 — AOT-backed core instance smoke test.
+//!
+//! Drives the new `instantiateWithOptions` API end-to-end against a
+//! tiny core module precompiled in-process via `aot_harness`. Lives in
+//! its own test step because `aot_harness.zig` is owned by the
+//! test-runner module — importing it from inside `wamr` would trigger
+//! Zig 0.16's "file exists in modules X and Y" error (cf. the
+//! `differential.zig` comment in `build.zig`).
+
+const std = @import("std");
+const wamr = @import("wamr");
+const aot_harness = @import("aot_harness.zig");
+
+const instance = wamr.component_instance;
+const ctypes = wamr.component_types;
+const core_types = wamr.types;
+const aot_runtime_mod = wamr.aot_runtime;
+
+test "#625 phase 1: instantiateWithOptions loads + runs an AOT core" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    // Minimal core module exporting one `i32 -> i32` function and a memory.
+    //   (module
+    //     (memory (export "memory") 1)
+    //     (func (export "add42") (param i32) (result i32)
+    //       local.get 0 i32.const 42 i32.add)
+    //   )
+    const core_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: (i32) -> i32
+        0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+        // function section: 1 fn, type 0
+        0x03, 0x02, 0x01, 0x00,
+        // memory section: 1 memory, min=1
+        0x05, 0x03, 0x01, 0x00, 0x01,
+        // export section: "memory" (mem 0), "add42" (func 0)
+        0x07, 0x12, 0x02,
+        0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
+        0x05, 'a', 'd', 'd', '4', '2', 0x00, 0x00,
+        // code section: local.get 0; i32.const 42; i32.add; end
+        0x0a, 0x09, 0x01, 0x07, 0x00,
+        0x20, 0x00,
+        0x41, 0x2a,
+        0x6a,
+        0x0b,
+    };
+
+    const allocator = std.testing.allocator;
+    const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, &core_wasm);
+    defer allocator.free(cwasm_bytes);
+
+    const core_modules = [_]ctypes.CoreModule{.{ .data = &core_wasm }};
+    const core_insts = [_]ctypes.CoreInstanceExpr{
+        .{ .instantiate = .{ .module_idx = 0, .args = &.{} } },
+    };
+    const component = ctypes.Component{
+        .core_modules = &core_modules,
+        .core_instances = &core_insts,
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &.{},
+        .exports = &.{},
+    };
+
+    const pcs = [_]instance.PrecompiledCore{
+        .{ .module_idx = 0, .cwasm_bytes = cwasm_bytes },
+    };
+    const inst = try instance.instantiateWithOptions(&component, allocator, .{
+        .precompiled_cores = &pcs,
+    });
+    defer inst.deinit();
+
+    // The AOT backend should be populated, the interp one should not.
+    try std.testing.expectEqual(@as(usize, 1), inst.core_instances.len);
+    try std.testing.expect(inst.core_instances[0].module_inst == null);
+    const ai = inst.core_instances[0].aot_inst orelse return error.TestFailed;
+
+    // Backend-agnostic memory lookup must surface the AOT memory.
+    const mem = inst.firstBackendMemory() orelse return error.TestFailed;
+    try std.testing.expect(mem.data.len >= core_types.MemoryInstance.page_size);
+
+    // The exported function should be discoverable through the backend
+    // adapter — same call shape as a future canon-ABI dispatch would use.
+    const be = inst.core_instances[0].backend() orelse return error.TestFailed;
+    const fn_idx = be.findExportFunc("add42") orelse return error.TestFailed;
+
+    // And we can drive it through the AOT runtime directly. This proves
+    // the loaded artifact is actually executable end-to-end on this
+    // host; the canon-ABI dispatch that ties this into
+    // `callComponentFuncByLocal` lands in #625 phase 3.
+    const param_types = [_]core_types.ValType{.i32};
+    const result_types = [_]core_types.ValType{.i32};
+    const args = [_]core_types.Value{.{ .i32 = 100 }};
+    var results_buf: [1]aot_runtime_mod.ScalarResult = .{.{ .i32 = 0 }};
+    const results = try aot_runtime_mod.callFuncScalar(
+        ai,
+        fn_idx,
+        &param_types,
+        &result_types,
+        &args,
+        &results_buf,
+    );
+    try std.testing.expectEqual(@as(usize, 1), results.len);
+    try std.testing.expectEqual(@as(i32, 142), results[0].i32);
+}

--- a/src/tests/component_precompile_test.zig
+++ b/src/tests/component_precompile_test.zig
@@ -1,0 +1,175 @@
+//! #625 phase 2 — precompile → manifest → loadManifest → instantiate
+//! round-trip smoke test.
+//!
+//! Builds a minimal component binary (preamble + one core module +
+//! one core instance) in-process, runs `precompileComponent` against
+//! a tmp directory, reads it back with `loadManifest`, and hands the
+//! resulting `PrecompiledCore` slice to `instantiateWithOptions`.
+//! Confirms the AOT artifact loaded from disk drives the same code
+//! path the phase 1 smoke test exercises with in-memory bytes.
+
+const std = @import("std");
+const wamr = @import("wamr");
+const aot_harness = @import("aot_harness.zig");
+
+const instance = wamr.component_instance;
+const ctypes = wamr.component_types;
+const core_types = wamr.types;
+const aot_runtime_mod = wamr.aot_runtime;
+const component_aot = wamr.component_aot;
+
+/// Same i32->i32 +42 module used by the phase-1 smoke test.
+const core_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    0x03, 0x02, 0x01, 0x00,
+    0x05, 0x03, 0x01, 0x00, 0x01,
+    0x07, 0x12, 0x02,
+    0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
+    0x05, 'a', 'd', 'd', '4', '2', 0x00, 0x00,
+    0x0a, 0x09, 0x01, 0x07, 0x00,
+    0x20, 0x00,
+    0x41, 0x2a,
+    0x6a,
+    0x0b,
+};
+
+/// LEB128-encode a u32 into `out` (assumed large enough; 5 bytes max).
+fn writeLeb(out: *std.ArrayList(u8), allocator: std.mem.Allocator, v: u32) !void {
+    var x = v;
+    while (true) {
+        var b: u8 = @intCast(x & 0x7f);
+        x >>= 7;
+        if (x != 0) b |= 0x80;
+        try out.append(allocator, b);
+        if (x == 0) break;
+    }
+}
+
+fn buildMinimalComponent(allocator: std.mem.Allocator) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    // Preamble: magic + component version (0x0001_000d little-endian).
+    try out.appendSlice(allocator, &.{ 0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00 });
+
+    // Section 1 (core_module): raw wasm bytes, prefixed by LEB size.
+    try out.append(allocator, 1);
+    try writeLeb(&out, allocator, @intCast(core_wasm.len));
+    try out.appendSlice(allocator, &core_wasm);
+
+    // Section 2 (core_instance): count=1, tag=0x00 (instantiate),
+    // module_idx=0, arg_count=0.
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(allocator);
+    try writeLeb(&body, allocator, 1); // count
+    try body.append(allocator, 0x00); // tag
+    try writeLeb(&body, allocator, 0); // module_idx
+    try writeLeb(&body, allocator, 0); // arg_count
+
+    try out.append(allocator, 2);
+    try writeLeb(&out, allocator, @intCast(body.items.len));
+    try out.appendSlice(allocator, body.items);
+
+    return out.toOwnedSlice(allocator);
+}
+
+test "#625 phase 2: precompile + loadManifest + instantiate round-trip" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const component_bytes = try buildMinimalComponent(allocator);
+    defer allocator.free(component_bytes);
+
+    // tmp dir that we own + clean up. Path is `.zig-cache/tmp/<sub_path>`
+    // per `std.testing.tmpDir`'s implementation.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    defer allocator.free(tmp_path);
+
+    // Precompile + write manifest.
+    var precomp = try component_aot.precompileComponent(allocator, component_bytes, tmp_path, .{});
+    defer precomp.deinit();
+    try std.testing.expectEqual(@as(usize, 1), precomp.manifest.modules.len);
+
+    // Load manifest from disk, verifying hashes + build id.
+    var loaded = try component_aot.loadManifest(allocator, tmp_path, component_bytes);
+    defer loaded.deinit();
+
+    const pcs = loaded.precompiledCores();
+    try std.testing.expectEqual(@as(usize, 1), pcs.len);
+    try std.testing.expectEqual(@as(u32, 0), pcs[0].module_idx);
+
+    // Hand the loaded artifacts to instantiateWithOptions. The
+    // component path should pick the AOT branch and skip the
+    // interpreter loader for this core.
+    //
+    // We build a Component literal here rather than parsing
+    // `component_bytes` again, because the test owns the component
+    // shape and there's no reason to round-trip through the loader
+    // (which is already exercised by the unit tests in loader.zig).
+    const core_modules = [_]ctypes.CoreModule{.{ .data = &core_wasm }};
+    const core_insts = [_]ctypes.CoreInstanceExpr{
+        .{ .instantiate = .{ .module_idx = 0, .args = &.{} } },
+    };
+    const component = ctypes.Component{
+        .core_modules = &core_modules,
+        .core_instances = &core_insts,
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &.{},
+        .exports = &.{},
+    };
+
+    const inst = try instance.instantiateWithOptions(&component, allocator, .{
+        .precompiled_cores = pcs,
+    });
+    defer inst.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), inst.core_instances.len);
+    try std.testing.expect(inst.core_instances[0].module_inst == null);
+    const ai = inst.core_instances[0].aot_inst orelse return error.TestFailed;
+
+    const be = inst.core_instances[0].backend() orelse return error.TestFailed;
+    const fn_idx = be.findExportFunc("add42") orelse return error.TestFailed;
+
+    const param_types = [_]core_types.ValType{.i32};
+    const result_types = [_]core_types.ValType{.i32};
+    const args = [_]core_types.Value{.{ .i32 = 100 }};
+    var results_buf: [1]aot_runtime_mod.ScalarResult = .{.{ .i32 = 0 }};
+    const results = try aot_runtime_mod.callFuncScalar(
+        ai,
+        fn_idx,
+        &param_types,
+        &result_types,
+        &args,
+        &results_buf,
+    );
+    try std.testing.expectEqual(@as(usize, 1), results.len);
+    try std.testing.expectEqual(@as(i32, 142), results[0].i32);
+}
+
+test "#625 phase 2: loadManifest rejects mismatched component bytes" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const component_bytes = try buildMinimalComponent(allocator);
+    defer allocator.free(component_bytes);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    defer allocator.free(tmp_path);
+
+    var precomp = try component_aot.precompileComponent(allocator, component_bytes, tmp_path, .{});
+    defer precomp.deinit();
+
+    // Hash should reject any other bytes.
+    const other_bytes = [_]u8{ 0xde, 0xad, 0xbe, 0xef };
+    try std.testing.expectError(error.ManifestComponentMismatch, component_aot.loadManifest(allocator, tmp_path, &other_bytes));
+}


### PR DESCRIPTION
Implements #625 in phases on this single branch.

## Phase 1 (this commit) — landed

Scaffolds the AOT load path without changing canon-ABI dispatch:

- New `CoreModuleBackend` / `CoreInstanceBackend` unions + adapter API in `src/component/core_backend.zig`.
- `ComponentInstance.Options.precompiled_cores` lets callers opt individual cores into the AOT runtime; defaults preserve pre-#625 behaviour.
- `CoreInstanceEntry.aot_inst` sibling field; `firstBackendMemory` for read-only memory-probe paths.
- New `instantiateWithOptions` entry; existing `instantiate` delegates.
- `aot_harness.compileWasmToAot` exposed for in-process test compilation.
- New smoke test (`src/tests/component_aot_smoke_test.zig`) compiles a tiny 1-fn / 1-memory core in-process, runs it through the new AOT path, asserts memory + export discovery + executes via `aot_runtime.callFuncScalar`.
- All 2882 existing tests pass; +1 new test.

## Phase 2 — pending

- `src/component/aot.zig` `precompileComponent(...)` walking `core_modules` through the existing compiler pipeline.
- Versioned `manifest.json` (component sha256 + wamr build id, per-core .cwasm path/hash).
- `wamrc compile-component <component.wasm> -o <out-dir>` subcommand; auto-detect component in plain `compile`.
- `loadPrecompiledComponent` helper that hydrates `Options.precompiled_cores` from a manifest dir.

## Phase 3 — pending

- Dispatch `executor.callComponentFuncByLocal` onto `AotInstance` via `aot_runtime.callFuncScalar` (canon-ABI lift on AOT exports).
- Cross-instance canon-lower-into-AOT wiring (per-import native arg-marshalling stubs) so shim cores can call into AOT cores.
- Drop the "big-core-only" guard, AOT-compile every embedded core including canon-lower shims.
- End-to-end aarch64 perf target: TCGC `compile()` < 5 s on Key Vault Secrets.

Auto-merge will be enabled after phase 3 lands and the perf target is verified.

Refs #625.