### PR TITLE
AOT cross-instance memory + global wiring (closes #649)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [zig, main]
   pull_request:
     branches: [zig, main]
+  workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -14,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: [self-hosted, Linux, X64]
             name: linux-x64
             shell: bash
-          - os: ubuntu-22.04-arm
+          - os: [self-hosted, Linux, ARM64]
             name: linux-arm64
             shell: bash
           - os: macos-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,6 @@ jobs:
         continue-on-error: true
         run: zig build -Doptimize=ReleaseSafe
 
-      - name: Build (wasm32-wasi cross-compile)
-        continue-on-error: true
-        run: zig build -Doptimize=ReleaseSafe -Dtarget=wasm32-wasi -Dstrip=true
-
       - name: Spec tests (JSON)
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
           - os: [self-hosted, Linux, ARM64]
             name: linux-arm64
             shell: bash
-          - os: macos-14
-            name: macos-arm64
-            shell: bash
           - os: windows-latest
             name: windows-x64
             shell: pwsh

--- a/scripts/bench_coldstart.py
+++ b/scripts/bench_coldstart.py
@@ -652,7 +652,17 @@ def main() -> int:
                 file=sys.stderr,
             )
 
-    tmp_root = Path("/work") if Path("/work").is_dir() else None
+    # Prefer the runner's own scratch dir (writable, already on the NVMe mount
+    # under self-hosted runners). Fall back to /work only if writable — the
+    # azure-nvme convention places /work on local disk but the runner user
+    # may not own its root. Otherwise let tempfile pick the system default.
+    runner_temp = os.environ.get("RUNNER_TEMP")
+    if runner_temp and os.access(runner_temp, os.W_OK):
+        tmp_root: str | None = runner_temp
+    elif os.access("/work", os.W_OK):
+        tmp_root = "/work"
+    else:
+        tmp_root = None
     with tempfile.TemporaryDirectory(prefix="bench-coldstart-", dir=tmp_root) as tmp:
         root = Path(tmp)
         try:

--- a/scripts/bench_coremark.py
+++ b/scripts/bench_coremark.py
@@ -245,7 +245,18 @@ def main() -> int:
     ensure_coremark_src(repo)
     coremark_src = repo / "tests/benchmarks/coremark/coremark"
 
-    with tempfile.TemporaryDirectory(prefix="bench-coremark-", dir="/work" if Path("/work").is_dir() else None) as tmp:
+    # Prefer the runner's own scratch dir (writable, already on the NVMe mount
+    # under self-hosted runners). Fall back to /work only if writable — the
+    # azure-nvme convention places /work on local disk but the runner user
+    # may not own its root. Otherwise let tempfile pick the system default.
+    runner_temp = os.environ.get("RUNNER_TEMP")
+    if runner_temp and os.access(runner_temp, os.W_OK):
+        tmp_root: str | None = runner_temp
+    elif os.access("/work", os.W_OK):
+        tmp_root = "/work"
+    else:
+        tmp_root = None
+    with tempfile.TemporaryDirectory(prefix="bench-coremark-", dir=tmp_root) as tmp:
         root = Path(tmp)
         try:
             wt_b = make_worktree(repo, args.baseline, root)

--- a/src/compiler/emit_aot.zig
+++ b/src/compiler/emit_aot.zig
@@ -56,6 +56,8 @@ pub const ImportEntry = struct {
     memory_min: u32 = 0,
     memory_max: ?u32 = null,
     memory_is64: bool = false,
+    global_val_type: types.ValType = .i32,
+    global_mutable: bool = false,
 };
 
 pub const MemoryEntry = struct {
@@ -215,7 +217,10 @@ pub fn emit(
                         }
                         try tmp.append(allocator, if (imp.memory_is64) 1 else 0);
                     },
-                    else => return error.UnsupportedImportKind,
+                    .global => {
+                        try tmp.append(allocator, @intFromEnum(imp.global_val_type));
+                        try tmp.append(allocator, if (imp.global_mutable) 1 else 0);
+                    },
                 }
             }
             try emitSection(allocator, &buf, 8, tmp.items);

--- a/src/compiler/emit_aot.zig
+++ b/src/compiler/emit_aot.zig
@@ -53,6 +53,9 @@ pub const ImportEntry = struct {
     table_elem_type: types.ValType = .funcref,
     table_min: u32 = 0,
     table_max: ?u32 = null,
+    memory_min: u32 = 0,
+    memory_max: ?u32 = null,
+    memory_is64: bool = false,
 };
 
 pub const MemoryEntry = struct {
@@ -201,6 +204,16 @@ pub fn emit(
                         } else {
                             try tmp.append(allocator, 0);
                         }
+                    },
+                    .memory => {
+                        try appendU32Le(&tmp, allocator, imp.memory_min);
+                        if (imp.memory_max) |max| {
+                            try tmp.append(allocator, 1);
+                            try appendU32Le(&tmp, allocator, max);
+                        } else {
+                            try tmp.append(allocator, 0);
+                        }
+                        try tmp.append(allocator, if (imp.memory_is64) 1 else 0);
                     },
                     else => return error.UnsupportedImportKind,
                 }

--- a/src/component/aot.zig
+++ b/src/component/aot.zig
@@ -245,9 +245,16 @@ pub fn compileCoreWasm(
                     .memory_is64 = memory_type.is_memory64,
                 }) catch return error.OutOfMemory;
             },
-            // TODO #649 phase 4: emit imported global descriptors once
-            // the loader/runtime can retain and wire them through instantiation.
-            .global => {},
+            .global => {
+                const global_type = imp.global_type orelse continue;
+                imports.append(ea, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .global,
+                    .global_val_type = global_type.val_type,
+                    .global_mutable = global_type.mutability == .mutable,
+                }) catch return error.OutOfMemory;
+            },
             .tag => {},
         }
     }

--- a/src/component/aot.zig
+++ b/src/component/aot.zig
@@ -234,9 +234,20 @@ pub fn compileCoreWasm(
                     .table_max = if (table_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
                 }) catch return error.OutOfMemory;
             },
-            // TODO #649 phase 1.5: emit imported memory/global descriptors once
+            .memory => {
+                const memory_type = imp.memory_type orelse continue;
+                imports.append(ea, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .memory,
+                    .memory_min = @intCast(memory_type.limits.min),
+                    .memory_max = if (memory_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
+                    .memory_is64 = memory_type.is_memory64,
+                }) catch return error.OutOfMemory;
+            },
+            // TODO #649 phase 4: emit imported global descriptors once
             // the loader/runtime can retain and wire them through instantiation.
-            .memory, .global => {},
+            .global => {},
             .tag => {},
         }
     }

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -2470,7 +2470,7 @@ fn firstUnsupportedAotImport(module: *const aot_loader.AotModule) ?aot_loader.Ao
             },
             // Tag imports still require cross-instance wiring that the
             // AOT runtime cannot synthesize today.
-            else => return imp,
+            .tag => return imp,
         }
     }
     return null;

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -1526,7 +1526,19 @@ pub fn instantiateWithOptions(
                             const imported_table_overrides = imported_table_overrides_opt orelse break :aot_blk;
                             defer if (imported_table_overrides.len > 0) allocator.free(imported_table_overrides);
 
-                            const aot_inst_ptr = aot_runtime.instantiateWithOverrides(aot_module_ptr, inst.allocator, imported_table_overrides) catch |err| {
+                            const imported_memory_overrides_opt = resolveAotImportedMemoryOverrides(
+                                allocator,
+                                inst,
+                                component,
+                                cis,
+                                ci_idx,
+                                ie.args,
+                                aot_module_ptr,
+                            ) catch break :aot_blk;
+                            const imported_memory_overrides = imported_memory_overrides_opt orelse break :aot_blk;
+                            defer if (imported_memory_overrides.len > 0) allocator.free(imported_memory_overrides);
+
+                            const aot_inst_ptr = aot_runtime.instantiateWithOverrides(aot_module_ptr, inst.allocator, imported_table_overrides, imported_memory_overrides) catch |err| {
                                 std.log.warn("aot core instantiate failed for module {d}: {s}", .{ ie.module_idx, @errorName(err) });
                                 break :aot_blk;
                             };
@@ -2421,12 +2433,15 @@ fn firstUnsupportedAotImport(module: *const aot_loader.AotModule) ?aot_loader.Ao
                 if (aot_host_bridge.isSpectestModule(imp.module_name)) continue;
                 return imp;
             },
-            // memory / table / global / tag imports always require
-            // cross-instance wiring that the AOT runtime cannot
-            // synthesize today (memory_base / tables_info_ptr in
-            // `VmCtx` are populated from the AotInstance's own
-            // allocations, not from a borrowed *MemoryInstance /
-            // *TableInstance shared with a sibling core).
+            // Tables and memories support cross-instance borrowing via
+            // `instantiateWithOverrides`'s `imported_table_overrides` /
+            // `imported_memory_overrides` slices. The caller's
+            // `resolveAotImported{Table,Memory}Overrides` will surface a
+            // null and fall back to interp if a `with` arg can't be
+            // satisfied, so we don't need to re-check feasibility here.
+            .table, .memory => continue,
+            // Global / tag imports still require cross-instance wiring
+            // that the AOT runtime cannot synthesize today.
             else => return imp,
         }
     }
