### PR TITLE
#672 AOT exception handling (multi-commit)

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -3068,6 +3068,8 @@ fn compileInst(
         // Phi must be lowered before codegen.
         .phi => unreachable,
         .parallel_copy => |pairs| try emitParallelCopy(code, pairs, reg_map, fctx.allocator),
+        // #672 EH ops — placeholder. Real lowering lands in commit 3.
+        .try_table_begin, .try_table_end, .throw, .throw_ref => return error.UnimplementedOp,
         else => {
             // Explicit failure for unimplemented ops. Previously this was a
             // silent no-op which produced incorrect code. Anything that lands

--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -3068,8 +3068,20 @@ fn compileInst(
         // Phi must be lowered before codegen.
         .phi => unreachable,
         .parallel_copy => |pairs| try emitParallelCopy(code, pairs, reg_map, fctx.allocator),
-        // #672 EH ops — placeholder. Real lowering lands in commit 3.
-        .try_table_begin, .try_table_end, .throw, .throw_ref => return error.UnimplementedOp,
+        // #672 EH ops — commit 3:
+        //   * try_table_begin / try_table_end: no-op. In-function catch
+        //     dispatch is deferred to a later commit; for now the catch
+        //     handler block is reached via normal br targets only (any
+        //     `throw` inside the region escapes as an uncaught trap).
+        //   * throw: spill payload into vmctx, call `aot_throw_uncaught`
+        //     trampoline (noreturn).
+        //   * throw_ref: route through the unreachable trap helper. The
+        //     exnref state lives in ExecEnv (interp-only); cross-arch
+        //     AOT exnref support arrives with cross-function unwind in
+        //     commit 5.
+        .try_table_begin, .try_table_end => {},
+        .throw => |th| try emitThrow(code, th, reg_map),
+        .throw_ref => try emitTrapHelperCall(code, vmctx_trap_unreachable_fn_slot),
         else => {
             // Explicit failure for unimplemented ops. Previously this was a
             // silent no-op which produced incorrect code. Anything that lands
@@ -6550,6 +6562,11 @@ const vmctx_elem_drop_fn_slot: u12 = 19; // byte 152, scale 8
 const vmctx_futex_wait32_fn_slot: u12 = 25; // byte 200, scale 8
 const vmctx_futex_wait64_fn_slot: u12 = 26; // byte 208, scale 8
 const vmctx_futex_notify_fn_slot: u12 = 27; // byte 216, scale 8
+// #672 EH slots — added in commit 3.
+const vmctx_tags_ptr_slot: u12 = 30; // byte 240, scale 8
+const vmctx_aot_throw_uncaught_fn_slot: u12 = 32; // byte 256, scale 8
+const vmctx_exception_params_byte_off: u32 = 264; // [16]u64 buffer base
+const vmctx_exception_param_count_slot_w: u12 = 98; // byte 392 (u32), scale 4
 
 // Per-table descriptor layout (`TableInfo`, 24 bytes):
 //   { ptr: u64, len: u32, _pad: u32, type_backing_ptr: u64 }
@@ -7521,6 +7538,51 @@ fn patchBCondHere(code: *emit.CodeBuffer, patch_off: usize) void {
 fn emitTrapHelperCall(code: *emit.CodeBuffer, slot: u12) !void {
     try code.movRegReg(.x0, .x19);
     try code.ldrImm(RegMap.tmp0, .x0, slot);
+    try code.blr(RegMap.tmp0);
+    try code.brk(0);
+}
+
+/// Lower IR `throw`. Terminator semantics let us clobber every caller-save
+/// register: the helper is noreturn (it longjmps via `trapLongjmp` when
+/// trap-as-error is armed, otherwise `std.process.exit(2)`).
+///
+/// Sequence (commit 3 of #672, leaf-function-only first cut):
+///   * Spill each operand into `vmctx.exception_params[i]`.
+///   * Write `param_count` into `vmctx.exception_param_count`.
+///   * Load `*TagInstance` from `vmctx.tags_ptr[tag_idx]` into x1.
+///   * mov x0, vmctx; ldr xtmp, [vmctx + aot_throw_uncaught_fn]; blr xtmp; brk 0.
+///
+/// Limitations: tag_idx must fit in the 12-bit unsigned scaled-by-8
+/// LDR immediate range (`tag_idx < 512`). Higher indices return
+/// `error.UnimplementedOp` for now; lifting this requires the indexed
+/// addressing path that `emitGlobalGet` already uses for large globals
+/// and is filed for the cross-function unwind commit (#672 commit 5).
+fn emitThrow(
+    code: *emit.CodeBuffer,
+    th: ir.Inst.Throw,
+    reg_map: *RegMap,
+) !void {
+    if (th.args.len > 16) return error.UnimplementedOp;
+    if (th.tag_idx >= 512) return error.UnimplementedOp;
+
+    // exception_params[i] = arg[i]. Single scratch (tmp0) reused across iterations.
+    for (th.args, 0..) |arg_vreg, i| {
+        const src = try useInto(code, reg_map, arg_vreg, RegMap.tmp0);
+        const slot: u12 = @intCast(vmctx_exception_params_byte_off / 8 + i);
+        try code.strImm(src, .x19, slot);
+    }
+
+    // exception_param_count = th.args.len (u32, scale-4 slot).
+    try code.movImm64(RegMap.tmp0, @as(u64, th.args.len));
+    try code.strImm32(RegMap.tmp0, .x19, vmctx_exception_param_count_slot_w);
+
+    // x1 = vmctx.tags_ptr[tag_idx].
+    try code.ldrImm(RegMap.tmp0, .x19, vmctx_tags_ptr_slot);
+    try code.ldrImm(.x1, RegMap.tmp0, @intCast(th.tag_idx));
+
+    // mov x0, vmctx; ldr tmp0, [vmctx + aot_throw_uncaught_fn]; blr tmp0; brk 0.
+    try code.movRegReg(.x0, .x19);
+    try code.ldrImm(RegMap.tmp0, .x19, vmctx_aot_throw_uncaught_fn_slot);
     try code.blr(RegMap.tmp0);
     try code.brk(0);
 }
@@ -14429,4 +14491,63 @@ test "relaxOutOfRangeConditionalBranches: in-range branches are not touched" {
     try std.testing.expectEqual(@as(usize, 0), patches.items[0].patch_offset);
     try std.testing.expect(patches.items[0].kind == .b_cond);
     try std.testing.expectEqual(target_off, block_offsets[1]);
+}
+
+// ── #672 commit 3: aarch64 EH codegen ────────────────────────────────
+
+test "#672 commit 3: throw lowers to STR / LDR / BLR + BRK" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0xDEAD }, .dest = v0, .type = .i32 });
+
+    const args = try allocator.alloc(ir.VReg, 1);
+    args[0] = v0;
+    try block.append(.{ .op = .{ .throw = .{ .tag_idx = 3, .args = args } } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+    try std.testing.expect(code.len > 0);
+    try std.testing.expect(code.len % 4 == 0);
+
+    // The throw sequence ends with `brk #0` (0xD4200000). Scan for it.
+    var found_brk = false;
+    var i: usize = 0;
+    while (i + 4 <= code.len) : (i += 4) {
+        const w = std.mem.readInt(u32, code[i..][0..4], .little);
+        if (w == 0xD4200000) {
+            found_brk = true;
+            break;
+        }
+    }
+    try std.testing.expect(found_brk);
+}
+
+test "#672 commit 3: try_table_begin / try_table_end are no-ops" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+
+    // Wrap a trivial body in try_table_begin / try_table_end.
+    const clauses = try allocator.alloc(ir.Inst.CatchClause, 0);
+    try block.append(.{ .op = .{ .try_table_begin = .{
+        .result_arity = 0,
+        .clauses = clauses,
+    } } });
+    try block.append(.{ .op = .{ .iconst_32 = 7 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .try_table_end = {} } });
+    try block.append(.{ .op = .{ .ret = v0 } });
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+    try std.testing.expect(code.len > 0);
+    try std.testing.expect(code.len % 4 == 0);
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1322,8 +1322,14 @@ fn compileInst(
         // x86_64 keeps the synth-local frameStore/frameLoad path.
         .parallel_copy => unreachable,
 
-        // #672 EH ops — placeholder. Real lowering lands in commit 4.
-        .try_table_begin, .try_table_end, .throw, .throw_ref => return error.UnimplementedOp,
+        // #672 EH ops — commit 3:
+        //   try_table_begin / try_table_end are scaffolding-only no-ops
+        //   so wasm using `try_table` (without taking the throw path on
+        //   x86_64) AOT-compiles. throw / throw_ref are intentionally
+        //   left as UnimplementedOp until the x86_64 counterpart of
+        //   commit 3 lands as commit 4 of #672.
+        .try_table_begin, .try_table_end => {},
+        .throw, .throw_ref => return error.UnimplementedOp,
     }
 }
 

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -68,6 +68,13 @@ const vmctx_table_set_fn_field: i32 = 192; // VmCtx.table_set_fn offset (usize)
 const vmctx_futex_wait32_fn_field: i32 = 200; // VmCtx.futex_wait32_fn offset (usize)
 const vmctx_futex_wait64_fn_field: i32 = 208; // VmCtx.futex_wait64_fn offset (usize)
 const vmctx_futex_notify_fn_field: i32 = 216; // VmCtx.futex_notify_fn offset (usize)
+// #672 commit 4: AOT exception-handling fields. Inserted before
+// `wasi_ctx` in the extern VmCtx struct so all earlier offsets above
+// remain stable.
+const vmctx_tags_ptr_field: i32 = 240; // VmCtx.tags_ptr offset (usize)
+const vmctx_aot_throw_uncaught_fn_field: i32 = 256; // VmCtx.aot_throw_uncaught_fn (usize)
+const vmctx_exception_params_field: i32 = 264; // VmCtx.exception_params base ([16]u64)
+const vmctx_exception_param_count_field: i32 = 392; // VmCtx.exception_param_count (u32)
 // Per-table descriptor layout (TableInfo, 24 bytes):
 //   { ptr: u64, len: u32, _pad: u32, type_backing_ptr: u64 }
 const table_info_ptr_off: i32 = 0;
@@ -111,6 +118,52 @@ fn emitOobCmpAndTrap(code: *emit.CodeBuffer) !void {
 fn emitTrapHelperCall(code: *emit.CodeBuffer, field_offset: i32) !void {
     try code.movRegReg(param_regs[0], .r10);
     try code.movRegMem(.rax, param_regs[0], field_offset);
+    try code.callReg(.rax);
+}
+
+/// #672 commit 4: emit lowering of the IR `throw` op on x86_64.
+///
+/// Mirror of `emitThrow` in src/compiler/codegen/aarch64/compile.zig.
+/// Sequence:
+///   for each arg:
+///     mov rax, <arg-vreg>            ; via useVReg (scratch=rax)
+///     mov [rbx + exception_params + i*8], rax
+///   mov [rbx + exception_param_count], r10d        ; param_count (u32)
+///   mov r10, [rbx + tags_ptr]
+///   mov param_regs[1], [r10 + tag_idx*8]           ; arg1 = *TagInstance
+///   mov param_regs[0], rbx                         ; arg0 = vmctx
+///   mov rax, [rbx + aot_throw_uncaught_fn]
+///   call rax                                       ; noreturn
+///
+/// `rbx` holds the VmCtx* throughout function execution
+/// (callee-saved, established by compileFunctionRA). Because `throw`
+/// is a terminator (the trampoline is noreturn) no caller-save snapshot
+/// is required; we can clobber any caller-save register freely.
+fn emitThrow(
+    code: *emit.CodeBuffer,
+    th: ir.Inst.Throw,
+    alloc_result: *const regalloc.AllocResult,
+) !void {
+    if (th.args.len > 16) return error.UnimplementedOp;
+
+    for (th.args, 0..) |arg_vreg, i| {
+        const src = try useVReg(code, alloc_result, arg_vreg, .rax);
+        const disp: i32 = vmctx_exception_params_field + @as(i32, @intCast(i)) * 8;
+        try code.movMemReg(.rbx, disp, src);
+    }
+
+    // exception_param_count = th.args.len (u32 store).
+    try code.movRegImm32(.r10, @intCast(th.args.len));
+    try code.movMemRegSized(.rbx, vmctx_exception_param_count_field, .r10, 4);
+
+    // r10 = vmctx.tags_ptr;  arg1 = r10[tag_idx]
+    try code.movRegMem(.r10, .rbx, vmctx_tags_ptr_field);
+    const tag_disp: i32 = @as(i32, @intCast(th.tag_idx)) * 8;
+    try code.movRegMem(param_regs[1], .r10, tag_disp);
+
+    // arg0 = vmctx; rax = aot_throw_uncaught_fn; call rax (noreturn).
+    try code.movRegReg(param_regs[0], .rbx);
+    try code.movRegMem(.rax, .rbx, vmctx_aot_throw_uncaught_fn_field);
     try code.callReg(.rax);
 }
 
@@ -1322,12 +1375,14 @@ fn compileInst(
         // x86_64 keeps the synth-local frameStore/frameLoad path.
         .parallel_copy => unreachable,
 
-        // #672 EH ops — commit 3:
-        //   try_table_begin / try_table_end are scaffolding-only no-ops
-        //   so wasm using `try_table` (without taking the throw path on
-        //   x86_64) AOT-compiles. throw / throw_ref are intentionally
-        //   left as UnimplementedOp until the x86_64 counterpart of
-        //   commit 3 lands as commit 4 of #672.
+        // #672 EH ops:
+        //   try_table_begin / try_table_end emit no machine code. The
+        //   handler block is reachable through normal `br` targets; full
+        //   catch dispatch arrives with the cross-function unwind work
+        //   (commit 5 of #672).
+        //   Stack-based compileInst is test-only on x86_64; production
+        //   compilation goes through compileInstRA, which carries the
+        //   real `throw` lowering (mirror of aarch64 emitThrow).
         .try_table_begin, .try_table_end => {},
         .throw, .throw_ref => return error.UnimplementedOp,
     }
@@ -4781,6 +4836,23 @@ fn compileInstRA(
         // ── Stubs for ops not commonly hit ────────────────────────────
         // Phi must be lowered before codegen.
         .phi => unreachable,
+
+        // #672 commit 4: AOT exception-handling ops on x86_64.
+        //   try_table_begin / try_table_end emit no machine code; the
+        //   handler block is reachable through normal `br` targets.
+        //   Full catch dispatch arrives with the cross-function unwind
+        //   work (commit 5 of #672).
+        //   throw lowers via `emitThrow` (mirror of aarch64).
+        //   throw_ref still routes through the uncaught trap helper:
+        //   exnref state lives in ExecEnv (interp-only); the AOT
+        //   counterpart arrives with commit 5.
+        .try_table_begin, .try_table_end => {},
+        .throw => |th| try emitThrow(code, th, alloc_result),
+        .throw_ref => {
+            try code.movRegReg(.r10, .rbx);
+            try emitTrapHelperCall(code, vmctx_trap_unreachable_fn_field);
+        },
+
         else => {
             // For unhandled ops, emit a no-op placeholder
             if (inst.dest) |dest| {
@@ -6750,4 +6822,66 @@ test "compileModule: regalloc hints — leaf 2-arg call emits no inter-vreg shuf
     const iconst_to_rdx = [_]u8{ 0x48, 0xC7, 0xC2, 0x02, 0x00, 0x00, 0x00 };
     try std.testing.expect(containsBytes(caller_code, &iconst_to_rsi));
     try std.testing.expect(containsBytes(caller_code, &iconst_to_rdx));
+}
+
+test "#672 commit 4: try_table_begin / try_table_end are no-ops on x86_64" {
+    // Verifies that wrapping a trivial body in try_table_begin / try_table_end
+    // AOT-compiles without error and produces only the body's machine code.
+    const allocator = std.testing.allocator;
+    var ir_module = ir.IrModule.init(allocator);
+    defer ir_module.deinit();
+
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    _ = try func.newBlock();
+    try func.getBlock(0).append(.{
+        .op = .{ .try_table_begin = .{ .result_arity = 0, .clauses = &.{} } },
+    });
+    try func.getBlock(0).append(.{ .op = .try_table_end });
+    try func.getBlock(0).append(.{ .op = .{ .ret = null } });
+    _ = try ir_module.addFunction(func);
+
+    const result = try compileModule(&ir_module, allocator);
+    defer allocator.free(result.code);
+    defer allocator.free(result.offsets);
+    // Compiling must succeed and produce a non-empty function body
+    // (prologue + epilogue at minimum).
+    try std.testing.expect(result.code.len > 0);
+}
+
+test "#672 commit 4: throw lowers to mov-arg + call qword [rbx + throw_fn]" {
+    // Builds a function whose body is `throw $tag i32.const 0xDEAD`.
+    // Verifies the emitted bytes include:
+    //   * a u32 store to [rbx + exception_param_count_field]  (sized MOV)
+    //   * a u64 load of vmctx.tags_ptr     mov r10, [rbx + 240]
+    //   * a u64 load of aot_throw_uncaught_fn  mov rax, [rbx + 256]
+    //   * `call rax` (FF D0)
+    const allocator = std.testing.allocator;
+    var ir_module = ir.IrModule.init(allocator);
+    defer ir_module.deinit();
+
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    _ = try func.newBlock();
+    const arg = func.newVReg();
+    try func.getBlock(0).append(.{ .op = .{ .iconst_32 = 0xDEAD }, .dest = arg, .type = .i32 });
+    const args = try allocator.alloc(ir.VReg, 1);
+    args[0] = arg;
+    try func.getBlock(0).append(.{ .op = .{ .throw = .{ .tag_idx = 0, .args = args } } });
+    _ = try ir_module.addFunction(func);
+
+    const result = try compileModule(&ir_module, allocator);
+    defer allocator.free(result.code);
+    defer allocator.free(result.offsets);
+
+    // mov r10, qword ptr [rbx + 240]
+    //   REX.W|R = 0x4C, opcode 0x8B,
+    //   ModR/M = 10_010_011 = 0x93 (mod=disp32, reg=r10.low3=2, rm=rbx.low3=3),
+    //   disp32 = 240 (little-endian).
+    try std.testing.expect(containsBytes(result.code, &.{ 0x4C, 0x8B, 0x93, 0xF0, 0x00, 0x00, 0x00 }));
+    // mov rax, qword ptr [rbx + 256]
+    //   REX.W = 0x48, opcode 0x8B,
+    //   ModR/M = 10_000_011 = 0x83 (mod=disp32, reg=rax=0, rm=rbx=3),
+    //   disp32 = 256 (0x100).
+    try std.testing.expect(containsBytes(result.code, &.{ 0x48, 0x8B, 0x83, 0x00, 0x01, 0x00, 0x00 }));
+    // call rax (FF D0)
+    try std.testing.expect(containsBytes(result.code, &.{ 0xFF, 0xD0 }));
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1321,6 +1321,9 @@ fn compileInst(
         // parallel_copy is an aarch64-only post-pipeline op (#540).
         // x86_64 keeps the synth-local frameStore/frameLoad path.
         .parallel_copy => unreachable,
+
+        // #672 EH ops — placeholder. Real lowering lands in commit 4.
+        .try_table_begin, .try_table_end, .throw, .throw_ref => return error.UnimplementedOp,
     }
 }
 

--- a/src/compiler/emit_aot.zig
+++ b/src/compiler/emit_aot.zig
@@ -22,6 +22,7 @@ pub const ExternalKind = enum(u8) {
     table = 0x01,
     memory = 0x02,
     global = 0x03,
+    tag = 0x04,
 };
 
 pub const AotEmitOptions = struct {
@@ -58,6 +59,10 @@ pub const ImportEntry = struct {
     memory_is64: bool = false,
     global_val_type: types.ValType = .i32,
     global_mutable: bool = false,
+    /// Function-type index describing the tag's parameter signature
+    /// (when `kind == .tag`). Matches the wasm tag-import payload after
+    /// dropping the always-zero attribute byte.
+    tag_type_idx: u32 = 0,
 };
 
 pub const MemoryEntry = struct {
@@ -89,6 +94,13 @@ pub const FuncTypeEntry = struct {
     results: []const u8,
 };
 
+/// Locally-declared tag (exception handling) entry. `type_idx` references
+/// the function-type describing the exception parameters; the tag attribute
+/// byte (always 0x00 in the MVP) is dropped on-wire.
+pub const TagEntry = struct {
+    type_idx: u32,
+};
+
 /// Emit an AOT binary to an owned byte buffer.
 pub fn emit(
     allocator: std.mem.Allocator,
@@ -104,6 +116,7 @@ pub fn emit(
     start_function: ?u32,
     func_types: ?[]const FuncTypeEntry,
     local_func_type_indices: ?[]const u32,
+    tags: ?[]const TagEntry,
 ) ![]u8 {
     var buf: std.ArrayList(u8) = .empty;
     errdefer buf.deinit(allocator);
@@ -221,6 +234,12 @@ pub fn emit(
                         try tmp.append(allocator, @intFromEnum(imp.global_val_type));
                         try tmp.append(allocator, if (imp.global_mutable) 1 else 0);
                     },
+                    .tag => {
+                        // Wire shape: just the type-idx u32. The MVP-EH
+                        // attribute byte (always 0x00) is omitted to match
+                        // `loader.zig:parseImportSection`'s reader.
+                        try appendU32Le(&tmp, allocator, imp.tag_type_idx);
+                    },
                 }
             }
             try emitSection(allocator, &buf, 8, tmp.items);
@@ -293,6 +312,19 @@ pub fn emit(
         try emitSection(allocator, &buf, 12, tmp.items);
     }
 
+    // Section 14: locally-declared tags (#672). Each entry is a u32 type-idx.
+    if (tags) |tag_list| {
+        if (tag_list.len > 0) {
+            var tmp: std.ArrayList(u8) = .empty;
+            defer tmp.deinit(allocator);
+            try appendU32Le(&tmp, allocator, @intCast(tag_list.len));
+            for (tag_list) |t| {
+                try appendU32Le(&tmp, allocator, t.type_idx);
+            }
+            try emitSection(allocator, &buf, 14, tmp.items);
+        }
+    }
+
     return buf.toOwnedSlice(allocator);
 }
 
@@ -328,7 +360,7 @@ fn buildTargetInfo(options: AotEmitOptions) [40]u8 {
 
 test "emit: minimal (no functions, no exports) has correct magic and version" {
     const allocator = std.testing.allocator;
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // At least header (8) + target_info section (8+40) + text section (8+0) + func section (8+4) + export section (8+4)
@@ -343,7 +375,7 @@ test "emit: one function offset produces valid function section" {
     const allocator = std.testing.allocator;
     const code = [_]u8{ 0xCC, 0xC3 }; // int3; ret
     const offsets = [_]u32{0};
-    const data = try emit(allocator, &code, &offsets, &.{}, .{}, null, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &code, &offsets, &.{}, .{}, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // Walk sections to find section type 3 (function)
@@ -374,7 +406,7 @@ test "emit: export section encodes name, kind, and index" {
         .kind = .function,
         .index = 7,
     }};
-    const data = try emit(allocator, &.{}, &.{}, &exports, .{}, null, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &exports, .{}, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // Walk sections to find section type 4 (export)
@@ -421,7 +453,7 @@ test "roundtrip: emit then load with AOT loader" {
     const data = try emit(allocator, &code, &offsets, &exports, .{
         .arch = arch_name,
         .e_machine = 0x3E,
-    }, null, null, null, null, null, null, null, null);
+    }, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // Parse back with the AOT loader
@@ -463,7 +495,7 @@ test "emit: import section round-trip" {
         .{ .module_name = "env", .field_name = "tbl", .kind = .table, .table_elem_type = .funcref, .table_min = 8, .table_max = 8 },
         .{ .module_name = "wasi_snapshot_preview1", .field_name = "clock_time_get", .kind = .function, .func_type_idx = 1 },
     };
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, &import_entries, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, &import_entries, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     const module = try aot_loader.load(data, allocator);
@@ -491,7 +523,7 @@ test "emit: memory section round-trip" {
         .{ .min_pages = 2, .max_pages = null },
         .{ .min_pages = 1, .max_pages = 256 },
     };
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, &mem_entries, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, &mem_entries, null, null, null, null, null, null);
     defer allocator.free(data);
 
     const module = try aot_loader.load(data, allocator);
@@ -513,7 +545,7 @@ test "emit: v128 global init payload round-trip" {
         .{ .val_type = 0x7F, .mutability = 0, .init_i64 = 0x1234 },
         .{ .val_type = 0x7B, .mutability = 1, .init_v128 = init_bits },
     };
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, &globals, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, &globals, null, null, null, null, null);
     defer allocator.free(data);
 
     const module = try aot_loader.load(data, allocator);
@@ -560,6 +592,7 @@ test "emit: type section and function type indices round-trip" {
         null,
         &ft_entries,
         &tidxs,
+        null,
     );
     defer allocator.free(data);
 
@@ -580,4 +613,52 @@ test "emit: type section and function type indices round-trip" {
     try std.testing.expectEqual(@as(u32, 1), module.local_func_type_indices[0]);
     try std.testing.expectEqual(@as(u32, 0), module.local_func_type_indices[1]);
     try std.testing.expectEqual(@as(u32, 1), module.local_func_type_indices[2]);
+}
+
+test "#672: tag imports and declared tags round-trip" {
+    const allocator = std.testing.allocator;
+    const aot_loader = @import("../runtime/aot/loader.zig");
+
+    // Import a tag from "env" referring to func_type 0 (one i32 param),
+    // and declare two local tags referring to func_types 0 and 1.
+    const import_entries = [_]ImportEntry{
+        .{ .module_name = "env", .field_name = "exn", .kind = .tag, .tag_type_idx = 0 },
+    };
+    const tag_entries = [_]TagEntry{
+        .{ .type_idx = 0 },
+        .{ .type_idx = 1 },
+    };
+
+    const data = try emit(
+        allocator,
+        &.{},
+        &.{},
+        &.{},
+        .{},
+        null,
+        &import_entries,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        &tag_entries,
+    );
+    defer allocator.free(data);
+
+    const module = try aot_loader.load(data, allocator);
+    defer aot_loader.unload(&module, allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), module.imports.len);
+    try std.testing.expectEqual(types.ExternalKind.tag, module.imports[0].kind);
+
+    try std.testing.expectEqual(@as(usize, 1), module.imported_tags.len);
+    try std.testing.expect(std.mem.eql(u8, module.imported_tags[0].module_name, "env"));
+    try std.testing.expect(std.mem.eql(u8, module.imported_tags[0].name, "exn"));
+    try std.testing.expectEqual(@as(u32, 0), module.imported_tags[0].type_idx);
+
+    try std.testing.expectEqual(@as(usize, 2), module.tag_types.len);
+    try std.testing.expectEqual(@as(u32, 0), module.tag_types[0]);
+    try std.testing.expectEqual(@as(u32, 1), module.tag_types[1]);
 }

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -93,6 +93,32 @@ fn globalValTypeByIdx(wasm_module: *const types.WasmModule, idx: u32) ?types.Val
     return wasm_module.globals[local_idx].global_type.val_type;
 }
 
+/// Resolve the param arity (and a borrowed type-index pointer) of a tag at
+/// global tag index `tag_idx`. Tags are indexed: imported tags come first,
+/// followed by `tag_types[]`. Each tag references a `func_type` whose
+/// `params` slice gives the throw-payload signature. Returns null if the
+/// index or any referenced type is out of range. #672.
+fn tagParamArity(wm: *const types.WasmModule, tag_idx: u32) ?u32 {
+    if (tag_idx < wm.import_tag_count) {
+        var i: u32 = 0;
+        for (wm.imports) |imp| {
+            if (imp.kind != .tag) continue;
+            if (i == tag_idx) {
+                const type_idx = imp.tag_type_idx orelse return null;
+                if (type_idx >= wm.types.len) return null;
+                return @intCast(wm.types[type_idx].params.len);
+            }
+            i += 1;
+        }
+        return null;
+    }
+    const local = tag_idx - wm.import_tag_count;
+    if (local >= wm.tag_types.len) return null;
+    const type_idx = wm.tag_types[local];
+    if (type_idx >= wm.types.len) return null;
+    return @intCast(wm.types[type_idx].params.len);
+}
+
 fn globalSlotAlignment(ty: ir.IrType) u32 {
     return switch (ty) {
         .v128 => 16,
@@ -255,7 +281,7 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
 
     // ── Control flow block stack ──────────────────────────────────────
     const BlockFrame = struct {
-        kind: enum { block, loop, @"if" },
+        kind: enum { block, loop, @"if", try_table },
         /// Block to jump to on `br` (end_block for block/if, header for loop).
         target_block: ir.BlockId,
         /// Continuation block after this construct ends.
@@ -410,6 +436,34 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     });
                     continue;
                 },
+                // #672 EH: skip immediates and push a dummy try_table frame
+                // so a matching `end` doesn't underflow the block stack.
+                .try_table => {
+                    _ = readBlockType(code, &ip, module_sigs);
+                    const clause_count = readU32(code, &ip);
+                    var ci: u32 = 0;
+                    while (ci < clause_count) : (ci += 1) {
+                        const ck = readU32(code, &ip);
+                        if (ck == 0 or ck == 1) _ = readU32(code, &ip);
+                        _ = readU32(code, &ip);
+                    }
+                    try block_stack.append(allocator, .{
+                        .kind = .try_table,
+                        .target_block = 0,
+                        .end_block = 0,
+                        .else_block = null,
+                        .stack_depth = vreg_stack.items.len,
+                        .param_types = NO_TYPES,
+                        .result_types = NO_TYPES,
+                        .param_locals = &[_]u32{},
+                        .result_locals = &[_]u32{},
+                    });
+                    continue;
+                },
+                .throw, .throw_ref => {
+                    skipOperands(code, &ip, op);
+                    continue;
+                },
                 else => {
                     // Skip operands for dead instructions
                     skipOperands(code, &ip, op);
@@ -478,10 +532,16 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                 // `MultipleTerminators`) and confuses the inliner.
                 const cur_insts = ir_func.getBlock(current_block).instructions.items;
                 const already_terminated = cur_insts.len != 0 and switch (cur_insts[cur_insts.len - 1].op) {
-                    .br, .br_if, .br_table, .ret, .ret_multi, .@"unreachable" => true,
+                    .br, .br_if, .br_table, .ret, .ret_multi, .@"unreachable", .throw, .throw_ref => true,
                     else => false,
                 };
                 if (!already_terminated) {
+                    // #672 EH: a try_table body that falls through must
+                    // emit `try_table_end` to bracket the begin op before
+                    // the implicit fall-through `br`.
+                    if (frame.kind == .try_table) {
+                        try ir_func.getBlock(current_block).append(.{ .op = .{ .try_table_end = {} } });
+                    }
                     try ir_func.getBlock(current_block).append(.{ .op = .{ .br = frame.end_block } });
                 }
                 current_block = frame.end_block;
@@ -589,6 +649,111 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
                     .param_locals = param_locals,
                     .result_locals = result_locals,
                 });
+            },
+            // #672 EH: `try_table` opens a region that catches matching
+            // exceptions and transfers to per-clause handlers. Commit 2
+            // emits the new IR op + records the clause table; the handler
+            // BlockIds resolve to the target frames' `target_block` (i.e.
+            // the block that label_idx names — same scope as `br`). Real
+            // CFG plumbing of the unwind path is wired in commit 3/4.
+            .try_table => {
+                const bt = readBlockType(code, &ip, module_sigs);
+                const n_params: usize = bt.params.len;
+                const clause_count = readU32(code, &ip);
+                const RawClause = struct { kind: u8, tag_idx: ?u32, label_idx: u32 };
+                const raw_clauses = try frame_alloc.alloc(RawClause, clause_count);
+                var ci: u32 = 0;
+                while (ci < clause_count) : (ci += 1) {
+                    const ck_raw = readU32(code, &ip);
+                    const ck: u8 = @intCast(ck_raw & 0xFF);
+                    var tag_idx: ?u32 = null;
+                    if (ck == 0 or ck == 1) tag_idx = readU32(code, &ip);
+                    const label_idx = readU32(code, &ip);
+                    raw_clauses[ci] = .{ .kind = ck, .tag_idx = tag_idx, .label_idx = label_idx };
+                }
+                const end_block = try ir_func.newBlock();
+                const param_locals = try allocLocals(frame_alloc, allocator, &local_types, &total_locals, &ir_func, bt.params);
+                const result_locals = try allocLocals(frame_alloc, allocator, &local_types, &total_locals, &ir_func, bt.results);
+                // Pop body params (top-last), store to param_locals.
+                if (n_params > 0 and vreg_stack.items.len >= n_params) {
+                    var i: usize = n_params;
+                    while (i > 0) {
+                        i -= 1;
+                        const v = safePop(&vreg_stack);
+                        try ir_func.getBlock(current_block).append(.{ .op = .{ .local_set = .{ .idx = param_locals[i], .val = v } } });
+                    }
+                }
+                const pre_depth = vreg_stack.items.len;
+                // Re-push params as fresh vregs inside the try body.
+                var pi: usize = 0;
+                while (pi < n_params) : (pi += 1) {
+                    const dest = ir_func.newVReg();
+                    try ir_func.getBlock(current_block).append(.{ .op = .{ .local_get = param_locals[pi] }, .dest = dest, .type = bt.params[pi] });
+                    try vreg_stack.append(allocator, dest);
+                }
+                try block_stack.append(allocator, .{
+                    .kind = .try_table,
+                    .target_block = end_block,
+                    .end_block = end_block,
+                    .else_block = null,
+                    .stack_depth = pre_depth,
+                    .param_types = bt.params,
+                    .result_types = bt.results,
+                    .param_locals = param_locals,
+                    .result_locals = result_locals,
+                });
+                // Resolve each clause's label_idx against the current
+                // block_stack (which now includes the try_table frame at
+                // top — label 0 names the try_table itself). The handler
+                // BlockId is the target the labelled construct uses for
+                // `br` (same lookup as `br`). For loop labels this is the
+                // header (re-enters the loop); for block/if/try_table
+                // labels this is the end_block.
+                const clauses = try ir_func.allocator.alloc(ir.Inst.CatchClause, clause_count);
+                ci = 0;
+                while (ci < clause_count) : (ci += 1) {
+                    const rc = raw_clauses[ci];
+                    var handler: ir.BlockId = end_block;
+                    if (rc.label_idx < block_stack.items.len) {
+                        const target_frame = block_stack.items[block_stack.items.len - 1 - rc.label_idx];
+                        handler = target_frame.target_block;
+                    }
+                    clauses[ci] = .{
+                        .kind = rc.kind,
+                        .tag_idx = rc.tag_idx,
+                        .handler = handler,
+                    };
+                }
+                try ir_func.getBlock(current_block).append(.{
+                    .op = .{ .try_table_begin = .{
+                        .result_arity = @intCast(bt.results.len),
+                        .clauses = clauses,
+                    } },
+                });
+            },
+            // #672 EH: throw — pop tag's params, emit terminator. Real
+            // unwind dispatch lands in commit 3+.
+            .throw => {
+                const tag_idx = readU32(code, &ip);
+                const arity = tagParamArity(wasm_module, tag_idx) orelse 0;
+                const args = try ir_func.allocator.alloc(ir.VReg, arity);
+                var ai: u32 = arity;
+                while (ai > 0) {
+                    ai -= 1;
+                    args[ai] = safePop(&vreg_stack);
+                }
+                try ir_func.getBlock(current_block).append(.{
+                    .op = .{ .throw = .{ .tag_idx = tag_idx, .args = args } },
+                });
+                dead_code = true;
+            },
+            // #672 EH: throw_ref — pop exnref, emit terminator.
+            .throw_ref => {
+                const exnref = safePop(&vreg_stack);
+                try ir_func.getBlock(current_block).append(.{
+                    .op = .{ .throw_ref = exnref },
+                });
+                dead_code = true;
             },
             .@"if" => {
                 const bt = readBlockType(code, &ip, module_sigs);
@@ -3634,6 +3799,35 @@ fn skipOperands(code: []const u8, ip: *usize, op: Opcode) void {
         .br_on_null, .br_on_non_null => _ = readU32(code, ip), // label depth
         .call_ref, .return_call_ref => _ = readU32(code, ip), // typeidx
         // ref_as_non_null has no operands
+        // #672 EH: try_table has blocktype + clause list; throw has a
+        // single u32 tag idx; throw_ref has no immediates.
+        .try_table => {
+            // Block type: signed-LEB128 byte (or multi-byte ref-htype) —
+            // mirrors the parsing in `readBlockType`. Simple skip suffices
+            // here because we never re-read these bytes.
+            if (ip.* < code.len) {
+                const b0 = code[ip.*];
+                if (b0 == 0x63 or b0 == 0x64) {
+                    ip.* += 1;
+                    while (ip.* < code.len) {
+                        const hb = code[ip.*];
+                        ip.* += 1;
+                        if ((hb & 0x80) == 0) break;
+                    }
+                } else {
+                    _ = leb128.readSignedLossy(i64, code, ip);
+                }
+            }
+            const clause_count = readU32(code, ip);
+            var ci: u32 = 0;
+            while (ci < clause_count) : (ci += 1) {
+                const ck = readU32(code, ip);
+                if (ck == 0 or ck == 1) _ = readU32(code, ip);
+                _ = readU32(code, ip);
+            }
+        },
+        .throw => _ = readU32(code, ip),
+        .throw_ref => {},
         // No operands
         else => {},
     }
@@ -7437,4 +7631,146 @@ test "lower: dead code after br is skipped" {
     } else |_| {
         // Error is also acceptable — we just shouldn't crash
     }
+}
+
+// ── #672 EH: try_table / throw / throw_ref lowering tests ──────────────
+
+test "lower throw: emits throw IR op as terminator" {
+    const allocator = std.testing.allocator;
+
+    // Tag type: takes one i32, no results.
+    const tag_ft = types.FuncType{ .params = &[_]types.ValType{.i32}, .results = &.{} };
+    const func_ft = types.FuncType{ .params = &.{}, .results = &.{} };
+
+    // Function body: i32.const 7; throw 0; end
+    const code = [_]u8{
+        0x41, 0x07, // i32.const 7
+        0x08, 0x00, // throw tag 0
+        0x0B, // end
+    };
+    const func = types.WasmFunction{
+        .type_idx = 1,
+        .func_type = func_ft,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &code,
+    };
+    var wm = types.WasmModule{};
+    wm.types = &[_]types.FuncType{ tag_ft, func_ft };
+    wm.functions = &[_]types.WasmFunction{func};
+    wm.tag_types = &[_]u32{0}; // local tag 0 uses type 0
+
+    var ir_module = try lowerModule(&wm, allocator);
+    defer ir_module.deinit();
+
+    const ir_func = &ir_module.functions.items[0];
+    // Find the throw instruction.
+    var saw_throw = false;
+    for (ir_func.blocks.items) |blk| {
+        for (blk.instructions.items) |inst| {
+            if (std.meta.activeTag(inst.op) == .throw) {
+                try std.testing.expectEqual(@as(u32, 0), inst.op.throw.tag_idx);
+                try std.testing.expectEqual(@as(usize, 1), inst.op.throw.args.len);
+                saw_throw = true;
+            }
+        }
+    }
+    try std.testing.expect(saw_throw);
+}
+
+test "lower throw_ref: emits throw_ref IR op as terminator" {
+    const allocator = std.testing.allocator;
+
+    // (func (param exnref) throw_ref) — exnref is lowered to a single
+    // 64-bit slot in the frontend, but for this shape test we just
+    // need an i32 local to feed the throw_ref.
+    const func_ft = types.FuncType{ .params = &[_]types.ValType{.i32}, .results = &.{} };
+
+    // Body: local.get 0; throw_ref; end
+    const code = [_]u8{
+        0x20, 0x00, // local.get 0
+        0x0A, // throw_ref
+        0x0B, // end
+    };
+    const func = types.WasmFunction{
+        .type_idx = 0,
+        .func_type = func_ft,
+        .local_count = 1,
+        .locals = &.{},
+        .code = &code,
+    };
+    var wm = types.WasmModule{};
+    wm.types = &[_]types.FuncType{func_ft};
+    wm.functions = &[_]types.WasmFunction{func};
+
+    var ir_module = try lowerModule(&wm, allocator);
+    defer ir_module.deinit();
+
+    const ir_func = &ir_module.functions.items[0];
+    var saw_throw_ref = false;
+    for (ir_func.blocks.items) |blk| {
+        for (blk.instructions.items) |inst| {
+            if (std.meta.activeTag(inst.op) == .throw_ref) {
+                saw_throw_ref = true;
+            }
+        }
+    }
+    try std.testing.expect(saw_throw_ref);
+}
+
+test "lower try_table: emits begin/end and records clauses" {
+    const allocator = std.testing.allocator;
+
+    const tag_ft = types.FuncType{ .params = &[_]types.ValType{.i32}, .results = &.{} };
+    const func_ft = types.FuncType{ .params = &.{}, .results = &.{} };
+
+    // try_table (catch 0 0) nop end end
+    //   0x1F = try_table
+    //   0x40 = block type void
+    //   0x01 = one clause
+    //     kind=0 (catch tag), tag_idx=0, label_idx=0
+    //   0x01 = nop
+    //   0x0B = end (try_table body)
+    //   0x0B = end (function)
+    const code = [_]u8{
+        0x1F, 0x40, 0x01, 0x00, 0x00, 0x00,
+        0x01,
+        0x0B,
+        0x0B,
+    };
+    const func = types.WasmFunction{
+        .type_idx = 1,
+        .func_type = func_ft,
+        .local_count = 0,
+        .locals = &.{},
+        .code = &code,
+    };
+    var wm = types.WasmModule{};
+    wm.types = &[_]types.FuncType{ tag_ft, func_ft };
+    wm.functions = &[_]types.WasmFunction{func};
+    wm.tag_types = &[_]u32{0};
+
+    var ir_module = try lowerModule(&wm, allocator);
+    defer ir_module.deinit();
+
+    const ir_func = &ir_module.functions.items[0];
+    var saw_begin = false;
+    var saw_end = false;
+    for (ir_func.blocks.items) |blk| {
+        for (blk.instructions.items) |inst| {
+            switch (inst.op) {
+                .try_table_begin => |tb| {
+                    try std.testing.expectEqual(@as(u32, 0), tb.result_arity);
+                    try std.testing.expectEqual(@as(usize, 1), tb.clauses.len);
+                    try std.testing.expectEqual(@as(u8, 0), tb.clauses[0].kind);
+                    try std.testing.expectEqual(@as(?u32, 0), tb.clauses[0].tag_idx);
+                    saw_begin = true;
+                },
+                .try_table_end => saw_end = true,
+                else => {},
+            }
+        }
+    }
+    try std.testing.expect(saw_begin);
+    try std.testing.expect(saw_end);
 }

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -468,6 +468,12 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
         .parallel_copy => |pairs| {
             for (pairs) |p| live.put(p.src, {}) catch {};
         },
+
+        // #672 EH ops. `throw`'s args are the live uses; `throw_ref`'s
+        // exnref is a single live use. `try_table_*` carry no vregs.
+        .try_table_begin, .try_table_end => {},
+        .throw => |th| for (th.args) |a| live.put(a, {}) catch {},
+        .throw_ref => |v| live.put(v, {}) catch {},
     }
 }
 
@@ -1034,6 +1040,11 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
         .parallel_copy => |pairs| {
             for (pairs) |p| last_use.put(p.src, pos) catch {};
         },
+
+        // #672 EH ops.
+        .try_table_begin, .try_table_end => {},
+        .throw => |th| for (th.args) |a| last_use.put(a, pos) catch {},
+        .throw_ref => |v| last_use.put(v, pos) catch {},
     }
 }
 

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -306,6 +306,75 @@ pub const Inst = struct {
         // Owned: the backing slice is freed by `BasicBlock.deinit` and
         // tracked alongside `phi` in `owned_phi_edges` / similar.
         parallel_copy: []const ParallelCopy,
+
+        // ── Exception handling (#672) ──────────────────────────────────
+        // Modern Wasm 3.0 EH only: try_table / throw / throw_ref.
+        // Legacy try/catch/rethrow/delegate/catch_all are NOT modelled.
+
+        /// Open a try region (matches the Wasm `try_table` opcode). The
+        /// op is emitted at the start of the try body and carries the
+        /// list of catch clauses with the IR `BlockId` of each handler.
+        ///
+        /// Codegen attaches an unwind table entry [try_start_pc,
+        /// try_end_pc, clauses_ptr] for the function; throws inside the
+        /// region consult this table to dispatch.
+        ///
+        /// Commit 2 only: lowering decodes try_table into this op +
+        /// normal block scaffolding; codegen still errors out.
+        try_table_begin: TryTableBegin,
+
+        /// Close the matching try region. Emitted at the `end` opcode
+        /// terminating a try_table body. Pairs 1:1 with `try_table_begin`
+        /// in well-formed wasm; codegen uses both to derive the
+        /// try_start_pc / try_end_pc range stored in the unwind table.
+        try_table_end: void,
+
+        /// Throw an exception (Wasm `throw` opcode). Terminator.
+        /// `tag_idx` indexes the *resolved* tag instance in the module's
+        /// tag space (imports first, then declared). `args` are popped
+        /// from the wasm operand stack at lowering time (count =
+        /// tag's func_type.params.len).
+        ///
+        /// At runtime, control transfers either to a matching catch in
+        /// an enclosing try region of the *same* function (commits 3-4)
+        /// or, when commit 5 lands, an enclosing frame's try region.
+        ///
+        /// Owned: `args` is freed by `BasicBlock.deinit`.
+        throw: Throw,
+
+        /// Rethrow a caught exnref (Wasm `throw_ref` opcode). Terminator.
+        /// `exnref` carries the exnref pushed by an earlier catch_ref /
+        /// catch_all_ref clause.
+        throw_ref: VReg,
+    };
+
+    /// One arm of a `try_table` instruction. `kind` maps directly to the
+    /// 4 wasm catch-clause discriminants:
+    ///   0 = catch tag        — handler receives the tag's params
+    ///   1 = catch_ref tag    — handler receives params + an exnref
+    ///   2 = catch_all        — handler receives no params
+    ///   3 = catch_all_ref    — handler receives a single exnref
+    pub const CatchClause = struct {
+        kind: u8,
+        tag_idx: ?u32 = null,
+        handler: BlockId,
+    };
+
+    pub const TryTableBegin = struct {
+        /// Number of results the try body yields on normal exit. Carried
+        /// through so codegen can size the spill area for the handler
+        /// resolution stub matching commit 5's cross-frame unwind.
+        result_arity: u32,
+        /// Owned slice freed by `BasicBlock.deinit` via
+        /// `owned_catch_clauses`.
+        clauses: []const CatchClause,
+    };
+
+    pub const Throw = struct {
+        tag_idx: u32,
+        /// Owned slice freed by `BasicBlock.deinit` via
+        /// `owned_throw_args`.
+        args: []const VReg,
     };
 
     pub const BinOp = struct {
@@ -896,6 +965,9 @@ pub const BasicBlock = struct {
                 .call_indirect => |ci| if (ci.args.len > 0) self.allocator.free(ci.args),
                 .call_ref => |cr| if (cr.args.len > 0) self.allocator.free(cr.args),
                 .ret_multi => |vregs| if (vregs.len > 0) self.allocator.free(vregs),
+                // #672 EH ops own their immediate slices.
+                .try_table_begin => |tt| if (tt.clauses.len > 0) self.allocator.free(tt.clauses),
+                .throw => |th| if (th.args.len > 0) self.allocator.free(th.args),
                 else => {},
             }
         }

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -539,6 +539,15 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
         .phi => {},
         // Parallel-copy operands handled separately (unbounded slice).
         .parallel_copy => {},
