### PR TITLE
feat(aot): trampoline dispatcher → componentTrampoline (#648 phase 3)

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -19,6 +19,7 @@ const HostTrapInfo = @import("../runtime/common/exec_env.zig").HostTrapInfo;
 const interp = @import("../runtime/interpreter/interp.zig");
 const indexspace = @import("indexspace.zig");
 const aot_runtime = @import("../runtime/aot/runtime.zig");
+const host_trampolines = @import("../runtime/aot/host_trampolines.zig");
 const core_backend = @import("core_backend.zig");
 const debugAotEnabled = core_backend.debugAotEnabled;
 const Allocator = std.mem.Allocator;
@@ -5888,6 +5889,10 @@ pub const ComponentTrampolineCtx = struct {
     param_types: []const ctypes.ValType,
     /// Component-level result types, same rationale.
     result_types: []const ctypes.ValType,
+    /// Optional component-level dispatch target used by the AOT host-import
+    /// trampoline pool, which has no ExecEnv and therefore calls straight into
+    /// `callComponentFuncByLocal` instead of the host-func path.
+    lift_target: ?ComponentInstance.ExportedFunc.Local = null,
     lower_opts: LowerOptions,
 
     /// Per-trampoline extension to the component's type indexspace, used
@@ -6185,6 +6190,166 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
             };
         }
     }