@@ -2558,6 +2573,60 @@ fn resolveAotImportedTableOverrides(
         if (source_inst_idx == std.math.maxInt(u32)) return null;
         if (source_inst_idx >= ci_idx) return null;
         overrides[i] = resolveCoreInstanceTableExport(inst, component, cis[source_inst_idx], imp_tbl.name) orelse return null;
+    }
+
+    return overrides;
+}
+
+fn resolveCoreInstanceMemoryExport(
+    inst: *const ComponentInstance,
+    component: *const ctypes.Component,
+    entry: ComponentInstance.CoreInstanceEntry,
+    export_name: []const u8,
+) ?*core_types.MemoryInstance {
+    if (entry.module_inst) |src_mi| {
+        const exp = src_mi.module.findExport(export_name, .memory) orelse return null;
+        if (exp.index >= src_mi.memories.len) return null;
+        return src_mi.memories[exp.index];
+    }
+    if (entry.aot_inst) |src_ai| {
+        const exp = src_ai.module.findExport(export_name, .memory) orelse return null;
+        if (exp.index >= src_ai.memories.len) return null;
+        return src_ai.memories[exp.index];
+    }
+    for (entry.inline_exports) |mem| {
+        if (!std.mem.eql(u8, mem.name, export_name)) continue;
+        if (mem.sort_idx.sort != .memory) break;
+        return resolveCoreMemoryToMI(inst, component, mem.sort_idx.idx);
+    }
+    return null;
+}
+
+fn resolveAotImportedMemoryOverrides(
+    allocator: std.mem.Allocator,
+    inst: *const ComponentInstance,
+    component: *const ctypes.Component,
+    cis: []const ComponentInstance.CoreInstanceEntry,
+    ci_idx: usize,
+    args: []const ctypes.CoreInstantiateArg,
+    module: *const aot_loader.AotModule,
+) error{OutOfMemory}!?[]?*core_types.MemoryInstance {
+    const imported_memories = module.importedMemories();
+    if (imported_memories.len == 0) return &.{};
+
+    const overrides = try allocator.alloc(?*core_types.MemoryInstance, imported_memories.len);
+    errdefer allocator.free(overrides);
+
+    for (imported_memories, 0..) |imp_mem, i| {
+        const source_inst_idx: u32 = arg_blk: {
+            for (args) |arg| {
+                if (std.mem.eql(u8, arg.name, imp_mem.module_name)) break :arg_blk arg.instance_idx;
+            }
+            break :arg_blk std.math.maxInt(u32);
+        };
+        if (source_inst_idx == std.math.maxInt(u32)) return null;
+        if (source_inst_idx >= ci_idx) return null;
+        overrides[i] = resolveCoreInstanceMemoryExport(inst, component, cis[source_inst_idx], imp_mem.name) orelse return null;
     }
 
     return overrides;

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -1538,7 +1538,19 @@ pub fn instantiateWithOptions(
                             const imported_memory_overrides = imported_memory_overrides_opt orelse break :aot_blk;
                             defer if (imported_memory_overrides.len > 0) allocator.free(imported_memory_overrides);
 
-                            const aot_inst_ptr = aot_runtime.instantiateWithOverrides(aot_module_ptr, inst.allocator, imported_table_overrides, imported_memory_overrides) catch |err| {
+                            const imported_global_overrides_opt = resolveAotImportedGlobalOverrides(
+                                allocator,
+                                inst,
+                                component,
+                                cis,
+                                ci_idx,
+                                ie.args,
+                                aot_module_ptr,
+                            ) catch break :aot_blk;
+                            const imported_global_overrides = imported_global_overrides_opt orelse break :aot_blk;
+                            defer if (imported_global_overrides.len > 0) allocator.free(imported_global_overrides);
+
+                            const aot_inst_ptr = aot_runtime.instantiateWithOverrides(aot_module_ptr, inst.allocator, imported_table_overrides, imported_memory_overrides, imported_global_overrides) catch |err| {
                                 std.log.warn("aot core instantiate failed for module {d}: {s}", .{ ie.module_idx, @errorName(err) });
                                 break :aot_blk;
                             };
@@ -2440,8 +2452,24 @@ fn firstUnsupportedAotImport(module: *const aot_loader.AotModule) ?aot_loader.Ao
             // null and fall back to interp if a `with` arg can't be
             // satisfied, so we don't need to re-check feasibility here.
             .table, .memory => continue,
-            // Global / tag imports still require cross-instance wiring
-            // that the AOT runtime cannot synthesize today.
+            // Immutable global imports flow through
+            // `imported_global_overrides`: the runtime borrows the
+            // exporter's `GlobalInstance` and bakes its value into the
+            // per-call globals slab. Mutable globals would need cross-core
+            // write-back, which requires either a per-global indirection
+            // in codegen or a slab-rebuild on each access; both are out of
+            // scope for this PR, so they still fall back to interp.
+            .global => {
+                for (module.importedGlobals()) |g| {
+                    if (!std.mem.eql(u8, g.module_name, imp.module_name)) continue;
+                    if (!std.mem.eql(u8, g.name, imp.field_name)) continue;
+                    if (g.mutable) return imp;
+                    break;
+                }
+                continue;
+            },
+            // Tag imports still require cross-instance wiring that the
+            // AOT runtime cannot synthesize today.
             else => return imp,
         }
     }
@@ -2627,6 +2655,60 @@ fn resolveAotImportedMemoryOverrides(
         if (source_inst_idx == std.math.maxInt(u32)) return null;
         if (source_inst_idx >= ci_idx) return null;
         overrides[i] = resolveCoreInstanceMemoryExport(inst, component, cis[source_inst_idx], imp_mem.name) orelse return null;
+    }
+
+    return overrides;
+}
+
+fn resolveCoreInstanceGlobalExport(
+    inst: *const ComponentInstance,
+    component: *const ctypes.Component,
+    entry: ComponentInstance.CoreInstanceEntry,
+    export_name: []const u8,
+) ?*core_types.GlobalInstance {
+    if (entry.module_inst) |src_mi| {
+        const exp = src_mi.module.findExport(export_name, .global) orelse return null;
+        if (exp.index >= src_mi.globals.len) return null;
+        return src_mi.globals[exp.index];
+    }
+    if (entry.aot_inst) |src_ai| {
+        const exp = src_ai.module.findExport(export_name, .global) orelse return null;
+        if (exp.index >= src_ai.globals.len) return null;
+        return src_ai.globals[exp.index];
+    }
+    for (entry.inline_exports) |g| {
+        if (!std.mem.eql(u8, g.name, export_name)) continue;
+        if (g.sort_idx.sort != .global) break;
+        return resolveCoreGlobalToMI(inst, component, g.sort_idx.idx);
+    }
+    return null;
+}
+
+fn resolveAotImportedGlobalOverrides(
+    allocator: std.mem.Allocator,
+    inst: *const ComponentInstance,
+    component: *const ctypes.Component,
+    cis: []const ComponentInstance.CoreInstanceEntry,
+    ci_idx: usize,
+    args: []const ctypes.CoreInstantiateArg,
+    module: *const aot_loader.AotModule,
+) error{OutOfMemory}!?[]?*core_types.GlobalInstance {
+    const imported_globals = module.importedGlobals();
+    if (imported_globals.len == 0) return &.{};
+
+    const overrides = try allocator.alloc(?*core_types.GlobalInstance, imported_globals.len);
+    errdefer allocator.free(overrides);
+
+    for (imported_globals, 0..) |imp_global, i| {
+        const source_inst_idx: u32 = arg_blk: {
+            for (args) |arg| {
+                if (std.mem.eql(u8, arg.name, imp_global.module_name)) break :arg_blk arg.instance_idx;
+            }
+            break :arg_blk std.math.maxInt(u32);
+        };
+        if (source_inst_idx == std.math.maxInt(u32)) return null;
+        if (source_inst_idx >= ci_idx) return null;
+        overrides[i] = resolveCoreInstanceGlobalExport(inst, component, cis[source_inst_idx], imp_global.name) orelse return null;
     }
 
     return overrides;

--- a/src/runtime/aot/loader.zig
+++ b/src/runtime/aot/loader.zig
@@ -71,6 +71,14 @@ pub const ImportedTableDesc = struct {
     max: ?u32,
 };
 
+pub const ImportedMemoryDesc = struct {
+    module_name: []const u8,
+    name: []const u8,
+    min: u32,
+    max: ?u32,
+    is64: bool = false,
+};
+
 /// A global initial value parsed from the AOT globals section.
 pub const AotGlobalInit = struct {
     val_type: u8,
@@ -113,6 +121,7 @@ pub const AotModule = struct {
     import_function_count: u32 = 0,
     imports: []const AotImportDesc = &.{},
     imported_tables: []const ImportedTableDesc = &.{},
+    imported_memories: []const ImportedMemoryDesc = &.{},
     memories: []const types.MemoryType = &.{},
     tables: []const types.TableType = &.{},
     data_segments: []const AotDataSegment = &.{},
@@ -130,6 +139,10 @@ pub const AotModule = struct {
 
     pub fn importedTables(self: *const AotModule) []const ImportedTableDesc {
         return self.imported_tables;
+    }
+
+    pub fn importedMemories(self: *const AotModule) []const ImportedMemoryDesc {
+        return self.imported_memories;
     }
 };
 
@@ -284,6 +297,9 @@ pub fn unload(module: *const AotModule, allocator: std.mem.Allocator) void {
     }
     if (module.imported_tables.len > 0) {
         allocator.free(module.imported_tables);
+    }
+    if (module.imported_memories.len > 0) {
+        allocator.free(module.imported_memories);
     }
     if (module.memories.len > 0) {
         allocator.free(module.memories);
@@ -466,6 +482,8 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
     var func_count: u32 = 0;
     var table_descs: std.ArrayList(ImportedTableDesc) = .empty;
     errdefer table_descs.deinit(allocator);
+    var memory_descs: std.ArrayList(ImportedMemoryDesc) = .empty;
+    errdefer memory_descs.deinit(allocator);
 
     for (0..count) |i| {
         const mod_name_len = try reader.readU32Le();
@@ -500,8 +518,21 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
                     .max = max,
                 }) catch return error.OutOfMemory;
             },
-            .memory, .global, .tag => {
-                // TODO #649 phase 1.5: preserve imported memory/global payloads.
+            .memory => {
+                const min = try reader.readU32Le();
+                const has_max = try reader.readByte();
+                const max: ?u32 = if (has_max != 0) try reader.readU32Le() else null;
+                const is64 = (try reader.readByte()) != 0;
+                memory_descs.append(allocator, .{
+                    .module_name = mod_name,
+                    .name = field_name,
+                    .min = min,
+                    .max = max,
+                    .is64 = is64,
+                }) catch return error.OutOfMemory;
+            },
+            .global, .tag => {
+                // TODO #649 phase 4: preserve imported global payloads.
                 _ = try reader.readU32Le();
             },
         }
@@ -518,6 +549,7 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
     module.imports = import_descs;
     module.import_function_count = func_count;
     module.imported_tables = table_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
+    module.imported_memories = memory_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
 }
 
 fn parseMemorySection(reader: *BinaryReader, section_size: u32, module: *AotModule, allocator: std.mem.Allocator) LoadError!void {

--- a/src/runtime/aot/loader.zig
+++ b/src/runtime/aot/loader.zig
@@ -79,6 +79,13 @@ pub const ImportedMemoryDesc = struct {
     is64: bool = false,
 };
 
+pub const ImportedGlobalDesc = struct {
+    module_name: []const u8,
+    name: []const u8,
+    val_type: types.ValType,
+    mutable: bool,
+};
+
 /// A global initial value parsed from the AOT globals section.
 pub const AotGlobalInit = struct {
     val_type: u8,
@@ -122,6 +129,7 @@ pub const AotModule = struct {
     imports: []const AotImportDesc = &.{},
     imported_tables: []const ImportedTableDesc = &.{},
     imported_memories: []const ImportedMemoryDesc = &.{},
+    imported_globals: []const ImportedGlobalDesc = &.{},
     memories: []const types.MemoryType = &.{},
     tables: []const types.TableType = &.{},
     data_segments: []const AotDataSegment = &.{},
@@ -143,6 +151,10 @@ pub const AotModule = struct {
 
     pub fn importedMemories(self: *const AotModule) []const ImportedMemoryDesc {
         return self.imported_memories;
+    }
+
+    pub fn importedGlobals(self: *const AotModule) []const ImportedGlobalDesc {
+        return self.imported_globals;
     }
 };
 
@@ -300,6 +312,9 @@ pub fn unload(module: *const AotModule, allocator: std.mem.Allocator) void {
     }
     if (module.imported_memories.len > 0) {
         allocator.free(module.imported_memories);
+    }
+    if (module.imported_globals.len > 0) {
+        allocator.free(module.imported_globals);
     }
     if (module.memories.len > 0) {
         allocator.free(module.memories);
@@ -484,6 +499,8 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
     errdefer table_descs.deinit(allocator);
     var memory_descs: std.ArrayList(ImportedMemoryDesc) = .empty;
     errdefer memory_descs.deinit(allocator);
+    var global_descs: std.ArrayList(ImportedGlobalDesc) = .empty;
+    errdefer global_descs.deinit(allocator);
 
     for (0..count) |i| {
         const mod_name_len = try reader.readU32Le();
@@ -531,8 +548,19 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
                     .is64 = is64,
                 }) catch return error.OutOfMemory;
             },
-            .global, .tag => {
-                // TODO #649 phase 4: preserve imported global payloads.
+            .global => {
+                const val_type: types.ValType = @enumFromInt(try reader.readByte());
+                const mutable = (try reader.readByte()) != 0;
+                global_descs.append(allocator, .{
+                    .module_name = mod_name,
+                    .name = field_name,
+                    .val_type = val_type,
+                    .mutable = mutable,
+                }) catch return error.OutOfMemory;
+            },
+            .tag => {
+                // TODO #649: preserve imported tag payloads (exception handling
+                // is not yet supported in AOT).
                 _ = try reader.readU32Le();
             },
         }
@@ -550,6 +578,7 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
     module.import_function_count = func_count;
     module.imported_tables = table_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
     module.imported_memories = memory_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
+    module.imported_globals = global_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
 }
 
 fn parseMemorySection(reader: *BinaryReader, section_size: u32, module: *AotModule, allocator: std.mem.Allocator) LoadError!void {

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -510,6 +510,12 @@ pub fn memGrowHelper(vmctx: *VmCtx, delta_pages: i32) callconv(.c) i32 {
     if (vmctx.instance_ptr == 0) return -1;
     const inst: *AotInstance = @ptrFromInt(vmctx.instance_ptr);
     if (inst.memories.len == 0) return -1;
+    // Refuse to grow a borrowed (imported) memory: reallocating the host
+    // buffer here would rebase memory.data.ptr, but the exporting sibling's
+    // `vmctx.memory_base` was captured at its own instantiate-time and would
+    // become a dangling pointer. Cross-instance grow propagation needs a
+    // vmctx-list on `MemoryInstance` — tracked separately.
+    if (inst.memories_owned.len > 0 and !inst.memories_owned[0]) return -1;
     const mem = inst.memories[0];
     const old_pages: u32 = mem.current_pages;
     if (delta_pages < 0) return -1;
@@ -877,6 +883,10 @@ const can_execute_native = native_arch != .unsupported;
 pub const AotInstance = struct {
     module: *const aot_loader.AotModule,
     memories: []*types.MemoryInstance,
+    /// True when the matching `memories[i]` entry was allocated by this
+    /// instance and should be released on destroy. Borrowed imported-memory
+    /// overrides leave this false so the exporting sibling retains ownership.
+    memories_owned: []bool = &.{},
     tables: []*types.TableInstance,
     /// True when the matching `tables[i]` entry was allocated by this
     /// instance and should be released on destroy. Borrowed imported-table
@@ -959,18 +969,22 @@ pub const RuntimeError = error{
 
 /// Instantiate an AOT module, producing a runnable AotInstance.
 pub fn instantiate(module: *const aot_loader.AotModule, allocator: std.mem.Allocator) RuntimeError!*AotInstance {
-    return instantiateWithOverrides(module, allocator, &.{});
+    return instantiateWithOverrides(module, allocator, &.{}, &.{});
 }
 
-/// Instantiate an AOT module, optionally borrowing `TableInstance`s for each
-/// imported-table slot. `imported_table_overrides[i]` maps to
-/// `module.importedTables()[i]`; null leaves that slot locally allocated.
+/// Instantiate an AOT module, optionally borrowing `TableInstance`s and
+/// `MemoryInstance`s for each imported-table / imported-memory slot.
+/// `imported_table_overrides[i]` maps to `module.importedTables()[i]`,
+/// `imported_memory_overrides[i]` to `module.importedMemories()[i]`;
+/// null leaves that slot locally allocated.
 pub fn instantiateWithOverrides(
     module: *const aot_loader.AotModule,
     allocator: std.mem.Allocator,
     imported_table_overrides: []const ?*types.TableInstance,
+    imported_memory_overrides: []const ?*types.MemoryInstance,
 ) RuntimeError!*AotInstance {
     std.debug.assert(imported_table_overrides.len == 0 or imported_table_overrides.len == module.importedTables().len);
+    std.debug.assert(imported_memory_overrides.len == 0 or imported_memory_overrides.len == module.importedMemories().len);
 
     var inst = allocator.create(AotInstance) catch return error.OutOfMemory;
     errdefer allocator.destroy(inst);
@@ -978,6 +992,7 @@ pub fn instantiateWithOverrides(
     inst.* = .{
         .module = module,
         .memories = &.{},
+        .memories_owned = &.{},
         .tables = &.{},
         .tables_owned = &.{},
         .globals = &.{},
@@ -999,12 +1014,18 @@ pub fn instantiateWithOverrides(
     }
     errdefer if (inst.elem_segments_dropped.len > 0) allocator.free(inst.elem_segments_dropped);
 
-    inst.memories = try allocateMemories(module, allocator);
-    errdefer freeMemories(inst.memories, allocator);
+    const mem_alloc = try allocateMemories(module, allocator, imported_memory_overrides);
+    inst.memories = mem_alloc.memories;
+    inst.memories_owned = mem_alloc.owned;
+    errdefer freeMemories(inst.memories, inst.memories_owned, allocator);
 
-    // Apply data segments to linear memory
+    // Apply data segments to locally-allocated linear memory only.
+    // Writing into a *borrowed* memory would scribble the exporter's bytes
+    // during the importer's instantiation, since both VmCtx's see the same
+    // backing buffer.
     for (module.data_segments) |seg| {
         if (seg.memory_idx >= inst.memories.len) continue;
+        if (seg.memory_idx < inst.memories_owned.len and !inst.memories_owned[seg.memory_idx]) continue;
         const mem = inst.memories[seg.memory_idx];
         const end = @as(usize, seg.offset) + seg.data.len;
         if (end > mem.data.len) continue;
@@ -1120,7 +1141,7 @@ pub fn destroy(inst: *AotInstance) void {
     if (inst.code_base) |base| {
         platform.munmap(@ptrCast(@constCast(base)), inst.code_size);
     }
-    freeMemories(inst.memories, allocator);
+    freeMemories(inst.memories, inst.memories_owned, allocator);
     freeTables(inst.tables, inst.tables_owned, allocator);
     freeGlobals(inst.globals, allocator);
     if (inst.global_offsets.len > 0) allocator.free(inst.global_offsets);
@@ -2000,40 +2021,89 @@ fn resolveHostFunctionsImpl(
 
 // ─── Allocation helpers ─────────────────────────────────────────────────────
 
-fn allocateMemories(module: *const aot_loader.AotModule, allocator: std.mem.Allocator) RuntimeError![]*types.MemoryInstance {
-    if (module.memories.len == 0) return &.{};
+const MemoriesAllocation = struct {
+    memories: []*types.MemoryInstance,
+    owned: []bool,
+};
 
-    const memories = allocator.alloc(*types.MemoryInstance, module.memories.len) catch return error.OutOfMemory;
+/// Allocate the memory slots for an instance. Imported memory slots are
+/// kept at the **front** of `memories` (so `memories[0]` still aliases the
+/// active linear memory the way `VmCtx.memory_base` wiring expects).
+/// Slots with a non-null entry in `imported_memory_overrides` are borrowed
+/// from the exporting sibling; everything else (and unoverriden imports)
+/// is locally allocated.
+fn allocateMemories(
+    module: *const aot_loader.AotModule,
+    allocator: std.mem.Allocator,
+    imported_memory_overrides: []const ?*types.MemoryInstance,
+) RuntimeError!MemoriesAllocation {
+    const imported = module.importedMemories();
+    const total_count = imported.len + module.memories.len;
+    if (total_count == 0) return .{ .memories = &.{}, .owned = &.{} };
+
+    const memories = allocator.alloc(*types.MemoryInstance, total_count) catch return error.OutOfMemory;
+    errdefer allocator.free(memories);
+    const owned = allocator.alloc(bool, total_count) catch return error.OutOfMemory;
+    errdefer allocator.free(owned);
+    @memset(owned, false);
+
     var initialized: usize = 0;
     errdefer {
-        for (0..initialized) |i| memories[i].release(allocator);
-        allocator.free(memories);
+        for (0..initialized) |i| {
+            if (owned[i]) memories[i].release(allocator);
+        }
     }
 
-    for (module.memories, 0..) |mem_type, i| {
-        const initial_pages: u32 = @intCast(@min(mem_type.limits.min, 65536));
-        const max_pages: u32 = @intCast(@min(mem_type.limits.max orelse 65536, 65536));
-        // Pre-allocate for memory.grow: use max_pages but cap at a reasonable default
-        const alloc_pages = @min(max_pages, @max(initial_pages, 256));
-        const size = @as(usize, alloc_pages) * types.MemoryInstance.page_size;
-
-        const data = allocator.alloc(u8, size) catch return error.OutOfMemory;
-        @memset(data, 0);
-        const mem = allocator.create(types.MemoryInstance) catch {
-            allocator.free(data);
-            return error.OutOfMemory;
+    for (imported, 0..) |desc, i| {
+        if (i < imported_memory_overrides.len) {
+            if (imported_memory_overrides[i]) |override| {
+                memories[i] = override;
+                initialized += 1;
+                continue;
+            }
+        }
+        const mem_type = types.MemoryType{
+            .limits = .{
+                .min = desc.min,
+                .max = if (desc.max) |max| @as(u64, max) else null,
+            },
+            .is_memory64 = desc.is64,
         };
-        mem.* = .{
-            .memory_type = mem_type,
-            .data = data,
-            .current_pages = initial_pages,
-            .max_pages = max_pages,
-        };
-        memories[i] = mem;
+        memories[i] = try allocateOneMemory(mem_type, allocator);
+        owned[i] = true;
         initialized += 1;
     }
 
-    return memories;
+    for (module.memories, 0..) |mem_type, local_i| {
+        const i = imported.len + local_i;
+        memories[i] = try allocateOneMemory(mem_type, allocator);
+        owned[i] = true;
+        initialized += 1;
+    }
+
+    return .{ .memories = memories, .owned = owned };
+}
+
+fn allocateOneMemory(mem_type: types.MemoryType, allocator: std.mem.Allocator) RuntimeError!*types.MemoryInstance {
+    const initial_pages: u32 = @intCast(@min(mem_type.limits.min, 65536));
+    const max_pages: u32 = @intCast(@min(mem_type.limits.max orelse 65536, 65536));
+    // Pre-allocate for memory.grow: use max_pages but cap at a reasonable default
+    const alloc_pages = @min(max_pages, @max(initial_pages, 256));
+    const size = @as(usize, alloc_pages) * types.MemoryInstance.page_size;
+
+    const data = allocator.alloc(u8, size) catch return error.OutOfMemory;
+    @memset(data, 0);
+    const mem = allocator.create(types.MemoryInstance) catch {
+        allocator.free(data);
+        return error.OutOfMemory;
+    };
+    mem.* = .{
+        .memory_type = mem_type,
+        .data = data,
+        .current_pages = initial_pages,
+        .max_pages = max_pages,
+    };
+    return mem;
 }
 
 const TablesAllocation = struct {
@@ -2192,9 +2262,13 @@ fn allocateGlobals(module: *const aot_loader.AotModule, allocator: std.mem.Alloc
     return globals;
 }
 
-fn freeMemories(memories: []*types.MemoryInstance, allocator: std.mem.Allocator) void {
-    for (memories) |m| m.release(allocator);
+fn freeMemories(memories: []*types.MemoryInstance, owned: []bool, allocator: std.mem.Allocator) void {
+    std.debug.assert(owned.len == 0 or owned.len == memories.len);
+    for (memories, 0..) |m, i| {
+        if (owned.len == 0 or owned[i]) m.release(allocator);
+    }
     if (memories.len > 0) allocator.free(memories);
+    if (owned.len > 0) allocator.free(owned);
 }
 
 fn freeTables(tables: []*types.TableInstance, owned: []bool, allocator: std.mem.Allocator) void {

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -893,6 +893,10 @@ pub const AotInstance = struct {
     /// overrides leave this false so the exporting sibling retains ownership.
     tables_owned: []bool = &.{},
     globals: []*types.GlobalInstance,
+    /// True when the matching `globals[i]` entry was allocated by this
+    /// instance and should be released on destroy. Borrowed imported-global
+    /// overrides leave this false so the exporting sibling retains ownership.
+    globals_owned: []bool = &.{},
     /// Byte offset for each wasm-flat global in `VmCtx.globals_ptr`.
     global_offsets: []u32 = &.{},
     /// Total byte size of the globals storage described by `global_offsets`.
@@ -969,22 +973,25 @@ pub const RuntimeError = error{
 
 /// Instantiate an AOT module, producing a runnable AotInstance.
 pub fn instantiate(module: *const aot_loader.AotModule, allocator: std.mem.Allocator) RuntimeError!*AotInstance {
-    return instantiateWithOverrides(module, allocator, &.{}, &.{});
+    return instantiateWithOverrides(module, allocator, &.{}, &.{}, &.{});
 }
 
-/// Instantiate an AOT module, optionally borrowing `TableInstance`s and
-/// `MemoryInstance`s for each imported-table / imported-memory slot.
+/// Instantiate an AOT module, optionally borrowing `TableInstance`s,
+/// `MemoryInstance`s, and `GlobalInstance`s for each imported slot.
 /// `imported_table_overrides[i]` maps to `module.importedTables()[i]`,
-/// `imported_memory_overrides[i]` to `module.importedMemories()[i]`;
-/// null leaves that slot locally allocated.
+/// `imported_memory_overrides[i]` to `module.importedMemories()[i]`,
+/// `imported_global_overrides[i]` to `module.importedGlobals()[i]`;
+/// null leaves that slot locally allocated (with a zero-valued default).
 pub fn instantiateWithOverrides(
     module: *const aot_loader.AotModule,
     allocator: std.mem.Allocator,
     imported_table_overrides: []const ?*types.TableInstance,
     imported_memory_overrides: []const ?*types.MemoryInstance,
+    imported_global_overrides: []const ?*types.GlobalInstance,
 ) RuntimeError!*AotInstance {
     std.debug.assert(imported_table_overrides.len == 0 or imported_table_overrides.len == module.importedTables().len);
     std.debug.assert(imported_memory_overrides.len == 0 or imported_memory_overrides.len == module.importedMemories().len);
+    std.debug.assert(imported_global_overrides.len == 0 or imported_global_overrides.len == module.importedGlobals().len);
 
     var inst = allocator.create(AotInstance) catch return error.OutOfMemory;
     errdefer allocator.destroy(inst);
@@ -996,6 +1003,7 @@ pub fn instantiateWithOverrides(
         .tables = &.{},
         .tables_owned = &.{},
         .globals = &.{},
+        .globals_owned = &.{},
         .allocator = allocator,
         .module_ref = module,
     };
@@ -1069,9 +1077,11 @@ pub fn instantiateWithOverrides(
         }
     }
 
-    inst.globals = try allocateGlobals(module, allocator);
-    errdefer freeGlobals(inst.globals, allocator);
-    const global_layout = try computeGlobalLayout(module.global_inits, allocator);
+    const global_alloc = try allocateGlobals(module, imported_global_overrides, allocator);
+    inst.globals = global_alloc.globals;
+    inst.globals_owned = global_alloc.owned;
+    errdefer freeGlobals(inst.globals, inst.globals_owned, allocator);
+    const global_layout = try computeGlobalLayout(module.importedGlobals(), module.global_inits, allocator);
     inst.global_offsets = global_layout.offsets;
     inst.global_storage_size = global_layout.size;
     errdefer if (inst.global_offsets.len > 0) allocator.free(inst.global_offsets);
@@ -1143,7 +1153,7 @@ pub fn destroy(inst: *AotInstance) void {
     }
     freeMemories(inst.memories, inst.memories_owned, allocator);
     freeTables(inst.tables, inst.tables_owned, allocator);
-    freeGlobals(inst.globals, allocator);
+    freeGlobals(inst.globals, inst.globals_owned, allocator);
     if (inst.global_offsets.len > 0) allocator.free(inst.global_offsets);
     if (inst.host_functions.len > 0) allocator.free(inst.host_functions);
     // inst.func_table aliases tables[0].native_backing (freed by TableInstance.release).
@@ -2202,34 +2212,98 @@ fn globalSlotSize(vt: types.ValType) u32 {
     };
 }
 
-fn computeGlobalLayout(inits: []const aot_loader.AotGlobalInit, allocator: std.mem.Allocator) RuntimeError!GlobalLayout {
-    if (inits.len == 0) return .{ .offsets = &.{}, .size = 0 };
+fn computeGlobalLayout(
+    imports: []const aot_loader.ImportedGlobalDesc,
+    inits: []const aot_loader.AotGlobalInit,
+    allocator: std.mem.Allocator,
+) RuntimeError!GlobalLayout {
+    const total = imports.len + inits.len;
+    if (total == 0) return .{ .offsets = &.{}, .size = 0 };
 
-    const offsets = allocator.alloc(u32, inits.len) catch return error.OutOfMemory;
+    const offsets = allocator.alloc(u32, total) catch return error.OutOfMemory;
     errdefer allocator.free(offsets);
 
     var next: u32 = 0;
+    // Imported globals come first in the wasm-flat global index space, so
+    // their slab offsets must match what the codegen baked into
+    // `global.get`/`global.set` instructions (frontend.zig also lays them
+    // out imports-first when computing `ir_module.global_offsets`).
+    for (imports, 0..) |g, i| {
+        next = alignForwardU32(next, globalSlotAlignment(g.val_type));
+        offsets[i] = next;
+        next += globalSlotSize(g.val_type);
+    }
     for (inits, 0..) |ginit, i| {
         const vt: types.ValType = @enumFromInt(ginit.val_type);
         next = alignForwardU32(next, globalSlotAlignment(vt));
-        offsets[i] = next;
+        offsets[imports.len + i] = next;
         next += globalSlotSize(vt);
     }
 
     return .{ .offsets = offsets, .size = next };
 }
 
-fn allocateGlobals(module: *const aot_loader.AotModule, allocator: std.mem.Allocator) RuntimeError![]*types.GlobalInstance {
-    if (module.global_inits.len == 0) return &.{};
+/// Allocate the wasm-flat `[]*GlobalInstance` slice for an AOT instance.
+///
+/// Imported globals come first (matching codegen's wasm-flat indexing
+/// established in `frontend.zig`); for each imported slot we either
+/// borrow the override's `GlobalInstance` (retained) or, when no override
+/// is provided, allocate a fresh zero-valued local stand-in. Locally
+/// defined globals follow, materialised from `module.global_inits`.
+///
+/// The returned `GlobalsAllocation.owned[i]` is true exactly when this
+/// instance allocated `globals[i]` itself (and therefore must release it
+/// in `destroy`). Borrowed import slots leave `owned[i] = false` so the
+/// exporting sibling retains lifetime ownership.
+const GlobalsAllocation = struct {
+    globals: []*types.GlobalInstance,
+    owned: []bool,
+};
 
-    const globals = allocator.alloc(*types.GlobalInstance, module.global_inits.len) catch return error.OutOfMemory;
+fn allocateGlobals(
+    module: *const aot_loader.AotModule,
+    imported_global_overrides: []const ?*types.GlobalInstance,
+    allocator: std.mem.Allocator,
+) RuntimeError!GlobalsAllocation {
+    const imports = module.importedGlobals();
+    const total = imports.len + module.global_inits.len;
+    if (total == 0) return .{ .globals = &.{}, .owned = &.{} };
+
+    const globals = allocator.alloc(*types.GlobalInstance, total) catch return error.OutOfMemory;
+    errdefer allocator.free(globals);
+    const owned = allocator.alloc(bool, total) catch return error.OutOfMemory;
+    errdefer allocator.free(owned);
+
     var initialized: usize = 0;
     errdefer {
-        for (0..initialized) |i| allocator.destroy(globals[i]);
-        allocator.free(globals);
+        for (0..initialized) |i| if (owned[i]) globals[i].release(allocator);
+    }
+
+    for (imports, 0..) |imp, i| {
+        if (imported_global_overrides.len > i and imported_global_overrides[i] != null) {
+            const shared = imported_global_overrides[i].?;
+            shared.retain();
+            globals[i] = shared;
+            owned[i] = false;
+        } else {
+            const g = allocator.create(types.GlobalInstance) catch return error.OutOfMemory;
+            g.* = .{
+                .global_type = .{
+                    .val_type = imp.val_type,
+                    .mutability = if (imp.mutable) .mutable else .immutable,
+                },
+                .value = defaultGlobalZero(imp.val_type),
+                .owned = true,
+                .ref_count = 1,
+            };
+            globals[i] = g;
+            owned[i] = true;
+        }
+        initialized += 1;
     }
 
     for (module.global_inits, 0..) |ginit, i| {
+        const slot = imports.len + i;
         const g = allocator.create(types.GlobalInstance) catch return error.OutOfMemory;
         const vt: types.ValType = @enumFromInt(ginit.val_type);
         // Tag the stored Value per the declared val_type so later
@@ -2255,11 +2329,27 @@ fn allocateGlobals(module: *const aot_loader.AotModule, allocator: std.mem.Alloc
             },
             .value = val,
         };
-        globals[i] = g;
+        globals[slot] = g;
+        owned[slot] = true;
         initialized += 1;
     }
 
-    return globals;
+    return .{ .globals = globals, .owned = owned };
+}
+
+fn defaultGlobalZero(vt: types.ValType) types.Value {
+    return switch (vt) {
+        .i32 => .{ .i32 = 0 },
+        .i64 => .{ .i64 = 0 },
+        .f32 => .{ .f32 = 0 },
+        .f64 => .{ .f64 = 0 },
+        .v128 => .{ .v128 = 0 },
+        .funcref => .{ .funcref = null },
+        .nonfuncref => .{ .nonfuncref = null },
+        .externref => .{ .externref = null },
+        .nonexternref => .{ .nonexternref = null },
+        else => .{ .i64 = 0 },
+    };
 }
 
 fn freeMemories(memories: []*types.MemoryInstance, owned: []bool, allocator: std.mem.Allocator) void {
@@ -2280,9 +2370,24 @@ fn freeTables(tables: []*types.TableInstance, owned: []bool, allocator: std.mem.
     if (owned.len > 0) allocator.free(owned);
 }
 
-fn freeGlobals(globals: []*types.GlobalInstance, allocator: std.mem.Allocator) void {
-    for (globals) |g| allocator.destroy(g);
+fn freeGlobals(globals: []*types.GlobalInstance, owned: []bool, allocator: std.mem.Allocator) void {
+    std.debug.assert(owned.len == 0 or owned.len == globals.len);
+    for (globals, 0..) |g, i| {
+        if (owned.len == 0) {
+            // Legacy callers pass owned=&.{} when all entries were
+            // unconditionally allocated by this instance (pre-#649-phase-4
+            // shape) — match the previous direct-destroy behaviour.
+            allocator.destroy(g);
+        } else {
+            // New-path: owned slots match the slab we created with
+            // ref_count=1; borrowed slots were retain()'d in allocateGlobals
+            // so they also need a matching release here.
+            _ = i;
+            g.release(allocator);
+        }
+    }
     if (globals.len > 0) allocator.free(globals);
+    if (owned.len > 0) allocator.free(owned);
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -1096,24 +1096,30 @@ fn compileToAot(
                     .table_max = if (table_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
                 });
             },
-            .memory, .global => {},
+            .memory => {
+                const memory_type = imp.memory_type orelse continue;
+                try import_entries.append(a, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .memory,
+                    .memory_min = @intCast(memory_type.limits.min),
+                    .memory_max = if (memory_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
+                    .memory_is64 = memory_type.is_memory64,
+                });
+            },
+            .global => {},
             .tag => unreachable,
         }
     }
 
     var mem_entries: std.ArrayList(emit_aot.MemoryEntry) = .empty;
-    // Imported memories first so `memory_idx` (combined import+local
-    // indexing per interpreter loader) continues to reference the right
-    // slot. `initWithRegistry` swaps the importer's fresh allocations
-    // for the exporter's shared `*MemoryInstance` post-instantiate.
-    for (module.imports) |imp| {
-        if (imp.kind != .memory) continue;
-        const mt = imp.memory_type orelse continue;
-        try mem_entries.append(a, .{
-            .min_pages = @intCast(mt.limits.min),
-            .max_pages = if (mt.limits.max) |m| @as(?u32, @intCast(m)) else null,
-        });
-    }
+    // Local memories only. Imported memories are now retained in the AOT
+    // format as `ImportedMemoryDesc` entries (read back via
+    // `module.importedMemories()`) and allocated/borrowed at instantiate
+    // time by `aot_runtime.allocateMemories`. Pre-#649-phase-3 we faked
+    // imports as local memories so `initWithRegistry` could rewrite them
+    // post-instantiate; the new path is shape-compatible because the
+    // runtime keeps imported slots at the front of `inst.memories`.
     for (module.memories) |mem| {
         try mem_entries.append(a, .{
             .min_pages = @intCast(mem.limits.min),

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -1107,7 +1107,16 @@ fn compileToAot(
                     .memory_is64 = memory_type.is_memory64,
                 });
             },
-            .global => {},
+            .global => {
+                const gt = imp.global_type orelse continue;
+                try import_entries.append(a, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .global,
+                    .global_val_type = gt.val_type,
+                    .global_mutable = gt.mutability == .mutable,
+                });
+            },
             .tag => unreachable,
         }
     }
@@ -1127,18 +1136,16 @@ fn compileToAot(
         });
     }
 
-    // Build the global entries with wasm-flat indexing: imported globals
-    // come first (at wasm indices [0, import_global_count)), then locals.
-    // This matches what the x86_64 codegen expects: `global.get N` emits
-    // a load at offset N*8 from the globals base, where N is the raw
-    // wasm index (imports + locals).
-    //
-    // For imports we resolve values from the spectest module (the spec
-    // suite's canonical host module). Unknown imports fall back to 0.
-    //
-    // For locals we run `evalInitExpr` against all preceding globals so
-    // that `global.get` / arithmetic bytecode inits produce correct
-    // values (e.g. global.wast's $z1..$z6 depend on imported globals).
+    // Build the global entries with wasm-flat indexing. Imported globals
+    // are now emitted via `import_entries` (the #649-phase-4 path) so the
+    // runtime owns their slots at `inst.globals[0..import_count]`. Only
+    // locally-defined globals go into `global_entries`. We still maintain
+    // `tmp_globals` covering imports + locals so `evalInitExpr` for local
+    // inits and elem-segment offset evaluation observe the correct
+    // wasm-flat indexing. Imported globals' values are patched into
+    // `inst.globals[k].value` after instantiation via `patchGlobals`, and
+    // the per-call `writeGlobalsToStorage` then snapshots them into the
+    // codegen-addressable slab.
     var global_entries: std.ArrayList(emit_aot.GlobalEntry) = .empty;
 
     // Temporary GlobalInstance list to feed evalInitExpr.
@@ -1148,7 +1155,11 @@ fn compileToAot(
         tmp_globals.deinit(a);
     }
 
-    // Imports first (only globals; other kinds are skipped).
+    // Imports first (only globals; other kinds are skipped). Values are
+    // used only to seed `tmp_globals` so local-global init exprs can
+    // resolve `global.get`; the runtime will create fresh zero-valued
+    // GlobalInstance slots for these imports, and `patchGlobals` rewrites
+    // them post-instantiate with the registry / spectest value.
     for (module.imports) |imp| {
         if (imp.kind != .global) continue;
         const gt = imp.global_type orelse continue;
@@ -1166,12 +1177,6 @@ fn compileToAot(
         const g = try a.create(types.GlobalInstance);
         g.* = .{ .global_type = gt, .value = val };
         try tmp_globals.append(a, g);
-        try global_entries.append(a, .{
-            .val_type = @intFromEnum(gt.val_type),
-            .mutability = if (gt.mutability == .mutable) @as(u8, 1) else @as(u8, 0),
-            .init_i64 = valueToI64(val),
-            .init_v128 = valueToV128(val),
-        });
     }
 
     // Locals: evaluate init expressions against the preceding globals.

--- a/src/tests/component_aot_smoke_test.zig
+++ b/src/tests/component_aot_smoke_test.zig
@@ -117,7 +117,7 @@ test "#649 phase 2: instantiateWithOverrides shares imported tables across AOT c
     try aot_runtime_mod.mapCodeExecutable(exporter_inst);
 
     const overrides = [_]?*core_types.TableInstance{exporter_inst.tables[0]};
-    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &overrides);
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &overrides, &.{});
     defer aot_runtime_mod.destroy(importer_inst);
     try std.testing.expectEqual(exporter_inst.tables[0], importer_inst.tables[0]);
     try std.testing.expect(!importer_inst.tables_owned[0]);
@@ -228,4 +228,134 @@ test "#625 phase 1: instantiateWithOptions loads + runs an AOT core" {
     );
     try std.testing.expectEqual(@as(usize, 1), results.len);
     try std.testing.expectEqual(@as(i32, 142), results[0].i32);
+}
+
+test "#649 phase 3: AOT loader retains imported memory descriptors" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    // (module
+    //   (import "env" "mem" (memory 2 7))
+    //   (func (export "noop"))
+    // )
+    const core_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: () -> ()
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        // import section: "env" "mem" memory min=2 max=7
+        0x02, 0x0d,
+        0x01, 0x03, 'e',  'n',  'v',  0x03, 'm',  'e',
+        'm',  0x02, 0x01, 0x02, 0x07,
+        // function section: 1 fn type 0
+        0x03, 0x02, 0x01, 0x00,
+        // export section: "noop" func 0
+        0x07, 0x08, 0x01, 0x04, 'n',  'o',  'o',  'p',
+        0x00, 0x00,
+        // code section: empty body
+        0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b,
+    };
+
+    const allocator = std.testing.allocator;
+    const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, &core_wasm);
+    defer allocator.free(cwasm_bytes);
+
+    const module = try aot_loader_mod.load(cwasm_bytes, allocator);
+    defer aot_loader_mod.unload(&module, allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), module.imports.len);
+    try std.testing.expectEqual(core_types.ExternalKind.memory, module.imports[0].kind);
+    try std.testing.expectEqual(@as(u32, 0), module.import_function_count);
+    try std.testing.expectEqual(@as(usize, 1), module.importedMemories().len);
+    const mem = module.importedMemories()[0];
+    try std.testing.expect(std.mem.eql(u8, mem.module_name, "env"));
+    try std.testing.expect(std.mem.eql(u8, mem.name, "mem"));
+    try std.testing.expectEqual(@as(u32, 2), mem.min);
+    try std.testing.expectEqual(@as(?u32, 7), mem.max);
+    try std.testing.expectEqual(false, mem.is64);
+}
+
+test "#649 phase 3: instantiateWithOverrides shares imported memory across AOT cores" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    // exporter:
+    //   (module
+    //     (memory (export "mem") 1)
+    //     (data (i32.const 0) "\55\44\33\22")
+    //   )
+    const exporter_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // memory section: 1 memory min=1
+        0x05, 0x03, 0x01, 0x00, 0x01,
+        // export section: "mem" mem 0
+        0x07, 0x07, 0x01, 0x03, 'm',  'e',  'm',  0x02,
+        0x00,
+        // data section: 1 active segment, memory 0, offset 0, 4 bytes
+        0x0b, 0x0a,
+        0x01, 0x00, 0x41, 0x00, 0x0b, 0x04, 0x55, 0x44,
+        0x33, 0x22,
+    };
+
+    // importer:
+    //   (module
+    //     (import "env" "mem" (memory 1))
+    //     (func (export "read") (result i32) i32.const 0 i32.load)
+    //   )
+    const importer_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: () -> i32
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+        // import section: "env" "mem" memory min=1
+        0x02, 0x0c,
+        0x01, 0x03, 'e',  'n',  'v',  0x03, 'm',  'e',
+        'm',  0x02, 0x00, 0x01,
+        // function section: 1 fn type 0
+        0x03, 0x02, 0x01, 0x00,
+        // export section: "read" func 0
+        0x07, 0x08, 0x01, 0x04, 'r',  'e',  'a',  'd',
+        0x00, 0x00,
+        // code section: locals=0; i32.const 0; i32.load align=2 offset=0; end
+        0x0a, 0x09, 0x01, 0x07, 0x00, 0x41, 0x00, 0x28,
+        0x02, 0x00, 0x0b,
+    };
+
+    const allocator = std.testing.allocator;
+    const exporter_cwasm = try aot_harness.compileWasmToAot(allocator, &exporter_wasm);
+    defer allocator.free(exporter_cwasm);
+    const importer_cwasm = try aot_harness.compileWasmToAot(allocator, &importer_wasm);
+    defer allocator.free(importer_cwasm);
+
+    var exporter_module = try aot_loader_mod.load(exporter_cwasm, allocator);
+    defer aot_loader_mod.unload(&exporter_module, allocator);
+    var importer_module = try aot_loader_mod.load(importer_cwasm, allocator);
+    defer aot_loader_mod.unload(&importer_module, allocator);
+
+    const exporter_inst = try aot_runtime_mod.instantiate(&exporter_module, allocator);
+    defer aot_runtime_mod.destroy(exporter_inst);
+
+    // Sentinel from the exporter's data segment must be live in its memory.
+    try std.testing.expectEqual(@as(u8, 0x55), exporter_inst.memories[0].data[0]);
+    try std.testing.expectEqual(@as(u8, 0x22), exporter_inst.memories[0].data[3]);
+
+    const overrides = [_]?*core_types.MemoryInstance{exporter_inst.memories[0]};
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &overrides);
+    defer aot_runtime_mod.destroy(importer_inst);
+    try std.testing.expectEqual(exporter_inst.memories[0], importer_inst.memories[0]);
+    try std.testing.expect(!importer_inst.memories_owned[0]);
+    try aot_runtime_mod.mapCodeExecutable(importer_inst);
+
+    const fn_idx = aot_runtime_mod.findExportFunc(importer_inst, "read") orelse return error.TestFailed;
+    const no_params = [_]core_types.ValType{};
+    const result_types = [_]core_types.ValType{.i32};
+    const no_args = [_]core_types.Value{};
+    var results_buf: [1]aot_runtime_mod.ScalarResult = .{.{ .i32 = 0 }};
+    const results = try aot_runtime_mod.callFuncScalar(
+        importer_inst,
+        fn_idx,
+        &no_params,
+        &result_types,
+        &no_args,
+        &results_buf,
+    );
+    try std.testing.expectEqual(@as(usize, 1), results.len);
+    // little-endian {0x55, 0x44, 0x33, 0x22} = 0x22334455
+    try std.testing.expectEqual(@as(i32, 0x22334455), results[0].i32);
 }

--- a/src/tests/component_aot_smoke_test.zig
+++ b/src/tests/component_aot_smoke_test.zig
@@ -480,3 +480,134 @@ test "#649 phase 4: instantiateWithOverrides shares imported globals across AOT 
     try std.testing.expectEqual(@as(usize, 1), results.len);
     try std.testing.expectEqual(@as(i32, 0x55), results[0].i32);
 }
+
+test "#649 phase 5: cross-AOT shared memory + table + global in one importer" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    // exporter:
+    //   (module
+    //     (func (result i32) i32.const 100)
+    //     (table (export "tbl") 1 1 funcref)
+    //     (memory (export "mem") 1)
+    //     (global (export "g") i32 (i32.const 3))
+    //     (export "f" (func 0))
+    //     (elem (i32.const 0) func 0)
+    //     (data (i32.const 0) "\07\00\00\00")
+    //   )
+    const exporter_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: () -> i32
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+        // function section: 1 fn type 0
+        0x03, 0x02, 0x01, 0x00,
+        // table section: 1 table funcref min=1 max=1
+        0x04, 0x05, 0x01, 0x70, 0x01, 0x01, 0x01,
+        // memory section: 1 memory min=1
+        0x05, 0x03, 0x01, 0x00, 0x01,
+        // global section: 1 global i32 immutable init=3
+        0x06, 0x06, 0x01, 0x7f, 0x00, 0x41, 0x03, 0x0b,
+        // export section: "mem", "tbl", "g"
+        0x07, 0x11, 0x03,
+        0x03, 'm',  'e',  'm',  0x02, 0x00,
+        0x03, 't',  'b',  'l',  0x01, 0x00,
+        0x01, 'g',  0x03, 0x00,
+        // elem section: 1 active segment table 0 offset 0, func [0]
+        0x09, 0x07, 0x01, 0x00, 0x41, 0x00, 0x0b, 0x01, 0x00,
+        // code section: 1 fn, body = i32.const 100; end (LEB 0xE4 0x00)
+        0x0a, 0x07, 0x01, 0x05, 0x00, 0x41, 0xe4, 0x00, 0x0b,
+        // data section: 1 active segment mem 0 offset 0 bytes [0x07 0x00 0x00 0x00]
+        0x0b, 0x0a, 0x01, 0x00, 0x41, 0x00, 0x0b, 0x04, 0x07, 0x00, 0x00, 0x00,
+    };
+
+    // importer:
+    //   (module
+    //     (type (func (result i32)))
+    //     (import "env" "mem" (memory 1))
+    //     (import "env" "tbl" (table 1 1 funcref))
+    //     (import "env" "g" (global i32))
+    //     (func (export "compute") (result i32)
+    //       i32.const 0 i32.load              ;; mem[0] = 7
+    //       global.get 0                       ;; g = 3
+    //       i32.add                            ;; 10
+    //       i32.const 0 call_indirect (type 0) ;; tbl[0]() = 100
+    //       i32.add)                           ;; 110
+    //   )
+    const importer_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: () -> i32
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+        // import section: 3 imports
+        //   "env" "mem" memory min=1                          (11 bytes)
+        //   "env" "tbl" table funcref min=1 max=1             (13 bytes)
+        //   "env" "g" global i32 immutable                    ( 9 bytes)
+        // payload = count(1) + 11 + 13 + 9 = 34 = 0x22
+        0x02, 0x22,
+        0x03,
+        0x03, 'e',  'n',  'v',  0x03, 'm',  'e',  'm',  0x02, 0x00, 0x01,
+        0x03, 'e',  'n',  'v',  0x03, 't',  'b',  'l',  0x01, 0x70, 0x01, 0x01, 0x01,
+        0x03, 'e',  'n',  'v',  0x01, 'g',  0x03, 0x7f, 0x00,
+        // function section: 1 fn type 0
+        0x03, 0x02, 0x01, 0x00,
+        // export section: "compute" func 0
+        0x07, 0x0b, 0x01, 0x07, 'c',  'o',  'm',  'p',  'u',  't',  'e',  0x00, 0x00,
+        // code section: locals=0; (load + add + call_indirect + add)
+        0x0a, 0x12, 0x01, 0x10, 0x00,
+        0x41, 0x00, 0x28, 0x02, 0x00,
+        0x23, 0x00,
+        0x6a,
+        0x41, 0x00, 0x11, 0x00, 0x00,
+        0x6a,
+        0x0b,
+    };
+
+    const allocator = std.testing.allocator;
+    const exporter_cwasm = try aot_harness.compileWasmToAot(allocator, &exporter_wasm);
+    defer allocator.free(exporter_cwasm);
+    const importer_cwasm = try aot_harness.compileWasmToAot(allocator, &importer_wasm);
+    defer allocator.free(importer_cwasm);
+
+    var exporter_module = try aot_loader_mod.load(exporter_cwasm, allocator);
+    defer aot_loader_mod.unload(&exporter_module, allocator);
+    var importer_module = try aot_loader_mod.load(importer_cwasm, allocator);
+    defer aot_loader_mod.unload(&importer_module, allocator);
+
+    const exporter_inst = try aot_runtime_mod.instantiate(&exporter_module, allocator);
+    defer aot_runtime_mod.destroy(exporter_inst);
+    try aot_runtime_mod.mapCodeExecutable(exporter_inst);
+
+    const table_overrides = [_]?*core_types.TableInstance{exporter_inst.tables[0]};
+    const memory_overrides = [_]?*core_types.MemoryInstance{exporter_inst.memories[0]};
+    const global_overrides = [_]?*core_types.GlobalInstance{exporter_inst.globals[0]};
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(
+        &importer_module,
+        allocator,
+        &table_overrides,
+        &memory_overrides,
+        &global_overrides,
+    );
+    defer aot_runtime_mod.destroy(importer_inst);
+    try std.testing.expectEqual(exporter_inst.tables[0], importer_inst.tables[0]);
+    try std.testing.expectEqual(exporter_inst.memories[0], importer_inst.memories[0]);
+    try std.testing.expectEqual(exporter_inst.globals[0], importer_inst.globals[0]);
+    try std.testing.expect(!importer_inst.tables_owned[0]);
+    try std.testing.expect(!importer_inst.memories_owned[0]);
+    try std.testing.expect(!importer_inst.globals_owned[0]);
+    try aot_runtime_mod.mapCodeExecutable(importer_inst);
+
+    const fn_idx = aot_runtime_mod.findExportFunc(importer_inst, "compute") orelse return error.TestFailed;
+    const no_params = [_]core_types.ValType{};
+    const result_types = [_]core_types.ValType{.i32};
+    const no_args = [_]core_types.Value{};
+    var results_buf: [1]aot_runtime_mod.ScalarResult = .{.{ .i32 = 0 }};
+    const results = try aot_runtime_mod.callFuncScalar(
+        importer_inst,
+        fn_idx,
+        &no_params,
+        &result_types,
+        &no_args,
+        &results_buf,
+    );
+    try std.testing.expectEqual(@as(usize, 1), results.len);
+    // mem[0]=7 + global=3 + tbl[0]()=100 = 110
+    try std.testing.expectEqual(@as(i32, 110), results[0].i32);
+}

--- a/src/tests/component_aot_smoke_test.zig
+++ b/src/tests/component_aot_smoke_test.zig
@@ -117,7 +117,7 @@ test "#649 phase 2: instantiateWithOverrides shares imported tables across AOT c
     try aot_runtime_mod.mapCodeExecutable(exporter_inst);
 
     const overrides = [_]?*core_types.TableInstance{exporter_inst.tables[0]};
-    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &overrides, &.{});
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &overrides, &.{}, &.{});
     defer aot_runtime_mod.destroy(importer_inst);
     try std.testing.expectEqual(exporter_inst.tables[0], importer_inst.tables[0]);
     try std.testing.expect(!importer_inst.tables_owned[0]);