+
+        // #672 EH ops. `throw.args` is unbounded (depends on tag arity),
+        // so we handle it the same way as `phi` / `parallel_copy` — the
+        // unbounded handling falls to callers that walk the slice
+        // explicitly. `throw_ref` has a single exnref use which fits
+        // the bounded list.
+        .try_table_begin, .try_table_end => {},
+        .throw => {},
+        .throw_ref => |v| list.append(v),
     }
     return list;
 }
@@ -1015,6 +1024,17 @@ pub fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
             for (@constCast(pairs)) |*p| {
                 if (p.src == old) p.src = new;
             }
+        },
+
+        // #672 EH ops.
+        .try_table_begin, .try_table_end => {},
+        .throw => |*th| {
+            for (@constCast(th.args)) |*a| {
+                if (a.* == old) a.* = new;
+            }
+        },
+        .throw_ref => |*v| {
+            if (v.* == old) v.* = new;
         },
     }
 }
@@ -5073,6 +5093,15 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
                 p.src += offset;
                 p.dst += offset;
             }
+        },
+
+        // #672 EH ops.
+        .try_table_begin, .try_table_end => {},
+        .throw => |*th| {
+            for (@constCast(th.args)) |*a| a.* += offset;
+        },
+        .throw_ref => |*v| {
+            v.* += offset;
         },
     }
 }