+}
+
+pub export fn wamrAotDispatchComponentTrampoline(
+    ctx_opaque: *anyopaque,
+    lowered_sig: *const host_trampolines.LoweredSig,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+) callconv(.c) host_trampolines.DispatchResult {
+    const ctx: *const ComponentTrampolineCtx = @ptrCast(@alignCast(ctx_opaque));
+    const result = dispatchAotComponentTrampoline(ctx, lowered_sig.*, .{ a0, a1, a2, a3, a4, a5 }) catch |err| {
+        if (debugAotEnabled()) {
+            std.debug.print(
+                "[aot-dispatch] canon.lower trampoline failed: {s}\n",
+                .{@errorName(err)},
+            );
+        }
+        return .{ .status = 1, .value = 0 };
+    };
+    return .{ .status = 0, .value = result };
+}
+
+fn dispatchAotComponentTrampoline(
+    ctx: *const ComponentTrampolineCtx,
+    lowered_sig: host_trampolines.LoweredSig,
+    regs: [6]u64,
+) !u64 {
+    if (ctx.lower_opts.is_async or ctx.is_async_func) return error.UnsupportedSignature;
+    if (lowered_sig.param_types.len + @intFromBool(lowered_sig.has_retptr) > regs.len)
+        return error.UnsupportedSignature;
+    if (lowered_sig.has_retptr and lowered_sig.result_types.len != 0)
+        return error.UnsupportedSignature;
+
+    const allocator = ctx.comp_inst.allocator;
+    const registry = if (ctx.extended_types.len > 0)
+        TypeRegistry.fromExtended(ctx.comp_inst.component, ctx.extended_types, ctx.extended_indexspace)
+    else
+        TypeRegistry.init(ctx.comp_inst.component);
+
+    if (countFlatTypes(registry, ctx.param_types) > MAX_FLAT_PARAMS) return error.UnsupportedSignature;
+
+    var args_stack_buf: [8]InterfaceValue = undefined;
+    const args_heap: ?[]InterfaceValue = if (ctx.param_types.len <= args_stack_buf.len)
+        null
+    else
+        try allocator.alloc(InterfaceValue, ctx.param_types.len);
+    defer if (args_heap) |h| allocator.free(h);
+    const args: []InterfaceValue = args_heap orelse args_stack_buf[0..ctx.param_types.len];
+
+    var reg_index: usize = 0;
+    for (ctx.param_types, 0..) |pt, i| {
+        args[i] = try liftAotDispatcherArg(pt, lowered_sig.param_types, &reg_index, &regs, registry, allocator);
+    }
+
+    var result_dest_ptr: u32 = 0;
+    if (lowered_sig.has_retptr) {
+        if (reg_index >= regs.len) return error.UnsupportedSignature;
+        result_dest_ptr = @truncate(regs[reg_index]);
+        reg_index += 1;
+    }
+    if (reg_index != lowered_sig.param_types.len + @intFromBool(lowered_sig.has_retptr))
+        return error.UnsupportedSignature;
+
+    var results_stack_buf: [4]InterfaceValue = undefined;
+    const results_heap: ?[]InterfaceValue = if (ctx.result_types.len <= results_stack_buf.len)
+        null
+    else
+        try allocator.alloc(InterfaceValue, ctx.result_types.len);
+    const results: []InterfaceValue = results_heap orelse results_stack_buf[0..ctx.result_types.len];
+    defer {
+        for (results) |r| r.deinit(allocator);
+        if (results_heap) |h| allocator.free(h);
+    }
+
+    if (ctx.lift_target) |target| {
+        try callComponentFuncByLocal(ctx.comp_inst, target, args, results, allocator);
+    } else {
+        const call = ctx.host_func.call orelse return error.HostFuncNotBound;
+        try call(ctx.host_func.context, ctx.comp_inst, args, results, allocator);
+    }
+
+    if (lowered_sig.has_retptr) {
+        const mem_idx = ctx.lower_opts.memory_idx orelse return error.MemoryNotAvailable;
+        const mem = ctx.comp_inst.resolveTopLevelMemory(mem_idx) orelse return error.MemoryNotAvailable;
+        var offset: u32 = result_dest_ptr;
+        for (results, ctx.result_types) |r, t| {
+            const al = typeAlign(registry, t);
+            offset = abi.alignUp(offset, al);
+            storeInterfaceValue(mem.data, offset, r, t, registry);
+            offset += typeSize(registry, t);
+        }
+        return 0;
+    }
+
+    if (ctx.result_types.len == 0) {
+        if (lowered_sig.result_types.len != 0) return error.UnsupportedSignature;
+        return 0;
+    }
+    if (ctx.result_types.len != 1 or lowered_sig.result_types.len != 1)
+        return error.UnsupportedSignature;
+    return lowerAotDispatcherResult(results[0], ctx.result_types[0], lowered_sig.result_types[0], registry);
+}
+
+fn liftAotDispatcherArg(
+    t: ctypes.ValType,
+    lowered_param_types: []const core_types.ValType,
+    reg_index: *usize,
+    regs: *const [6]u64,
+    registry: TypeRegistry,
+    allocator: Allocator,
+) !InterfaceValue {
+    switch (t) {
+        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .char, .own, .borrow, .future, .stream, .error_context, .enum_ => {
+            if (reg_index.* >= lowered_param_types.len or lowered_param_types[reg_index.*] != .i32)
+                return error.UnsupportedSignature;
+            const slots = [_]u32{@truncate(regs[reg_index.*])};
+            reg_index.* += 1;
+            return abi.liftFlatReg(slots[0..], t, registry, allocator);
+        },
+        .s64, .u64 => {
+            if (reg_index.* >= lowered_param_types.len or lowered_param_types[reg_index.*] != .i64)
+                return error.UnsupportedSignature;
+            const raw = regs[reg_index.*];
+            const slots = [_]u32{ @truncate(raw), @truncate(raw >> 32) };
+            reg_index.* += 1;
+            return abi.liftFlatReg(slots[0..], t, registry, allocator);
+        },
+        .string, .list => {
+            if (reg_index.* + 1 >= lowered_param_types.len or
+                lowered_param_types[reg_index.*] != .i32 or
+                lowered_param_types[reg_index.* + 1] != .i32)
+                return error.UnsupportedSignature;
+            const slots = [_]u32{
+                @truncate(regs[reg_index.*]),
+                @truncate(regs[reg_index.* + 1]),
+            };
+            reg_index.* += 2;
+            return abi.liftFlatReg(slots[0..], t, registry, allocator);
+        },
+        else => return error.UnsupportedSignature,
+    }
+}
+
+fn lowerAotDispatcherResult(
+    val: InterfaceValue,
+    t: ctypes.ValType,
+    lowered_ty: core_types.ValType,
+    registry: TypeRegistry,
+) !u64 {
+    if (lowered_ty == .f32 or lowered_ty == .f64) return error.UnsupportedSignature;
+    const lowered = try lowerScalarArg(val, t, registry);
+    if (lowered.ty != lowered_ty) return error.UnsupportedSignature;
+    return switch (lowered.ty) {
+        .i32 => @as(u64, @intCast(@as(u32, @bitCast(lowered.value.i32)))),
+        .i64 => @as(u64, @bitCast(lowered.value.i64)),
+        else => error.UnsupportedSignature,
+    };
 }
 
 /// Async-lower (`canon.lower (async)`) status-word encoding (#551). Given

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const core_types = @import("../common/types.zig");
 
 const page_size = std.heap.page_size_min;
 
