### PR TITLE
Phase D: unwrap composed components for AOT (#662)

### DIFF
--- a/phase-d-notes.md
+++ b/phase-d-notes.md
@@ -1,0 +1,164 @@
+# Phase D diagnosis — composed components on AOT (#662)
+
+## Status
+
+**Partial progress, blocked on AOT canon-lower trampoline plumbing.**
+Loader/CLI fix landed in this branch; the wasi-p2 skip entries for the
+two composed-component fixtures (`zig-calculator-cmd.composed.wasm`,
+`mixed-zig-rust-calc.composed.wasm`) and the `build.zig` `wireComponentRun`
+skip flags remain in place because the AOT runtime cannot yet bridge the
+cross-sub-component function imports those fixtures introduce.
+
+## Reproduction (after this branch's loader fix)
+
+```
+zig build install component-examples
+./zig-out/bin/wamr run zig-out/component-examples/zig-calculator-cmd.composed.wasm
+```
+
+```
+wamr: auto-precompiling 6 cores in memory (no on-disk bundle; pass --precompiled-dir or run `wamrc compile-component` to persist)
+warning: [aot reject] core module 0 import 'docs:adder/add@0.1.0.add' (function) cannot be resolved by AOT yet (#644)
+Error: failed to instantiate component (the `wamr` CLI runs all components through the AOT runtime; see issue #644)
+```
+
+Wasmtime parity (control):
+
+```
+wasmtime run -S cli-exit-with-code zig-out/component-examples/zig-calculator-cmd.composed.wasm
+40 + 2 = 42
+100 + 200 = 300  (exit 0)
+```
+
+## Root cause
+
+`wabt component compose -d` produces a top-level component shaped like:
+
+```
+component
+├── component  (the original `wabt component new` calculator-cmd, with 5 cores)
+├── component  (the original `wabt component new` adder,          with 1 core)
+├── instance  (instantiate calculator-cmd sub-component)
+├── instance  (instantiate adder sub-component)
+└── alias / export  (re-expose wasi:cli/run from the inner instance)
+```
+
+The actual core modules — including the calculator-cmd's main wasip1
+core whose `_start` does the printing — live **inside the nested
+sub-components**, not at the top level. So:
+
+1. `wamr.component_loader.load(...)` returns a top-level `Component`
+   with `core_modules.len == 0` and `core_instances.len == 0`. Each
+   element of `components[]` recursively holds the real cores.
+2. Sub-component instantiation in `src/component/instance.zig`
+   (the `sub_instances` loop at the end of `instantiateWithOptions`)
+   recurses correctly on the interpreter, because each sub-component
+   has its own non-empty `core_instances` that drive the
+   `module_arena`-backed interpreter path.
+3. The wamr `run` CLI is AOT-only (#644), so it needs every core in
+   every nested sub-component to be precompiled and reachable through
+   `Options.precompiled_cores`.
+
+## What this branch does fix
+
+Two narrow changes, both required by any future complete fix:
+
+1. **`src/main.zig` auto-precompile walker.** Recursively walks
+   `parsed.components` to discover every core module across the
+   sub-component tree, compiles each, and emits a `PrecompiledCore`
+   entry per core.
+
+2. **`src/component/core_backend.zig` `PrecompiledCore` scoping.**
+   Adds an optional `core_wasm: ?[]const u8` raw-bytes identity to
+   `PrecompiledCore`. `Options.findPrecompiled` now takes the
+   `component.core_modules[idx].data` slice plus the local
+   `module_idx`. Slice identity is stable across re-parses of the same
+   `wasm_data` (both `main.zig` and `wasi_cli_adapter.zig` re-parse
+   the same buffer), so a single `precompiled_cores` slice can be
+   shared by the root component and every sub-component without their
+   local `module_idx` values colliding.
+
+3. **`src/component/instance.zig` sub-instance options propagation.**
+   The `sub_instances` loop now uses
+   `instantiateWithOptions(subcomp, allocator, inst.options)` instead
+   of the bare `instantiate(...)`, so nested sub-components inherit
+   the parent's `precompiled_cores` + `aot_only` flag.
+
+With (1)–(3) in place, the loader/CLI side of Phase D is done: every
+core in a composed-component tree gets discovered, compiled, and the
+matching cwasm artifact reaches the right sub-component instantiation
+point.
+
+## What still blocks running the fixtures
+
+The calculator-cmd's main wasip1 core, after composition, imports a
+**non-WASI** function:
+
+```
+import function docs:adder/add@0.1.0.add : (i32, i32) -> (i32);
+```
+
+The composer wires this import to a `canon.lower` of the adder
+sub-component's `add` export. On the **interpreter** side this is
+handled by installing a `componentTrampoline` + per-slot
+`ComponentTrampolineCtx` on the importing core's `host_func_entries`
+slot, which bridges the core call back into the host `HostFunc` that
+lifts arguments, calls the adder core, and lowers the result.
+
+On the **AOT** side, that trampoline plumbing is explicitly deferred
+per `src/component/instance.zig:1659-1665`:
+
+> Phase 1: AOT cores skip cross-instance import wiring /
+> canon-lower trampoline plumbing (handled by the interp path below
+> for interp cores). Feasibility check above guarantees we only
+> commit to AOT for cores that don't need any of that. Richer
+> wiring lands in a follow-up.
+
+The pre-flight feasibility check (`firstUnsupportedAotImport`,
+`src/component/instance.zig:2546`) only accepts function imports
+whose `module_name` is a known WASI or spectest host; everything
+else — including all composed component-level WIT imports — is
+rejected and surfaces `error.AotImportUnresolvable` under
+`aot_only = true`.
+
+## Estimated work for the full fix
+
+Adding canon-lower trampoline support on AOT is the missing piece.
+Sketch:
+
+- Extend `src/runtime/aot/host_trampolines.zig`: the existing
+  `TrampolinePool` already produces `componentTrampoline`-style stubs
+  for canon-lowered AOT functions inside a single core. The composed
+  case needs the same stub family to be wired as *imports* on the
+  importing AOT core's import-function table — i.e., for each
+  unresolved function import that matches a `canon.lower`-backed
+  sibling sub-component export, install a pool slot pointing at the
+  sibling's lifted `HostFunc` and patch the AOT instance's import
+  slot to call into it.
+- Relax `firstUnsupportedAotImport` to recognize those resolvable
+  function imports (need to consult the parent component's
+  canon/instance index spaces, which means the feasibility check has
+  to take the `Component*` and the `with`-args of the importing
+  `core_instances.instantiate`, not just the parsed `AotModule`).
+- Add cross-instance memory/table sharing for AOT cores that the
+  current code path already supports through
+  `imported_table_overrides` / `imported_memory_overrides` —
+  composed-component cores share memory across cores in the same
+  sub-component (e.g. the calculator-cmd has 5 cores that need to
+  reach the main memory), so this must work end-to-end on AOT.
+
+Realistic LoC: ~400–800 in `src/runtime/aot/`, `src/component/
+instance.zig`, and `src/runtime/aot/host_trampolines.zig`, plus
+fixtures and tests. Substantially more than the ~200-line cap in
+the Phase D prompt.
+
+## Recommended split
+
+- **This branch (`wamr-662-d`)**: land the loader/CLI walker +
+  `PrecompiledCore` scoping. They are safe no-ops for every
+  non-composed fixture and the only reasonable foundation for the
+  AOT trampoline work. Keep the wasi-p2 skip entries + the
+  `build.zig` gates intact (do *not* drop them yet).
+- **Follow-up (issue #662 phase D2)**: AOT canon-lower trampolines
+  for cross-sub-component function imports. Drops the skip entries +
+  flips the gates.

--- a/src/component/core_backend.zig
+++ b/src/component/core_backend.zig
@@ -125,6 +125,22 @@ pub const CoreInstanceBackend = union(enum) {
 pub const PrecompiledCore = struct {
     module_idx: u32,
     cwasm_bytes: []const u8,
+    /// Optional raw-bytes identity of the core module that produced
+    /// this cwasm. Both `wamr.component_loader.load` invocations
+    /// against the same `wasm_data` buffer produce identical slices
+    /// for `core_modules[i].data`, so slice (ptr+len) equality is a
+    /// stable cross-parse key. When set, `findPrecompiled` matches
+    /// by `core_wasm`; when null, it falls back to matching by
+    /// `module_idx` against the *root* component (legacy on-disk
+    /// manifests + test fixtures that only have top-level cores).
+    ///
+    /// `wamr run`'s auto-precompile walks composed-component trees
+    /// (`wabt component compose -d` output) and stamps `core_wasm`
+    /// on every emitted entry so cores nested inside sub-components
+    /// can be found during recursive `instantiateWithOptions` of
+    /// those sub-components without their inner local `module_idx`
+    /// colliding with the root's. (#662 phase D)
+    core_wasm: ?[]const u8 = null,
 };
 
 /// Process-global toggle for AOT debug diagnostics. Off by default;
@@ -159,10 +175,24 @@ pub const Options = struct {
     /// fall back to interp" behaviour. See issue #644.
     aot_only: bool = false,
 
-    /// Find a precompiled artifact for a given core-module index.
-    pub fn findPrecompiled(self: Options, module_idx: u32) ?[]const u8 {
+    /// Find a precompiled artifact for a given core-module slot.
+    /// `core_wasm` is the raw module bytes from
+    /// `component.core_modules[module_idx].data`. Entries with
+    /// `core_wasm` set are matched by slice identity (stable across
+    /// re-parses of the same input); entries without (legacy
+    /// callers) are matched by `module_idx` alone.
+    pub fn findPrecompiled(
+        self: Options,
+        core_wasm: []const u8,
+        module_idx: u32,
+    ) ?[]const u8 {
         for (self.precompiled_cores) |pc| {
-            if (pc.module_idx == module_idx) return pc.cwasm_bytes;
+            if (pc.core_wasm) |cw| {
+                if (cw.ptr == core_wasm.ptr and cw.len == core_wasm.len)
+                    return pc.cwasm_bytes;
+            } else {
+                if (pc.module_idx == module_idx) return pc.cwasm_bytes;
+            }
         }
         return null;
     }
@@ -176,11 +206,35 @@ test "Options.findPrecompiled hits + misses" {
         .{ .module_idx = 2, .cwasm_bytes = &bytes_b },
     };
     const opts = Options{ .precompiled_cores = &pcs };
-    try std.testing.expectEqualSlices(u8, &bytes_a, opts.findPrecompiled(0).?);
-    try std.testing.expectEqualSlices(u8, &bytes_b, opts.findPrecompiled(2).?);
-    try std.testing.expectEqual(@as(?[]const u8, null), opts.findPrecompiled(1));
-    try std.testing.expectEqual(@as(?[]const u8, null), opts.findPrecompiled(99));
+    // Legacy entries (no `core_wasm`) match by `module_idx`; the
+    // `core_wasm` arg is ignored for those.
+    const dummy: []const u8 = &.{};
+    try std.testing.expectEqualSlices(u8, &bytes_a, opts.findPrecompiled(dummy, 0).?);
+    try std.testing.expectEqualSlices(u8, &bytes_b, opts.findPrecompiled(dummy, 2).?);
+    try std.testing.expectEqual(@as(?[]const u8, null), opts.findPrecompiled(dummy, 1));
+    try std.testing.expectEqual(@as(?[]const u8, null), opts.findPrecompiled(dummy, 99));
 
     const empty_opts = Options{};
-    try std.testing.expectEqual(@as(?[]const u8, null), empty_opts.findPrecompiled(0));
+    try std.testing.expectEqual(@as(?[]const u8, null), empty_opts.findPrecompiled(dummy, 0));
+}
+
+test "Options.findPrecompiled scoped by core_wasm slice identity" {
+    // Two modules with the *same* local `module_idx = 0` (composed
+    // component case: each sub-component has its own indexing).
+    // Distinguished by `core_wasm` slice identity.
+    const mod_x_src = [_]u8{ 0xDE, 0xAD, 0xBE, 0xEF };
+    const mod_y_src = [_]u8{ 0xCA, 0xFE, 0xBA, 0xBE };
+    const cwasm_x = [_]u8{ 1, 1, 1 };
+    const cwasm_y = [_]u8{ 2, 2, 2 };
+    const pcs = [_]PrecompiledCore{
+        .{ .module_idx = 0, .cwasm_bytes = &cwasm_x, .core_wasm = &mod_x_src },
+        .{ .module_idx = 0, .cwasm_bytes = &cwasm_y, .core_wasm = &mod_y_src },
+    };
+    const opts = Options{ .precompiled_cores = &pcs };
+    try std.testing.expectEqualSlices(u8, &cwasm_x, opts.findPrecompiled(&mod_x_src, 0).?);
+    try std.testing.expectEqualSlices(u8, &cwasm_y, opts.findPrecompiled(&mod_y_src, 0).?);
+    // A third slice that matches neither (different ptr) returns null
+    // even though `module_idx` matches both entries.
+    const mod_z_src = [_]u8{ 0, 0, 0, 0 };
+    try std.testing.expectEqual(@as(?[]const u8, null), opts.findPrecompiled(&mod_z_src, 0));
 }

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -1464,7 +1464,7 @@ pub fn instantiateWithOptions(
                     else => continue,
                 };
                 if (ie.module_idx >= component.core_modules.len) continue;
-                const cwasm_bytes = inst.options.findPrecompiled(ie.module_idx) orelse continue;
+                const cwasm_bytes = inst.options.findPrecompiled(component.core_modules[ie.module_idx].data, ie.module_idx) orelse continue;
                 const mod_alloc = inst.module_arena.allocator();
                 const probe_mod = mod_alloc.create(aot_loader.AotModule) catch break :blk true;
                 probe_mod.* = aot_loader.load(cwasm_bytes, mod_alloc) catch break :blk true;
@@ -1497,7 +1497,7 @@ pub fn instantiateWithOptions(
                     else => continue,
                 };
                 if (ie.module_idx >= component.core_modules.len) continue;
-                const cwasm_bytes = inst.options.findPrecompiled(ie.module_idx) orelse {
+                const cwasm_bytes = inst.options.findPrecompiled(component.core_modules[ie.module_idx].data, ie.module_idx) orelse {
                     std.log.warn(
                         "[aot reject] core module {d} has no precompiled artifact; `wamr` is AOT-only (#644)",
                         .{ie.module_idx},
@@ -1549,7 +1549,7 @@ pub fn instantiateWithOptions(
                     // warning + fall through to the interp path that
                     // already knows how to wire these.
                     if (!force_all_interp) blk_aot_try: {
-                        const cwasm_bytes = inst.options.findPrecompiled(ie.module_idx) orelse break :blk_aot_try;
+                        const cwasm_bytes = inst.options.findPrecompiled(core_mod.data, ie.module_idx) orelse break :blk_aot_try;
                         aot_blk: {
                             const mod_alloc = inst.module_arena.allocator();
                             const aot_module_ptr = mod_alloc.create(aot_loader.AotModule) catch break :aot_blk;
@@ -2204,7 +2204,17 @@ pub fn instantiateWithOptions(
                         // path keeps handling them.
                         continue;
                     }
-                    subs[i] = instantiate(subcomp, allocator) catch
+                    // Propagate the parent's instantiation options
+                    // (precompiled_cores, aot_only) into the sub-
+                    // component so composed components produced by
+                    // `wabt component compose -d` — whose actual cores
+                    // live inside nested sub-components — pick up the
+                    // precompiled artifacts that `wamr run` emits for
+                    // them. `PrecompiledCore.component` scopes each
+                    // entry to a specific (sub-)component pointer so
+                    // sibling sub-components don't collide on shared
+                    // local `module_idx` values. (#662 phase D)
+                    subs[i] = instantiateWithOptions(subcomp, allocator, inst.options) catch
                         return error.SubComponentInstantiateFailed;
                 },
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -518,7 +518,41 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                         std.debug.print("Error: failed to parse component for auto-precompile: {s}\n", .{@errorName(err)});
                         return 1;
                     };
-                    const ncore = parsed.core_modules.len;
+                    // Recursively collect every core module from the
+                    // top level *and* every nested sub-component. The
+                    // top level of a `wabt component compose -d`
+                    // composed component has zero cores of its own —
+                    // the actual command + adder cores live inside
+                    // its two nested sub-components (#662 phase D).
+                    // Each entry pairs the core's raw module bytes
+                    // (a stable cross-parse identity) with its
+                    // *local* `module_idx` within the component that
+                    // contains it; `Options.findPrecompiled` matches
+                    // on the bytes-slice so sub-component
+                    // instantiations don't collide on shared local
+                    // indices.
+                    const CoreRef = struct {
+                        data: []const u8,
+                        local_idx: u32,
+                    };
+                    var all_cores: std.ArrayListUnmanaged(CoreRef) = .empty;
+                    defer all_cores.deinit(load_arena.allocator());
+                    const Walker = struct {
+                        fn walk(
+                            comp: *const wamr.component_types.Component,
+                            list: *std.ArrayListUnmanaged(CoreRef),
+                            arena: std.mem.Allocator,
+                        ) !void {
+                            for (comp.core_modules, 0..) |cm, mi| {
+                                try list.append(arena, .{ .data = cm.data, .local_idx = @intCast(mi) });
+                            }
+                            for (comp.components) |child| {
+                                try walk(child, list, arena);
+                            }
+                        }
+                    };
+                    Walker.walk(&parsed, &all_cores, load_arena.allocator()) catch return 1;
+                    const ncore = all_cores.items.len;
                     if (ncore == 0) {
                         std.debug.print("Error: component contains no core modules\n", .{});
                         return 1;
@@ -528,8 +562,8 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                         .{ ncore, if (ncore == 1) @as([]const u8, "") else "s" },
                     );
                     auto_cores.ensureTotalCapacity(allocator, ncore) catch return 1;
-                    for (parsed.core_modules, 0..) |cm, idx| {
-                        const cwasm = wamr.component_aot.compileCoreWasm(allocator, cm.data, .{}) catch |err| {
+                    for (all_cores.items, 0..) |ref, idx| {
+                        const cwasm = wamr.component_aot.compileCoreWasm(allocator, ref.data, .{}) catch |err| {
                             std.debug.print(
                                 "Error: auto-precompile failed for core module {d}: {s} (issue #644)\n",
                                 .{ idx, @errorName(err) },
@@ -537,8 +571,9 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                             return 1;
                         };
                         auto_cores.appendAssumeCapacity(.{
-                            .module_idx = @intCast(idx),
+                            .module_idx = ref.local_idx,
                             .cwasm_bytes = cwasm,
+                            .core_wasm = ref.data,
                         });
                     }
                 }


### PR DESCRIPTION
Partial progress on phase D of #662 (composed-component support on the AOT-only `wamr run` CLI). Refs #644. Builds on #661 (merged).

> ⚠️ **Partial fix.** Lays the loader/CLI groundwork; the two composed
> fixtures still don't run end-to-end. See `phase-d-notes.md` in this
> branch for the full diagnosis and the recommended follow-up split.

## What this PR does

- **`src/main.zig` auto-precompile walker** now recursively walks
  `parsed.components` to discover every core module across nested
  sub-components. `wabt component compose -d` output carries its
  cores inside sub-components, and previously tripped
  `Error: component contains no core modules` at startup.
- **`src/component/core_backend.zig`** adds an optional
  `core_wasm: ?[]const u8` to `PrecompiledCore`. `Options.findPrecompiled`
  scopes lookups by slice identity (stable across re-parses of the
  same `wasm_data` buffer), so sibling sub-components don't collide
  on their local `module_idx` values. Legacy entries without
  `core_wasm` keep their old `module_idx`-only matching for on-disk
  manifests + tests.
- **`src/component/instance.zig`** threads `inst.options` into the
  `sub_instances` loop so nested sub-component instantiation inherits
  `precompiled_cores` + `aot_only`.

`zig build test` is clean. No existing fixture changes behaviour.

## What's still blocked

Both composed fixtures still fail:

```
$ ./zig-out/bin/wamr run zig-out/component-examples/zig-calculator-cmd.composed.wasm
wamr: auto-precompiling 6 cores in memory (no on-disk bundle; pass --precompiled-dir or run `wamrc compile-component` to persist)
warning: [aot reject] core module 0 import 'docs:adder/add@0.1.0.add' (function) cannot be resolved by AOT yet (#644)
Error: failed to instantiate component (the `wamr` CLI runs all components through the AOT runtime; see issue #644)
```

Root cause: the composed calculator-cmd's main core imports
`docs:adder/add@0.1.0.add`, which the composer wires to a `canon.lower`
of the adder sub-component's `add` export. The interp side handles
this via `componentTrampoline` install on the importing core's
host-func slot; the AOT side has no equivalent plumbing — explicitly
deferred at `src/component/instance.zig:1659-1665`:

> Phase 1: AOT cores skip cross-instance import wiring / canon-lower
> trampoline plumbing [...] Richer wiring lands in a follow-up.

Adding that support is a substantial AOT-runtime change — well past
the ~200-line cap on the Phase D prompt — so per the prompt's escape
hatch I stopped, kept the loader/scoping fix (it's a prerequisite for
any future AOT trampoline work and a safe no-op for every existing
non-composed fixture), and wrote the full diagnosis up in
[`phase-d-notes.md`](https://github.com/cataggar/wamr/blob/wamr-662-d/phase-d-notes.md).

The `tests/wasi-p2-testsuite-skip.json` entries and the `build.zig`
`wireComponentRun(.{ .skip_wamr = !aot_broken_components })` gates for
the two composed fixtures are intentionally **kept** here so CI stays
green; flipping them belongs in the follow-up that adds the AOT
trampoline plumbing (suggested issue label: `#662 phase D2`).

## Wasmtime parity (control)

```
$ wasmtime run -S cli-exit-with-code zig-out/component-examples/zig-calculator-cmd.composed.wasm
40 + 2 = 42
100 + 200 = 300                        (exit 0)

$ wasmtime run -S cli-exit-with-code zig-out/component-examples/mixed-zig-rust-calc.composed.wasm
40 + 2 = 42
100 + 200 = 300                        (exit 0)
```