### PR TITLE
fix(cli): align `wamr run` auto-detect with `wamrc compile-component` default output (#645)

### DIFF
--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -620,11 +620,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
         std.process.exit(1);
     };
     const out_dir = output_dir orelse blk: {
-        const stem = if (std.mem.endsWith(u8, in_path, ".wasm"))
-            in_path[0 .. in_path.len - ".wasm".len]
-        else
-            in_path;
-        break :blk try std.mem.concat(allocator, u8, &.{ stem, ".cwasm.d" });
+        break :blk try wamr.component_aot.defaultPrecompiledDirFor(allocator, in_path);
     };
 
     const io = init.io;

--- a/src/component/aot.zig
+++ b/src/component/aot.zig
@@ -61,6 +61,19 @@ pub const LoadError = error{
     OutOfMemory,
 };
 
+/// Convention for the default precompiled-bundle directory next to a
+/// component file: strip a trailing `.wasm` (if present) and append
+/// `.cwasm.d`. Used both by `wamrc compile-component` (default `-o`)
+/// and by `wamr run`'s auto-detect probe — they must stay in sync
+/// (issue #645). Caller owns the returned slice.
+pub fn defaultPrecompiledDirFor(allocator: std.mem.Allocator, in_path: []const u8) ![]u8 {
+    const stem = if (std.mem.endsWith(u8, in_path, ".wasm"))
+        in_path[0 .. in_path.len - ".wasm".len]
+    else
+        in_path;
+    return std.mem.concat(allocator, u8, &.{ stem, ".cwasm.d" });
+}
+
 /// Manifest schema version. Bump when the on-disk layout or
 /// serialization changes in a way that older loaders cannot read.
 pub const manifest_format_version: u32 = 1;
@@ -513,4 +526,22 @@ test "isComponent: core module vs component" {
     try std.testing.expectEqual(true, try isComponent(&comp));
     try std.testing.expectError(error.InvalidMagic, isComponent(&bad));
     try std.testing.expectError(error.InvalidMagic, isComponent(&.{}));
+}
+
+test "defaultPrecompiledDirFor: strips .wasm and appends .cwasm.d (#645)" {
+    const alloc = std.testing.allocator;
+
+    const a = try defaultPrecompiledDirFor(alloc, "/tmp/stdio-echo.wasm");
+    defer alloc.free(a);
+    try std.testing.expectEqualStrings("/tmp/stdio-echo.cwasm.d", a);
+
+    // No .wasm suffix → append directly (preserves the prior fallback).
+    const b = try defaultPrecompiledDirFor(alloc, "/tmp/stdio-echo");
+    defer alloc.free(b);
+    try std.testing.expectEqualStrings("/tmp/stdio-echo.cwasm.d", b);
+
+    // .wasm appears mid-path but not as suffix → don't strip.
+    const c = try defaultPrecompiledDirFor(alloc, "/tmp/a.wasm.bak");
+    defer alloc.free(c);
+    try std.testing.expectEqualStrings("/tmp/a.wasm.bak.cwasm.d", c);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -459,7 +459,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                 // Auto-probe `<input>.cwasm.d/manifest.json`. Don't
                 // fail the run if the bundle is absent / stale — just
                 // tell the user we're skipping it.
-                const sibling = std.fmt.allocPrint(allocator, "{s}.cwasm.d", .{path}) catch return 1;
+                const sibling = wamr.component_aot.defaultPrecompiledDirFor(allocator, path) catch return 1;
                 defer allocator.free(sibling);
                 const probe = std.fs.path.join(allocator, &.{ sibling, "manifest.json" }) catch return 1;
                 defer allocator.free(probe);


### PR DESCRIPTION
Closes #645.

## Bug
`wamr run`'s auto-probe built `<input>.wasm.cwasm.d`, but `wamrc compile-component`'s default output is `<input>.cwasm.d` (with trailing `.wasm` stripped). So for the typical `stdio-echo.wasm` workflow, auto-detect silently never matched and the run fell through to the interpreter.

## Fix
Lift the convention into a single helper in `src/component/aot.zig`:

```zig
pub fn defaultPrecompiledDirFor(allocator, in_path) ![]u8
```

Strip a trailing `.wasm` (if present) and append `.cwasm.d`. Call it from both:
- `src/main.zig` — the CLI auto-probe.
- `src/compiler/main.zig` — the wamrc default `-o` resolver.

## Verification
- Unit test added in `src/component/aot.zig` covering `.wasm` suffix, no suffix, and the `.wasm.bak` middle-of-path case.
- `zig build test --summary all`: 2888/2895 pass (7 skipped, +1 new test vs baseline).
- End-to-end:
  ```
  $ wamrc compile-component /tmp/hello.component.wasm
  → /tmp/hello.component.cwasm.d/
  $ wamr run /tmp/hello.component.wasm
  wamr: loaded AOT bundle from /tmp/hello.component.cwasm.d (5 cores precompiled)
  ```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>