--- a/src/compiler/ir/print.zig
+++ b/src/compiler/ir/print.zig
@@ -374,6 +374,21 @@ fn formatPayload(op: ir.Inst.Op, w: *std.Io.Writer) Error!void {
         .f64x2_extract_lane,
         .f64x2_replace_lane,
         => try formatGenericSimdPayload(op, w),
+
+        // #672 EH ops.
+        .try_table_begin => |tb| {
+            try w.print(" results={d} clauses={d}", .{ tb.result_arity, tb.clauses.len });
+        },
+        .try_table_end => {},
+        .throw => |th| {
+            try w.print(" tag={d} args=[", .{th.tag_idx});
+            for (th.args, 0..) |a, i| {
+                if (i != 0) try w.print(",", .{});
+                try w.print("v{d}", .{a});
+            }
+            try w.print("]", .{});
+        },
+        .throw_ref => |v| try w.print(" v{d}", .{v}),
     }
 }
 

--- a/src/compiler/ir/verifier.zig
+++ b/src/compiler/ir/verifier.zig
@@ -493,6 +493,11 @@ pub fn forEachOperand(
         .parallel_copy => |pairs| {
             for (pairs) |p| cb(ctx, p.src);
         },
+
+        // #672 EH ops.
+        .try_table_begin, .try_table_end => {},
+        .throw => |th| for (th.args) |a| cb(ctx, a),
+        .throw_ref => |v| cb(ctx, v),
     }
 }
 