@@ -13,9 +14,37 @@ pub const MAX_SLOTS: u32 = 256;
 
 const StubFn = *const fn () callconv(.c) void;
 
+pub const LoweredSig = struct {
+    param_types: []const core_types.ValType,
+    result_types: []const core_types.ValType,
+    has_retptr: bool = false,
+};
+
+pub const DispatchResult = extern struct {
+    status: u32,
+    value: u64,
+};
+
+extern fn wamrAotDispatchComponentTrampoline(
+    ctx_opaque: *anyopaque,
+    lowered_sig: *const LoweredSig,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+) callconv(.c) DispatchResult;
+
 pub const Slot = struct {
     component_inst: *anyopaque,
     canon_lower_idx: u32,
+    ctx: ?*anyopaque = null,
+    lowered_sig: LoweredSig = .{
+        .param_types = &.{},
+        .result_types = &.{},
+        .has_retptr = false,
+    },
 };
 
 var g_active_pool: ?*TrampolinePool = null;
@@ -25,20 +54,14 @@ pub fn setActivePool(pool: ?*TrampolinePool) void {
 }
 
 pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64) callconv(.c) u64 {
-    _ = a0;
-    _ = a1;
-    _ = a2;
-    _ = a3;
-    _ = a4;
-    _ = a5;
-
     const pool = g_active_pool orelse return 0;
     if (slot >= pool.next_slot) return 0;
 
     const entry = pool.slots[slot];
-    _ = entry.component_inst;
-    _ = entry.canon_lower_idx;
-    return 0;
+    const ctx = entry.ctx orelse return 0;
+    const dispatched = wamrAotDispatchComponentTrampoline(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5);
+    if (dispatched.status != 0) return 0;
+    return dispatched.value;
 }
 
 pub const TrampolinePool = struct {
@@ -67,6 +90,23 @@ pub const TrampolinePool = struct {
             .memory = memory,
             .slots = slots,
         };
+    }
+
+    pub fn allocSlotWithCtx(self: *TrampolinePool, ctx: *anyopaque, lowered_sig: LoweredSig) !StubFn {
+        const slot = self.next_slot;
+        if (slot >= MAX_SLOTS) return error.OutOfTrampolineSlots;
+
+        self.slots[slot] = .{
+            .component_inst = ctx,
+            .canon_lower_idx = 0,
+            .ctx = ctx,
+            .lowered_sig = lowered_sig,
+        };
+        self.next_slot += 1;
+        writeStub(self.stubBytes(slot));
+        g_active_pool = self;
+
+        return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
     }
 
     pub fn allocSlot(self: *TrampolinePool, component_inst: *anyopaque, canon_lower_idx: u32) !StubFn {

--- a/src/tests/aot_host_trampolines_test.zig
+++ b/src/tests/aot_host_trampolines_test.zig
@@ -1,6 +1,32 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const host_trampolines = @import("../runtime/aot/host_trampolines.zig");
+const executor = @import("../component/executor.zig");
+const instance = @import("../component/instance.zig");
+const ctypes = @import("../component/types.zig");
+const core_types = @import("../runtime/common/types.zig");
+
+const memory_core_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d,
+    0x01, 0x00, 0x00, 0x00,
+    0x05, 0x03, 0x01, 0x00,
+    0x01,
+};
+const empty_core_inst_args = [_]ctypes.CoreInstantiateArg{};
+const memory_core_modules = [_]ctypes.CoreModule{.{ .data = &memory_core_wasm }};
+const memory_core_insts = [_]ctypes.CoreInstanceExpr{.{ .instantiate = .{ .module_idx = 0, .args = &empty_core_inst_args } }};
+const memory_component = ctypes.Component{
+    .core_modules = &memory_core_modules,
+    .core_instances = &memory_core_insts,
+    .core_types = &.{},
+    .components = &.{},
+    .instances = &.{},
+    .aliases = &.{},
+    .types = &.{},
+    .canons = &.{},
+    .imports = &.{},
+    .exports = &.{},
+};
 
 fn linuxMappingContainsAddress(allocator: std.mem.Allocator, addr: usize) !bool {
     if (builtin.os.tag != .linux) return true;
@@ -29,6 +55,15 @@ fn linuxMappingContainsAddress(allocator: std.mem.Allocator, addr: usize) !bool 
     }
 
     return false;
