### PR TITLE
feat(aot): trampoline pool scaffold (#648 phase 1)

### DIFF
--- a/src/runtime/aot/host_bridge.zig
+++ b/src/runtime/aot/host_bridge.zig
@@ -8,6 +8,11 @@
 const std = @import("std");
 const VmCtx = @import("runtime.zig").VmCtx;
 const wasi_core = @import("../../wasi/wasi_core.zig");
+const host_trampolines = @import("host_trampolines.zig");
+
+pub const TrampolinePool = host_trampolines.TrampolinePool;
+
+var g_trampoline_pool: ?*TrampolinePool = null;
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
@@ -131,6 +136,15 @@ pub fn isSpectestModule(module_name: []const u8) bool {
     return std.mem.eql(u8, module_name, "spectest");
 }
 
+pub fn setTrampolinePool(pool: ?*TrampolinePool) void {
+    g_trampoline_pool = pool;
+    host_trampolines.setActivePool(pool);
+}
+
+pub fn getTrampolinePool() ?*TrampolinePool {
+    return g_trampoline_pool;
+}
+
 /// Resolve a `spectest.*` function name to a no-op AOT adapter. Returns null
 /// for names outside the spec's standard surface (print/print_i32/... etc).
 pub fn resolveAotSpectestFunction(name: []const u8) ?*const anyopaque {
@@ -154,8 +168,8 @@ pub fn resolveAotSpectestFunction(name: []const u8) ?*const anyopaque {
 
 test "resolveAotHostFunction: all known functions resolve" {
     const names = [_][]const u8{
-        "fd_write",      "fd_seek",           "fd_close",
-        "fd_fdstat_get", "fd_prestat_get",    "fd_prestat_dir_name",
+        "fd_write",       "fd_seek",           "fd_close",
+        "fd_fdstat_get",  "fd_prestat_get",    "fd_prestat_dir_name",
         "clock_time_get", "environ_sizes_get", "environ_get",
         "args_sizes_get", "args_get",          "proc_exit",
     };
@@ -213,6 +227,19 @@ test "aotClockTimeGet: returns time" {
     try std.testing.expectEqual(wasi_core.WASI_ESUCCESS, result);
     const nanos = std.mem.readInt(u64, mem[0..8], .little);
     try std.testing.expect(nanos > 0);
+}
+
+test "trampoline pool getter/setter roundtrip" {
+    var pool: TrampolinePool = undefined;
+
+    setTrampolinePool(&pool);
+    try std.testing.expectEqual(&pool, getTrampolinePool().?);
+    setTrampolinePool(null);
+    try std.testing.expect(getTrampolinePool() == null);
+}
+
+test {
+    _ = @import("../../tests/aot_host_trampolines_test.zig");
 }
 
 test "aotEnvironSizesGet: writes zeroes" {

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -1,0 +1,112 @@
+//! AOT host-import trampoline pool scaffold.
+//!
+//! Phase 1 keeps the mapping RW-only and returns stub function pointers; later
+//! phases will write real machine code and flip the mapping executable.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const page_size = std.heap.page_size_min;
+
+pub const STUB_BYTES: usize = 32;
+pub const MAX_SLOTS: u32 = 256;
+
+const StubFn = *const fn () callconv(.c) void;
+
+pub const Slot = struct {
+    component_inst: *anyopaque,
+    canon_lower_idx: u32,
+};
+
+var g_active_pool: ?*TrampolinePool = null;
+
+pub fn setActivePool(pool: ?*TrampolinePool) void {
+    g_active_pool = pool;
+}
+
+pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64) callconv(.c) u64 {
+    _ = a0;
+    _ = a1;
+    _ = a2;
+    _ = a3;
+    _ = a4;
+    _ = a5;
+
+    const pool = g_active_pool orelse return 0;
+    if (slot >= pool.next_slot) return 0;
+
+    const entry = pool.slots[slot];
+    _ = entry.component_inst;
+    _ = entry.canon_lower_idx;
+    return 0;
+}
+
+pub const TrampolinePool = struct {
+    memory: []align(page_size) u8,
+    slots: []Slot,
+    next_slot: u32 = 0,
+
+    pub fn init(allocator: std.mem.Allocator) !TrampolinePool {
+        if (builtin.os.tag == .windows) return error.UnsupportedPlatform;
+
+        const slots = try allocator.alloc(Slot, MAX_SLOTS);
+        errdefer allocator.free(slots);
+
+        const map_len = std.mem.alignForward(usize, @as(usize, MAX_SLOTS) * STUB_BYTES, page_size);
+        const memory = try std.posix.mmap(
+            null,
+            map_len,
+            .{ .READ = true, .WRITE = true },
+            .{ .TYPE = .PRIVATE, .ANONYMOUS = true },
+            -1,
+            0,
+        );
+        @memset(memory, 0);
+
+        return .{
+            .memory = memory,
+            .slots = slots,
+        };
+    }
+
+    pub fn allocSlot(self: *TrampolinePool, component_inst: *anyopaque, canon_lower_idx: u32) !StubFn {
+        const slot = self.next_slot;
+        if (slot >= MAX_SLOTS) return error.OutOfTrampolineSlots;
+
+        self.slots[slot] = .{
+            .component_inst = component_inst,
+            .canon_lower_idx = canon_lower_idx,
+        };
+        self.next_slot += 1;
+        writeStub(self.stubBytes(slot));
+        g_active_pool = self;
+
+        return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
+    }
+
+    pub fn deinit(self: *TrampolinePool, allocator: std.mem.Allocator) void {
+        if (g_active_pool == self) g_active_pool = null;
+        std.posix.munmap(self.memory);
+        allocator.free(self.slots);
+        self.* = undefined;
+    }
+
+    fn stubPtr(self: *TrampolinePool, slot: u32) [*]u8 {
+        return self.memory.ptr + (@as(usize, slot) * STUB_BYTES);
+    }
+
+    fn stubBytes(self: *TrampolinePool, slot: u32) []u8 {
+        const start = @as(usize, slot) * STUB_BYTES;
+        return self.memory[start .. start + STUB_BYTES];
+    }
+};
+
+fn writeStub(bytes: []u8) void {
+    @memset(bytes, 0);
+    const head = switch (builtin.cpu.arch) {
+        .x86_64 => &[_]u8{0xC3},
+        .aarch64 => &[_]u8{ 0xC0, 0x03, 0x5F, 0xD6 },
+        else => &[_]u8{0x00},
+    };
+    @memcpy(bytes[0..head.len], head);
+}

--- a/src/tests/aot_host_trampolines_test.zig
+++ b/src/tests/aot_host_trampolines_test.zig
@@ -81,5 +81,11 @@ test "#648 phase 1: trampoline pool allocates mmap-backed stub slots" {
 
     host_trampolines.setActivePool(null);
     pool.deinit(allocator);
-    try std.testing.expect(!(try linuxMappingContainsAddress(allocator, base_addr)));
+    // The post-munmap "is the address still mapped?" check only works on
+    // Linux because it parses /proc/self/maps. On non-Linux we trust that
+    // pool.deinit calls munmap and skip the assertion (the deinit itself
+    // would crash if mmap state were corrupt).
+    if (builtin.os.tag == .linux) {
+        try std.testing.expect(!(try linuxMappingContainsAddress(allocator, base_addr)));
+    }
 }

--- a/src/tests/aot_host_trampolines_test.zig
+++ b/src/tests/aot_host_trampolines_test.zig
@@ -1,0 +1,85 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const host_trampolines = @import("../runtime/aot/host_trampolines.zig");
+
+fn linuxMappingContainsAddress(allocator: std.mem.Allocator, addr: usize) !bool {
+    if (builtin.os.tag != .linux) return true;
+
+    const fd = try std.posix.openat(std.posix.AT.FDCWD, "/proc/self/maps", .{}, 0);
+    defer _ = std.posix.system.close(fd);
+
+    const contents = try allocator.alloc(u8, 1 << 20);
+    defer allocator.free(contents);
+
+    var total: usize = 0;
+    while (total < contents.len) {
+        const amt = try std.posix.read(fd, contents[total..]);
+        if (amt == 0) break;
+        total += amt;
+    }
+
+    var lines = std.mem.tokenizeScalar(u8, contents[0..total], '\n');
+    while (lines.next()) |line| {
+        var fields = std.mem.tokenizeScalar(u8, line, ' ');
+        const range = fields.next() orelse continue;
+        const dash = std.mem.indexOfScalar(u8, range, '-') orelse continue;
+        const start = std.fmt.parseUnsigned(usize, range[0..dash], 16) catch continue;
+        const end = std.fmt.parseUnsigned(usize, range[dash + 1 ..], 16) catch continue;
+        if (addr >= start and addr < end) return true;
+    }
+
+    return false;
+}
+
+test "#648 phase 1: trampoline pool allocates mmap-backed stub slots" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    var pool = try host_trampolines.TrampolinePool.init(allocator);
+
+    const base_addr = @intFromPtr(pool.memory.ptr);
+    try std.testing.expectEqual(@as(usize, 0), base_addr & (std.heap.page_size_min - 1));
+    try std.testing.expect(try linuxMappingContainsAddress(allocator, base_addr));
+
+    var fake_component_0: usize = 0x10;
+    var fake_component_1: usize = 0x20;
+    var fake_component_2: usize = 0x30;
+    var fake_component_3: usize = 0x40;
+
+    const stub0 = try pool.allocSlot(@ptrCast(&fake_component_0), 11);
+    const stub1 = try pool.allocSlot(@ptrCast(&fake_component_1), 22);
+    const stub2 = try pool.allocSlot(@ptrCast(&fake_component_2), 33);
+    const stub3 = try pool.allocSlot(@ptrCast(&fake_component_3), 44);
+
+    host_trampolines.setActivePool(&pool);
+    defer host_trampolines.setActivePool(null);
+
+    const addrs = [_]usize{
+        @intFromPtr(stub0),
+        @intFromPtr(stub1),
+        @intFromPtr(stub2),
+        @intFromPtr(stub3),
+    };
+    inline for (0..addrs.len) |i| {
+        inline for (i + 1..addrs.len) |j| {
+            try std.testing.expect(addrs[i] != addrs[j]);
+        }
+    }
+
+    for (addrs, 0..) |addr, i| {
+        try std.testing.expect(addr >= base_addr);
+        try std.testing.expect(addr < base_addr + pool.memory.len);
+        try std.testing.expectEqual(@as(usize, i) * host_trampolines.STUB_BYTES, addr - base_addr);
+        const byte: *const u8 = @ptrFromInt(addr);
+        _ = byte.*;
+    }
+
+    try std.testing.expectEqual(@as(u32, 4), pool.next_slot);
+    try std.testing.expectEqual(@as(u32, 22), pool.slots[1].canon_lower_idx);
+    try std.testing.expectEqual(@intFromPtr(&fake_component_2), @intFromPtr(pool.slots[2].component_inst));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(3, 1, 2, 3, 4, 5, 6));
+
+    host_trampolines.setActivePool(null);
+    pool.deinit(allocator);
+    try std.testing.expect(!(try linuxMappingContainsAddress(allocator, base_addr)));
+}


### PR DESCRIPTION
## Summary
- add src/runtime/aot/host_trampolines.zig with an RW-only TrampolinePool, slot metadata, stub slot allocation, and a phase-1 genericDispatcher
- expose setTrampolinePool / getTrampolinePool from src/runtime/aot/host_bridge.zig without changing existing AOT-vs-interp import resolution behavior
- cover slot allocation, direct dispatcher calls, readable mapped stubs, and munmap teardown with a focused trampoline test under src/tests/

## Deferred to later phases
- platform-specific trampoline asm emission
- switching the stub pages to PROT_EXEC / mprotect
- wiring firstUnsupportedAotImport to consult the pool
- calling the real componentTrampoline path from genericDispatcher

Refs #644
Follow-up context: #647, #648