@@ -505,6 +510,8 @@ pub fn isTerminator(op: ir.Inst.Op) bool {
         .ret,
         .ret_multi,
         .@"unreachable",
+        .throw,
+        .throw_ref,
         => true,
         .call => |c| c.tail,
         .call_indirect => |c| c.tail,
@@ -1286,6 +1293,15 @@ fn checkOneInst(ctx: OperandCheckCtx, inst: ir.Inst) VerifyError!void {
 
         // Parallel copy: each pair carries its own width.
         .parallel_copy => |pairs| for (pairs) |p| try ctx.expect(p.src, p.ty, "src"),
+
+        // #672 EH ops: try_table_begin / try_table_end carry no vreg
+        // operands. `throw`'s args are popped at lowering time; their
+        // widths are derived from the tag's func_type so we don't try
+        // to re-typecheck them here in commit 2. `throw_ref` carries a
+        // single exnref which we model as i32 for now (no dedicated
+        // exnref width yet).
+        .try_table_begin, .try_table_end, .throw => {},
+        .throw_ref => |v| try ctx.expect(v, .i32, "exnref"),
     }
 }
 

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -409,6 +409,30 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         }
     }
 
+    // Locally-declared tags (#672). Mirrors `module.tag_types` 1:1.
+    var tag_entries: std.ArrayList(emit_aot.TagEntry) = .empty;
+    defer tag_entries.deinit(allocator);
+    for (module.tag_types) |type_idx| {
+        try tag_entries.append(allocator, .{ .type_idx = type_idx });
+    }
+
+    // Surface tag imports too. The outer `for (module.imports)` loop above
+    // intentionally still drops `.memory` / `.global` because the standalone
+    // `wamrc` path doesn't carry imported memory/global descriptors; tags
+    // are different because the component-mode path (`src/component/aot.zig`)
+    // and this path both need the loader to reconstruct `imported_tags` for
+    // cross-instance wiring.
+    for (module.imports) |imp| {
+        if (imp.kind != .tag) continue;
+        const type_idx = imp.tag_type_idx orelse continue;
+        try import_entries.append(allocator, .{
+            .module_name = imp.module_name,
+            .field_name = imp.field_name,
+            .kind = .tag,
+            .tag_type_idx = type_idx,
+        });
+    }
+
     // Build memory entries from the parsed wasm module
     var mem_entries: std.ArrayList(emit_aot.MemoryEntry) = .empty;
     defer mem_entries.deinit(allocator);
