### PR TITLE
feat(cli): consume wamrc compile-component AOT bundles in `wamr run` (#642)

### DIFF
--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -23126,6 +23126,7 @@ const ctypes_root = @import("types.zig");
 const component_loader = @import("loader.zig");
 const executor_root = @import("executor.zig");
 const abi_root = @import("canonical_abi.zig");
+const core_backend = @import("core_backend.zig");
 
 pub const RunComponentError = error{
     LoadFailed,
@@ -23862,12 +23863,21 @@ pub fn populateWasiProviders(
 
 /// Run an already-loaded component. See `runComponentBytes` for the
 /// byte-level entry point and the policy notes that apply equally here.
+///
+/// `precompiled_cores` opts individual embedded core modules into the
+/// AOT runtime (#625 / #642). Empty slice (the default) keeps every
+/// core on the interpreter — byte-identical to the pre-#642 behaviour.
 pub fn runLoadedComponent(
     component: *const ctypes_root.Component,
     allocator: Allocator,
     adapter: *WasiCliAdapter,
+    precompiled_cores: []const core_backend.PrecompiledCore,
 ) RunComponentError!RunOutcome {
-    const inst = instance_mod.instantiate(component, allocator) catch return error.InstantiateFailed;
+    const inst = instance_mod.instantiateWithOptions(
+        component,
+        allocator,
+        .{ .precompiled_cores = precompiled_cores },
+    ) catch return error.InstantiateFailed;
     defer inst.deinit();
 
     var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
@@ -23927,6 +23937,7 @@ pub fn runComponentBytes(
     data: []const u8,
     allocator: Allocator,
     adapter: *WasiCliAdapter,
+    precompiled_cores: []const core_backend.PrecompiledCore,
 ) RunComponentError!RunOutcome {
     const component_storage = allocator.create(ctypes_root.Component) catch return error.OutOfMemory;
     defer allocator.destroy(component_storage);
@@ -23939,9 +23950,9 @@ pub fn runComponentBytes(
     // `populateWasiProviders`; the missing piece was teaching the CLI to
     // call the right export. (#520)
     if (hasWasiCliRunP3Export(component_storage)) {
-        return runLoadedComponentP3(component_storage, allocator, adapter);
+        return runLoadedComponentP3(component_storage, allocator, adapter, precompiled_cores);
     }
-    return runLoadedComponent(component_storage, allocator, adapter);
+    return runLoadedComponent(component_storage, allocator, adapter, precompiled_cores);
 }
 
 /// Return true iff the top-level component exports a `wasi:cli/run@0.3.x`
@@ -24004,8 +24015,13 @@ pub fn runLoadedComponentP3(
     component: *const ctypes_root.Component,
     allocator: Allocator,
     adapter: *WasiCliAdapter,
+    precompiled_cores: []const core_backend.PrecompiledCore,
 ) RunComponentError!RunOutcome {
-    const inst = instance_mod.instantiate(component, allocator) catch return error.InstantiateFailed;
+    const inst = instance_mod.instantiateWithOptions(
+        component,
+        allocator,
+        .{ .precompiled_cores = precompiled_cores },
+    ) catch return error.InstantiateFailed;
     defer inst.deinit();
 
     var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
@@ -24072,11 +24088,12 @@ pub fn runComponentBytesP3(
     data: []const u8,
     allocator: Allocator,
     adapter: *WasiCliAdapter,
+    precompiled_cores: []const core_backend.PrecompiledCore,
 ) RunComponentError!RunOutcome {
     const component_storage = allocator.create(ctypes_root.Component) catch return error.OutOfMemory;
     defer allocator.destroy(component_storage);
     component_storage.* = component_loader.load(data, allocator) catch return error.LoadFailed;
-    return runLoadedComponentP3(component_storage, allocator, adapter);
+    return runLoadedComponentP3(component_storage, allocator, adapter, precompiled_cores);
 }
 
 pub const ServeHttpOptions = struct {
@@ -24319,11 +24336,12 @@ pub fn serveHttpComponentBytes(
     allocator: Allocator,
     adapter: *WasiCliAdapter,
     options: ServeHttpOptions,
+    precompiled_cores: []const core_backend.PrecompiledCore,
 ) anyerror!void {
     const component_storage = allocator.create(ctypes_root.Component) catch return error.OutOfMemory;
     defer allocator.destroy(component_storage);
     component_storage.* = component_loader.load(data, allocator) catch return error.LoadFailed;
-    return serveLoadedHttpComponent(component_storage, allocator, adapter, options);
+    return serveLoadedHttpComponent(component_storage, allocator, adapter, options, precompiled_cores);
 }
 
 pub fn serveLoadedHttpComponent(
@@ -24331,8 +24349,13 @@ pub fn serveLoadedHttpComponent(
     allocator: Allocator,
     adapter: *WasiCliAdapter,
     options: ServeHttpOptions,
+    precompiled_cores: []const core_backend.PrecompiledCore,
 ) anyerror!void {
-    const inst = instance_mod.instantiate(component, allocator) catch return error.InstantiateFailed;
+    const inst = instance_mod.instantiateWithOptions(
+        component,
+        allocator,
+        .{ .precompiled_cores = precompiled_cores },
+    ) catch return error.InstantiateFailed;
     defer inst.deinit();
 
     var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
@@ -25051,7 +25074,7 @@ test "runLoadedComponent: matches versioned WASI import names" {
     var adapter = WasiCliAdapter.init(testing.allocator);
     defer adapter.deinit();
 
-    const outcome = try runLoadedComponent(&component, testing.allocator, &adapter);
+    const outcome = try runLoadedComponent(&component, testing.allocator, &adapter, &.{});
     try testing.expect(outcome.is_ok);
     try testing.expectEqualStrings("hello, world!\n", adapter.getStdoutBytes());
 }
@@ -25339,7 +25362,7 @@ test "stdio-echo: end-to-end real wasi-p2 component (#156)" {
     defer adapter.deinit();
     adapter.setStdinBytes("hello\n");
 
-    const outcome = runComponentBytes(data, arena_alloc, &adapter) catch |err| {
+    const outcome = runComponentBytes(data, arena_alloc, &adapter, &.{}) catch |err| {
         std.debug.print("stdio-echo run failed: {s}\n", .{@errorName(err)});
         std.debug.print("stdout so far: {s}\n", .{adapter.getStdoutBytes()});
         std.debug.print("stderr so far: {s}\n", .{adapter.getStderrBytes()});
@@ -25394,7 +25417,7 @@ test "stdio-echo: live host stdio via pipe-redirected fds (#474)" {
         );
         defer adapter.deinit();
 
-        const outcome = runComponentBytes(data, arena_alloc, &adapter) catch |err| {
+        const outcome = runComponentBytes(data, arena_alloc, &adapter, &.{}) catch |err| {
             _ = linux.close(stdout_fds[1]);
             std.debug.print("stdio-echo (live) run failed: {s}\n", .{@errorName(err)});
             return err;

--- a/src/main.zig
+++ b/src/main.zig
@@ -95,6 +95,13 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     // rewrites synchronously after every mutation. Null ⇒ in-memory
     // only (default, behaviour-compatible with PR #601).
     var keyvalue_store_path: ?[]const u8 = null;
+    // `--precompiled-dir=<path>` (#642): explicit path to a
+    // `wamrc compile-component` output bundle (manifest.json + per-core
+    // .cwasm artifacts). When unset, `runRun` probes for a sibling
+    // `<input>.cwasm.d/manifest.json` next to the component file and
+    // uses it on a best-effort basis (mismatch → warning + interpreter
+    // fallback). When set, the bundle is mandatory: any error is fatal.
+    var precompiled_dir: ?[]const u8 = null;
     var listen_address: ?std.Io.net.IpAddress = null;
     // `--tls-cert=<path>` + `--tls-key=<path>` (or the combined
     // `--tls-pem=<path>`) (#583 follow-up to #595): when both cert
@@ -292,6 +299,31 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                     return 2;
                 }
                 keyvalue_store_path = spec;
+            } else if (std.mem.eql(u8, arg, "--precompiled-dir") or std.mem.startsWith(u8, arg, "--precompiled-dir=")) {
+                // `--precompiled-dir <path>` (#642): explicit path to a
+                // `wamrc compile-component` output directory containing
+                // `manifest.json` + `module<N>.cwasm`. Cores in the bundle
+                // are loaded as AOT; cores missing from the manifest fall
+                // back to the interpreter. A mismatched / stale manifest
+                // is a hard error (vs. the silent fallback used by the
+                // sibling auto-detect path below).
+                if (precompiled_dir != null) {
+                    std.debug.print("error: --precompiled-dir specified more than once\n", .{});
+                    return 2;
+                }
+                const spec = if (std.mem.eql(u8, arg, "--precompiled-dir")) blk: {
+                    i += 1;
+                    if (i >= run_args.len) {
+                        std.debug.print("error: --precompiled-dir requires a path to a wamrc compile-component output dir\n", .{});
+                        return 2;
+                    }
+                    break :blk run_args[i];
+                } else arg["--precompiled-dir=".len..];
+                if (spec.len == 0) {
+                    std.debug.print("error: --precompiled-dir path is empty\n", .{});
+                    return 2;
+                }
+                precompiled_dir = spec;
             } else if (std.mem.eql(u8, arg, "--")) {
                 past_options = true;
             } else {
@@ -399,6 +431,58 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                 std.debug.print("Error: --config-store '{s}': {}\n", .{ config_store_path orelse "", err });
                 return 2;
             };
+            // #642: resolve the AOT precompiled-cores bundle.
+            //
+            //  * `--precompiled-dir <path>` (explicit, mandatory): any
+            //    error opening / validating the manifest is fatal so the
+            //    user knows the AOT path isn't being taken.
+            //  * sibling `<input>.cwasm.d/manifest.json` (auto-detect,
+            //    best-effort): mismatch / stale / missing → one
+            //    `warning: ...` line on stderr and we fall through to
+            //    the interpreter path (matches wasmtime's behaviour).
+            //
+            // The `LoadedManifest`'s lifetime must outlive
+            // `runComponent` / `runHttpComponent` because the mmapped
+            // `.cwasm` buffers it owns are borrowed by the
+            // `PrecompiledCore` slice handed to the instance loader.
+            var loaded_manifest: ?wamr.component_aot.LoadedManifest = null;
+            defer if (loaded_manifest) |*lm| lm.deinit();
+
+            if (precompiled_dir) |dir| {
+                loaded_manifest = wamr.component_aot.loadManifest(allocator, dir, wasm_data) catch |err| {
+                    std.debug.print("Error: --precompiled-dir '{s}': {s}\n", .{ dir, loadManifestErrorMessage(err) });
+                    return 2;
+                };
+                const n = loaded_manifest.?.precompiledCores().len;
+                std.debug.print("wamr: loaded AOT bundle from {s} ({d} core{s} precompiled)\n", .{ dir, n, if (n == 1) @as([]const u8, "") else "s" });
+            } else {
+                // Auto-probe `<input>.cwasm.d/manifest.json`. Don't
+                // fail the run if the bundle is absent / stale — just
+                // tell the user we're skipping it.
+                const sibling = std.fmt.allocPrint(allocator, "{s}.cwasm.d", .{path}) catch return 1;
+                defer allocator.free(sibling);
+                const probe = std.fs.path.join(allocator, &.{ sibling, "manifest.json" }) catch return 1;
+                defer allocator.free(probe);
+                const io_probe = init.io;
+                const cwd_probe = std.Io.Dir.cwd();
+                const exists = blk: {
+                    var f = cwd_probe.openFile(io_probe, probe, .{}) catch break :blk false;
+                    f.close(io_probe);
+                    break :blk true;
+                };
+                if (exists) {
+                    if (wamr.component_aot.loadManifest(allocator, sibling, wasm_data)) |lm| {
+                        loaded_manifest = lm;
+                        const n = lm.precompiledCores().len;
+                        std.debug.print("wamr: loaded AOT bundle from {s} ({d} core{s} precompiled)\n", .{ sibling, n, if (n == 1) @as([]const u8, "") else "s" });
+                    } else |err| {
+                        std.debug.print("warning: ignoring AOT bundle at {s}: {s}\n", .{ sibling, loadManifestErrorMessage(err) });
+                    }
+                }
+            }
+            const precompiled_cores: []const wamr.component_core_backend.PrecompiledCore =
+                if (loaded_manifest) |lm| lm.precompiledCores() else &.{};
+
             if (listen_address) |addr| {
                 // Load + parse the TLS cert + key at startup, so a
                 // missing file / malformed PEM surfaces before `bind`
@@ -418,9 +502,9 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                     };
                 }
                 defer if (tls_config) |*c| c.deinit();
-                return runHttpComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, addr, effective_log_level, if (tls_config) |*c| c else null);
+                return runHttpComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, addr, effective_log_level, if (tls_config) |*c| c else null, precompiled_cores);
             }
-            return runComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, map_dirs.items, allow_net.items, effective_log_level, cfg_entries, keyvalue_store_path);
+            return runComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, map_dirs.items, allow_net.items, effective_log_level, cfg_entries, keyvalue_store_path, precompiled_cores);
         }
     }
 
@@ -572,6 +656,7 @@ fn runComponent(
     log_level: ?wamr.wasi_cli_adapter.WasiLogLevel,
     config_store: []const wamr.wasi_cli_adapter.ConfigEntry,
     keyvalue_store_path: ?[]const u8,
+    precompiled_cores: []const wamr.component_core_backend.PrecompiledCore,
 ) u8 {
     const adapter_mod = wamr.wasi_cli_adapter;
     // Wire the adapter's stdio directly to the host process's
@@ -671,7 +756,7 @@ fn runComponent(
     defer arena.deinit();
     const arena_alloc = arena.allocator();
 
-    const outcome = adapter_mod.runComponentBytes(data, arena_alloc, &adapter) catch |err| {
+    const outcome = adapter_mod.runComponentBytes(data, arena_alloc, &adapter, precompiled_cores) catch |err| {
         switch (err) {
             error.NoRunExport => std.debug.print(
                 "Error: component does not expose a top-level `run` export. " ++
@@ -716,6 +801,7 @@ fn runHttpComponent(
     listen_address: std.Io.net.IpAddress,
     log_level: ?wamr.wasi_cli_adapter.WasiLogLevel,
     tls_config: ?*const wamr.wasi_cli_adapter.HttpsTlsConfig,
+    precompiled_cores: []const wamr.component_core_backend.PrecompiledCore,
 ) u8 {
     const adapter_mod = wamr.wasi_cli_adapter;
     var adapter = adapter_mod.WasiCliAdapter.init(allocator);
@@ -740,7 +826,7 @@ fn runHttpComponent(
         .listen_address = listen_address,
         .announce_listening = listen_address.getPort() == 0,
         .tls_config = tls_config,
-    }) catch |err| {
+    }, precompiled_cores) catch |err| {
         switch (err) {
             error.NoIncomingHandlerExport => std.debug.print(
                 "Error: component does not export `wasi:http/incoming-handler.handle`.\n",
@@ -1049,6 +1135,19 @@ fn writeStdout(io: std.Io, text: []const u8) void {
 /// Map an `HttpsTlsConfig.LoadError` to a short, user-facing
 /// diagnostic string. Used by `runRun` to surface cert / key load
 /// failures before bind in a uniform format.
+fn loadManifestErrorMessage(err: wamr.component_aot.LoadError) []const u8 {
+    return switch (err) {
+        error.ManifestNotFound => "manifest.json not found in the directory",
+        error.ManifestParseFailed => "manifest.json could not be parsed",
+        error.ManifestVersionMismatch => "manifest format version not understood by this build",
+        error.ManifestBuildIdMismatch => "manifest was produced by a different wamr build (recompile with `wamrc compile-component`)",
+        error.ManifestComponentMismatch => "manifest's component hash does not match this component (stale bundle — recompile with `wamrc compile-component`)",
+        error.CwasmReadFailed => "could not read a .cwasm artifact referenced from the manifest",
+        error.CwasmHashMismatch => "a .cwasm artifact's contents differ from the manifest's recorded hash (tampered or partial write)",
+        error.OutOfMemory => "out of memory while loading the manifest",
+    };
+}
+
 fn tlsLoadErrorMessage(err: wamr.wasi_cli_adapter.HttpsTlsConfig.LoadError) []const u8 {
     return switch (err) {
         error.TlsCertFileNotFound => "certificate file not found",
@@ -1130,6 +1229,18 @@ const run_usage =
     \\                           file containing both certificate chain
     \\                           and private key. Mutually exclusive with
     \\                           --tls-cert / --tls-key.
+    \\  --precompiled-dir PATH   For components: load AOT-compiled cores from
+    \\                           a `wamrc compile-component` output directory
+    \\                           (containing manifest.json + module<N>.cwasm).
+    \\                           Cores in the bundle execute via the AOT
+    \\                           runtime; cores missing from the manifest
+    \\                           fall back to the interpreter. A mismatched
+    \\                           manifest is a hard error. When this flag
+    \\                           is omitted, `wamr run` auto-detects a
+    \\                           sibling `<input>.cwasm.d/manifest.json`
+    \\                           and uses it on a best-effort basis
+    \\                           (mismatch -> warning + interpreter
+    \\                           fallback).
     \\
 ;
 


### PR DESCRIPTION
Closes #642.

## What
`wamr run` now uses the AOT bundle produced by `wamrc compile-component`:

1. **Auto-detect** a sibling `<input>.cwasm.d/manifest.json` next to the input component. On load failure (mismatched hash, stale manifest, unreadable file), prints a `warning:` line and falls back to the interpreter.
2. **Explicit** `--precompiled-dir <path>` flag. On load failure, hard errors and exits 2.

Successful load prints (stderr):
```
wamr: loaded AOT bundle from <dir> (m/n cores precompiled)
```

## How
- Added an additive `precompiled_cores: []const core_backend.PrecompiledCore` parameter to the six adapter dispatch entry points in `src/component/wasi_cli_adapter.zig`:
  - `runLoadedComponent` / `runComponentBytes`
  - `runLoadedComponentP3` / `runComponentBytesP3`
  - `serveLoadedHttpComponent` / `serveHttpComponentBytes`
- Switched their internal `instantiate` call to `instantiateWithOptions(..., .{ .precompiled_cores = ... })`.
- Default empty slice keeps every existing call site (tests + embedders) source- and behaviour-compatible.
- Threaded the slice through `runComponent` / `runHttpComponent` in `src/main.zig`.

## Verification
- `zig build` — clean (no warnings).
- `zig build test --summary all` — 2887/2894 pass (7 skipped, same as baseline).
- Backward compatible: existing tests pass `&.{}` and exercise the interpreter path unchanged.
- The AOT instantiation path itself is already covered by the round-trip test in `src/tests/component_precompile_test.zig` (asserts `core_instances[i].aot_inst != null` after `instantiateWithOptions` with a non-empty slice).

## Out of scope
Per #642: no `wamr precompile` subcommand, no cache invalidation beyond `(build_id, component_hash)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>