### PR TITLE
feat(aot): canon-ABI scalar fast path lifts result/variant/enum (#650 phase A)

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -473,13 +473,13 @@ fn callComponentFuncByLocalAot(
     var core_result_types: [1]core_types.ValType = undefined;
 
     for (args, param_types, 0..) |val, pt, i| {
-        const cv = lowerScalarArg(val, pt) catch return error.AotPathUnsupported;
+        const cv = lowerScalarArg(val, pt, registry) catch return error.AotPathUnsupported;
         arg_buf[i] = cv.value;
         core_param_types[i] = cv.ty;
     }
 
     if (result_types.len == 1) {
-        core_result_types[0] = scalarValType(result_types[0]) catch return error.AotPathUnsupported;
+        core_result_types[0] = scalarValType(result_types[0], registry) catch return error.AotPathUnsupported;
     }
 
     var results_buf: [1]aot_runtime.ScalarResult = .{.{ .i32 = 0 }};
@@ -493,14 +493,21 @@ fn callComponentFuncByLocalAot(
     ) catch return error.TrapInCoreFunction;
 
     if (result_types.len == 1) {
-        out_results[0] = liftScalarResult(results[0], result_types[0]) catch
+        out_results[0] = liftScalarResult(results[0], result_types[0], registry) catch
             return error.AotPathUnsupported;
     }
 }
 
 const LoweredScalar = struct { ty: core_types.ValType, value: core_types.Value };
 
-fn lowerScalarArg(val: InterfaceValue, t: ctypes.ValType) !LoweredScalar {
+/// Lower an interface value to a single core value slot. Handles
+/// primitives directly; for compound types, only those that flatten
+/// to exactly 1 i32 slot are accepted (today: `enum`,
+/// `result<(),()>`, and `variant` whose every arm is empty). Anything
+/// else (multi-slot results, list/string, payload-bearing variants,
+/// records/tuples) routes through `error.AotPathUnsupported` — that's
+/// the #650 phase B work.
+fn lowerScalarArg(val: InterfaceValue, t: ctypes.ValType, registry: TypeRegistry) !LoweredScalar {
     return switch (t) {
         .bool => .{ .ty = .i32, .value = .{ .i32 = if (val.bool) 1 else 0 } },
         .s8 => .{ .ty = .i32, .value = .{ .i32 = @as(i32, val.s8) } },
@@ -513,21 +520,36 @@ fn lowerScalarArg(val: InterfaceValue, t: ctypes.ValType) !LoweredScalar {
         .u64 => .{ .ty = .i64, .value = .{ .i64 = @bitCast(val.u64) } },
         .f32 => .{ .ty = .f32, .value = .{ .f32 = @bitCast(val.f32) } },
         .f64 => .{ .ty = .f64, .value = .{ .f64 = @bitCast(val.f64) } },
+        .enum_ => .{ .ty = .i32, .value = .{ .i32 = @bitCast(val.enum_val) } },
+        .result, .variant => blk: {
+            if (abi.flattenCount(registry, t) != 1) return error.AotPathUnsupported;
+            const disc: u32 = switch (val) {
+                .result_val => |r| if (r.is_ok) 0 else 1,
+                .variant_val => |v| v.discriminant,
+                else => return error.AotPathUnsupported,
+            };
+            break :blk .{ .ty = .i32, .value = .{ .i32 = @bitCast(disc) } };
+        },
         else => error.AotPathUnsupported,
     };
 }
 
-fn scalarValType(t: ctypes.ValType) !core_types.ValType {
+fn scalarValType(t: ctypes.ValType, registry: TypeRegistry) !core_types.ValType {
     return switch (t) {
         .bool, .s8, .u8, .s16, .u16, .s32, .u32, .char => .i32,
         .s64, .u64 => .i64,
         .f32 => .f32,
         .f64 => .f64,
+        .enum_ => .i32,
+        .result, .variant => blk: {
+            if (abi.flattenCount(registry, t) != 1) return error.AotPathUnsupported;
+            break :blk .i32;
+        },
         else => error.AotPathUnsupported,
     };
 }
 
-fn liftScalarResult(r: aot_runtime.ScalarResult, t: ctypes.ValType) !InterfaceValue {
+fn liftScalarResult(r: aot_runtime.ScalarResult, t: ctypes.ValType, registry: TypeRegistry) !InterfaceValue {
     return switch (t) {
         .bool => .{ .bool = (r.i32 != 0) },
         .s8 => .{ .s8 = @truncate(r.i32) },
@@ -540,6 +562,19 @@ fn liftScalarResult(r: aot_runtime.ScalarResult, t: ctypes.ValType) !InterfaceVa
         .u64 => .{ .u64 = @bitCast(r.i64) },
         .f32 => .{ .f32 = @bitCast(r.f32) },
         .f64 => .{ .f64 = @bitCast(r.f64) },
+        .enum_ => .{ .enum_val = @bitCast(r.i32) },
+        .result => blk: {
+            if (abi.flattenCount(registry, t) != 1) return error.AotPathUnsupported;
+            const disc: u32 = @bitCast(r.i32);
+            // Canon ABI: 0 = ok, 1 = err. Both arms empty in this fast
+            // path so payload is null on either side.
+            break :blk .{ .result_val = .{ .is_ok = disc == 0, .payload = null } };
+        },
+        .variant => blk: {
+            if (abi.flattenCount(registry, t) != 1) return error.AotPathUnsupported;
+            const disc: u32 = @bitCast(r.i32);
+            break :blk .{ .variant_val = .{ .discriminant = disc, .payload = null } };
+        },
         else => error.AotPathUnsupported,
     };
 }

--- a/src/tests/component_aot_canonlift_test.zig
+++ b/src/tests/component_aot_canonlift_test.zig
@@ -163,3 +163,116 @@ test "#625 phase 3: AOT path rejects unsupported shapes cleanly" {
         executor.callComponentFuncByLocal(inst, local, &args, &results, allocator),
     );
 }
+
+// #650 phase A — `result<(),()>` lifts onto AOT scalar fast path.
+//
+// Core wasm exports `(func "ok" (result i32) i32.const 0)` and
+// `(func "err" (result i32) i32.const 1)`; canon.lift retypes them
+// as `(func) -> result<(), ()>`, which flattens to a single i32
+// discriminant slot. Pre-#650, `liftScalarResult` only knew
+// primitives so this hit `error.AotPathUnsupported` even though
+// the shape lives in one i32. After #650 phase A, both calls
+// surface as `result_val { is_ok=true/false, payload=null }`.
+//
+// This is the headline case for wit-bindgen-emitted CLI
+// components whose `wasi:cli/run.run` lifts as
+// `func() -> result<_, _>`.
+const result_core_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    // type: () -> i32
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+    // funcs: 2 funcs, both type 0
+    0x03, 0x03, 0x02, 0x00, 0x00,
+    // memory: 1 page
+    0x05, 0x03, 0x01, 0x00, 0x01,
+    // exports: memory, ok, err  (count=3, payload = 9+5+6 = 20 -> total 21)
+    0x07, 0x15, 0x03,
+    0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
+    0x02, 'o', 'k', 0x00, 0x00,
+    0x03, 'e', 'r', 'r', 0x00, 0x01,
+    // code: 2 funcs, each body 4 bytes (locals=0, i32.const X, end) -> count + 2*(1+4) = 11
+    0x0a, 0x0b, 0x02,
+    0x04, 0x00, 0x41, 0x00, 0x0b,
+    0x04, 0x00, 0x41, 0x01, 0x0b,
+};
+
+test "#650 phase A: AOT lifts result<(),()> via scalar fast path" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, &result_core_wasm);
+    defer allocator.free(cwasm_bytes);
+
+    const core_modules = [_]ctypes.CoreModule{.{ .data = &result_core_wasm }};
+    const core_insts = [_]ctypes.CoreInstanceExpr{
+        .{ .instantiate = .{ .module_idx = 0, .args = &.{} } },
+    };
+
+    // type 0: result<(),()>; type 1: () -> result<(),()> (referencing type 0).
+    const types = [_]ctypes.TypeDef{
+        .{ .result = .{ .ok = null, .err = null } },
+        .{ .func = .{
+            .params = &.{},
+            .results = .{ .unnamed = .{ .result = 0 } },
+        } },
+    };
+    const lift_opts = [_]ctypes.CanonOpt{};
+    const canons = [_]ctypes.Canon{
+        .{ .lift = .{ .core_func_idx = 0, .type_idx = 1, .opts = &lift_opts } },
+        .{ .lift = .{ .core_func_idx = 1, .type_idx = 1, .opts = &lift_opts } },
+    };
+    const exports = [_]ctypes.ExportDecl{
+        .{ .name = "ok", .desc = .{ .func = 1 }, .sort_idx = .{ .sort = .func, .idx = 0 } },
+        .{ .name = "err", .desc = .{ .func = 1 }, .sort_idx = .{ .sort = .func, .idx = 1 } },
+    };
+    const component = ctypes.Component{
+        .core_modules = &core_modules,
+        .core_instances = &core_insts,
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &types,
+        .canons = &canons,
+        .imports = &.{},
+        .exports = &exports,
+    };
+
+    const pcs = [_]instance.PrecompiledCore{
+        .{ .module_idx = 0, .cwasm_bytes = cwasm_bytes },
+    };
+    const inst = try instance.instantiateWithOptions(&component, allocator, .{
+        .precompiled_cores = &pcs,
+    });
+    defer inst.deinit();
+
+    try std.testing.expect(inst.core_instances[0].aot_inst != null);
+
+    // ok arm
+    {
+        const ef = inst.getExport("ok") orelse return error.TestFailed;
+        const local = switch (ef) {
+            .local => |l| l,
+            else => return error.TestFailed,
+        };
+        var results: [1]abi.InterfaceValue = .{.{ .s32 = 0 }};
+        try executor.callComponentFuncByLocal(inst, local, &.{}, &results, allocator);
+        const rv = results[0].result_val;
+        try std.testing.expect(rv.is_ok);
+        try std.testing.expect(rv.payload == null);
+    }
+
+    // err arm
+    {
+        const ef = inst.getExport("err") orelse return error.TestFailed;
+        const local = switch (ef) {
+            .local => |l| l,
+            else => return error.TestFailed,
+        };
+        var results: [1]abi.InterfaceValue = .{.{ .s32 = 0 }};
+        try executor.callComponentFuncByLocal(inst, local, &.{}, &results, allocator);
+        const rv = results[0].result_val;
+        try std.testing.expect(!rv.is_ok);
+        try std.testing.expect(rv.payload == null);
+    }
+}


### PR DESCRIPTION
Phase A of #650. Extends `lowerScalarArg` / `scalarValType` / `liftScalarResult` in `src/component/executor.zig` to handle compound interface types whose canon-ABI flattening produces exactly one i32 slot.

## What this enables

* `enum` — always 1 i32 (the discriminant tag).
* `result<T, U>` with both arms empty (e.g. `result<(), ()>`) — flattens to 1 i32 (0=ok, 1=err).
* `variant` where every arm is empty — flattens to 1 i32.

**Headline case:** wit-bindgen-emitted CLI components type their `wasi:cli/run.run` export as `func() -> result<_, _>`. Pre-#650 the AOT scalar fast path rejected this with `error.AotPathUnsupported`. After this PR the lift surfaces as `InterfaceValue.result_val { is_ok, payload = null }` and the AOT path completes for these shapes.

## Eligibility gate

The check uses `abi.flattenCount(registry, t) == 1`. Any compound shape that does not collapse to a single i32 (payload-bearing variants, multi-slot results, `list`/`string`, records/tuples, multi-arm variants with payloads) still routes to `AotPathUnsupported`. Memory-backed lower/lift for those shapes is **#650 phase B** (CallFrame abstraction).

## Out of scope

* Memory-backed lower/lift for lists/strings/records (phase B, follow-up).
* The cross-instance wiring (#649) and per-import C-ABI trampolines (#648) that stdio-echo.wasm needs to actually exercise this path on AOT — those are independent pieces. Phase A still lands clean value, since any single-core AOT component returning `result<_,_>` now works.

## Test

New fixture in `src/tests/component_aot_canonlift_test.zig`: a core wasm exporting two `(func (result i32))` bodies returning 0 and 1, lifted as `func() -> result<(),()>`. Both arms asserted to surface with the right `is_ok` and a null payload. `zig build test` shows 2889/2896 pass (7 skipped, 0 failed).

## References
* #650 (umbrella for canon-ABI lift work)
* #644 (umbrella issue), #648 (trampoline pool), #649 (cross-instance wiring)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>