@@ -336,7 +336,7 @@ test "#649 phase 3: instantiateWithOverrides shares imported memory across AOT c
     try std.testing.expectEqual(@as(u8, 0x22), exporter_inst.memories[0].data[3]);
 
     const overrides = [_]?*core_types.MemoryInstance{exporter_inst.memories[0]};
-    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &overrides);
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &overrides, &.{});
     defer aot_runtime_mod.destroy(importer_inst);
     try std.testing.expectEqual(exporter_inst.memories[0], importer_inst.memories[0]);
     try std.testing.expect(!importer_inst.memories_owned[0]);
@@ -358,4 +358,125 @@ test "#649 phase 3: instantiateWithOverrides shares imported memory across AOT c
     try std.testing.expectEqual(@as(usize, 1), results.len);
     // little-endian {0x55, 0x44, 0x33, 0x22} = 0x22334455
     try std.testing.expectEqual(@as(i32, 0x22334455), results[0].i32);
+}
+
+test "#649 phase 4: AOT loader retains imported global descriptors" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    // (module
+    //   (import "env" "g" (global i32))
+    //   (func (export "noop"))
+    // )
+    const core_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: () -> ()
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        // import section: "env" "g" global i32 immutable
+        0x02, 0x0a,
+        0x01, 0x03, 'e',  'n',  'v',  0x01, 'g',  0x03,
+        0x7f, 0x00,
+        // function section: 1 fn type 0
+        0x03, 0x02, 0x01, 0x00,
+        // export section: "noop" func 0
+        0x07, 0x08, 0x01, 0x04, 'n',  'o',  'o',  'p',
+        0x00, 0x00,
+        // code section: empty body
+        0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b,
+    };
+
+    const allocator = std.testing.allocator;
+    const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, &core_wasm);
+    defer allocator.free(cwasm_bytes);
+
+    const module = try aot_loader_mod.load(cwasm_bytes, allocator);
+    defer aot_loader_mod.unload(&module, allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), module.imports.len);
+    try std.testing.expectEqual(core_types.ExternalKind.global, module.imports[0].kind);
+    try std.testing.expectEqual(@as(u32, 0), module.import_function_count);
+    try std.testing.expectEqual(@as(usize, 1), module.importedGlobals().len);
+    const g = module.importedGlobals()[0];
+    try std.testing.expect(std.mem.eql(u8, g.module_name, "env"));
+    try std.testing.expect(std.mem.eql(u8, g.name, "g"));
+    try std.testing.expectEqual(core_types.ValType.i32, g.val_type);
+    try std.testing.expectEqual(false, g.mutable);
+}
+
+test "#649 phase 4: instantiateWithOverrides shares imported globals across AOT cores" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    // exporter:
+    //   (module
+    //     (global (export "g") i32 (i32.const 0x55))
+    //   )
+    const exporter_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // global section: 1 global, i32 immutable, init i32.const 0x55 (LEB: 0xD5 0x00)
+        0x06, 0x07, 0x01, 0x7f, 0x00, 0x41, 0xd5, 0x00,
+        0x0b,
+        // export section: "g" global 0
+        0x07, 0x05, 0x01, 0x01, 'g',  0x03, 0x00,
+    };
+
+    // importer:
+    //   (module
+    //     (import "env" "g" (global i32))
+    //     (func (export "read") (result i32) global.get 0)
+    //   )
+    const importer_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: () -> i32
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+        // import section: "env" "g" global i32 immutable
+        0x02, 0x0a,
+        0x01, 0x03, 'e',  'n',  'v',  0x01, 'g',  0x03,
+        0x7f, 0x00,
+        // function section: 1 fn type 0
+        0x03, 0x02, 0x01, 0x00,
+        // export section: "read" func 0
+        0x07, 0x08, 0x01, 0x04, 'r',  'e',  'a',  'd',
+        0x00, 0x00,
+        // code section: locals=0; global.get 0; end
+        0x0a, 0x06, 0x01, 0x04, 0x00, 0x23, 0x00, 0x0b,
+    };
+
+    const allocator = std.testing.allocator;
+    const exporter_cwasm = try aot_harness.compileWasmToAot(allocator, &exporter_wasm);
+    defer allocator.free(exporter_cwasm);
+    const importer_cwasm = try aot_harness.compileWasmToAot(allocator, &importer_wasm);
+    defer allocator.free(importer_cwasm);
+
+    var exporter_module = try aot_loader_mod.load(exporter_cwasm, allocator);
+    defer aot_loader_mod.unload(&exporter_module, allocator);
+    var importer_module = try aot_loader_mod.load(importer_cwasm, allocator);
+    defer aot_loader_mod.unload(&importer_module, allocator);
+
+    const exporter_inst = try aot_runtime_mod.instantiate(&exporter_module, allocator);
+    defer aot_runtime_mod.destroy(exporter_inst);
+
+    // Exporter's global must hold the i32.const literal value after init.
+    try std.testing.expectEqual(@as(i32, 0x55), exporter_inst.globals[0].value.i32);
+
+    const overrides = [_]?*core_types.GlobalInstance{exporter_inst.globals[0]};
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &.{}, &overrides);
+    defer aot_runtime_mod.destroy(importer_inst);
+    try std.testing.expectEqual(exporter_inst.globals[0], importer_inst.globals[0]);
+    try std.testing.expect(!importer_inst.globals_owned[0]);
+    try aot_runtime_mod.mapCodeExecutable(importer_inst);
+
+    const fn_idx = aot_runtime_mod.findExportFunc(importer_inst, "read") orelse return error.TestFailed;
+    const no_params = [_]core_types.ValType{};
+    const result_types = [_]core_types.ValType{.i32};
+    const no_args = [_]core_types.Value{};
+    var results_buf: [1]aot_runtime_mod.ScalarResult = .{.{ .i32 = 0 }};
+    const results = try aot_runtime_mod.callFuncScalar(
+        importer_inst,
+        fn_idx,
+        &no_params,
+        &result_types,
+        &no_args,
+        &results_buf,
+    );
+    try std.testing.expectEqual(@as(usize, 1), results.len);
+    try std.testing.expectEqual(@as(i32, 0x55), results[0].i32);
 }


