### PR TITLE
feat(aot): mutable cross-instance imported globals (#660 item 2)

### DIFF
--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -1711,13 +1711,9 @@ pub fn instantiateWithOptions(
                                 break :aot_blk;
                             };
                             cis[ci_idx] = .{ .aot_inst = aot_inst_ptr };
-                            // Phase 1: AOT cores skip cross-instance import
-                            // wiring / canon-lower trampoline plumbing
-                            // (handled by the interp path below for interp
-                            // cores). Feasibility check above guarantees we
-                            // only commit to AOT for cores that don't need
-                            // any of that. Richer wiring lands in a
-                            // follow-up.
+                            // AOT cross-instance overrides were resolved
+                            // above before instantiation; unresolved imports
+                            // either fall back to interp or use a trap stub.
                             continue;
                         }
                     }
@@ -2593,8 +2589,11 @@ fn isWasiCliRunName(name: []const u8) bool {
 /// is satisfied by `resolveAotImportedFunctionOverrides` which
 /// installs either a cross-instance core-to-core thunk (when the
 /// import resolves to a sibling core's exported func) or a trap-on-
-/// call stub (#662 Phase C). Mutable globals and tag imports remain
-/// out of scope — those still surface here as unsupported (#660).
+/// call stub (#662 Phase C). Mutable globals borrow the exporter's
+/// retained `GlobalInstance` and AOT call exit now writes mutable
+/// imported slab slots back to that canonical value (#660 item 2).
+/// Tag imports remain out of scope and still surface here as
+/// unsupported.
 /// Returns the first unsupported import, or null when the core is
 /// safe to commit to the AOT backend (#644). A null `imports` slice
 /// (no imports at all) is always supported.
@@ -2615,22 +2614,12 @@ fn firstUnsupportedAotImport(module: *const aot_loader.AotModule) ?aot_loader.Ao
             // null and fall back to interp if a `with` arg can't be
             // satisfied, so we don't need to re-check feasibility here.
             .table, .memory => continue,
-            // Immutable global imports flow through
-            // `imported_global_overrides`: the runtime borrows the
-            // exporter's `GlobalInstance` and bakes its value into the
-            // per-call globals slab. Mutable globals would need cross-core
-            // write-back, which requires either a per-global indirection
-            // in codegen or a slab-rebuild on each access; both are out of
-            // scope for this PR, so they still fall back to interp.
-            .global => {
-                for (module.importedGlobals()) |g| {
-                    if (!std.mem.eql(u8, g.module_name, imp.module_name)) continue;
-                    if (!std.mem.eql(u8, g.name, imp.field_name)) continue;
-                    if (g.mutable) return imp;
-                    break;
-                }
-                continue;
-            },
+            // Global imports flow through `imported_global_overrides`: the
+            // runtime borrows the exporter's retained `GlobalInstance` and
+            // seeds each AOT call's globals slab from it. Mutable imports are
+            // accepted because call exit flushes the slab slot back to that
+            // canonical value (#660 item 2).
+            .global => continue,
             // Tag imports still require cross-instance wiring that the
             // AOT runtime cannot synthesize today.
             .tag => return imp,

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -1688,18 +1688,39 @@ pub fn writeGlobalsToStorage(inst: *const AotInstance, storage: []u8) void {
 }
 
 pub fn readGlobalsFromStorage(inst: *AotInstance, storage: []const u8) void {
+    const imported_count = inst.module.importedGlobals().len;
     for (inst.globals, 0..) |g, i| {
-        const off = globalOffsetAt(inst, i) orelse continue;
-        g.value = switch (g.value) {
-            .v128 => if (off + 16 <= storage.len)
-                .{ .v128 = std.mem.readInt(u128, storage[off..][0..16], .little) }
-            else
-                g.value,
-            else => if (off + 8 <= storage.len)
-                globalValueFromI64(inst, g.value, std.mem.readInt(i64, storage[off..][0..8], .little))
-            else
-                g.value,
-        };
+        if (i < imported_count and i < inst.globals_owned.len and !inst.globals_owned[i]) continue;
+        readGlobalSlotFromStorage(inst, g, i, storage);
+    }
+    flushImportedGlobalsToStorage(inst, storage);
+}
+
+fn readGlobalSlotFromStorage(inst: *const AotInstance, g: *types.GlobalInstance, i: usize, storage: []const u8) void {
+    const off = globalOffsetAt(inst, i) orelse return;
+    g.value = switch (g.value) {
+        .v128 => if (off + 16 <= storage.len)
+            .{ .v128 = std.mem.readInt(u128, storage[off..][0..16], .little) }
+        else
+            g.value,
+        else => if (off + 8 <= storage.len)
+            globalValueFromI64(inst, g.value, std.mem.readInt(i64, storage[off..][0..8], .little))
+        else
+            g.value,
+    };
+}
+
+pub fn flushImportedGlobalsToStorage(inst: *AotInstance, storage: []const u8) void {
+    const imported = inst.module.importedGlobals();
+    for (imported, 0..) |desc, i| {
+        if (!desc.mutable) continue;
+        if (i >= inst.globals.len) continue;
+        // Imported globals are per-call snapshots in AOT code. Mutable borrowed
+        // imports must be written back on call exit so sibling importers see the
+        // canonical GlobalInstance update. Concurrent host re-entry is
+        // last-writer-wins at the call boundary (#660); true interleaving would
+        // require per-access indirection instead of the slab fast path.
+        readGlobalSlotFromStorage(inst, inst.globals[i], i, storage);
     }
 }
 
@@ -2346,6 +2367,8 @@ fn allocateGlobals(
         if (imported_global_overrides.len > i and imported_global_overrides[i] != null) {
             const shared = imported_global_overrides[i].?;
             shared.retain();
+            // Exact exporter GlobalInstance; call-exit flush updates the
+            // canonical value observed by sibling importers (#660).
             globals[i] = shared;
             owned[i] = false;
         } else {

--- a/src/tests/component_aot_smoke_test.zig
+++ b/src/tests/component_aot_smoke_test.zig
@@ -140,6 +140,107 @@ test "#649 phase 2: instantiateWithOverrides shares imported tables across AOT c
     try std.testing.expectEqual(@as(i32, 7), results[0].i32);
 }
 
+test "#660 item 2: AOT mutable imported global writes back across component cores" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const exporter_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: () -> i32, () -> ()
+        0x01, 0x08, 0x02, 0x60, 0x00, 0x01, 0x7f, 0x60, 0x00, 0x00,
+        // function section: readG type 0, write_one type 1
+        0x03, 0x03, 0x02, 0x00, 0x01,
+        // global section: (global (mut i32) (i32.const 0))
+        0x06, 0x06, 0x01, 0x7f, 0x01, 0x41, 0x00, 0x0b,
+        // export section: global "g", funcs "readG" and "write_one"
+        0x07, 0x19, 0x03,
+        0x01, 'g', 0x03, 0x00,
+        0x05, 'r', 'e', 'a', 'd', 'G', 0x00, 0x00,
+        0x09, 'w', 'r', 'i', 't', 'e', '_', 'o', 'n', 'e', 0x00, 0x01,
+        // code section: readG => global.get 0; write_one => global.set 0 to 1
+        0x0a, 0x0d, 0x02,
+        0x04, 0x00, 0x23, 0x00, 0x0b,
+        0x06, 0x00, 0x41, 0x01, 0x24, 0x00, 0x0b,
+    };
+    const importer_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: () -> (), () -> i32
+        0x01, 0x08, 0x02, 0x60, 0x00, 0x00, 0x60, 0x00, 0x01, 0x7f,
+        // import section: (import "a" "g" (global (mut i32)))
+        0x02, 0x08, 0x01, 0x01, 'a', 0x01, 'g', 0x03, 0x7f, 0x01,
+        // function section: write42 type 0, readG type 1
+        0x03, 0x03, 0x02, 0x00, 0x01,
+        // export section: funcs "write42" and "readG"
+        0x07, 0x13, 0x02,
+        0x07, 'w', 'r', 'i', 't', 'e', '4', '2', 0x00, 0x00,
+        0x05, 'r', 'e', 'a', 'd', 'G', 0x00, 0x01,
+        // code section: write42 => global.set 0 to 42; readG => global.get 0
+        0x0a, 0x0d, 0x02,
+        0x06, 0x00, 0x41, 0x2a, 0x24, 0x00, 0x0b,
+        0x04, 0x00, 0x23, 0x00, 0x0b,
+    };
+
+    const allocator = std.testing.allocator;
+    const exporter_cwasm = try aot_harness.compileWasmToAot(allocator, &exporter_wasm);
+    defer allocator.free(exporter_cwasm);
+    const importer_cwasm = try aot_harness.compileWasmToAot(allocator, &importer_wasm);
+    defer allocator.free(importer_cwasm);
+
+    const core_modules = [_]ctypes.CoreModule{
+        .{ .data = &exporter_wasm },
+        .{ .data = &importer_wasm },
+    };
+    const importer_args = [_]ctypes.CoreInstantiateArg{.{ .name = "a", .instance_idx = 0 }};
+    const core_insts = [_]ctypes.CoreInstanceExpr{
+        .{ .instantiate = .{ .module_idx = 0, .args = &.{} } },
+        .{ .instantiate = .{ .module_idx = 1, .args = &importer_args } },
+    };
+    const component = ctypes.Component{
+        .core_modules = &core_modules,
+        .core_instances = &core_insts,
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &.{},
+        .types = &.{},
+        .canons = &.{},
+        .imports = &.{},
+        .exports = &.{},
+    };
+    const pcs = [_]instance.PrecompiledCore{
+        .{ .module_idx = 0, .cwasm_bytes = exporter_cwasm },
+        .{ .module_idx = 1, .cwasm_bytes = importer_cwasm },
+    };
+    const inst = try instance.instantiateWithOptions(&component, allocator, .{
+        .precompiled_cores = &pcs,
+        .aot_only = true,
+    });
+    defer inst.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), inst.core_instances.len);
+    const exporter_ai = inst.core_instances[0].aot_inst orelse return error.TestFailed;
+    const importer_ai = inst.core_instances[1].aot_inst orelse return error.TestFailed;
+    try std.testing.expectEqual(exporter_ai.globals[0], importer_ai.globals[0]);
+    try std.testing.expect(!importer_ai.globals_owned[0]);
+
+    const a_read = aot_runtime_mod.findExportFunc(exporter_ai, "readG") orelse return error.TestFailed;
+    const a_write_one = aot_runtime_mod.findExportFunc(exporter_ai, "write_one") orelse return error.TestFailed;
+    const b_write42 = aot_runtime_mod.findExportFunc(importer_ai, "write42") orelse return error.TestFailed;
+    const b_read = aot_runtime_mod.findExportFunc(importer_ai, "readG") orelse return error.TestFailed;
+    const no_params = [_]core_types.ValType{};
+    const no_results = [_]core_types.ValType{};
+    const i32_results = [_]core_types.ValType{.i32};
+    const no_args = [_]core_types.Value{};
+    var results_buf: [1]aot_runtime_mod.ScalarResult = .{.{ .i32 = 0 }};
+
+    _ = try aot_runtime_mod.callFuncScalar(importer_ai, b_write42, &no_params, &no_results, &no_args, &results_buf);
+    const a_after_b_write = try aot_runtime_mod.callFuncScalar(exporter_ai, a_read, &no_params, &i32_results, &no_args, &results_buf);
+    try std.testing.expectEqual(@as(i32, 42), a_after_b_write[0].i32);
+
+    _ = try aot_runtime_mod.callFuncScalar(exporter_ai, a_write_one, &no_params, &no_results, &no_args, &results_buf);
+    const b_after_a_write = try aot_runtime_mod.callFuncScalar(importer_ai, b_read, &no_params, &i32_results, &no_args, &results_buf);
+    try std.testing.expectEqual(@as(i32, 1), b_after_a_write[0].i32);
+}
+
 test "#625 phase 1: instantiateWithOptions loads + runs an AOT core" {
     if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
 


### PR DESCRIPTION
Implements #660 item 2.

- Drops the mutable-global AOT import gate in `src/component/instance.zig` (`firstUnsupportedAotImport`, around line 2618 on this branch).
- Adds call-exit write-back semantics in `src/runtime/aot/runtime.zig` via `flushImportedGlobalsToStorage`, with the last-writer-wins call-boundary trade-off documented there.
- Adds regression test `#660 item 2: AOT mutable imported global writes back across component cores` in `src/tests/component_aot_smoke_test.zig`.

Validation:
- `zig build test --summary failures`
- `zig build wasi-testsuite`
- `zig build wasi-p3-testsuite -Doptimize=ReleaseSafe`