@@ -528,6 +552,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         module.start_function,
         if (func_type_entries.items.len > 0) func_type_entries.items else null,
         if (local_func_tidx_list.items.len > 0) local_func_tidx_list.items else null,
+        if (tag_entries.items.len > 0) tag_entries.items else null,
     );
     defer allocator.free(aot_binary);
 

--- a/src/component/aot.zig
+++ b/src/component/aot.zig
@@ -256,7 +256,15 @@ pub fn compileCoreWasm(
                     .global_mutable = global_type.mutability == .mutable,
                 }) catch return error.OutOfMemory;
             },
-            .tag => {},
+            .tag => {
+                const type_idx = imp.tag_type_idx orelse continue;
+                imports.append(ea, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .tag,
+                    .tag_type_idx = type_idx,
+                }) catch return error.OutOfMemory;
+            },
         }
     }
 
@@ -298,6 +306,14 @@ pub fn compileCoreWasm(
     var local_func_tidx_list: std.ArrayList(u32) = .empty;
     for (module.functions) |f| {
         local_func_tidx_list.append(ea, f.type_idx) catch return error.OutOfMemory;
+    }
+
+    // Locally-declared tags (#672). `module.tag_types` is parallel to the
+    // wasm tag section: each entry is a function-type index describing the
+    // exception parameters.
+    var tag_entries: std.ArrayList(emit_aot.TagEntry) = .empty;
+    for (module.tag_types) |type_idx| {
+        tag_entries.append(ea, .{ .type_idx = type_idx }) catch return error.OutOfMemory;
     }
 
     // Build global entries in wasm-flat order (imported globals first,
@@ -391,6 +407,7 @@ pub fn compileCoreWasm(
         module.start_function,
         if (func_type_entries.items.len > 0) func_type_entries.items else null,
         if (local_func_tidx_list.items.len > 0) local_func_tidx_list.items else null,
+        if (tag_entries.items.len > 0) tag_entries.items else null,
     ) catch return error.CoreCompileFailed;
 }
 

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -1701,7 +1701,29 @@ pub fn instantiateWithOptions(
                             };
                             defer if (imported_function_overrides.len > 0) allocator.free(imported_function_overrides);
 
-                            const aot_inst_ptr = aot_runtime.instantiateWithOverrides(aot_module_ptr, inst.allocator, imported_table_overrides, imported_memory_overrides, imported_global_overrides, imported_function_overrides, &.{}) catch |err| {
+                            const imported_tag_overrides_opt = resolveAotImportedTagOverrides(
+                                allocator,
+                                cis,
+                                ci_idx,
+                                ie.args,
+                                aot_module_ptr,
+                            ) catch {
+                                if (aot_only) {
+                                    std.log.warn("[aot reject] core module {d}: imported tag override resolution failed", .{ie.module_idx});
+                                    return error.AotImportUnresolvable;
+                                }
+                                break :aot_blk;
+                            };
+                            const imported_tag_overrides = imported_tag_overrides_opt orelse {
+                                if (aot_only) {
+                                    std.log.warn("[aot reject] core module {d}: cross-instance tag wiring failed (#670)", .{ie.module_idx});
+                                    return error.AotImportUnresolvable;
+                                }
+                                break :aot_blk;
+                            };
+                            defer if (imported_tag_overrides.len > 0) allocator.free(imported_tag_overrides);
+
+                            const aot_inst_ptr = aot_runtime.instantiateWithOverrides(aot_module_ptr, inst.allocator, imported_table_overrides, imported_memory_overrides, imported_global_overrides, imported_function_overrides, imported_tag_overrides) catch |err| {
                                 std.log.warn("aot core instantiate failed for module {d}: {s}", .{ ie.module_idx, @errorName(err) });
                                 if (aot_only) return error.AotImportUnresolvable;
                                 break :aot_blk;
@@ -2622,9 +2644,11 @@ fn firstUnsupportedAotImport(module: *const aot_loader.AotModule) ?aot_loader.Ao
             // accepted because call exit flushes the slab slot back to that
             // canonical value (#660 item 2).
             .global => continue,
-            // Tag imports still require cross-instance wiring that the
-            // AOT runtime cannot synthesize today.
-            .tag => return imp,
+            // Tag imports are wired the same way as globals/tables/memories:
+            // a sibling core's exported `TagInstance` is passed in via
+            // `imported_tag_overrides` so AOT cores can `throw` and `catch`
+            // a shared tag identity. Closes #670.
+            .tag => continue,
         }
     }
     return null;