### PR DESCRIPTION
Closes #649.

Builds on the table-import phases (#654, #656) by adding memory and
global support, so all three non-function import kinds can now be
shared across AOT cores in the same component instead of forcing
the entire component to fall back to the interpreter.

## Phases (commits)

### Phase 3 — imported memory descriptors end-to-end
* `emit_aot`: `.memory` ImportEntry arm + payload `(min, has_max,
  max?, is64)`.
* `loader`: `ImportedMemoryDesc` + `module.importedMemories()`.
* `component/aot.zig`: emit imported memories from `imp.memory_type`.
* `runtime`: `instantiateWithOverrides(..., imported_memory_overrides)`,
  `allocateMemories` borrows the exporter's `MemoryInstance` when an
  override is supplied; data segments targeting borrowed memories are
  skipped to avoid scribbling on the exporter; `aotMemoryGrow` traps
  with a clear log if asked to grow a borrowed memory (full
  cross-instance grow propagation is left to a follow-up).
* `component/instance.zig`: `resolveAotImportedMemoryOverrides`
  walking `args`. `firstUnsupportedAotImport` accepts `.memory`.

### Phase 4 — imported (immutable) global descriptors end-to-end
* `emit_aot`: `.global` ImportEntry arm + payload `(val_type,
  mutable)`.
* `loader`: `ImportedGlobalDesc` + `module.importedGlobals()`.
* `component/aot.zig`: emit imported globals from `imp.global_type`.
* `runtime`: `instantiateWithOverrides(..., imported_global_overrides)`,
  `allocateGlobals` borrows the exporter's `GlobalInstance` (refcount
  retain) for imports; per-call `writeGlobalsToStorage` snapshots
  each `inst.globals[i].value` into the codegen-addressable slab,
  which is correct for **immutable** imports. Mutable globals still
  fall back to interp because cross-core mutability would require
  per-global indirection in codegen.
