### PR TITLE
feat(aot): canon-ABI lift phase B.2 — multi-slot + spilled params (#650)

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -465,20 +465,64 @@ fn callComponentFuncByLocalAot(
     const flat_param_count = countFlatTypes(registry, param_types);
     const flat_result_count = countFlatTypes(registry, result_types);
 
-    // Phase B.1 still requires params to flatten into ≤ MAX_FLAT_PARAMS
-    // single-slot scalars. Memory-spilled params and >1-slot compound
-    // params are deferred to phase B.2.
-    if (flat_param_count > MAX_FLAT_PARAMS) return error.AotPathUnsupported;
-    if (args.len > 16) return error.AotPathUnsupported;
+    // #650 phase B.2: support up to MAX_FLAT_PARAMS=16 flat slots
+    // emitted from compound/multi-slot params (string/list/s64/u64/f64
+    // = 2 slots each; 1-slot compounds via lowerScalarArg). When total
+    // flat-param slots exceed MAX_FLAT_PARAMS, the canon ABI spec says
+    // spill all params to a tuple in linear memory and pass a single
+    // i32 retptr — symmetric to the spilled-results path below.
+    if (args.len != param_types.len) return error.AotPathUnsupported;
 
-    var arg_buf: [17]core_types.Value = undefined; // +1 slot for retptr
-    var core_param_types: [17]core_types.ValType = undefined;
+    // +1 slot reserved for trailing retptr in the spilled-result path.
+    const SLOT_CAP: usize = MAX_FLAT_PARAMS + 1;
+    var arg_buf: [SLOT_CAP]core_types.Value = undefined;
+    var core_param_types: [SLOT_CAP]core_types.ValType = undefined;
     var core_result_types: [1]core_types.ValType = undefined;
 
-    for (args, param_types, 0..) |val, pt, i| {
-        const cv = lowerScalarArg(val, pt, registry) catch return error.AotPathUnsupported;
-        arg_buf[i] = cv.value;
-        core_param_types[i] = cv.ty;
+    var core_arg_count: usize = 0;
+    if (flat_param_count > MAX_FLAT_PARAMS) {
+        // Memory-spill: realloc a param tuple, store every arg, pass ptr.
+        if (ai.memories.len == 0) return error.AotPathUnsupported;
+        const mem_pre: []u8 = ai.memories[0].data;
+        _ = mem_pre;
+        const realloc_idx = lift_opts.realloc_idx orelse return error.AotPathUnsupported;
+
+        const tuple_size = computeTupleSize(registry, param_types);
+        const tuple_align = computeTupleAlign(registry, param_types);
+        const realloc_args = [_]core_types.Value{
+            .{ .i32 = 0 }, .{ .i32 = 0 }, .{ .i32 = @intCast(tuple_align) }, .{ .i32 = @intCast(tuple_size) },
+        };
+        const rpt = [_]core_types.ValType{ .i32, .i32, .i32, .i32 };
+        const rrt = [_]core_types.ValType{.i32};
+        var rbuf: [1]aot_runtime.ScalarResult = .{.{ .i32 = 0 }};
+        const rres = aot_runtime.callFuncScalar(
+            ai, realloc_idx, &rpt, &rrt, &realloc_args, &rbuf,
+        ) catch return error.TrapInCoreFunction;
+        const params_ptr: u32 = @bitCast(rres[0].i32);
+
+        // Re-acquire memory after realloc (mem.grow may relocate).
+        const mem: []u8 = ai.memories[0].data;
+        var off: u32 = params_ptr;
+        for (args, param_types) |val, pt| {
+            const al = typeAlign(registry, pt);
+            off = abi.alignUp(off, al);
+            storeInterfaceValue(mem, off, val, pt, registry);
+            off += typeSize(registry, pt);
+        }
+        arg_buf[0] = .{ .i32 = @bitCast(params_ptr) };
+        core_param_types[0] = .i32;
+        core_arg_count = 1;
+    } else {
+        // Flat path: emit one or more core slots per interface arg.
+        for (args, param_types) |val, pt| {
+            const slots_left = SLOT_CAP - core_arg_count;
+            const written = lowerFlatRecur(
+                val, pt, registry,
+                arg_buf[core_arg_count..][0..slots_left],
+                core_param_types[core_arg_count..][0..slots_left],
+            ) catch return error.AotPathUnsupported;
+            core_arg_count += written;
+        }
     }
 
     // Spilled-result path (#650 phase B.1): when the lifted result
@@ -512,16 +556,18 @@ fn callComponentFuncByLocalAot(
         const retptr: u32 = @bitCast(realloc_results[0].i32);
 
         // Append retptr as the last core arg.
-        arg_buf[args.len] = .{ .i32 = @bitCast(retptr) };
-        core_param_types[args.len] = .i32;
+        if (core_arg_count >= SLOT_CAP) return error.AotPathUnsupported;
+        arg_buf[core_arg_count] = .{ .i32 = @bitCast(retptr) };
+        core_param_types[core_arg_count] = .i32;
+        const total_args = core_arg_count + 1;
 
         var results_buf: [1]aot_runtime.ScalarResult = undefined;
         _ = aot_runtime.callFuncScalar(
             ai,
             exported.core_func_idx,
-            core_param_types[0 .. args.len + 1],
+            core_param_types[0..total_args],
             &.{},
-            arg_buf[0 .. args.len + 1],
+            arg_buf[0..total_args],
             &results_buf,
         ) catch return error.TrapInCoreFunction;
 
@@ -553,9 +599,9 @@ fn callComponentFuncByLocalAot(
     const results = aot_runtime.callFuncScalar(
         ai,
         exported.core_func_idx,
-        core_param_types[0..args.len],
+        core_param_types[0..core_arg_count],
         core_result_types[0..result_types.len],
-        arg_buf[0..args.len],
+        arg_buf[0..core_arg_count],
         &results_buf,
     ) catch return error.TrapInCoreFunction;
 
@@ -566,6 +612,69 @@ fn callComponentFuncByLocalAot(
 }
 
 const LoweredScalar = struct { ty: core_types.ValType, value: core_types.Value };
+
+/// Lower an interface value into one or more flat core slots, writing
+/// to `out_vals` and `out_types` (must have length ≥ flatten-count of
+/// `t`). Returns the number of slots written. Used by the AOT path to
+/// emit canon-ABI flat-param slots without an `ExecEnv`.
+///
+/// Handles primitives — including multi-slot ones (s64/u64=2 i64-or-
+/// i32-pair, f64=2 slots, string=2 i32, list=2 i32) — plus the 1-slot
+/// compound shapes the scalar fast path already accepts (`enum`,
+/// `result<(),()>`-style empty-payload variants/results). Anything
+/// requiring per-slot variant-arm zero-fills with mixed-type joins is
+/// deferred (returns `error.AotPathUnsupported`).
+fn lowerFlatRecur(
+    val: InterfaceValue,
+    t: ctypes.ValType,
+    registry: TypeRegistry,
+    out_vals: []core_types.Value,
+    out_types: []core_types.ValType,
+) !usize {
+    switch (t) {
+        .s64 => {
+            if (out_vals.len < 1) return error.AotPathUnsupported;
+            out_vals[0] = .{ .i64 = val.s64 };
+            out_types[0] = .i64;
+            return 1;
+        },
+        .u64 => {
+            if (out_vals.len < 1) return error.AotPathUnsupported;
+            out_vals[0] = .{ .i64 = @bitCast(val.u64) };
+            out_types[0] = .i64;
+            return 1;
+        },
+        .f64 => {
+            if (out_vals.len < 1) return error.AotPathUnsupported;
+            out_vals[0] = .{ .f64 = @bitCast(val.f64) };
+            out_types[0] = .f64;
+            return 1;
+        },
+        .string => {
+            if (out_vals.len < 2) return error.AotPathUnsupported;
+            out_vals[0] = .{ .i32 = @bitCast(val.string.ptr) };
+            out_vals[1] = .{ .i32 = @bitCast(val.string.len) };
+            out_types[0] = .i32;
+            out_types[1] = .i32;
+            return 2;
+        },
+        .list => {
+            if (out_vals.len < 2) return error.AotPathUnsupported;
+            out_vals[0] = .{ .i32 = @bitCast(val.list.ptr) };
+            out_vals[1] = .{ .i32 = @bitCast(val.list.len) };
+            out_types[0] = .i32;
+            out_types[1] = .i32;
+            return 2;
+        },
+        else => {
+            if (out_vals.len < 1) return error.AotPathUnsupported;
+            const cv = try lowerScalarArg(val, t, registry);
+            out_vals[0] = cv.value;
+            out_types[0] = cv.ty;
+            return 1;
+        },
+    }
+}
 
 /// Lower an interface value to a single core value slot. Handles
 /// primitives directly; for compound types, only those that flatten

--- a/src/tests/component_aot_canonlift_test.zig
+++ b/src/tests/component_aot_canonlift_test.zig
@@ -115,16 +115,19 @@ test "#625 phase 3: AOT path rejects unsupported shapes cleanly" {
         .{ .instantiate = .{ .module_idx = 0, .args = &.{} } },
     };
 
-    // Declare the lift as taking a `string` param (which flattens to
-    // 2 i32 slots + needs memory) so the scalar fast path bails with
-    // AotPathUnsupported rather than producing wrong results.
-    const params = [_]ctypes.NamedValType{.{ .name = "s", .type = .string }};
+    // Declare the lift as taking a `tuple<u32,u32>` param (compound,
+    // 2 flat slots). Phase B.2 handles string/list/multi-slot
+    // primitives, but compound aggregate params (records / tuples /
+    // payload-bearing variants) still bail with AotPathUnsupported.
+    const tuple_fields = [_]ctypes.ValType{ .u32, .u32 };
+    const params = [_]ctypes.NamedValType{.{ .name = "p", .type = .{ .tuple = 0 } }};
     const types = [_]ctypes.TypeDef{
+        .{ .tuple = .{ .fields = &tuple_fields } },
         .{ .func = .{ .params = &params, .results = .{ .unnamed = .s32 } } },
     };
     const lift_opts = [_]ctypes.CanonOpt{};
     const canons = [_]ctypes.Canon{
-        .{ .lift = .{ .core_func_idx = 0, .type_idx = 0, .opts = &lift_opts } },
+        .{ .lift = .{ .core_func_idx = 0, .type_idx = 1, .opts = &lift_opts } },
     };
     const exports = [_]ctypes.ExportDecl{
         .{ .name = "go", .desc = .{ .func = 0 }, .sort_idx = .{ .sort = .func, .idx = 0 } },
@@ -156,7 +159,8 @@ test "#625 phase 3: AOT path rejects unsupported shapes cleanly" {
         else => return error.TestFailed,
     };
 
-    const args = [_]abi.InterfaceValue{.{ .string = .{ .ptr = 0, .len = 0 } }};
+    const tup_field = [_]abi.InterfaceValue{ .{ .u32 = 0 }, .{ .u32 = 0 } };
+    const args = [_]abi.InterfaceValue{.{ .tuple_val = &tup_field }};
     var results: [1]abi.InterfaceValue = .{.{ .s32 = 0 }};
     try std.testing.expectError(
         error.AotPathUnsupported,
@@ -389,4 +393,84 @@ test "#650 phase B.1: AOT lifts tuple<u32,u32> via retptr" {
     try std.testing.expectEqual(@as(usize, 2), tup.len);
     try std.testing.expectEqual(@as(u32, 0xAA), tup[0].u32);
     try std.testing.expectEqual(@as(u32, 0xBB), tup[1].u32);
+}
+
+// #650 phase B.2 — multi-slot flat params on AOT.
+//
+// Core wasm exports `(func "len" (param i32 i32) (result i32))` that
+// returns its second i32 arg (i.e. the string length). canon.lift
+// retypes it as `func(s: string) -> u32`. The string param flattens
+// to 2 i32 slots, exceeding what the pre-B.2 single-slot lowerScalarArg
+// could emit. Phase B.2's `lowerFlatRecur` writes both slots into the
+// AOT arg buffer.
+const string_param_core_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    // type: (i32 i32) -> i32
+    0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f,
+    // funcs: 1 func type 0
+    0x03, 0x02, 0x01, 0x00,
+    // memory: 1 page
+    0x05, 0x03, 0x01, 0x00, 0x01,
+    // exports: memory, len  (count=3 -> wait 2; payload: 9 + 6 = 15 + 1)
+    0x07, 0x10, 0x02,
+    0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
+    0x03, 'l', 'e', 'n', 0x00, 0x00,
+    // code: 1 func, body = locals(1 byte) + local.get 1 + end (4 bytes)
+    0x0a, 0x06, 0x01,
+    0x04, 0x00, 0x20, 0x01, 0x0b,
+};
+
+test "#650 phase B.2: AOT lowers string param (multi-slot flat)" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, &string_param_core_wasm);
+    defer allocator.free(cwasm_bytes);
+
+    const core_modules = [_]ctypes.CoreModule{.{ .data = &string_param_core_wasm }};
+    const core_insts = [_]ctypes.CoreInstanceExpr{
+        .{ .instantiate = .{ .module_idx = 0, .args = &.{} } },
+    };
+
+    const params = [_]ctypes.NamedValType{.{ .name = "s", .type = .string }};
+    const types = [_]ctypes.TypeDef{
+        .{ .func = .{ .params = &params, .results = .{ .unnamed = .u32 } } },
+    };
+    const lift_opts = [_]ctypes.CanonOpt{};
+    const canons = [_]ctypes.Canon{
+        .{ .lift = .{ .core_func_idx = 0, .type_idx = 0, .opts = &lift_opts } },
+    };
+    const exports = [_]ctypes.ExportDecl{
+        .{ .name = "len", .desc = .{ .func = 0 }, .sort_idx = .{ .sort = .func, .idx = 0 } },
+    };
+    const component = ctypes.Component{
+        .core_modules = &core_modules,
+        .core_instances = &core_insts,
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &types,
+        .canons = &canons,
+        .imports = &.{},
+        .exports = &exports,
+    };
+
+    const pcs = [_]instance.PrecompiledCore{
+        .{ .module_idx = 0, .cwasm_bytes = cwasm_bytes },
+    };
+    const inst = try instance.instantiateWithOptions(&component, allocator, .{
+        .precompiled_cores = &pcs,
+    });
+    defer inst.deinit();
+
+    const ef = inst.getExport("len") orelse return error.TestFailed;
+    const local = switch (ef) {
+        .local => |l| l,
+        else => return error.TestFailed,
+    };
+    const args = [_]abi.InterfaceValue{.{ .string = .{ .ptr = 0x100, .len = 42 } }};
+    var results: [1]abi.InterfaceValue = .{.{ .s32 = 0 }};
+    try executor.callComponentFuncByLocal(inst, local, &args, &results, allocator);
+    try std.testing.expectEqual(@as(u32, 42), results[0].u32);
 }


### PR DESCRIPTION
Closes phase B.2 of #650.

## What this does

Mirror of phase B.1 (#652) on the param side. Pre-this-PR the AOT canon-lift fast path's per-param loop only emitted a single core slot per interface arg, so any function whose params flatten to >1 slot — including the very common `string` / `list<u8>` shapes — bailed with `error.AotPathUnsupported`.

* New `lowerFlatRecur` helper writes 1+ flat core slots per param: multi-slot primitives (`s64`/`u64`/`f64`/`string`/`list` = 2 slots each) + the 1-slot scalar/compound shapes already covered by `lowerScalarArg`.
* When total flat-param slots exceed `MAX_FLAT_PARAMS=16` the canon ABI specifies spilling all params to a tuple in linear memory; this PR adds that path: realloc a param tuple, store every arg via `storeInterfaceValue`, pass a single `i32` retptr to the core.
* Symmetric to the spilled-results path landed in #652 — same realloc + memory re-acquire + canon-ABI tuple layout.

## Tests

* New `#650 phase B.2: AOT lowers string param (multi-slot flat)` fixture: a `(i32 i32) -> i32` core that returns its second arg, lifted as `func(s: string) -> u32`. Asserts the `string` length slot round-trips.
* The `#625 phase 3: AOT path rejects unsupported shapes cleanly` regression-canary is rebased onto a `tuple<u32,u32>` param (still unsupported), since `string` is now supported.
* Full `zig build test` locally: 2891/2898 pass, 7 skipped (non-AOT env), 0 failures.

## Out of scope (defer)

Compound aggregate params (records / tuples / payload-bearing variants) flat-lowering still hits `error.AotPathUnsupported`. They can be added by extending `lowerFlatRecur` to recurse on `registry.get(idx)`, mirroring `liftFlatReg`. The spilled-params path (>16 flat slots) handles them today via `storeInterfaceValue`.

Refs: #644, #650, #647, #651, #652.