### PR TITLE
feat(aot): imported-table descriptors through loader (#649 phase 1)

### DIFF
--- a/src/compiler/emit_aot.zig
+++ b/src/compiler/emit_aot.zig
@@ -8,6 +8,7 @@
 //!   [sections...] each: [4 bytes type] [4 bytes size] [payload]
 
 const std = @import("std");
+const types = @import("../runtime/common/types.zig");
 
 /// AOT binary magic number ("\0aot" little-endian).
 pub const aot_magic: u32 = 0x746f6100;
@@ -48,7 +49,10 @@ pub const ImportEntry = struct {
     module_name: []const u8,
     field_name: []const u8,
     kind: ExternalKind,
-    func_type_idx: u32,
+    func_type_idx: u32 = 0,
+    table_elem_type: types.ValType = .funcref,
+    table_min: u32 = 0,
+    table_max: ?u32 = null,
 };
 
 pub const MemoryEntry = struct {
@@ -172,7 +176,9 @@ pub fn emit(
         }
     }
 
-    // Section 8: imports (module_name, field_name, kind, func_type_idx per entry)
+    // Section 8: imports.
+    //   function: module_name, field_name, kind, func_type_idx
+    //   table   : module_name, field_name, kind, elem_type, min, has_max, max?
     if (imports) |import_list| {
         if (import_list.len > 0) {
             var tmp: std.ArrayList(u8) = .empty;
@@ -184,7 +190,20 @@ pub fn emit(
                 try appendU32Le(&tmp, allocator, @intCast(imp.field_name.len));
                 try tmp.appendSlice(allocator, imp.field_name);
                 try tmp.append(allocator, @intFromEnum(imp.kind));
-                try appendU32Le(&tmp, allocator, imp.func_type_idx);
+                switch (imp.kind) {
+                    .function => try appendU32Le(&tmp, allocator, imp.func_type_idx),
+                    .table => {
+                        try tmp.append(allocator, @intFromEnum(imp.table_elem_type));
+                        try appendU32Le(&tmp, allocator, imp.table_min);
+                        if (imp.table_max) |max| {
+                            try tmp.append(allocator, 1);
+                            try appendU32Le(&tmp, allocator, max);
+                        } else {
+                            try tmp.append(allocator, 0);
+                        }
+                    },
+                    else => return error.UnsupportedImportKind,
+                }
             }
             try emitSection(allocator, &buf, 8, tmp.items);
         }
@@ -423,6 +442,7 @@ test "emit: import section round-trip" {
 
     const import_entries = [_]ImportEntry{
         .{ .module_name = "wasi_snapshot_preview1", .field_name = "fd_write", .kind = .function, .func_type_idx = 0 },
+        .{ .module_name = "env", .field_name = "tbl", .kind = .table, .table_elem_type = .funcref, .table_min = 8, .table_max = 8 },
         .{ .module_name = "wasi_snapshot_preview1", .field_name = "clock_time_get", .kind = .function, .func_type_idx = 1 },
     };
     const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, &import_entries, null, null, null, null, null, null);
@@ -432,10 +452,17 @@ test "emit: import section round-trip" {
     defer aot_loader.unload(&module, allocator);
 
     try std.testing.expectEqual(@as(u32, 2), module.import_function_count);
-    try std.testing.expectEqual(@as(usize, 2), module.imports.len);
+    try std.testing.expectEqual(@as(usize, 3), module.imports.len);
     try std.testing.expect(std.mem.eql(u8, module.imports[0].module_name, "wasi_snapshot_preview1"));
     try std.testing.expect(std.mem.eql(u8, module.imports[0].field_name, "fd_write"));
-    try std.testing.expect(std.mem.eql(u8, module.imports[1].field_name, "clock_time_get"));
+    try std.testing.expectEqual(types.ExternalKind.table, module.imports[1].kind);
+    try std.testing.expect(std.mem.eql(u8, module.imports[2].field_name, "clock_time_get"));
+    try std.testing.expectEqual(@as(usize, 1), module.imported_tables.len);
+    try std.testing.expect(std.mem.eql(u8, module.imported_tables[0].module_name, "env"));
+    try std.testing.expect(std.mem.eql(u8, module.imported_tables[0].name, "tbl"));
+    try std.testing.expectEqual(types.ValType.funcref, module.imported_tables[0].elem_type);
+    try std.testing.expectEqual(@as(u32, 8), module.imported_tables[0].min);
+    try std.testing.expectEqual(@as(?u32, 8), module.imported_tables[0].max);
 }
 
 test "emit: memory section round-trip" {
@@ -485,7 +512,6 @@ test "emit: v128 global init payload round-trip" {
 test "emit: type section and function type indices round-trip" {
     const allocator = std.testing.allocator;
     const aot_loader = @import("../runtime/aot/loader.zig");
-    const types = @import("../runtime/common/types.zig");
 
     // Two func types:
     //   type 0: () -> ()

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -387,13 +387,25 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
     var import_entries: std.ArrayList(emit_aot.ImportEntry) = .empty;
     defer import_entries.deinit(allocator);
     for (module.imports) |imp| {
-        if (imp.kind == .function) {
-            try import_entries.append(allocator, .{
+        switch (imp.kind) {
+            .function => try import_entries.append(allocator, .{
                 .module_name = imp.module_name,
                 .field_name = imp.field_name,
                 .kind = .function,
                 .func_type_idx = imp.func_type_idx orelse 0,
-            });
+            }),
+            .table => {
+                const table_type = imp.table_type orelse continue;
+                try import_entries.append(allocator, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .table,
+                    .table_elem_type = table_type.elem_type,
+                    .table_min = @intCast(table_type.limits.min),
+                    .table_max = if (table_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
+                });
+            },
+            .memory, .global, .tag => {},
         }
     }
 

--- a/src/component/aot.zig
+++ b/src/component/aot.zig
@@ -216,13 +216,28 @@ pub fn compileCoreWasm(
 
     var imports: std.ArrayList(emit_aot.ImportEntry) = .empty;
     for (module.imports) |imp| {
-        if (imp.kind == .function) {
-            imports.append(ea, .{
+        switch (imp.kind) {
+            .function => imports.append(ea, .{
                 .module_name = imp.module_name,
                 .field_name = imp.field_name,
                 .kind = .function,
                 .func_type_idx = imp.func_type_idx orelse 0,
-            }) catch return error.OutOfMemory;
+            }) catch return error.OutOfMemory,
+            .table => {
+                const table_type = imp.table_type orelse continue;
+                imports.append(ea, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .table,
+                    .table_elem_type = table_type.elem_type,
+                    .table_min = @intCast(table_type.limits.min),
+                    .table_max = if (table_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
+                }) catch return error.OutOfMemory;
+            },
+            // TODO #649 phase 1.5: emit imported memory/global descriptors once
+            // the loader/runtime can retain and wire them through instantiation.
+            .memory, .global => {},
+            .tag => {},
         }
     }
 

--- a/src/runtime/aot/loader.zig
+++ b/src/runtime/aot/loader.zig
@@ -59,7 +59,16 @@ pub const AotImportDesc = struct {
     module_name: []const u8,
     field_name: []const u8,
     kind: types.ExternalKind,
-    func_type_idx: u32,
+    /// Only meaningful for `.function` imports.
+    func_type_idx: u32 = 0,
+};
+
+pub const ImportedTableDesc = struct {
+    module_name: []const u8,
+    name: []const u8,
+    elem_type: types.ValType,
+    min: u32,
+    max: ?u32,
 };
 
 /// A global initial value parsed from the AOT globals section.
@@ -103,6 +112,7 @@ pub const AotModule = struct {
     exports: []const types.ExportDesc = &.{},
     import_function_count: u32 = 0,
     imports: []const AotImportDesc = &.{},
+    imported_tables: []const ImportedTableDesc = &.{},
     memories: []const types.MemoryType = &.{},
     tables: []const types.TableType = &.{},
     data_segments: []const AotDataSegment = &.{},
@@ -116,6 +126,10 @@ pub const AotModule = struct {
             if (exp.kind == kind and std.mem.eql(u8, exp.name, name)) return exp;
         }
         return null;
+    }
+
+    pub fn importedTables(self: *const AotModule) []const ImportedTableDesc {
+        return self.imported_tables;
     }
 };
 
@@ -267,6 +281,9 @@ pub fn unload(module: *const AotModule, allocator: std.mem.Allocator) void {
     }
     if (module.exports.len > 0) {
         allocator.free(module.exports);
+    }
+    if (module.imported_tables.len > 0) {
+        allocator.free(module.imported_tables);
     }
     if (module.memories.len > 0) {
         allocator.free(module.memories);
@@ -447,6 +464,9 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
     }
 
     var func_count: u32 = 0;
+    var table_descs: std.ArrayList(ImportedTableDesc) = .empty;
+    errdefer table_descs.deinit(allocator);
+
     for (0..count) |i| {
         const mod_name_len = try reader.readU32Le();
         const mod_name_bytes = try reader.readBytes(mod_name_len);
@@ -459,10 +479,32 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
         @memcpy(field_name, field_name_bytes);
 
         const kind_raw = try reader.readByte();
-        const func_type_idx = try reader.readU32Le();
         const kind: types.ExternalKind = @enumFromInt(kind_raw);
+        var func_type_idx: u32 = 0;
 
-        if (kind == .function) func_count += 1;
+        switch (kind) {
+            .function => {
+                func_type_idx = try reader.readU32Le();
+                func_count += 1;
+            },
+            .table => {
+                const elem_type: types.ValType = @enumFromInt(try reader.readByte());
+                const min = try reader.readU32Le();
+                const has_max = try reader.readByte();
+                const max: ?u32 = if (has_max != 0) try reader.readU32Le() else null;
+                table_descs.append(allocator, .{
+                    .module_name = mod_name,
+                    .name = field_name,
+                    .elem_type = elem_type,
+                    .min = min,
+                    .max = max,
+                }) catch return error.OutOfMemory;
+            },
+            .memory, .global, .tag => {
+                // TODO #649 phase 1.5: preserve imported memory/global payloads.
+                _ = try reader.readU32Le();
+            },
+        }
 
         import_descs[i] = .{
             .module_name = mod_name,
@@ -475,6 +517,7 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
 
     module.imports = import_descs;
     module.import_function_count = func_count;
+    module.imported_tables = table_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
 }
 
 fn parseMemorySection(reader: *BinaryReader, section_size: u32, module: *AotModule, allocator: std.mem.Allocator) LoadError!void {

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -2007,6 +2007,8 @@ fn allocateMemories(module: *const aot_loader.AotModule, allocator: std.mem.Allo
 }
 
 fn allocateTables(module: *const aot_loader.AotModule, allocator: std.mem.Allocator) RuntimeError![]*types.TableInstance {
+    // TODO #649 phase 2: prepend borrowed imported table slots from
+    // `module.importedTables()` before allocating local tables.
     if (module.tables.len == 0) return &.{};
 
     const tables = allocator.alloc(*types.TableInstance, module.tables.len) catch return error.OutOfMemory;

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -1078,12 +1078,27 @@ fn compileToAot(
         // Skip tag imports — AOT does not support exception handling, and
         // emit_aot.ExternalKind has no .tag variant.
         if (imp.kind == .tag) continue;
-        try import_entries.append(a, .{
-            .module_name = imp.module_name,
-            .field_name = imp.field_name,
-            .kind = @enumFromInt(@intFromEnum(imp.kind)),
-            .func_type_idx = imp.func_type_idx orelse 0,
-        });
+        switch (imp.kind) {
+            .function => try import_entries.append(a, .{
+                .module_name = imp.module_name,
+                .field_name = imp.field_name,
+                .kind = .function,
+                .func_type_idx = imp.func_type_idx orelse 0,
+            }),
+            .table => {
+                const table_type = imp.table_type orelse continue;
+                try import_entries.append(a, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .table,
+                    .table_elem_type = table_type.elem_type,
+                    .table_min = @intCast(table_type.limits.min),
+                    .table_max = if (table_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
+                });
+            },
+            .memory, .global => {},
+            .tag => unreachable,
+        }
     }
 
     var mem_entries: std.ArrayList(emit_aot.MemoryEntry) = .empty;

--- a/src/tests/component_aot_smoke_test.zig
+++ b/src/tests/component_aot_smoke_test.zig
@@ -14,7 +14,49 @@ const aot_harness = @import("aot_harness.zig");
 const instance = wamr.component_instance;
 const ctypes = wamr.component_types;
 const core_types = wamr.types;
+const aot_loader_mod = wamr.aot_loader;
 const aot_runtime_mod = wamr.aot_runtime;
+
+test "#649 phase 1: AOT loader retains imported table descriptors" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const core_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: () -> ()
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        // import section: (import "env" "tbl" (table 8 8 funcref))
+        0x02, 0x0e,
+        0x01, 0x03, 'e',  'n',  'v',  0x03, 't',  'b',
+        'l',  0x01, 0x70, 0x01, 0x08, 0x08,
+        // function section: 1 local function of type 0
+        0x03, 0x02,
+        0x01, 0x00,
+        // export section: export local func 0 as "run"
+        0x07, 0x07, 0x01, 0x03, 'r',  'u',
+        'n',  0x00, 0x00,
+        // code section: empty body
+        0x0a, 0x04, 0x01, 0x02, 0x00,
+        0x0b,
+    };
+
+    const allocator = std.testing.allocator;
+    const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, &core_wasm);
+    defer allocator.free(cwasm_bytes);
+
+    const module = try aot_loader_mod.load(cwasm_bytes, allocator);
+    defer aot_loader_mod.unload(&module, allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), module.imports.len);
+    try std.testing.expectEqual(core_types.ExternalKind.table, module.imports[0].kind);
+    try std.testing.expectEqual(@as(u32, 0), module.import_function_count);
+    try std.testing.expectEqual(@as(usize, 1), module.importedTables().len);
+    const table = module.importedTables()[0];
+    try std.testing.expect(std.mem.eql(u8, table.module_name, "env"));
+    try std.testing.expect(std.mem.eql(u8, table.name, "tbl"));
+    try std.testing.expectEqual(core_types.ValType.funcref, table.elem_type);
+    try std.testing.expectEqual(@as(u32, 8), table.min);
+    try std.testing.expectEqual(@as(?u32, 8), table.max);
+}
 
 test "#625 phase 1: instantiateWithOptions loads + runs an AOT core" {
     if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
@@ -32,17 +74,15 @@ test "#625 phase 1: instantiateWithOptions loads + runs an AOT core" {
         // function section: 1 fn, type 0
         0x03, 0x02, 0x01, 0x00,
         // memory section: 1 memory, min=1
-        0x05, 0x03, 0x01, 0x00, 0x01,
+        0x05, 0x03, 0x01, 0x00,
+        0x01,
         // export section: "memory" (mem 0), "add42" (func 0)
-        0x07, 0x12, 0x02,
-        0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
-        0x05, 'a', 'd', 'd', '4', '2', 0x00, 0x00,
+        0x07, 0x12, 0x02, 0x06, 'm',  'e',  'm',
+        'o',  'r',  'y',  0x02, 0x00, 0x05, 'a',  'd',
+        'd',  '4',  '2',  0x00, 0x00,
         // code section: local.get 0; i32.const 42; i32.add; end
-        0x0a, 0x09, 0x01, 0x07, 0x00,
-        0x20, 0x00,
-        0x41, 0x2a,
-        0x6a,
-        0x0b,
+        0x0a, 0x09, 0x01,
+        0x07, 0x00, 0x20, 0x00, 0x41, 0x2a, 0x6a, 0x0b,
     };
 
     const allocator = std.testing.allocator;


### PR DESCRIPTION
## Summary
- rescope #649 phase 1 to imported **tables only** for the stdio-echo path
- emit imported table descriptors from the AOT compiler paths and retain them in the AOT loader/module metadata
- add a round-trip test covering a core wasm module with one imported table

## Deferred
- imported memory/global descriptors remain out of scope for this PR and are still skipped
- cross-instance imported-table wiring in the AOT runtime remains follow-up work for phase 2
- executable-memory / mprotect work remains in #648

## Context
- umbrella issue: #644
- builds on the import gating introduced in #647
- this PR provides the parse/plumb step needed before #649 phase 2 can wire borrowed table instances