* `component/instance.zig`: `resolveAotImportedGlobalOverrides`.
  `firstUnsupportedAotImport` accepts `.global` only when the
  matching `ImportedGlobalDesc` is immutable.
* `aot_harness`: switch imported globals from the legacy
  prefix-as-locals trick to the new path. `patchGlobals` still sets
  spectest/registry values post-instantiate so the spec suite is
  unaffected.

### Phase 5 — combined integration test + final flip
* `firstUnsupportedAotImport`: `else => return imp` becomes
  `.tag => return imp` — `.tag` (exception handling) is now the
  only remaining AOT-incompatible import kind.
* New end-to-end test: an exporter that exposes a memory, a table,
  and an immutable global; an importer that imports all three and
  computes `mem[0] + global + tbl[0]() = 7 + 3 + 100 = 110`. Exercises
  every override slice in concert — the shape `stdio-echo.wasm`'s
  glue core needs.

## Verification

```
zig build test --summary all
# Build Summary: 44/44 steps succeeded; 2910/2917 tests passed (7 skipped)
```

3 new tests vs. main:
* `#649 phase 3: AOT loader retains imported memory descriptors`
* `#649 phase 3: instantiateWithOverrides shares imported memory across AOT cores`
* `#649 phase 4: AOT loader retains imported global descriptors`
* `#649 phase 4: instantiateWithOverrides shares imported globals across AOT cores`
* `#649 phase 5: cross-AOT shared memory + table + global in one importer`

## Out of scope (follow-ups)

* Cross-instance memory.grow propagation — every importer captures
  `memory_base` / `memory_size` at instantiate time; growing on the
  exporter side rebases the buffer and invalidates those captures.
  For now `aotMemoryGrow` traps when asked to grow a borrowed
  memory; full propagation needs a vmctx-list on `MemoryInstance`.
* Mutable cross-instance globals — would require either a per-global
  indirection in codegen or a slab rebuild on each access.
* `.tag` imports — wasm exception handling is still unsupported in
  the AOT runtime.


Follow-ups tracked in #660.