@@ -2860,6 +2884,62 @@ fn resolveAotImportedGlobalOverrides(
         if (source_inst_idx == std.math.maxInt(u32)) return null;
         if (source_inst_idx >= ci_idx) return null;
         overrides[i] = resolveCoreInstanceGlobalExport(inst, component, cis[source_inst_idx], imp_global.name) orelse return null;
+    }
+
+    return overrides;
+}
+
+/// #672 commit 5: resolve a sibling core instance's exported tag by name.
+/// Both interp module-instances and AOT instances expose tags through
+/// `module.findExport(name, .tag)` indexed into a `tags: []*TagInstance`
+/// slot, so the lookup shape mirrors `resolveCoreInstanceGlobalExport`.
+fn resolveCoreInstanceTagExport(
+    entry: ComponentInstance.CoreInstanceEntry,
+    export_name: []const u8,
+) ?*core_types.TagInstance {
+    if (entry.module_inst) |src_mi| {
+        const exp = src_mi.module.findExport(export_name, .tag) orelse return null;
+        if (exp.index >= src_mi.tags.len) return null;
+        return src_mi.tags[exp.index];
+    }
+    if (entry.aot_inst) |src_ai| {
+        const exp = src_ai.module.findExport(export_name, .tag) orelse return null;
+        if (exp.index >= src_ai.tags.len) return null;
+        return src_ai.tags[exp.index];
+    }
+    // Inline-export bundles don't expose tag instances today (no fixture
+    // exercises that path); fall through as unresolved so the caller can
+    // either reject AOT or surface a clear error.
+    return null;
+}
+
+/// #672 commit 5: build the `imported_tag_overrides[]` slice for an AOT
+/// core's `instantiateWithOverrides` call. Each entry borrows a sibling
+/// instance's exported `TagInstance` so throw / catch see the same
+/// identity across cores in the same component (closes #670).
+fn resolveAotImportedTagOverrides(
+    allocator: std.mem.Allocator,
+    cis: []const ComponentInstance.CoreInstanceEntry,
+    ci_idx: usize,
+    args: []const ctypes.CoreInstantiateArg,
+    module: *const aot_loader.AotModule,
+) error{OutOfMemory}!?[]?*core_types.TagInstance {
+    const imported_tags = module.importedTags();
+    if (imported_tags.len == 0) return &.{};
+
+    const overrides = try allocator.alloc(?*core_types.TagInstance, imported_tags.len);
+    errdefer allocator.free(overrides);
+
+    for (imported_tags, 0..) |imp_tag, i| {
+        const source_inst_idx: u32 = arg_blk: {
+            for (args) |arg| {
+                if (std.mem.eql(u8, arg.name, imp_tag.module_name)) break :arg_blk arg.instance_idx;
+            }
+            break :arg_blk std.math.maxInt(u32);
+        };
+        if (source_inst_idx == std.math.maxInt(u32)) return null;
+        if (source_inst_idx >= ci_idx) return null;
+        overrides[i] = resolveCoreInstanceTagExport(cis[source_inst_idx], imp_tag.name) orelse return null;
     }
 
     return overrides;

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -1701,7 +1701,7 @@ pub fn instantiateWithOptions(
                             };
                             defer if (imported_function_overrides.len > 0) allocator.free(imported_function_overrides);
 
-                            const aot_inst_ptr = aot_runtime.instantiateWithOverrides(aot_module_ptr, inst.allocator, imported_table_overrides, imported_memory_overrides, imported_global_overrides, imported_function_overrides) catch |err| {
+                            const aot_inst_ptr = aot_runtime.instantiateWithOverrides(aot_module_ptr, inst.allocator, imported_table_overrides, imported_memory_overrides, imported_global_overrides, imported_function_overrides, &.{}) catch |err| {
                                 std.log.warn("aot core instantiate failed for module {d}: {s}", .{ ie.module_idx, @errorName(err) });
                                 if (aot_only) return error.AotImportUnresolvable;
                                 break :aot_blk;

--- a/src/runtime/aot/loader.zig
+++ b/src/runtime/aot/loader.zig
@@ -29,6 +29,7 @@ pub const AotSectionType = enum(u32) {
     elem = 11,
     start = 12,
     type = 13,
+    tag = 14,
     _,
 };
 
@@ -86,6 +87,15 @@ pub const ImportedGlobalDesc = struct {
     mutable: bool,
 };
 
+/// A tag (exception handling) import. `type_idx` references the function-type
+/// describing the exception parameters (tag attribute is always `0x00` for
+/// the MVP).
+pub const ImportedTagDesc = struct {
+    module_name: []const u8,
+    name: []const u8,
+    type_idx: u32,
+};
+
 /// A global initial value parsed from the AOT globals section.
 pub const AotGlobalInit = struct {
     val_type: u8,
@@ -130,6 +140,12 @@ pub const AotModule = struct {
     imported_tables: []const ImportedTableDesc = &.{},
     imported_memories: []const ImportedMemoryDesc = &.{},
     imported_globals: []const ImportedGlobalDesc = &.{},
+    imported_tags: []const ImportedTagDesc = &.{},
+    /// Type indices for locally-declared tags (parallel to the wasm tag
+    /// section). Each entry references `func_types[i]` describing the
+    /// exception parameters. Matches the interpreter's
+    /// `WasmModule.tag_types`.
+    tag_types: []const u32 = &.{},
     memories: []const types.MemoryType = &.{},
     tables: []const types.TableType = &.{},
     data_segments: []const AotDataSegment = &.{},
@@ -155,6 +171,10 @@ pub const AotModule = struct {
 
     pub fn importedGlobals(self: *const AotModule) []const ImportedGlobalDesc {
         return self.imported_globals;
+    }
+
+    pub fn importedTags(self: *const AotModule) []const ImportedTagDesc {
+        return self.imported_tags;
     }
 };
 
@@ -271,6 +291,9 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!AotModule 
             .type => {
                 try parseTypeSection(&reader, section_size, &module, allocator);
             },
+            .tag => {
+                try parseTagSection(&reader, section_size, &module, allocator);
+            },
             else => {
                 // Skip unknown/unhandled sections
                 reader.pos += section_size;
@@ -315,6 +338,12 @@ pub fn unload(module: *const AotModule, allocator: std.mem.Allocator) void {
     }
     if (module.imported_globals.len > 0) {
         allocator.free(module.imported_globals);
+    }
+    if (module.imported_tags.len > 0) {
+        allocator.free(module.imported_tags);
+    }
+    if (module.tag_types.len > 0) {
+        allocator.free(module.tag_types);
     }
     if (module.memories.len > 0) {
         allocator.free(module.memories);
@@ -421,6 +450,25 @@ fn parseTypeSection(reader: *BinaryReader, section_size: u32, module: *AotModule
     module.func_types = entries;
 }
 
+/// Parse the AOT tag section (#672): a u32 count followed by `count` u32
+/// type indices, one per locally-declared tag. Matches the on-wire shape of
+/// the wasm tag section after the per-tag attribute byte (always 0x00 in
+/// MVP exception handling) is dropped during emit.
+fn parseTagSection(reader: *BinaryReader, section_size: u32, module: *AotModule, allocator: std.mem.Allocator) LoadError!void {
+    if (section_size < 4) return error.InvalidSection;
+    const count = try reader.readU32Le();
+    if (count == 0) return;
+    const needed = @as(usize, count) * 4;
+    if (reader.remaining() < needed) return error.UnexpectedEnd;
+
+    const tag_types = allocator.alloc(u32, count) catch return error.OutOfMemory;
+    errdefer allocator.free(tag_types);
+    for (0..count) |i| {
+        tag_types[i] = try reader.readU32Le();
+    }
+    module.tag_types = tag_types;
+}
+
 fn parseExportSection(reader: *BinaryReader, section_size: u32, module: *AotModule, allocator: std.mem.Allocator) LoadError!void {
     if (section_size < 4) return error.InvalidSection;
     const count = try reader.readU32Le();
@@ -501,6 +549,8 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
     errdefer memory_descs.deinit(allocator);
     var global_descs: std.ArrayList(ImportedGlobalDesc) = .empty;
     errdefer global_descs.deinit(allocator);
+    var tag_descs: std.ArrayList(ImportedTagDesc) = .empty;
+    errdefer tag_descs.deinit(allocator);
 
     for (0..count) |i| {
         const mod_name_len = try reader.readU32Le();
@@ -559,9 +609,15 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
                 }) catch return error.OutOfMemory;
             },
             .tag => {
-                // TODO #649: preserve imported tag payloads (exception handling
-                // is not yet supported in AOT).
-                _ = try reader.readU32Le();
+                // #672 commit 1: surface tag imports through to instantiation.
+                // Wire format is a single u32 type-idx (matches the legacy
+                // discard at the same offset).
+                const type_idx = try reader.readU32Le();
+                tag_descs.append(allocator, .{
+                    .module_name = mod_name,
+                    .name = field_name,
+                    .type_idx = type_idx,
+                }) catch return error.OutOfMemory;
             },
         }
 
@@ -579,6 +635,7 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
     module.imported_tables = table_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
     module.imported_memories = memory_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
     module.imported_globals = global_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
+    module.imported_tags = tag_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
 }
 
 fn parseMemorySection(reader: *BinaryReader, section_size: u32, module: *AotModule, allocator: std.mem.Allocator) LoadError!void {

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -375,6 +375,33 @@ pub const VmCtx = extern struct {
     /// exceeds `memory_size`. Handles overlapping regions (memmove
     /// semantics).
     mem_copy_fn: usize = 0,
+    /// Pointer to `[]*TagInstance` for this instance — `inst.tags.ptr`.
+    /// AOT codegen for `throw` indexes this to resolve `tag_idx` →
+    /// `*TagInstance` at runtime. Length matches `tags_count`.
+    /// Issue #672.
+    tags_ptr: usize = 0,
+    /// Number of entries in `tags_ptr`.
+    tags_count: u32 = 0,
+    /// Padding to keep the following 8-byte field aligned.
+    _pad_tags: u32 = 0,
+    /// `fn (*VmCtx, *TagInstance) noreturn` — invoked by AOT-compiled
+    /// `throw` when no in-function catch handler claims the exception.
+    /// Reads `exception_params` / `exception_param_count`, records the
+    /// pending exception, and longjmps via `trapLongjmp` (Windows) or
+    /// exits the process (other platforms) — mirroring `trap_unreachable_fn`.
+    /// Issue #672.
+    aot_throw_uncaught_fn: usize = 0,
+    /// Scratch buffer where AOT-compiled `throw` writes the wasm operand
+    /// stack values that constitute the exception payload, one per slot.
+    /// 16 slots = max exception arity supported by the leaf-function
+    /// path. Read by `aotThrowUncaught` to relay them to the embedder.
+    /// Per-thread isolation is the embedder's responsibility (one VmCtx
+    /// per call-frame chain).
+    exception_params: [16]u64 = [_]u64{0} ** 16,
+    /// Valid-prefix length of `exception_params` for the most recent throw.
+    exception_param_count: u32 = 0,
+    /// Padding so `wasi_ctx` stays 8-byte aligned.
+    _pad_exc: u32 = 0,
     /// Opaque pointer to the `WasiCtx` driving the WASI host imports
     /// for this AOT instance (issue #644 + Approach A). `0` means no
     /// WASI context was attached — AOT WASI adapters in
@@ -465,6 +492,23 @@ pub fn aotTrapInvalidConversion(vmctx: *VmCtx) callconv(.c) noreturn {
     _ = vmctx;
     if (@atomicLoad(bool, &g_trap_catching, .seq_cst)) trapLongjmp();
     std.debug.print("wasm trap: invalid conversion to integer\n", .{});
+    std.process.exit(2);
+}
+
+/// Host helper invoked from AOT-compiled `throw` when control flow
+/// cannot find a matching catch handler inside the current function
+/// (the only case lowered by commit 3 of #672). Reads the payload
+/// AOT codegen stored in `vmctx.exception_params` (count =
+/// `vmctx.exception_param_count`) and surfaces an uncaught-exception
+/// trap. Cross-function unwind + in-function catch dispatch are
+/// scheduled for later commits in PR #674; once they land, this helper
+/// becomes the leaf fallback only.
+pub fn aotThrowUncaught(vmctx: *VmCtx, tag_inst: *types.TagInstance) callconv(.c) noreturn {
+    if (@atomicLoad(bool, &g_trap_catching, .seq_cst)) trapLongjmp();
+    std.debug.print(
+        "wasm trap: uncaught exception (tag=0x{x}, payload_words={d})\n",
+        .{ @intFromPtr(tag_inst), vmctx.exception_param_count },
+    );
     std.process.exit(2);
 }
 
@@ -1277,6 +1321,14 @@ fn refreshVmCtxForInstance(inst: *AotInstance, globals_buf: ?[]u8) void {
     vmctx.trap_idivz_fn = @intFromPtr(&aotTrapIntDivZero);
     vmctx.trap_iovf_fn = @intFromPtr(&aotTrapIntOverflow);
     vmctx.trap_ivc_fn = @intFromPtr(&aotTrapInvalidConversion);
+    vmctx.aot_throw_uncaught_fn = @intFromPtr(&aotThrowUncaught);
+    if (inst.tags.len > 0) {
+        vmctx.tags_ptr = @intFromPtr(inst.tags.ptr);
+        vmctx.tags_count = @intCast(inst.tags.len);
+    } else {
+        vmctx.tags_ptr = 0;
+        vmctx.tags_count = 0;
+    }
     vmctx.table_grow_fn = @intFromPtr(&tableGrowHelper);
     vmctx.tables_info_ptr = if (inst.tables_info.len > 0) @intFromPtr(inst.tables_info.ptr) else 0;
     vmctx.table_init_fn = @intFromPtr(&tableInitHelper);
@@ -2904,6 +2956,11 @@ test "VmCtx layout: fields at expected offsets" {
     try std.testing.expectEqual(@as(usize, 216), @offsetOf(VmCtx, "futex_notify_fn"));
     try std.testing.expectEqual(@as(usize, 224), @offsetOf(VmCtx, "mem_fill_fn"));
     try std.testing.expectEqual(@as(usize, 232), @offsetOf(VmCtx, "mem_copy_fn"));
+    try std.testing.expectEqual(@as(usize, 240), @offsetOf(VmCtx, "tags_ptr"));
+    try std.testing.expectEqual(@as(usize, 248), @offsetOf(VmCtx, "tags_count"));
+    try std.testing.expectEqual(@as(usize, 256), @offsetOf(VmCtx, "aot_throw_uncaught_fn"));
+    try std.testing.expectEqual(@as(usize, 264), @offsetOf(VmCtx, "exception_params"));
+    try std.testing.expectEqual(@as(usize, 392), @offsetOf(VmCtx, "exception_param_count"));
 }
 
 test "getFuncAddr: import indices return null" {

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -918,6 +918,13 @@ pub const AotInstance = struct {
     /// instance. Borrowed imported-global overrides leave this false, but are
     /// still retain()'d on borrow and release()'d on destroy.
     globals_owned: []bool = &.{},
+    /// Tag instances (#672). `tags[0..import_tag_count]` are imported (and may
+    /// be borrowed from a sibling instance via `imported_tag_overrides`);
+    /// `tags[import_tag_count..]` are locally declared and own-allocated
+    /// from `module.tag_types`. `tags_owned[i]` distinguishes the two for
+    /// cleanup purposes (borrowed entries are NOT freed on destroy).
+    tags: []*types.TagInstance = &.{},
+    tags_owned: []bool = &.{},
     /// Byte offset for each wasm-flat global in `VmCtx.globals_ptr`.
     global_offsets: []u32 = &.{},
     /// Total byte size of the globals storage described by `global_offsets`.
@@ -1004,14 +1011,15 @@ pub const RuntimeError = error{
 
 /// Instantiate an AOT module, producing a runnable AotInstance.
 pub fn instantiate(module: *const aot_loader.AotModule, allocator: std.mem.Allocator) RuntimeError!*AotInstance {
-    return instantiateWithOverrides(module, allocator, &.{}, &.{}, &.{}, &.{});
+    return instantiateWithOverrides(module, allocator, &.{}, &.{}, &.{}, &.{}, &.{});
 }
 
 /// Instantiate an AOT module, optionally borrowing `TableInstance`s,
-/// `MemoryInstance`s, and `GlobalInstance`s for each imported slot.
-/// `imported_table_overrides[i]` maps to `module.importedTables()[i]`,
+/// `MemoryInstance`s, `GlobalInstance`s, and `TagInstance`s for each imported
+/// slot. `imported_table_overrides[i]` maps to `module.importedTables()[i]`,
 /// `imported_memory_overrides[i]` to `module.importedMemories()[i]`,
-/// `imported_global_overrides[i]` to `module.importedGlobals()[i]`;
+/// `imported_global_overrides[i]` to `module.importedGlobals()[i]`,
+/// `imported_tag_overrides[i]` to `module.importedTags()[i]`;
 /// null leaves that slot locally allocated (with a zero-valued default).
 ///
 /// `imported_function_overrides[i]` maps to the *i-th function import*
@@ -1026,11 +1034,13 @@ pub fn instantiateWithOverrides(
     imported_memory_overrides: []const ?*types.MemoryInstance,
     imported_global_overrides: []const ?*types.GlobalInstance,
     imported_function_overrides: []const ?*const anyopaque,
+    imported_tag_overrides: []const ?*types.TagInstance,
 ) RuntimeError!*AotInstance {
     std.debug.assert(imported_table_overrides.len == 0 or imported_table_overrides.len == module.importedTables().len);
     std.debug.assert(imported_memory_overrides.len == 0 or imported_memory_overrides.len == module.importedMemories().len);
     std.debug.assert(imported_global_overrides.len == 0 or imported_global_overrides.len == module.importedGlobals().len);
     std.debug.assert(imported_function_overrides.len == 0 or imported_function_overrides.len == module.import_function_count);
+    std.debug.assert(imported_tag_overrides.len == 0 or imported_tag_overrides.len == module.importedTags().len);
 
     var inst = allocator.create(AotInstance) catch return error.OutOfMemory;
     errdefer allocator.destroy(inst);
@@ -1043,6 +1053,8 @@ pub fn instantiateWithOverrides(
         .tables_owned = &.{},
         .globals = &.{},
         .globals_owned = &.{},
+        .tags = &.{},
+        .tags_owned = &.{},
         .allocator = allocator,
         .module_ref = module,
     };
@@ -1125,6 +1137,16 @@ pub fn instantiateWithOverrides(
     inst.global_storage_size = global_layout.size;
     errdefer if (inst.global_offsets.len > 0) allocator.free(inst.global_offsets);
 
+    // #672 commit 1: allocate tag instances. Imported entries borrow when
+    // an override is supplied (cross-instance tag identity, future #670);
+    // otherwise we synthesize a fresh local instance derived from the
+    // declared param arity so the instance is self-consistent even when
+    // no exporter has been wired yet.
+    const tag_alloc = try allocateTags(module, imported_tag_overrides, allocator);
+    inst.tags = tag_alloc.tags;
+    inst.tags_owned = tag_alloc.owned;
+    errdefer freeTags(inst.tags, inst.tags_owned, allocator);
+
     // Resolve AOT host functions for imports
     inst.host_functions = try resolveHostFunctionsWithOverrides(module, allocator, imported_function_overrides);
 
@@ -1197,6 +1219,7 @@ pub fn destroy(inst: *AotInstance) void {
     freeMemories(inst.memories, inst.memories_owned, allocator);
     freeTables(inst.tables, inst.tables_owned, allocator);
     freeGlobals(inst.globals, inst.globals_owned, allocator);
+    freeTags(inst.tags, inst.tags_owned, allocator);
     if (inst.global_offsets.len > 0) allocator.free(inst.global_offsets);
     if (inst.host_functions.len > 0) allocator.free(inst.host_functions);
     // inst.func_table aliases tables[0].native_backing (freed by TableInstance.release).
@@ -2474,6 +2497,85 @@ fn freeGlobals(globals: []*types.GlobalInstance, owned: []bool, allocator: std.m
     if (owned.len > 0) allocator.free(owned);
 }
 
+// ─── Tags (#672) ────────────────────────────────────────────────────────────
+
+const TagsAllocation = struct {
+    tags: []*types.TagInstance,
+    owned: []bool,
+};
+
+/// Allocate (or borrow) `TagInstance`s for every imported + declared tag.
+/// `imported_tag_overrides[i]` (if non-null) borrows a sibling instance's
+/// tag for `module.importedTags()[i]`; otherwise a fresh `TagInstance` is
+/// synthesized so the slot is well-formed even with no exporter wired.
+/// Local (declared) tag arity is read from `module.func_types[type_idx]`.
+fn allocateTags(
+    module: *const aot_loader.AotModule,
+    imported_tag_overrides: []const ?*types.TagInstance,
+    allocator: std.mem.Allocator,
+) RuntimeError!TagsAllocation {
+    const import_tags = module.importedTags();
+    const total = import_tags.len + module.tag_types.len;
+    if (total == 0) return .{ .tags = &.{}, .owned = &.{} };
+
+    const tags = allocator.alloc(*types.TagInstance, total) catch return error.OutOfMemory;
+    errdefer allocator.free(tags);
+    const owned = allocator.alloc(bool, total) catch return error.OutOfMemory;
+    errdefer allocator.free(owned);
+
+    // Synthesize a placeholder for failure paths so freeTags can iterate
+    // before any real allocation has happened.
+    var created: usize = 0;
+    errdefer for (tags[0..created], owned[0..created]) |t, o| {
+        if (o) allocator.destroy(t);
+    };
+
+    for (import_tags, 0..) |imp_desc, i| {
+        if (i < imported_tag_overrides.len) {
+            if (imported_tag_overrides[i]) |borrowed| {
+                tags[i] = borrowed;
+                owned[i] = false;
+                created += 1;
+                continue;
+            }
+        }
+        // No override → synthesize a local placeholder with the declared
+        // import's arity. Cross-instance identity is resolved later
+        // (commit 6, closes #670).
+        const arity = arityForTypeIdx(module, imp_desc.type_idx);
+        const t = allocator.create(types.TagInstance) catch return error.OutOfMemory;
+        t.* = .{ .param_arity = arity };
+        tags[i] = t;
+        owned[i] = true;
+        created += 1;
+    }
+
+    for (module.tag_types, 0..) |type_idx, j| {
+        const slot = import_tags.len + j;
+        const t = allocator.create(types.TagInstance) catch return error.OutOfMemory;
+        t.* = .{ .param_arity = arityForTypeIdx(module, type_idx) };
+        tags[slot] = t;
+        owned[slot] = true;
+        created += 1;
+    }
+
+    return .{ .tags = tags, .owned = owned };
+}
+
+fn arityForTypeIdx(module: *const aot_loader.AotModule, type_idx: u32) u32 {
+    if (type_idx >= module.func_types.len) return 0;
+    return @intCast(module.func_types[type_idx].params.len);
+}
+
+fn freeTags(tags: []*types.TagInstance, owned: []bool, allocator: std.mem.Allocator) void {
+    std.debug.assert(owned.len == 0 or owned.len == tags.len);
+    for (tags, 0..) |t, i| {
+        if (owned.len == 0 or owned[i]) allocator.destroy(t);
+    }
+    if (tags.len > 0) allocator.free(tags);
+    if (owned.len > 0) allocator.free(owned);
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 test "instantiate: empty module" {
@@ -2524,6 +2626,71 @@ test "findExportFunc: returns null for missing export" {
     try std.testing.expectEqual(@as(?u32, null), findExportFunc(inst, "nonexistent"));
 }
 
+test "#672: instantiate allocates TagInstance for declared tags" {
+    // A module declaring two tags with different param-arity should
+    // surface `inst.tags` parallel to `module.tag_types`, with each
+    // entry's `param_arity` taken from `module.func_types[type_idx]`.
+    const params0 = [_]types.ValType{ .i32, .i32 };
+    const params1 = [_]types.ValType{.i64};
+    const ftypes = [_]aot_loader.AotFuncType{
+        .{ .params = &params0, .results = &.{} },
+        .{ .params = &params1, .results = &.{} },
+    };
+    const tags = [_]u32{ 0, 1 };
+    const module = aot_loader.AotModule{
+        .func_types = &ftypes,
+        .tag_types = &tags,
+    };
+
+    const inst = try instantiate(&module, std.testing.allocator);
+    defer destroy(inst);
+
+    try std.testing.expectEqual(@as(usize, 2), inst.tags.len);
+    try std.testing.expectEqual(@as(usize, 2), inst.tags_owned.len);
+    try std.testing.expect(inst.tags_owned[0]);
+    try std.testing.expect(inst.tags_owned[1]);
+    try std.testing.expectEqual(@as(u32, 2), inst.tags[0].param_arity);
+    try std.testing.expectEqual(@as(u32, 1), inst.tags[1].param_arity);
+}
+
+test "#672: instantiate borrows imported tag overrides" {
+    // An imported tag whose `imported_tag_overrides[i]` is non-null
+    // should borrow that `*TagInstance` rather than synthesizing a fresh
+    // one; the borrowed entry must NOT be freed on destroy.
+    const params = [_]types.ValType{.i32};
+    const ftypes = [_]aot_loader.AotFuncType{
+        .{ .params = &params, .results = &.{} },
+    };
+    const imported = [_]aot_loader.ImportedTagDesc{
+        .{ .module_name = "env", .name = "exn", .type_idx = 0 },
+    };
+    const module = aot_loader.AotModule{
+        .func_types = &ftypes,
+        .imported_tags = &imported,
+    };
+
+    // Stand-in exporter tag — allocated by the test, not by the runtime.
+    const exporter_tag = try std.testing.allocator.create(types.TagInstance);
+    defer std.testing.allocator.destroy(exporter_tag);
+    exporter_tag.* = .{ .param_arity = 1 };
+
+    const overrides = [_]?*types.TagInstance{exporter_tag};
+    const inst = try instantiateWithOverrides(
+        &module,
+        std.testing.allocator,
+        &.{},
+        &.{},
+        &.{},
+        &.{},
+        &overrides,
+    );
+    defer destroy(inst);
+
+    try std.testing.expectEqual(@as(usize, 1), inst.tags.len);
+    try std.testing.expectEqual(exporter_tag, inst.tags[0]);
+    try std.testing.expect(!inst.tags_owned[0]);
+}
+
 test "findExportFunc: finds exported function" {
     const exports = [_]types.ExportDesc{
         .{ .name = "memory", .kind = .memory, .index = 0 },
@@ -2571,7 +2738,7 @@ test "memory.grow propagates to cross-instance AOT memory subscribers" {
     };
     const importer_module = aot_loader.AotModule{ .imported_memories = &imported_mems };
     const memory_overrides = [_]?*types.MemoryInstance{exporter.memories[0]};
-    const importer = try instantiateWithOverrides(&importer_module, std.testing.allocator, &.{}, &memory_overrides, &.{}, &.{});
+    const importer = try instantiateWithOverrides(&importer_module, std.testing.allocator, &.{}, &memory_overrides, &.{}, &.{}, &.{});
     defer destroy(importer);
 
     try std.testing.expectEqual(exporter.memories[0], importer.memories[0]);
@@ -2634,7 +2801,7 @@ test "#660 item 4: borrowed memory overrides are retained until importer destroy
     try std.testing.expectEqual(@as(u8, 0xa5), exporter_inst.memories[0].data[7]);
 
     const overrides = [_]?*types.MemoryInstance{exporter_inst.memories[0]};
-    const importer_inst = try instantiateWithOverrides(&importer_module, std.testing.allocator, &.{}, &overrides, &.{}, &.{});
+    const importer_inst = try instantiateWithOverrides(&importer_module, std.testing.allocator, &.{}, &overrides, &.{}, &.{}, &.{});
     try std.testing.expectEqual(exporter_inst.memories[0], importer_inst.memories[0]);
     try std.testing.expect(!importer_inst.memories_owned[0]);
     try std.testing.expectEqual(@as(u32, 2), exporter_inst.memories[0].ref_count);
@@ -2666,7 +2833,7 @@ test "#660 item 4: borrowed table overrides are retained until importer destroy"
     try std.testing.expectEqual(@as(u32, 1), exporter_inst.tables[0].ref_count);
 
     const overrides = [_]?*types.TableInstance{exporter_inst.tables[0]};
-    const importer_inst = try instantiateWithOverrides(&importer_module, std.testing.allocator, &overrides, &.{}, &.{}, &.{});
+    const importer_inst = try instantiateWithOverrides(&importer_module, std.testing.allocator, &overrides, &.{}, &.{}, &.{}, &.{});
     try std.testing.expectEqual(exporter_inst.tables[0], importer_inst.tables[0]);
     try std.testing.expect(!importer_inst.tables_owned[0]);
     try std.testing.expectEqual(@as(u32, 2), exporter_inst.tables[0].ref_count);

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -1057,10 +1057,6 @@ fn compileToAot(
 
     var exports: std.ArrayList(emit_aot.ExportEntry) = .empty;
     for (module.exports) |exp| {
-        // emit_aot.ExternalKind lacks .tag (0x04); exception handling is not
-        // supported in AOT. Drop tag exports rather than panicking on the enum
-        // conversion below.
-        if (exp.kind == .tag) continue;
         try exports.append(a, .{
             .name = exp.name,
             .kind = @enumFromInt(@intFromEnum(exp.kind)),
@@ -1075,9 +1071,6 @@ fn compileToAot(
     // two spectest imports; skipping imports turns that into out-of-range.
     var import_entries: std.ArrayList(emit_aot.ImportEntry) = .empty;
     for (module.imports) |imp| {
-        // Skip tag imports — AOT does not support exception handling, and
-        // emit_aot.ExternalKind has no .tag variant.
-        if (imp.kind == .tag) continue;
         switch (imp.kind) {
             .function => try import_entries.append(a, .{
                 .module_name = imp.module_name,
@@ -1117,7 +1110,17 @@ fn compileToAot(
                     .global_mutable = gt.mutability == .mutable,
                 });
             },
-            .tag => unreachable,
+            .tag => {
+                // #672 commit 5: surface tag imports so the AOT loader can
+                // reconstruct `imported_tags` for cross-instance wiring (#670).
+                const type_idx = imp.tag_type_idx orelse continue;
+                try import_entries.append(a, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .tag,
+                    .tag_type_idx = type_idx,
+                });
+            },
         }
     }
 

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -1275,6 +1275,12 @@ fn compileToAot(
     const tidxs = try a.alloc(u32, module.functions.len);
     for (module.functions, 0..) |f, i| tidxs[i] = f.type_idx;
 
+    // Locally-declared tags (#672) — mirrors `module.tag_types` 1:1.
+    var tag_entries: std.ArrayList(emit_aot.TagEntry) = .empty;
+    for (module.tag_types) |type_idx| {
+        try tag_entries.append(a, .{ .type_idx = type_idx });
+    }
+
     return try emit_aot.emit(
         allocator,
         code,
@@ -1289,6 +1295,7 @@ fn compileToAot(
         module.start_function,
         if (ft_entries.items.len > 0) ft_entries.items else null,
         if (tidxs.len > 0) tidxs else null,
+        if (tag_entries.items.len > 0) tag_entries.items else null,
     );
 }
 

--- a/src/tests/component_aot_smoke_test.zig
+++ b/src/tests/component_aot_smoke_test.zig
@@ -117,7 +117,7 @@ test "#649 phase 2: instantiateWithOverrides shares imported tables across AOT c
     try aot_runtime_mod.mapCodeExecutable(exporter_inst);
 
     const overrides = [_]?*core_types.TableInstance{exporter_inst.tables[0]};
-    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &overrides, &.{}, &.{}, &.{});
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &overrides, &.{}, &.{}, &.{}, &.{});
     defer aot_runtime_mod.destroy(importer_inst);
     try std.testing.expectEqual(exporter_inst.tables[0], importer_inst.tables[0]);
     try std.testing.expect(!importer_inst.tables_owned[0]);
@@ -437,7 +437,7 @@ test "#649 phase 3: instantiateWithOverrides shares imported memory across AOT c
     try std.testing.expectEqual(@as(u8, 0x22), exporter_inst.memories[0].data[3]);
 
     const overrides = [_]?*core_types.MemoryInstance{exporter_inst.memories[0]};
-    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &overrides, &.{}, &.{});
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &overrides, &.{}, &.{}, &.{});
     defer aot_runtime_mod.destroy(importer_inst);
     try std.testing.expectEqual(exporter_inst.memories[0], importer_inst.memories[0]);
     try std.testing.expect(!importer_inst.memories_owned[0]);
@@ -559,7 +559,7 @@ test "#649 phase 4: instantiateWithOverrides shares imported globals across AOT 
     try std.testing.expectEqual(@as(i32, 0x55), exporter_inst.globals[0].value.i32);
 
     const overrides = [_]?*core_types.GlobalInstance{exporter_inst.globals[0]};
-    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &.{}, &overrides, &.{});
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(&importer_module, allocator, &.{}, &.{}, &overrides, &.{}, &.{});
     defer aot_runtime_mod.destroy(importer_inst);
     try std.testing.expectEqual(exporter_inst.globals[0], importer_inst.globals[0]);
     try std.testing.expect(!importer_inst.globals_owned[0]);
@@ -685,6 +685,7 @@ test "#649 phase 5: cross-AOT shared memory + table + global in one importer" {
         &table_overrides,
         &memory_overrides,
         &global_overrides,
+        &.{},
         &.{},
     );
     defer aot_runtime_mod.destroy(importer_inst);

--- a/src/tests/component_aot_smoke_test.zig
+++ b/src/tests/component_aot_smoke_test.zig
@@ -714,3 +714,71 @@ test "#649 phase 5: cross-AOT shared memory + table + global in one importer" {
     // mem[0]=7 + global=3 + tbl[0]()=100 = 110
     try std.testing.expectEqual(@as(i32, 110), results[0].i32);
 }
+
+test "#670 / #672 commit 5: instantiateWithOverrides shares imported tags across AOT cores" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    // exporter:
+    //   (module
+    //     (type (func (param i32)))
+    //     (tag (export "t") (type 0))
+    //   )
+    const exporter_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: (i32) -> ()
+        0x01, 0x05, 0x01, 0x60, 0x01, 0x7f, 0x00,
+        // tag section (id=13): 1 entry, attribute=0x00, type_idx=0
+        0x0d, 0x03, 0x01, 0x00, 0x00,
+        // export section: "t" tag 0
+        0x07, 0x05, 0x01, 0x01, 't',  0x04, 0x00,
+    };
+
+    // importer:
+    //   (module
+    //     (type (func (param i32)))
+    //     (import "env" "t" (tag (type 0)))
+    //   )
+    const importer_wasm = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type section: (i32) -> ()
+        0x01, 0x05, 0x01, 0x60, 0x01, 0x7f, 0x00,
+        // import section: "env" "t" tag attribute=0 type_idx=0
+        0x02, 0x0a,
+        0x01, 0x03, 'e',  'n',  'v',  0x01, 't',  0x04,
+        0x00, 0x00,
+    };
+
+    const allocator = std.testing.allocator;
+    const exporter_cwasm = try aot_harness.compileWasmToAot(allocator, &exporter_wasm);
+    defer allocator.free(exporter_cwasm);
+    const importer_cwasm = try aot_harness.compileWasmToAot(allocator, &importer_wasm);
+    defer allocator.free(importer_cwasm);
+
+    var exporter_module = try aot_loader_mod.load(exporter_cwasm, allocator);
+    defer aot_loader_mod.unload(&exporter_module, allocator);
+    var importer_module = try aot_loader_mod.load(importer_cwasm, allocator);
+    defer aot_loader_mod.unload(&importer_module, allocator);
+
+    const exporter_inst = try aot_runtime_mod.instantiate(&exporter_module, allocator);
+    defer aot_runtime_mod.destroy(exporter_inst);
+
+    try std.testing.expectEqual(@as(usize, 1), exporter_inst.tags.len);
+
+    const overrides = [_]?*core_types.TagInstance{exporter_inst.tags[0]};
+    const importer_inst = try aot_runtime_mod.instantiateWithOverrides(
+        &importer_module,
+        allocator,
+        &.{},
+        &.{},
+        &.{},
+        &.{},
+        &overrides,
+    );
+    defer aot_runtime_mod.destroy(importer_inst);
+
+    // Cross-instance tag identity: importer.tags[0] must equal exporter's
+    // tag pointer (same allocation, not a copy) and must NOT be owned.
+    try std.testing.expectEqual(@as(usize, 1), importer_inst.tags.len);
+    try std.testing.expectEqual(exporter_inst.tags[0], importer_inst.tags[0]);
+    try std.testing.expect(!importer_inst.tags_owned[0]);
+}


### PR DESCRIPTION
Single-PR, multi-commit work toward AOT exception handling. Plan and
status are tracked in #672. Closes #670 in the final commit.

This PR opens with commit 1 of 6:

### Commit 1 — tag descriptors + AOT module wiring  ✅ (this push)

Surfaces wasm tag imports and declared tags through the AOT pipeline
end-to-end. No executing-code behaviour change — `throw` / `throw_ref`
/ `try_table` are still rejected at the frontend. Cross-instance tag
identity (closes #670) lands in the final commit.

- New AOT section 14 (`tag`) + `TagEntry` carrying a func-type idx per
  declared tag.
- `parseImportSection` now materializes `ImportedTagDesc` from `.tag`
  entries (replaces the legacy single-u32 discard).
- `AotInstance.tags` / `tags_owned`; `allocateTags` derives
  `param_arity` from `func_types[type_idx]`.
- `instantiateWithOverrides` gains a trailing `imported_tag_overrides`
  so commit 6 can borrow exporter tags.
- Tests: emit→load round-trip; declared-tag arity; borrowed override.

Full suite passes: 2922/2929 (7 pre-existing skips).

### Pending

- C2 — IR ops + frontend lowering for try_table/throw/throw_ref (codegen still errors).
- C3 — aarch64 codegen (leaf-function-only).
- C4 — x86_64 codegen.
- C5 — cross-function unwind.
- C6 — cross-instance tag identity (closes #670) + EH testsuite acceptance.

Refs #672, #670.