### PR TITLE
Phase C: AOT cross-instance fn imports (#662)

### DIFF
--- a/phase-c-inventory.md
+++ b/phase-c-inventory.md
@@ -1,0 +1,150 @@
+# Phase C — AOT cross-instance fn-import inventory (#662)
+
+Tool: `WAMR_AOT_DEBUG=1 ./zig-out/bin/wamr run …` with a temporary debug
+hook in `firstUnsupportedAotImport` (see `src/component/instance.zig`).
+The hook prints every non-WASI/non-spectest function import (and every
+table/memory/global/tag import) for each core that the AOT-only policy
+walks. Output below is collated per fixture and grouped by what wiring
+each import actually needs.
+
+The inventory captures the four representative fixtures called out in
+the task: `zig-hello`, `zig-exit`, `zig-http`, and one p3 fixture
+(`cli-stdio`). The p3 surface as a whole follows the same shape as
+`cli-stdio`.
+
+## Findings summary
+
+* `__main_module__.{_start, cabi_realloc}` is the **only true
+  cross-instance core-to-core import** in the component-examples set —
+  the wabt-bundled wasi-preview1→preview2 adapter imports these from
+  the main core via `(instance (instantiate $adapter (with
+  "__main_module__" (instance $main))))`.
+* Every other rejected import on the four fixtures is **either a
+  canon.lower trampoline** (interface name like
+  `wasi:cli/stdout@0.2.6.get-stdout`) **or a canon-builtin** import
+  (`[task-return]`, `[context-get-0]`, `[waitable-*]`,
+  `[stream-*]`, `[future-*]`, …). Neither is "cross-instance" in the
+  core-to-core sense; both need host-bridge plumbing that lives in
+  Phase D / #520 / #533 territory.
+* The wabt adapter cores in zig-hello / zig-exit / zig-http carry a
+  large `wasi:*@0.2.6` canon.lower surface, but at runtime the
+  preview1 imports of the *main* core are satisfied directly by the
+  AOT host bridge (`wasi_snapshot_preview1`), so the adapter body is
+  effectively dead code — its exports are never reached on the
+  call paths these examples exercise. We can therefore make the
+  adapter merely *instantiate* (install best-effort thunks) without
+  having to make every adapter import actually do useful work.
+* p3 fixtures are dominated by **canon-builtin** imports
+  (`[task-return]run`, `[task-cancel]`, `[context-get-0]`,
+  `[waitable-join]`, `[waitable-set-{new,poll,drop}]`,
+  `[stream-{new,read,write,cancel-read,cancel-write,drop-readable,drop-writable}-*]`,
+  `[future-{new,read,write,cancel-read,cancel-write,drop-readable,drop-writable}-*]`)
+  plus host canon.lower over `wasi:cli/* @ 0.2.0`,
+  `wasi:io/* @ 0.2.0`. The p3 surface cannot be unblocked by
+  cross-instance fn-import wiring alone; those imports must reach
+  `dispatchCanonBuiltin` / `componentTrampoline` from the AOT side,
+  which is out of scope for Phase C.
+
+## zig-hello.component.wasm
+
+* Core 0 (main): only `env.memory` + `wasi_snapshot_preview1.*`
+  imports → already AOT-clean.
+* Core 1 (wabt preview1→preview2 adapter):
+
+### cross-instance core-to-core (in scope for Phase C)
+- module=`__main_module__`, field=`_start`,             sig=`() -> ()`
+- module=`__main_module__`, field=`cabi_realloc`,       sig=`(i32,i32,i32,i32) -> i32`
+
+### canon.lower host-trampoline imports (out of scope; install trap stub)
+- `wasi:cli/stdout@0.2.6.get-stdout` `() -> i32`
+- `wasi:cli/stderr@0.2.6.get-stderr` `() -> i32`
+- `wasi:io/streams@0.2.6.[method]output-stream.blocking-write-and-flush` `(i32,i32,i32,i32) -> ()`
+- `wasi:io/streams@0.2.6.[resource-drop]output-stream` `(i32) -> ()`
+- `wasi:filesystem/preopens@0.2.6.get-directories` `(i32) -> ()`
+- `wasi:filesystem/types@0.2.6.[method]descriptor.write-via-stream` `(i32,i64,i32) -> ()`
+
+## zig-exit.component.wasm
+
+Same shape as zig-hello (same wabt adapter on top of a slightly
+different main core).
+
+### cross-instance core-to-core (in scope)
+- `__main_module__._start` `() -> ()`
+- `__main_module__.cabi_realloc` `(i32,i32,i32,i32) -> i32`
+
+### canon.lower host-trampoline imports (out of scope; trap stub OK)
+- `wasi:cli/exit@0.2.6.exit` `(i32) -> ()`
+- `wasi:cli/exit@0.2.6.exit-with-code` `(i32) -> ()`
+- `wasi:cli/stdout@0.2.6.get-stdout` `() -> i32`
+- `wasi:cli/stderr@0.2.6.get-stderr` `() -> i32`
+- `wasi:io/streams@0.2.6.[method]output-stream.blocking-write-and-flush` `(i32,i32,i32,i32) -> ()`
+- `wasi:io/streams@0.2.6.[resource-drop]output-stream` `(i32) -> ()`
+- `wasi:filesystem/preopens@0.2.6.get-directories` `(i32) -> ()`
+- `wasi:filesystem/types@0.2.6.[method]descriptor.write-via-stream` `(i32,i64,i32) -> ()`
+
+## zig-http.component.wasm
+
+Not separately runnable today (the smoke-driver gate is currently
+behind `aot_broken_components`); shape mirrors zig-hello with an
+extra `wasi:http@0.2.6` canon.lower surface on the adapter.
+
+## cli-stdio.wasm (one representative p3 fixture)
+
+The first rejected import is the **canon-builtin** `task-return`:
+
+```
+[export]wasi:cli/run@0.3.0-rc-2026-03-15 . [task-return]run   (i32) -> ()
+```
+
+The full p3 reject set on `cli-stdio` (canon-builtins + canon.lower
+of preview2 interfaces):
+
+### canon-builtins (Phase D / #520 territory)
+- `[export]wasi:cli/run@0.3.0-rc-2026-03-15.[task-return]run` `(i32) -> ()`
+- `[export]$root.[task-cancel]` `() -> ()`
+- `$root.[context-get-0]` `() -> i32`
+- `$root.[context-set-0]` `(i32) -> ()`
+- `$root.[waitable-join]` `(i32,i32) -> ()`
+- `$root.[waitable-set-new]` `() -> i32`
+- `$root.[waitable-set-poll]` `(i32,i32) -> i32`
+- `$root.[waitable-set-drop]` `(i32) -> ()`
+- (cli-stdio adds the stream-*/future-* set on `wasi:cli/std{in,out,err}@0.3.0-rc`):
+  `[stream-new-0]`, `[stream-{cancel,drop}-{read,write}-0]`,
+  `[async-lower][stream-{read,write}-0]`, plus the matching `future-*`
+  surface — all sig `(i32,…) -> i32 / -> ()` / `() -> i64`.
+
+### canon.lower over preview2 interfaces (host trampolines)
+- `wasi:cli/std{in,out,err}@0.3.0-rc-2026-03-15.{read-via-stream,write-via-stream}`
+- `wasi:cli/environment@0.3.0-rc-2026-03-15.{get-arguments,get-environment,get-initial-cwd}`
+- The full `wasi:io/{error,poll,streams}@0.2.0` resource-drop set +
+  pollable.block + output-stream.{check-write,write,blocking-flush,subscribe}
+- The full `wasi:cli/terminal-*@0.2.0` resource-drop + `get-terminal-*` set
+- `wasi:cli/environment@0.2.0.get-environment`
+- `wasi:cli/exit@0.2.0.exit`
+- `wasi:cli/stdin@0.2.0.get-stdin`,  `wasi:cli/stdout@0.2.0.get-stdout`, `wasi:cli/stderr@0.2.0.get-stderr`
+
+## scope conclusion for Phase C
+
+The only set of imports this PR can legitimately *wire* is the
+cross-instance core-to-core pair (`__main_module__._start`,
+`__main_module__.cabi_realloc`). Everything else collapses to one of:
+
+1. **Canon-builtin** dispatch (`dispatchCanonBuiltin`) — out of scope
+   here, blocks the entire p3 surface, tracked in #520 / Phase D.
+2. **Canon.lower into a host import** (`componentTrampoline` /
+   `dispatchAotComponentTrampoline`) — also out of scope here, blocks
+   any p2/p3 fixture that actually calls into preview2 interfaces.
+
+For the three component-examples (zig-hello, zig-exit, zig-http) the
+adapter's canon.lower imports are **dead code** at runtime — the main
+core's preview1 imports are satisfied directly by the AOT host bridge
+via `host_bridge.isWasiModule`. Installing a `trap-on-call` stub for
+those adapter-side canon.lower imports is enough to let the component
+instantiate; the actual `dispatchCanonBuiltin` /
+`componentTrampoline` plumbing remains follow-up work.
+
+For the 38 p3 fixtures, the canon-builtin imports are on the **hot
+path**; trap-on-call stubs would just push the failure from
+instantiation time to call time. The p3 skip entries in
+`tests/wasi-p3-testsuite-skip.json` therefore stay in place until
+canon-builtin + canon.lower bridging lands.

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -6223,6 +6223,133 @@ pub export fn wamrAotDispatchComponentTrampoline(
     return .{ .status = 0, .value = result };
 }
 
+/// Per-import context for the cross-instance core-to-core thunk (#662).
+/// Owned by `ComponentInstance.cross_instance_thunk_ctxs`; the trampoline
+/// pool slot stores `*CrossInstanceThunkCtx` as its `ctx`.
+pub const CrossInstanceThunkCtx = struct {
+    /// Sibling AOT instance whose `func_idx` we will re-issue the call into.
+    target_ai: *aot_runtime.AotInstance,
+    /// Index into the sibling's function-index space.
+    target_func_idx: u32,
+    /// Cached param-type slice (core ValTypes) for `callFuncScalar`. Slices
+    /// are owned by the component-instance arena.
+    param_types: []const core_types.ValType,
+    result_types: []const core_types.ValType,
+    /// Human-readable label used in trap-shaped error messages.
+    label: []const u8,
+};
+
+/// Cross-instance core-to-core dispatcher (#662). The trampoline pool stub
+/// shifts caller regs right by one to inject `slot` as the first C-ABI arg,
+/// so when the AOT codegen calls a host import as
+/// `host_fn(vmctx, arg0, arg1, …)`, the dispatcher receives
+/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a5=arg4)`. We ignore `a0`
+/// (importer's vmctx — the sibling AotInstance builds its own vmctx
+/// internally in `callFuncScalar`) and use `a1..a5` as lowered wasm args.
+/// Calls outside the trampoline pool's 5-arg-in-regs envelope return a
+/// failing status; richer signatures land in a follow-up.
+pub export fn wamrAotDispatchCrossInstance(
+    ctx_opaque: *anyopaque,
+    lowered_sig: *const host_trampolines.LoweredSig,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+) callconv(.c) host_trampolines.DispatchResult {
+    _ = a0; // importer's vmctx; the sibling AotInstance builds its own.
+    const ctx: *const CrossInstanceThunkCtx = @ptrCast(@alignCast(ctx_opaque));
+    const result = dispatchAotCrossInstance(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, 0 }) catch |err| {
+        if (debugAotEnabled()) {
+            std.debug.print(
+                "[aot-dispatch] cross-instance thunk '{s}' failed: {s}\n",
+                .{ ctx.label, @errorName(err) },
+            );
+        }
+        return .{ .status = 1, .value = 0 };
+    };
+    return .{ .status = 0, .value = result };
+}
+
+fn dispatchAotCrossInstance(
+    ctx: *const CrossInstanceThunkCtx,
+    lowered_sig: host_trampolines.LoweredSig,
+    arg_regs: [6]u64,
+) !u64 {
+    // We support up to 5 args in registers (a1..a5 in the dispatcher's
+    // frame, since a0 is the importer's vmctx). Spilled-arg / spilled-result
+    // shapes route through the lift trampoline pathway, not this one.
+    if (lowered_sig.has_retptr) return error.UnsupportedSignature;
+    if (lowered_sig.param_types.len > 5) return error.UnsupportedSignature;
+    if (lowered_sig.result_types.len > 1) return error.UnsupportedSignature;
+    if (lowered_sig.param_types.len != ctx.param_types.len) return error.UnsupportedSignature;
+    if (lowered_sig.result_types.len != ctx.result_types.len) return error.UnsupportedSignature;
+    for (lowered_sig.param_types, ctx.param_types) |a, b| if (a != b) return error.UnsupportedSignature;
+    for (lowered_sig.result_types, ctx.result_types) |a, b| if (a != b) return error.UnsupportedSignature;
+
+    var args_buf: [5]core_types.Value = undefined;
+    for (ctx.param_types, 0..) |pt, i| {
+        args_buf[i] = switch (pt) {
+            .i32 => .{ .i32 = @bitCast(@as(u32, @truncate(arg_regs[i]))) },
+            .i64 => .{ .i64 = @bitCast(arg_regs[i]) },
+            .f32 => .{ .f32 = @bitCast(@as(u32, @truncate(arg_regs[i]))) },
+            .f64 => .{ .f64 = @bitCast(arg_regs[i]) },
+            else => return error.UnsupportedSignature,
+        };
+    }
+
+    var results_buf: [1]aot_runtime.ScalarResult = .{.{ .i32 = 0 }};
+    const results = aot_runtime.callFuncScalar(
+        ctx.target_ai,
+        ctx.target_func_idx,
+        ctx.param_types,
+        ctx.result_types,
+        args_buf[0..ctx.param_types.len],
+        &results_buf,
+    ) catch return error.TrapInCoreFunction;
+
+    if (ctx.result_types.len == 0) return 0;
+    return switch (ctx.result_types[0]) {
+        .i32 => @as(u64, @intCast(@as(u32, @bitCast(results[0].i32)))),
+        .i64 => @bitCast(results[0].i64),
+        .f32 => @as(u64, @intCast(@as(u32, @bitCast(results[0].f32)))),
+        .f64 => @bitCast(results[0].f64),
+        else => error.UnsupportedSignature,
+    };
+}
+
+/// Trap-on-call stub dispatcher (#662 follow-up). The trampoline pool
+/// installs this dispatcher for non-WASI fn imports the AOT bridge has
+/// no wiring for yet (canon.lower / canon-builtin). Instantiation
+/// succeeds, but any actual call returns a failing `DispatchResult` so
+/// the AOT codegen's host-call site sees a clean trap rather than a
+/// segfault through a null host slot.
+pub export fn wamrAotDispatchTrapStub(
+    ctx_opaque: *anyopaque,
+    lowered_sig: *const host_trampolines.LoweredSig,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+) callconv(.c) host_trampolines.DispatchResult {
+    _ = lowered_sig;
+    _ = a0;
+    _ = a1;
+    _ = a2;
+    _ = a3;
+    _ = a4;
+    _ = a5;
+    if (debugAotEnabled()) {
+        const label_ptr: *const [*:0]const u8 = @ptrCast(@alignCast(ctx_opaque));
+        std.debug.print("[aot-dispatch] trap-stub fired for unbridged import '{s}' (#662 follow-up)\n", .{label_ptr.*});
+    }
+    return .{ .status = 1, .value = 0 };
+}
+
+
 fn dispatchAotComponentTrampoline(
     ctx: *const ComponentTrampolineCtx,
     lowered_sig: host_trampolines.LoweredSig,

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -12,6 +12,7 @@ const async_mod = @import("async.zig");
 const core_backend = @import("core_backend.zig");
 const aot_loader = @import("../runtime/aot/loader.zig");
 const aot_runtime = @import("../runtime/aot/runtime.zig");
+const host_trampolines = @import("../runtime/aot/host_trampolines.zig");
 
 const aot_host_bridge = @import("../runtime/aot/host_bridge.zig");
 
@@ -247,6 +248,23 @@ pub const ComponentInstance = struct {
     /// in `canon_builtin_ctxs`; that list remains the sole owner and is
     /// what `deinit` walks to free the contexts exactly once. (#533)
     canon_builtin_ctx_by_canon_idx: std.AutoHashMapUnmanaged(u32, *executor_mod.CanonBuiltinTrampolineCtx) = .empty,
+    /// Per-(component-instance) host-trampoline pool. Lazily created the
+    /// first time an AOT core needs a cross-instance fn-import thunk or a
+    /// trap-on-call stub (#662 Phase C). Slots own the executable shim
+    /// memory; the `cross_instance_thunk_ctxs` ArrayList owns the per-slot
+    /// `CrossInstanceThunkCtx` payloads they reference.
+    aot_trampoline_pool: ?*host_trampolines.TrampolinePool = null,
+    /// Per-(component-instance) ownership of cross-instance thunk
+    /// contexts (`*executor_mod.CrossInstanceThunkCtx`). Each entry is
+    /// referenced as the `ctx` of an `aot_trampoline_pool` slot installed
+    /// in a sibling AOT instance's `host_functions[]` table; freed
+    /// together on `deinit` (#662 Phase C).
+    cross_instance_thunk_ctxs: std.ArrayListUnmanaged(*executor_mod.CrossInstanceThunkCtx) = .empty,
+    /// Per-(component-instance) ownership of trap-stub label C strings
+    /// (`*const [*:0]const u8` payloads). Each entry is referenced from a
+    /// `aot_trampoline_pool` trap slot's `ctx` so a debug-mode log line
+    /// can name the un-bridged import (#662 follow-up).
+    trap_stub_labels: std.ArrayListUnmanaged([*:0]const u8) = .empty,
     /// Pending core-module start functions whose execution was deferred
     /// during `instantiate` so canon-lower trampoline `host_funcs` can be
     /// bound by `linkImports` first. Drained by `linkImports` in core-instance
@@ -1314,6 +1332,27 @@ pub const ComponentInstance = struct {
         }
         self.canon_builtin_ctxs.deinit(self.allocator);
         self.canon_builtin_ctx_by_canon_idx.deinit(self.allocator);
+        for (self.cross_instance_thunk_ctxs.items) |ctx| {
+            self.allocator.free(ctx.param_types);
+            self.allocator.free(ctx.result_types);
+            self.allocator.free(ctx.label);
+            self.allocator.destroy(ctx);
+        }
+        self.cross_instance_thunk_ctxs.deinit(self.allocator);
+        for (self.trap_stub_labels.items) |label_ptr| {
+            // Each label was allocated as a null-terminated `[]u8` via
+            // `allocator.alloc(u8, n)`; recover the slice (including the
+            // trailing nul) and free it.
+            const label_z: [*:0]const u8 = label_ptr;
+            const len = std.mem.len(label_z);
+            const slice = label_z[0 .. len + 1];
+            self.allocator.free(slice);
+        }
+        self.trap_stub_labels.deinit(self.allocator);
+        if (self.aot_trampoline_pool) |pool| {
+            pool.deinit(self.allocator);
+            self.allocator.destroy(pool);
+        }
         self.pending_core_starts.deinit(self.allocator);
         if (self.core_instances.len > 0) {
             const inst_mod = @import("../runtime/interpreter/instance.zig");
@@ -1644,7 +1683,23 @@ pub fn instantiateWithOptions(
                             };
                             defer if (imported_global_overrides.len > 0) allocator.free(imported_global_overrides);
 
-                            const aot_inst_ptr = aot_runtime.instantiateWithOverrides(aot_module_ptr, inst.allocator, imported_table_overrides, imported_memory_overrides, imported_global_overrides) catch |err| {
+                            const imported_function_overrides = resolveAotImportedFunctionOverrides(
+                                allocator,
+                                inst,
+                                component,
+                                cis,
+                                ci_idx,
+                                ie.args,
+                                ie.module_idx,
+                                aot_module_ptr,
+                            ) catch |err| {
+                                std.log.warn("[aot reject] core module {d}: imported function override resolution failed: {s}", .{ ie.module_idx, @errorName(err) });
+                                if (aot_only) return error.AotImportUnresolvable;
+                                break :aot_blk;
+                            };
+                            defer if (imported_function_overrides.len > 0) allocator.free(imported_function_overrides);
+
+                            const aot_inst_ptr = aot_runtime.instantiateWithOverrides(aot_module_ptr, inst.allocator, imported_table_overrides, imported_memory_overrides, imported_global_overrides, imported_function_overrides) catch |err| {
                                 std.log.warn("aot core instantiate failed for module {d}: {s}", .{ ie.module_idx, @errorName(err) });
                                 if (aot_only) return error.AotImportUnresolvable;
                                 break :aot_blk;
@@ -2533,24 +2588,26 @@ fn isWasiCliRunName(name: []const u8) bool {
 
 /// Probe whether every import declared by an AOT-loaded core module
 /// has a wire-up the AOT runtime can satisfy. Today the AOT host
-/// bridge only knows the preview1 `wasi`/`wasi_snapshot_preview1`/
-/// `wasi_unstable` modules and `spectest`; everything else — and in
-/// particular wit-bindgen-emitted P2 cores whose function imports
-/// resolve via component-level `canon.lower` defs under interface
-/// names like `wasi:io/streams@0.2.0`, plus any cross-instance
-/// memory / table / global imports — has no AOT-side wiring and
-/// would fault on first use. Returns the first unsupported import,
-/// or null when the core is safe to commit to the AOT backend
-/// (#644). A null `imports` slice (no imports at all) is always
-/// supported.
+/// bridge knows preview1 `wasi`/`wasi_snapshot_preview1`/
+/// `wasi_unstable` and `spectest` directly; any other function import
+/// is satisfied by `resolveAotImportedFunctionOverrides` which
+/// installs either a cross-instance core-to-core thunk (when the
+/// import resolves to a sibling core's exported func) or a trap-on-
+/// call stub (#662 Phase C). Mutable globals and tag imports remain
+/// out of scope — those still surface here as unsupported (#660).
+/// Returns the first unsupported import, or null when the core is
+/// safe to commit to the AOT backend (#644). A null `imports` slice
+/// (no imports at all) is always supported.
 fn firstUnsupportedAotImport(module: *const aot_loader.AotModule) ?aot_loader.AotImportDesc {
     for (module.imports) |imp| {
         switch (imp.kind) {
-            .function => {
-                if (aot_host_bridge.isWasiModule(imp.module_name)) continue;
-                if (aot_host_bridge.isSpectestModule(imp.module_name)) continue;
-                return imp;
-            },
+            // Function imports route through `resolveAotImportedFunctionOverrides`
+            // at instantiation time. WASI / spectest land in the host bridge;
+            // everything else gets a cross-instance thunk or a trap-on-call
+            // stub. Instantiation always succeeds; calls into unbridged
+            // imports surface as a clean trap rather than a null-slot
+            // segfault (#662 Phase C).
+            .function => continue,
             // Tables and memories support cross-instance borrowing via
             // `instantiateWithOverrides`'s `imported_table_overrides` /
             // `imported_memory_overrides` slices. The caller's
@@ -2641,10 +2698,7 @@ fn resolveCoreMemoryToMI(
     const ref = indexspace.resolveCoreMemory(component, core_mem_idx) orelse return null;
     const ie = component.aliases[ref.aliased].instance_export;
     if (ie.instance_idx >= inst.core_instances.len) return null;
-    const src_mi = inst.core_instances[ie.instance_idx].module_inst orelse return null;
-    const exp = src_mi.module.findExport(ie.name, .memory) orelse return null;
-    if (exp.index >= src_mi.memories.len) return null;
-    return src_mi.memories[exp.index];
+    return resolveCoreInstanceMemoryExport(inst, component, inst.core_instances[ie.instance_idx], ie.name);
 }
 
 fn resolveCoreInstanceTableExport(
@@ -2820,6 +2874,226 @@ fn resolveAotImportedGlobalOverrides(
     return overrides;
 }
 
+/// Lazily allocate the component-instance trampoline pool used to hand
+/// AOT cores executable thunks for non-WASI fn imports (#662 Phase C).
+fn ensureAotTrampolinePool(inst: *ComponentInstance) !*host_trampolines.TrampolinePool {
+    if (inst.aot_trampoline_pool) |pool| return pool;
+    const pool = try inst.allocator.create(host_trampolines.TrampolinePool);
+    errdefer inst.allocator.destroy(pool);
+    pool.* = try host_trampolines.TrampolinePool.init(inst.allocator);
+    inst.aot_trampoline_pool = pool;
+    return pool;
+}
+
+/// Build the `imported_function_overrides[]` slice for an AOT core's
+/// `instantiateWithOverrides` call. WASI / spectest imports are left as
+/// null (the AOT runtime fills them from `host_bridge` at resolve time).
+/// Every other function import either resolves to a sibling core's
+/// exported func (→ cross-instance thunk via the trampoline pool) or is
+/// left wired as a trap-on-call stub so instantiation succeeds but a
+/// later call surfaces a clean trap rather than a segfault through a
+/// null host slot. (#662 Phase C).
+fn resolveAotImportedFunctionOverrides(
+    allocator: std.mem.Allocator,
+    inst: *ComponentInstance,
+    component: *const ctypes.Component,
+    cis: []const ComponentInstance.CoreInstanceEntry,
+    ci_idx: usize,
+    args: []const ctypes.CoreInstantiateArg,
+    module_idx: u32,
+    module: *const aot_loader.AotModule,
+) ![]const ?*const anyopaque {
+    if (module.import_function_count == 0) return &.{};
+
+    const overrides = try allocator.alloc(?*const anyopaque, module.import_function_count);
+    errdefer allocator.free(overrides);
+    @memset(overrides, null);
+
+    var func_idx: u32 = 0;
+    for (module.imports) |imp| {
+        if (imp.kind != .function) continue;
+        defer func_idx += 1;
+
+        // WASI / spectest stay null so the runtime can pick them up from
+        // `host_bridge` (matches the existing behaviour pre-#662).
+        if (aot_host_bridge.isWasiModule(imp.module_name)) continue;
+        if (aot_host_bridge.isSpectestModule(imp.module_name)) continue;
+
+        // Look up the `with` arg that names this import's wasm module.
+        const source_inst_idx: u32 = arg_blk: {
+            for (args) |arg| {
+                if (std.mem.eql(u8, arg.name, imp.module_name)) break :arg_blk arg.instance_idx;
+            }
+            break :arg_blk std.math.maxInt(u32);
+        };
+
+        var thunk: ?*const anyopaque = null;
+        if (source_inst_idx != std.math.maxInt(u32) and source_inst_idx < ci_idx) {
+            thunk = installCrossInstanceThunk(allocator, inst, component, cis[source_inst_idx], imp, module) catch |err| blk: {
+                std.log.warn(
+                    "[aot reject] core module {d}: cross-instance thunk for '{s}.{s}' failed ({s}); installing trap-on-call stub",
+                    .{ module_idx, imp.module_name, imp.field_name, @errorName(err) },
+                );
+                break :blk null;
+            };
+        }
+
+        if (thunk == null) {
+            // No sibling-core wiring available — install a trap-on-call
+            // stub so instantiation succeeds. Any actual call surfaces a
+            // clean trap via `wamrAotDispatchTrapStub`.
+            thunk = installTrapStub(allocator, inst, imp, module_idx) catch |err| blk: {
+                std.log.warn(
+                    "[aot reject] core module {d}: failed to install trap stub for '{s}.{s}': {s}",
+                    .{ module_idx, imp.module_name, imp.field_name, @errorName(err) },
+                );
+                break :blk null;
+            };
+        }
+
+        overrides[func_idx] = thunk;
+    }
+
+    return overrides;
+}
+
+/// Resolve a `(core_instance_entry, export_name)` reference to a
+/// concrete `(target_ai, target_func_idx)` pair for the cross-instance
+/// thunk. Walks through inline-exports + alias chains the same way
+/// `resolveCoreInstanceMemoryExport` does for memories.
+fn resolveCoreInstanceFuncToAi(
+    inst: *const ComponentInstance,
+    component: *const ctypes.Component,
+    entry: ComponentInstance.CoreInstanceEntry,
+    export_name: []const u8,
+) ?struct { ai: *aot_runtime.AotInstance, func_idx: u32 } {
+    if (entry.aot_inst) |src_ai| {
+        const exp = src_ai.module.findExport(export_name, .function) orelse return null;
+        return .{ .ai = src_ai, .func_idx = exp.index };
+    }
+    if (entry.module_inst != null) return null; // sibling on interp backend
+    for (entry.inline_exports) |mem| {
+        if (!std.mem.eql(u8, mem.name, export_name)) continue;
+        if (mem.sort_idx.sort != .func) break;
+        // Resolve through aliases to find the underlying aot_inst.
+        const cf = indexspace.resolveCoreFunc(component, mem.sort_idx.idx) orelse return null;
+        switch (cf) {
+            .aliased => |alias_idx| {
+                if (alias_idx >= component.aliases.len) return null;
+                const al = component.aliases[alias_idx];
+                const ie_al = switch (al) {
+                    .instance_export => |x| x,
+                    else => return null,
+                };
+                if (ie_al.instance_idx >= inst.core_instances.len) return null;
+                return resolveCoreInstanceFuncToAi(inst, component, inst.core_instances[ie_al.instance_idx], ie_al.name);
+            },
+            else => return null,
+        }
+    }
+    return null;
+}
+
+fn installCrossInstanceThunk(
+    allocator: std.mem.Allocator,
+    inst: *ComponentInstance,
+    component: *const ctypes.Component,
+    source_entry: ComponentInstance.CoreInstanceEntry,
+    imp: aot_loader.AotImportDesc,
+    module: *const aot_loader.AotModule,
+) !*const anyopaque {
+    // Only support sibling AOT cores today. Sibling interp cores fall
+    // through to a trap stub (calling across backends without a richer
+    // bridge would produce the same null-slot segfault we are trying to
+    // avoid).
+    const resolved = resolveCoreInstanceFuncToAi(inst, component, source_entry, imp.field_name) orelse return error.UnsupportedCrossInstanceSource;
+    const target_ai = resolved.ai;
+    const target_func_idx = resolved.func_idx;
+
+    if (imp.func_type_idx >= module.func_types.len) return error.InvalidFuncType;
+    const ft = module.func_types[imp.func_type_idx];
+
+    // Only register-fit signatures land in this fast path. Anything else
+    // returns an error → the caller installs a trap stub instead.
+    if (ft.params.len > 5) return error.SignatureTooWide;
+    if (ft.results.len > 1) return error.MultipleResultsUnsupported;
+    for (ft.params) |p| switch (p) {
+        .i32, .i64, .f32, .f64 => {},
+        else => return error.UnsupportedParamType,
+    };
+    for (ft.results) |r| switch (r) {
+        .i32, .i64, .f32, .f64 => {},
+        else => return error.UnsupportedResultType,
+    };
+
+    const param_types = try allocator.alloc(core_types.ValType, ft.params.len);
+    errdefer allocator.free(param_types);
+    for (ft.params, 0..) |p, i| param_types[i] = p;
+    const result_types = try allocator.alloc(core_types.ValType, ft.results.len);
+    errdefer allocator.free(result_types);
+    for (ft.results, 0..) |r, i| result_types[i] = r;
+
+    const label = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ imp.module_name, imp.field_name });
+    errdefer allocator.free(label);
+
+    const ctx = try allocator.create(executor_mod.CrossInstanceThunkCtx);
+    errdefer allocator.destroy(ctx);
+    ctx.* = .{
+        .target_ai = target_ai,
+        .target_func_idx = target_func_idx,
+        .param_types = param_types,
+        .result_types = result_types,
+        .label = label,
+    };
+    try inst.cross_instance_thunk_ctxs.append(allocator, ctx);
+    errdefer _ = inst.cross_instance_thunk_ctxs.pop();
+
+    const pool = try ensureAotTrampolinePool(inst);
+    const stub = try pool.allocCrossInstanceSlot(@ptrCast(ctx), .{
+        .param_types = param_types,
+        .result_types = result_types,
+        .has_retptr = false,
+    });
+    return @ptrCast(stub);
+}
+
+fn installTrapStub(
+    allocator: std.mem.Allocator,
+    inst: *ComponentInstance,
+    imp: aot_loader.AotImportDesc,
+    module_idx: u32,
+) !*const anyopaque {
+    // Allocate a null-terminated label so the dispatcher can `printf` it
+    // under WAMR_AOT_DEBUG without copying.
+    const len = imp.module_name.len + 1 + imp.field_name.len;
+    const buf = try allocator.alloc(u8, len + 1);
+    errdefer allocator.free(buf);
+    @memcpy(buf[0..imp.module_name.len], imp.module_name);
+    buf[imp.module_name.len] = '.';
+    @memcpy(buf[imp.module_name.len + 1 ..][0..imp.field_name.len], imp.field_name);
+    buf[len] = 0;
+
+    const label_z: [*:0]const u8 = @ptrCast(buf.ptr);
+    try inst.trap_stub_labels.append(allocator, label_z);
+    errdefer _ = inst.trap_stub_labels.pop();
+
+    if (core_backend.debugAotEnabled()) {
+        std.debug.print(
+            "[aot-bridge] core module {d}: installing trap-on-call stub for un-bridged import '{s}.{s}' (#662 follow-up)\n",
+            .{ module_idx, imp.module_name, imp.field_name },
+        );
+    }
+
+    const pool = try ensureAotTrampolinePool(inst);
+    // The trap dispatcher reads `ctx_opaque` as a `*const [*:0]const u8`
+    // when debug logging is enabled, so we hand it a pointer to the
+    // owned label entry in the ArrayList (stable because the list never
+    // shrinks before `deinit`).
+    const slot_ptr = &inst.trap_stub_labels.items[inst.trap_stub_labels.items.len - 1];
+    const stub = try pool.allocTrapSlot(@ptrCast(slot_ptr));
+    return @ptrCast(stub);
+}
+
 fn resolveCoreGlobalToMI(
     inst: *const ComponentInstance,
     component: *const ctypes.Component,
@@ -2828,10 +3102,7 @@ fn resolveCoreGlobalToMI(
     const ref = indexspace.resolveCoreGlobal(component, core_glob_idx) orelse return null;
     const ie = component.aliases[ref.aliased].instance_export;
     if (ie.instance_idx >= inst.core_instances.len) return null;
-    const src_mi = inst.core_instances[ie.instance_idx].module_inst orelse return null;
-    const exp = src_mi.module.findExport(ie.name, .global) orelse return null;
-    if (exp.index >= src_mi.globals.len) return null;
-    return src_mi.globals[exp.index];
+    return resolveCoreInstanceGlobalExport(inst, component, inst.core_instances[ie.instance_idx], ie.name);
 }
 
 /// Walk `component.type_indexspace[idx]` (loader-populated) to find the

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -43,6 +43,42 @@ extern fn wamrAotDispatchComponentTrampoline(
     a5: u64,
 ) callconv(.c) DispatchResult;
 
+/// Cross-instance core-to-core fn-import dispatcher (#662). Implemented in
+/// `src/component/executor.zig`. The first slot (`a0`) is the importer's
+/// vmctx, which the dispatcher ignores; `a1..a5` are the lowered wasm args
+/// per the AOT codegen calling convention.
+extern fn wamrAotDispatchCrossInstance(
+    ctx_opaque: *anyopaque,
+    lowered_sig: *const LoweredSig,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+) callconv(.c) DispatchResult;
+
+/// Trap-on-call stub for non-WASI function imports that have no AOT-side
+/// wiring yet (e.g. adapter-core canon.lower imports left over after #662
+/// Phase C). Returns a failing `DispatchResult` so the caller traps with
+/// a clean status rather than jumping through a null host slot.
+extern fn wamrAotDispatchTrapStub(
+    ctx_opaque: *anyopaque,
+    lowered_sig: *const LoweredSig,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+) callconv(.c) DispatchResult;
+
+pub const DispatchKind = enum(u8) {
+    canon_lower,
+    cross_instance,
+    trap_stub,
+};
+
 pub const Slot = struct {
     component_inst: *anyopaque,
     canon_lower_idx: u32,
@@ -52,6 +88,7 @@ pub const Slot = struct {
         .result_types = &.{},
         .has_retptr = false,
     },
+    dispatch_kind: DispatchKind = .canon_lower,
 };
 
 var g_active_pool: ?*TrampolinePool = null;
@@ -66,7 +103,11 @@ pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64,
 
     const entry = pool.slots[slot];
     const ctx = entry.ctx orelse return 0;
-    const dispatched = wamrAotDispatchComponentTrampoline(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5);
+    const dispatched = switch (entry.dispatch_kind) {
+        .canon_lower => wamrAotDispatchComponentTrampoline(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
+        .cross_instance => wamrAotDispatchCrossInstance(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
+        .trap_stub => wamrAotDispatchTrapStub(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
+    };
     if (dispatched.status != 0) return 0;
     return dispatched.value;
 }
@@ -131,6 +172,51 @@ pub const TrampolinePool = struct {
         self.slots[slot] = .{
             .component_inst = component_inst,
             .canon_lower_idx = canon_lower_idx,
+        };
+        self.next_slot += 1;
+        writeStub(self.stubBytes(slot), slot);
+        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
+        g_active_pool = self;
+
+        return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
+    }
+
+    /// Allocate a slot for a cross-instance core-to-core fn-import thunk
+    /// (#662). The stub forwards the importer's vmctx + lowered wasm args
+    /// to `wamrAotDispatchCrossInstance`, which re-issues the call into
+    /// the sibling AotInstance via `aot_runtime.callFuncScalar`.
+    pub fn allocCrossInstanceSlot(self: *TrampolinePool, ctx: *anyopaque, lowered_sig: LoweredSig) !StubFn {
+        const slot = self.next_slot;
+        if (slot >= MAX_SLOTS) return error.OutOfTrampolineSlots;
+
+        self.slots[slot] = .{
+            .component_inst = ctx,
+            .canon_lower_idx = 0,
+            .ctx = ctx,
+            .lowered_sig = lowered_sig,
+            .dispatch_kind = .cross_instance,
+        };
+        self.next_slot += 1;
+        writeStub(self.stubBytes(slot), slot);
+        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
+        g_active_pool = self;
+
+        return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
+    }
+
+    /// Allocate a slot for a "trap on call" stub. The instantiation flow
+    /// installs these for non-WASI fn imports that have no AOT-side wiring
+    /// (canon.lower / canon-builtin) yet — instantiation succeeds, but any
+    /// actual call traps with a clean status (#662 follow-up).
+    pub fn allocTrapSlot(self: *TrampolinePool, ctx: *anyopaque) !StubFn {
+        const slot = self.next_slot;
+        if (slot >= MAX_SLOTS) return error.OutOfTrampolineSlots;
+
+        self.slots[slot] = .{
+            .component_inst = ctx,
+            .canon_lower_idx = 0,
+            .ctx = ctx,
+            .dispatch_kind = .trap_stub,
         };
         self.next_slot += 1;
         writeStub(self.stubBytes(slot), slot);

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -117,15 +117,23 @@ pub const TrampolinePool = struct {
     slots: []Slot,
     next_slot: u32 = 0,
 
-    pub fn init(allocator: std.mem.Allocator) !TrampolinePool {
-        if (builtin.os.tag == .windows) return error.UnsupportedPlatform;
-        switch (builtin.cpu.arch) {
-            .x86_64, .aarch64 => {},
-            else => return error.UnsupportedPlatform,
-        }
+    // Whether RWX trampoline pages are supported on the build target.
+    // Gated at comptime so the `std.posix.mmap` call below is not analysed
+    // on Windows / unsupported arches — that previously forced an explicit
+    // `linkLibC` on every binary reachable from `TrampolinePool.init`
+    // (broke `wamr.exe` Windows build under #662 Phase C, where the lazy
+    // pool ctor became reachable from the CLI).
+    const supports_pool: bool = blk: {
+        if (builtin.os.tag == .windows) break :blk false;
+        if (builtin.cpu.arch != .x86_64 and builtin.cpu.arch != .aarch64) break :blk false;
         // macOS aarch64 forbids RWX mmap without MAP_JIT + pthread_jit_write_protect_np;
         // not worth wiring up for stdio-echo's needs. AOT layer falls back to interp.
-        if (builtin.os.tag == .macos and builtin.cpu.arch == .aarch64) return error.UnsupportedPlatform;
+        if (builtin.os.tag == .macos and builtin.cpu.arch == .aarch64) break :blk false;
+        break :blk true;
+    };
+
+    pub fn init(allocator: std.mem.Allocator) !TrampolinePool {
+        if (comptime !supports_pool) return error.UnsupportedPlatform;
 
         const slots = try allocator.alloc(Slot, MAX_SLOTS);
         errdefer allocator.free(slots);
@@ -227,6 +235,11 @@ pub const TrampolinePool = struct {
     }
 
     pub fn deinit(self: *TrampolinePool, allocator: std.mem.Allocator) void {
+        if (comptime !supports_pool) {
+            allocator.free(self.slots);
+            self.* = undefined;
+            return;
+        }
         if (g_active_pool == self) g_active_pool = null;
         std.posix.munmap(self.memory);
         allocator.free(self.slots);

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -992,7 +992,7 @@ pub const RuntimeError = error{
 
 /// Instantiate an AOT module, producing a runnable AotInstance.
 pub fn instantiate(module: *const aot_loader.AotModule, allocator: std.mem.Allocator) RuntimeError!*AotInstance {
-    return instantiateWithOverrides(module, allocator, &.{}, &.{}, &.{});
+    return instantiateWithOverrides(module, allocator, &.{}, &.{}, &.{}, &.{});
 }
 
 /// Instantiate an AOT module, optionally borrowing `TableInstance`s,
@@ -1001,16 +1001,24 @@ pub fn instantiate(module: *const aot_loader.AotModule, allocator: std.mem.Alloc
 /// `imported_memory_overrides[i]` to `module.importedMemories()[i]`,
 /// `imported_global_overrides[i]` to `module.importedGlobals()[i]`;
 /// null leaves that slot locally allocated (with a zero-valued default).
+///
+/// `imported_function_overrides[i]` maps to the *i-th function import*
+/// in `module.imports` declaration order. A non-null entry replaces the
+/// host-bridge / spectest resolution (used by #662 Phase C to wire
+/// cross-instance core-to-core fn imports + trap-on-call stubs through
+/// `host_trampolines`).
 pub fn instantiateWithOverrides(
     module: *const aot_loader.AotModule,
     allocator: std.mem.Allocator,
     imported_table_overrides: []const ?*types.TableInstance,
     imported_memory_overrides: []const ?*types.MemoryInstance,
     imported_global_overrides: []const ?*types.GlobalInstance,
+    imported_function_overrides: []const ?*const anyopaque,
 ) RuntimeError!*AotInstance {
     std.debug.assert(imported_table_overrides.len == 0 or imported_table_overrides.len == module.importedTables().len);
     std.debug.assert(imported_memory_overrides.len == 0 or imported_memory_overrides.len == module.importedMemories().len);
     std.debug.assert(imported_global_overrides.len == 0 or imported_global_overrides.len == module.importedGlobals().len);
+    std.debug.assert(imported_function_overrides.len == 0 or imported_function_overrides.len == module.import_function_count);
 
     var inst = allocator.create(AotInstance) catch return error.OutOfMemory;
     errdefer allocator.destroy(inst);
@@ -1106,7 +1114,7 @@ pub fn instantiateWithOverrides(
     errdefer if (inst.global_offsets.len > 0) allocator.free(inst.global_offsets);
 
     // Resolve AOT host functions for imports
-    inst.host_functions = try resolveHostFunctions(module, allocator);
+    inst.host_functions = try resolveHostFunctionsWithOverrides(module, allocator, imported_function_overrides);
 
     // Intern each declared module type into the process-global registry and
     // build a module-local sig_table (type_idx → canonical u32 sig_id). Only
@@ -2001,7 +2009,15 @@ fn resolveHostFunctions(
     module: *const aot_loader.AotModule,
     allocator: std.mem.Allocator,
 ) RuntimeError![]const ?*const anyopaque {
-    return resolveHostFunctionsImpl(module, allocator, null);
+    return resolveHostFunctionsImpl(module, allocator, null, &.{});
+}
+
+fn resolveHostFunctionsWithOverrides(
+    module: *const aot_loader.AotModule,
+    allocator: std.mem.Allocator,
+    overrides: []const ?*const anyopaque,
+) RuntimeError![]const ?*const anyopaque {
+    return resolveHostFunctionsImpl(module, allocator, null, overrides);
 }
 
 /// Resolve host functions with optional custom HostImports (comptime-typed).
@@ -2010,13 +2026,14 @@ pub fn resolveHostFunctionsWithHosts(
     allocator: std.mem.Allocator,
     comptime HostImportsT: ?type,
 ) RuntimeError![]const ?*const anyopaque {
-    return resolveHostFunctionsImpl(module, allocator, HostImportsT);
+    return resolveHostFunctionsImpl(module, allocator, HostImportsT, &.{});
 }
 
 fn resolveHostFunctionsImpl(
     module: *const aot_loader.AotModule,
     allocator: std.mem.Allocator,
     comptime HostImportsT: ?type,
+    overrides: []const ?*const anyopaque,
 ) RuntimeError![]const ?*const anyopaque {
     if (module.import_function_count == 0) return &.{};
 
@@ -2028,10 +2045,17 @@ fn resolveHostFunctionsImpl(
     for (module.imports) |imp| {
         if (imp.kind == .function) {
             if (func_idx < module.import_function_count) {
+                // Layer 0: caller-supplied per-import override (#662 Phase C
+                // cross-instance fn imports + trap-on-call stubs).
+                if (func_idx < overrides.len) {
+                    if (overrides[func_idx]) |entry| host_fns[func_idx] = entry;
+                }
                 // Layer 1: custom HostImports (comptime-resolved)
-                if (HostImportsT) |HI| {
-                    if (HI.resolve(imp.module_name, imp.field_name)) |entry| {
-                        host_fns[func_idx] = entry.aot_fn;
+                if (host_fns[func_idx] == null) {
+                    if (HostImportsT) |HI| {
+                        if (HI.resolve(imp.module_name, imp.field_name)) |entry| {
+                            host_fns[func_idx] = entry.aot_fn;
+                        }
                     }
                 }
                 // Layer 2: WASI / spectest (only if not already resolved)

--- a/src/tests/component_aot_smoke_test.zig
+++ b/src/tests/component_aot_smoke_test.zig
@@ -117,7 +117,7 @@ test "#649 phase 2: instantiateWithOverrides shares imported tables across AOT c
     try aot_runtime_mod.mapCodeExecutable(exporter_inst);
 
     const overrides = [_]?*core_types.TableInstance{exporter_inst.tables[0]};
-    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &overrides, &.{}, &.{});
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &overrides, &.{}, &.{}, &.{});
     defer aot_runtime_mod.destroy(importer_inst);
     try std.testing.expectEqual(exporter_inst.tables[0], importer_inst.tables[0]);
     try std.testing.expect(!importer_inst.tables_owned[0]);
@@ -336,7 +336,7 @@ test "#649 phase 3: instantiateWithOverrides shares imported memory across AOT c
     try std.testing.expectEqual(@as(u8, 0x22), exporter_inst.memories[0].data[3]);
 
     const overrides = [_]?*core_types.MemoryInstance{exporter_inst.memories[0]};
-    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &overrides, &.{});
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &overrides, &.{}, &.{});
     defer aot_runtime_mod.destroy(importer_inst);
     try std.testing.expectEqual(exporter_inst.memories[0], importer_inst.memories[0]);
     try std.testing.expect(!importer_inst.memories_owned[0]);
@@ -458,7 +458,7 @@ test "#649 phase 4: instantiateWithOverrides shares imported globals across AOT 
     try std.testing.expectEqual(@as(i32, 0x55), exporter_inst.globals[0].value.i32);
 
     const overrides = [_]?*core_types.GlobalInstance{exporter_inst.globals[0]};
-    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &.{}, &overrides);
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &.{}, &overrides, &.{});
     defer aot_runtime_mod.destroy(importer_inst);
     try std.testing.expectEqual(exporter_inst.globals[0], importer_inst.globals[0]);
     try std.testing.expect(!importer_inst.globals_owned[0]);
@@ -584,6 +584,7 @@ test "#649 phase 5: cross-AOT shared memory + table + global in one importer" {
         &table_overrides,
         &memory_overrides,
         &global_overrides,
+        &.{},
     );
     defer aot_runtime_mod.destroy(importer_inst);
     try std.testing.expectEqual(exporter_inst.tables[0], importer_inst.tables[0]);


### PR DESCRIPTION
Phase C of #662. Implements the cross-instance core-to-core fn-import wiring on the AOT host bridge so a sibling AOT core can call into another sibling AOT core directly, plus a trap-on-call stub for non-WASI fn imports that still need their own AOT bridging.

## Inventory

See `phase-c-inventory.md` (committed in the first commit) for the full per-fixture surface walk that drove this PR. TL;DR:

* The only true cross-instance core-to-core fn-import in the component-examples set is the wabt preview1→preview2 adapter pulling `__main_module__.{_start, cabi_realloc}` from the main core. Phase C wires these.
* Every other rejected import on the four representative fixtures (zig-hello, zig-exit, zig-http, cli-stdio) is either a canon.lower trampoline (interface name like `wasi:cli/stdout@0.2.6.get-stdout`) or a canon-builtin (`[task-return]`, `[context-get-0]`, `[waitable-*]`, `[stream-*]`, `[future-*]`). Both need their own AOT bridging that lives in Phase D / #520 / #533.

## Code shape

* New `host_trampolines` slot kinds: `cross_instance` and `trap_stub`, alongside the existing `canon_lower` shape. `genericDispatcher` routes on `slot.dispatch_kind`.
* New `executor.wamrAotDispatchCrossInstance` + `CrossInstanceThunkCtx`. The dispatcher ignores the importer's vmctx (`a0`) since `aot_runtime.callFuncScalar` builds its own vmctx for the sibling instance.
* New `executor.wamrAotDispatchTrapStub` that returns a failing `DispatchResult` so the AOT codegen's host-call site traps cleanly rather than segfaulting through a null host slot.
* `aot_runtime.instantiateWithOverrides` gains a fourth override slice `imported_function_overrides[]` parallel to the existing table/memory/global overrides; `resolveHostFunctionsImpl` consults it before WASI / spectest fallback.
* `instance.zig` walks each AOT core's imports and assembles the override slice via the new `resolveAotImportedFunctionOverrides` + `installCrossInstanceThunk` + `installTrapStub` helpers. Per-component-instance ownership of the trampoline pool, thunk ctxs, and trap-stub labels is added to `ComponentInstance` with matching `deinit` cleanup.
* Drive-by fixes for two latent bugs that this PR exposes (the inline-exports tail in `resolveCoreMemoryToMI` and `resolveCoreGlobalToMI` previously short-circuited `module_inst orelse return null` — sibling AOT cores were never considered).

## Validation

* `zig build test --summary failures` is clean.
* `./zig-out/bin/wamr run zig-out/component-examples/zig-hello.component.wasm` now resolves cross-instance `__main_module__._start` (the original Phase C reject) — it then fails further along on a *table* cross-wiring gap in core 3 of the wabt adapter, which is #660 territory. Same shape for zig-exit / zig-http. No fixtures clear end-to-end yet; see scope notes below.
* p3 fixtures still fail on canon-builtin / canon.lower imports (out of scope for Phase C).

## Skip lists

**Unchanged.** No `tests/wasi-p3-testsuite-skip.json` or `tests/wasi-p2-testsuite-skip.json` entries are removed in this PR. The `-Daot-broken-components=false` gate on zig-hello / zig-exit / zig-http stays in place too. Three reasons:

1. The component-examples fixtures need cross-instance *table* wiring on top of Phase C's fn-import work to actually instantiate end-to-end (see #660).
2. The 38 wasi-p3 fixtures hit canon-builtin imports (`[task-return]`, `[context-get-0]`, `[waitable-*]`, `[stream-*]`, `[future-*]`) on the *hot* path before reaching anything Phase C would unblock.
3. Trap-on-call stubs let instantiation succeed but the very first call into one of those imports traps cleanly, which still surfaces as a test failure.

## Caveats / follow-ups

* The cross-instance thunk fast path supports up to 5 register-fit i32/i64/f32/f64 params and at most one register-fit result. Spilled-arg / spilled-result / non-scalar shapes return `error.UnsupportedSignature` from the dispatcher and the caller falls back to a trap stub. Richer shapes can land later without disturbing the contract.
* The trampoline pool's stub layout puts the importer's vmctx in `a0` and shifts wasm args right by one — `wamrAotDispatchCrossInstance` accounts for that; future canon.lower / canon-builtin dispatchers that get plumbed through the same pool will need to mirror this offset.
* I retained a debug-gated `[aot-bridge]` log for the trap-stub install path so future runs under `WAMR_AOT_DEBUG=1` clearly name which import got a stub vs. a real thunk.