+}
+
+fn instantiateMemoryComponent() !*instance.ComponentInstance {
+    return instance.instantiate(&memory_component, std.testing.allocator);
+}
+
+fn expectStoredPtrLen(mem: []const u8, offset: u32, expected_ptr: u32, expected_len: u32) !void {
+    try std.testing.expectEqual(expected_ptr, std.mem.readInt(u32, mem[offset..][0..4], .little));
+    try std.testing.expectEqual(expected_len, std.mem.readInt(u32, mem[offset + 4 ..][0..4], .little));
 }
 
 test "#648 phase 1: trampoline pool allocates mmap-backed stub slots" {
@@ -81,11 +116,211 @@ test "#648 phase 1: trampoline pool allocates mmap-backed stub slots" {
 
     host_trampolines.setActivePool(null);
     pool.deinit(allocator);
-    // The post-munmap "is the address still mapped?" check only works on
-    // Linux because it parses /proc/self/maps. On non-Linux we trust that
-    // pool.deinit calls munmap and skip the assertion (the deinit itself
-    // would crash if mmap state were corrupt).
     if (builtin.os.tag == .linux) {
         try std.testing.expect(!(try linuxMappingContainsAddress(allocator, base_addr)));
     }
+}
+
+test "#648 phase 3: genericDispatcher handles (i32) -> ()" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const Host = struct {
+        const State = struct { called: bool = false, arg: i32 = 0 };
+
+        fn drop(ctx: ?*anyopaque, _: *instance.ComponentInstance, args: []const instance.InterfaceValue, results: []instance.InterfaceValue, _: std.mem.Allocator) !void {
+            const state: *State = @ptrCast(@alignCast(ctx.?));
+            try std.testing.expectEqual(@as(usize, 1), args.len);
+            try std.testing.expectEqual(@as(usize, 0), results.len);
+            state.called = true;
+            state.arg = args[0].s32;
+        }
+    };
+
+    const inst = try instantiateMemoryComponent();
+    defer inst.deinit();
+    var pool = try host_trampolines.TrampolinePool.init(std.testing.allocator);
+    defer pool.deinit(std.testing.allocator);
+
+    var state = Host.State{};
+    const param_types = [_]ctypes.ValType{.s32};
+    const result_types = [_]ctypes.ValType{};
+    var ctx = executor.ComponentTrampolineCtx{
+        .comp_inst = inst,
+        .host_func = .{ .context = @ptrCast(&state), .call = &Host.drop },
+        .param_types = &param_types,
+        .result_types = &result_types,
+        .lower_opts = .{},
+    };
+    const lowered_params = [_]core_types.ValType{.i32};
+    const lowered_results = [_]core_types.ValType{};
+    _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
+
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 41, 0, 0, 0, 0, 0));
+    try std.testing.expect(state.called);
+    try std.testing.expectEqual(@as(i32, 41), state.arg);
+}
+
+test "#648 phase 3: genericDispatcher handles () -> i32" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const Host = struct {
+        fn get(_: ?*anyopaque, _: *instance.ComponentInstance, args: []const instance.InterfaceValue, results: []instance.InterfaceValue, _: std.mem.Allocator) !void {
+            try std.testing.expectEqual(@as(usize, 0), args.len);
+            try std.testing.expectEqual(@as(usize, 1), results.len);
+            results[0] = .{ .s32 = 77 };
+        }
+    };
+
+    const inst = try instantiateMemoryComponent();
+    defer inst.deinit();
+    var pool = try host_trampolines.TrampolinePool.init(std.testing.allocator);
+    defer pool.deinit(std.testing.allocator);
+
+    const param_types = [_]ctypes.ValType{};
+    const result_types = [_]ctypes.ValType{.s32};
+    var ctx = executor.ComponentTrampolineCtx{
+        .comp_inst = inst,
+        .host_func = .{ .call = &Host.get },
+        .param_types = &param_types,
+        .result_types = &result_types,
+        .lower_opts = .{},
+    };
+    const lowered_params = [_]core_types.ValType{};
+    const lowered_results = [_]core_types.ValType{.i32};
+    _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
+
+    try std.testing.expectEqual(@as(u64, 77), host_trampolines.genericDispatcher(0, 0, 0, 0, 0, 0, 0));
+}
+
+test "#648 phase 3: genericDispatcher handles (i32) -> i32" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const Host = struct {
+        fn subscribe(_: ?*anyopaque, _: *instance.ComponentInstance, args: []const instance.InterfaceValue, results: []instance.InterfaceValue, _: std.mem.Allocator) !void {
+            try std.testing.expectEqual(@as(i32, 12), args[0].s32);
+            results[0] = .{ .s32 = args[0].s32 + 5 };
+        }
+    };
+
+    const inst = try instantiateMemoryComponent();
+    defer inst.deinit();
+    var pool = try host_trampolines.TrampolinePool.init(std.testing.allocator);
+    defer pool.deinit(std.testing.allocator);
+
+    const param_types = [_]ctypes.ValType{.s32};
+    const result_types = [_]ctypes.ValType{.s32};
+    var ctx = executor.ComponentTrampolineCtx{
+        .comp_inst = inst,
+        .host_func = .{ .call = &Host.subscribe },
+        .param_types = &param_types,
+        .result_types = &result_types,
+        .lower_opts = .{},
+    };
+    const lowered_params = [_]core_types.ValType{.i32};
+    const lowered_results = [_]core_types.ValType{.i32};
+    _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
+
+    try std.testing.expectEqual(@as(u64, 17), host_trampolines.genericDispatcher(0, 12, 0, 0, 0, 0, 0));
+}
+
+test "#648 phase 3: genericDispatcher handles (i32 i32) -> () retptr" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const Host = struct {
+        fn checkWrite(_: ?*anyopaque, _: *instance.ComponentInstance, args: []const instance.InterfaceValue, results: []instance.InterfaceValue, _: std.mem.Allocator) !void {
+            try std.testing.expectEqual(@as(i32, 9), args[0].s32);
+            results[0] = .{ .string = .{ .ptr = 0x55, .len = 7 } };
+        }
+    };
+
+    const inst = try instantiateMemoryComponent();
+    defer inst.deinit();
+    var pool = try host_trampolines.TrampolinePool.init(std.testing.allocator);
+    defer pool.deinit(std.testing.allocator);
+
+    const param_types = [_]ctypes.ValType{.s32};
+    const result_types = [_]ctypes.ValType{.string};
+    var ctx = executor.ComponentTrampolineCtx{
+        .comp_inst = inst,
+        .host_func = .{ .call = &Host.checkWrite },
+        .param_types = &param_types,
+        .result_types = &result_types,
+        .lower_opts = .{ .memory_idx = 0 },
+    };
+    const lowered_params = [_]core_types.ValType{.i32};
+    _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &.{}, .has_retptr = true });
+
+    const retptr: u32 = 24;
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 9, retptr, 0, 0, 0, 0));
+    const mem = inst.resolveTopLevelMemory(0).?.data;
+    try expectStoredPtrLen(mem, retptr, 0x55, 7);
+}
+
+test "#648 phase 3: genericDispatcher handles (i32 i32 i32 i32) -> ()" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const Host = struct {
+        fn write(_: ?*anyopaque, _: *instance.ComponentInstance, args: []const instance.InterfaceValue, results: []instance.InterfaceValue, _: std.mem.Allocator) !void {
+            try std.testing.expectEqual(@as(i32, 3), args[0].s32);
+            try std.testing.expectEqual(@as(u32, 0x40), args[1].list.ptr);
+            try std.testing.expectEqual(@as(u32, 5), args[1].list.len);
+            results[0] = .{ .string = .{ .ptr = 0x80, .len = 5 } };
+        }
+    };
+
+    const inst = try instantiateMemoryComponent();
+    defer inst.deinit();
+    var pool = try host_trampolines.TrampolinePool.init(std.testing.allocator);
+    defer pool.deinit(std.testing.allocator);
+
+    const param_types = [_]ctypes.ValType{ .s32, .{ .list = 0 } };
+    const result_types = [_]ctypes.ValType{.string};
+    var ctx = executor.ComponentTrampolineCtx{
+        .comp_inst = inst,
+        .host_func = .{ .call = &Host.write },
+        .param_types = &param_types,
+        .result_types = &result_types,
+        .lower_opts = .{ .memory_idx = 0 },
+    };
+    const lowered_params = [_]core_types.ValType{ .i32, .i32, .i32 };
+    _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &.{}, .has_retptr = true });
+
+    const retptr: u32 = 40;
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 3, 0x40, 5, retptr, 0, 0));
+    const mem = inst.resolveTopLevelMemory(0).?.data;
+    try expectStoredPtrLen(mem, retptr, 0x80, 5);
+}
+
+test "#648 phase 3: genericDispatcher handles (i32 i64 i32) -> ()" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const Host = struct {
+        fn blockingRead(_: ?*anyopaque, _: *instance.ComponentInstance, args: []const instance.InterfaceValue, results: []instance.InterfaceValue, _: std.mem.Allocator) !void {
+            try std.testing.expectEqual(@as(i32, 4), args[0].s32);
+            try std.testing.expectEqual(@as(u64, 0x1_0000_0002), args[1].u64);
+            results[0] = .{ .string = .{ .ptr = 0x90, .len = 2 } };
+        }
+    };
+
+    const inst = try instantiateMemoryComponent();
+    defer inst.deinit();
+    var pool = try host_trampolines.TrampolinePool.init(std.testing.allocator);
+    defer pool.deinit(std.testing.allocator);
+
+    const param_types = [_]ctypes.ValType{ .s32, .u64 };
+    const result_types = [_]ctypes.ValType{.string};
+    var ctx = executor.ComponentTrampolineCtx{
+        .comp_inst = inst,
+        .host_func = .{ .call = &Host.blockingRead },
+        .param_types = &param_types,
+        .result_types = &result_types,
+        .lower_opts = .{ .memory_idx = 0 },
+    };
+    const lowered_params = [_]core_types.ValType{ .i32, .i64 };
+    _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &.{}, .has_retptr = true });
+
+    const retptr: u32 = 56;
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 4, 0x1_0000_0002, retptr, 0, 0, 0));
+    const mem = inst.resolveTopLevelMemory(0).?.data;
+    try expectStoredPtrLen(mem, retptr, 0x90, 2);
 }


### PR DESCRIPTION
## Summary
- add `allocSlotWithCtx` + lowered-signature metadata to AOT host trampoline slots
- wire `genericDispatcher` into canon-lower lifting / result-lowering logic for integer-only flat args and retptr writes
- add direct dispatcher tests for the 6 stdio-echo signature shapes

## Deferred
- real asm stubs + RWX / `mprotect` work remains in #648 phase 2
- floating-point args/results are still unsupported
- async canon.lower targets are still unsupported
- memory-spilled params (>16 flat slots) are still unsupported

Refs #644
Refs #648