### PR TITLE
Close #676: precompile-component recurses into nested sub-components

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -550,6 +550,22 @@ pub fn build(b: *std.Build) void {
     const run_component_precompile_tests = b.addRunArtifact(component_precompile_tests);
     test_step.dependOn(&run_component_precompile_tests.step);
 
+    // #676: wamrc compile-component must recurse into nested
+    // sub-components (the dominant shape of `wabt component
+    // compose -d` / `wasm-tools compose` output). Companion to the
+    // single-core round-trip above.
+    const component_precompile_nested_module = b.createModule(.{
+        .root_source_file = b.path("src/tests/component_precompile_nested_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    component_precompile_nested_module.addImport("wamr", lib_module);
+    const component_precompile_nested_tests = b.addTest(.{
+        .root_module = component_precompile_nested_module,
+    });
+    const run_component_precompile_nested_tests = b.addRunArtifact(component_precompile_nested_tests);
+    test_step.dependOn(&run_component_precompile_nested_tests.step);
+
     // Phase 3: canon.lift dispatches onto AOT cores (#625).
     const component_aot_canonlift_module = b.createModule(.{
         .root_source_file = b.path("src/tests/component_aot_canonlift_test.zig"),

--- a/src/component/aot.zig
+++ b/src/component/aot.zig
@@ -57,6 +57,14 @@ pub const LoadError = error{
     ManifestVersionMismatch,
     ManifestBuildIdMismatch,
     ManifestComponentMismatch,
+    /// v2 manifest references a `core_sha256` that no core in the
+    /// supplied component bytes matches (or vice versa) — the
+    /// manifest was produced from a different component shape than
+    /// the one being loaded.
+    ManifestCoreMismatch,
+    /// v2 loader couldn't re-parse `expected_component_bytes` to
+    /// walk its nested-component tree.
+    ComponentParseFailed,
     CwasmReadFailed,
     CwasmHashMismatch,
     OutOfMemory,
@@ -77,17 +85,38 @@ pub fn defaultPrecompiledDirFor(allocator: std.mem.Allocator, in_path: []const u
 
 /// Manifest schema version. Bump when the on-disk layout or
 /// serialization changes in a way that older loaders cannot read.
-pub const manifest_format_version: u32 = 1;
+///
+/// History:
+///   * v1 — single top-level loop, one `ManifestModuleEntry` per
+///     `component.core_modules[idx]`. No `core_sha256`; matching at
+///     load time was `module_idx`-only against the root component.
+///   * v2 — recursive walker; one entry per *leaf* core anywhere in
+///     the nested-component tree. `core_sha256` is the primary key.
+///     Required for `wabt component compose -d` /
+///     `wasm-tools compose` output whose cores live inside
+///     sub-components. (#676)
+pub const manifest_format_version: u32 = 2;
 
 /// Per-core entry in the manifest.
 pub const ManifestModuleEntry = struct {
-    /// Index into `component.core_modules` this artifact precompiles.
+    /// Leaf-local core-module index — i.e. the position within the
+    /// `core_modules` slice of the (sub-)component that *directly*
+    /// contains this core. Used by the v1 fallback loader (which
+    /// matches against the root component); v2 manifests carry it
+    /// for debugging only and match by `core_sha256` instead.
     idx: u32,
     /// Relative path under the manifest's directory (e.g. `module3.cwasm`).
     path: []const u8,
     /// Hex sha256 of the `.cwasm` bytes, used to detect tampering
     /// or partial writes on load.
     sha256: []const u8,
+    /// Hex sha256 of the **raw core-module bytes** (`core_mod.data`)
+    /// that produced this cwasm. Primary key for cross-parse
+    /// identity in v2 manifests — `loadManifest` recomputes this
+    /// per visited core in the live component tree and matches
+    /// against this field. Null/empty on v1-shaped JSON read from
+    /// disk (back-compat for fixtures persisted before #676).
+    core_sha256: ?[]const u8 = null,
 };
 
 /// Top-level manifest. Serialized to / parsed from `manifest.json`.
@@ -498,18 +527,44 @@ pub fn precompileComponent(
     // memory while each core is being AOT-compiled. The `core_mod.data`
     // slices borrow from `component_bytes` (owned by the caller), so
     // they remain valid after `load_arena.deinit()`.
-    var core_data_list: std.ArrayList([]const u8) = .empty;
+    //
+    // Recurses into `component.components` so cores inside nested
+    // sub-components (the dominant shape of `wabt component compose -d`
+    // / `wasm-tools compose` output) are precompiled too — without
+    // this the manifest is always empty for composed components and
+    // `--precompiled-dir` falls back to in-memory AOT on every cold
+    // start. (#676)
+    const CoreRef = struct {
+        data: []const u8,
+        /// Position within the `core_modules[]` of the (sub-)component
+        /// that directly contains this core. Persisted as
+        /// `ManifestModuleEntry.idx` for human debugging and for the
+        /// v1-fallback loader path.
+        local_idx: u32,
+    };
+    var core_data_list: std.ArrayList(CoreRef) = .empty;
     defer core_data_list.deinit(allocator);
     {
         var load_arena = std.heap.ArenaAllocator.init(allocator);
         defer load_arena.deinit();
         const component = component_loader.load(component_bytes, load_arena.allocator()) catch
             return error.InvalidComponent;
-        core_data_list.ensureTotalCapacity(allocator, component.core_modules.len) catch
-            return error.OutOfMemory;
-        for (component.core_modules) |core_mod| {
-            core_data_list.appendAssumeCapacity(core_mod.data);
-        }
+        const Walker = struct {
+            fn walk(
+                comp: *const ctypes.Component,
+                list: *std.ArrayList(CoreRef),
+                alloc: std.mem.Allocator,
+            ) PrecompileError!void {
+                for (comp.core_modules, 0..) |cm, mi| {
+                    list.append(alloc, .{ .data = cm.data, .local_idx = @intCast(mi) }) catch
+                        return error.OutOfMemory;
+                }
+                for (comp.components) |child| {
+                    try walk(child, list, alloc);
+                }
+            }
+        };
+        try Walker.walk(&component, &core_data_list, allocator);
     }
 
     // Result-owned arena holds all strings the caller might read off
@@ -529,8 +584,8 @@ pub fn precompileComponent(
     var entries: std.ArrayList(ManifestModuleEntry) = .empty;
     entries.ensureTotalCapacity(ra, core_data_list.items.len) catch return error.OutOfMemory;
 
-    for (core_data_list.items, 0..) |core_data, idx| {
-        const cwasm = compileCoreWasm(allocator, core_data, opts) catch |err| {
+    for (core_data_list.items, 0..) |core_ref, idx| {
+        const cwasm = compileCoreWasm(allocator, core_ref.data, opts) catch |err| {
             std.log.err("precompileComponent: core {d} compile failed: {s}", .{ idx, @errorName(err) });
             return err;
         };
@@ -544,10 +599,12 @@ pub fn precompileComponent(
         };
 
         const hex = hexSha256(ra, cwasm) catch return error.OutOfMemory;
+        const core_hex = hexSha256(ra, core_ref.data) catch return error.OutOfMemory;
         entries.append(ra, .{
-            .idx = @intCast(idx),
+            .idx = core_ref.local_idx,
             .path = rel_path,
             .sha256 = hex,
+            .core_sha256 = core_hex,
         }) catch return error.OutOfMemory;
     }
 
@@ -607,7 +664,12 @@ pub fn loadManifest(
         .{ .ignore_unknown_fields = true },
     ) catch return error.ManifestParseFailed;
 
-    if (parsed.version != manifest_format_version) return error.ManifestVersionMismatch;
+    // v1 was top-level-only and matched by root `module_idx`; v2
+    // (#676) recurses into nested sub-components and matches by raw
+    // core-bytes sha256. Both still rejected when `wamr_build_id`
+    // doesn't match — AOT codegen isn't stable across versions.
+    if (parsed.version != 1 and parsed.version != manifest_format_version)
+        return error.ManifestVersionMismatch;
     if (!std.mem.eql(u8, parsed.wamr_build_id, config.version)) return error.ManifestBuildIdMismatch;
 
     // Verify the manifest was produced from the component the caller
@@ -647,8 +709,80 @@ pub fn loadManifest(
     }
 
     const pcs = allocator.alloc(core_backend.PrecompiledCore, parsed.modules.len) catch return error.OutOfMemory;
-    for (parsed.modules, 0..) |mod, i| {
-        pcs[i] = .{ .module_idx = mod.idx, .cwasm_bytes = cwasm_buffers[i] };
+    errdefer allocator.free(pcs);
+
+    // v2 (or any manifest entry carrying `core_sha256`) lets us
+    // recurse into nested sub-components and match each on-disk
+    // entry to the live core_modules[i].data slice by raw-bytes
+    // sha256. The runtime's `findPrecompiled` then matches by
+    // slice identity, sidestepping module_idx collisions across
+    // sibling sub-components. (#676)
+    const any_core_sha = blk: {
+        for (parsed.modules) |mod| if (mod.core_sha256 != null) break :blk true;
+        break :blk false;
+    };
+
+    if (any_core_sha) {
+        // Re-parse the component into a scratch arena to walk its
+        // nested-component tree. `core_mod.data` slices reference
+        // `expected_component_bytes` (owned by the caller) so they
+        // remain valid after `scratch.deinit()`; only the parse
+        // bookkeeping lives in the arena.
+        var scratch = std.heap.ArenaAllocator.init(allocator);
+        defer scratch.deinit();
+        const live = component_loader.load(expected_component_bytes, scratch.allocator()) catch
+            return error.ComponentParseFailed;
+
+        const Visit = struct { data: []const u8, local_idx: u32, hex: [64]u8 };
+        var visits: std.ArrayList(Visit) = .empty;
+        defer visits.deinit(scratch.allocator());
+
+        const Walker = struct {
+            fn walk(
+                comp: *const ctypes.Component,
+                list: *std.ArrayList(Visit),
+                alloc: std.mem.Allocator,
+            ) error{OutOfMemory}!void {
+                for (comp.core_modules, 0..) |cm, mi| {
+                    var d: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+                    std.crypto.hash.sha2.Sha256.hash(cm.data, &d, .{});
+                    var h: [64]u8 = undefined;
+                    const hc = "0123456789abcdef";
+                    for (d, 0..) |b, j| {
+                        h[j * 2] = hc[b >> 4];
+                        h[j * 2 + 1] = hc[b & 0x0f];
+                    }
+                    try list.append(alloc, .{ .data = cm.data, .local_idx = @intCast(mi), .hex = h });
+                }
+                for (comp.components) |child| try walk(child, list, alloc);
+            }
+        };
+        Walker.walk(&live, &visits, scratch.allocator()) catch return error.OutOfMemory;
+
+        // For every manifest entry, locate the matching live core by
+        // core_sha256 and stamp a `PrecompiledCore` with slice
+        // identity (`core_wasm = core_mod.data`).
+        for (parsed.modules, 0..) |mod, i| {
+            const want = mod.core_sha256 orelse return error.ManifestCoreMismatch;
+            const match = blk: {
+                for (visits.items) |v| {
+                    if (std.mem.eql(u8, &v.hex, want)) break :blk v;
+                }
+                break :blk null;
+            };
+            const v = match orelse return error.ManifestCoreMismatch;
+            pcs[i] = .{
+                .module_idx = v.local_idx,
+                .cwasm_bytes = cwasm_buffers[i],
+                .core_wasm = v.data,
+            };
+        }
+    } else {
+        // v1 fallback: legacy on-disk shape with top-level-only
+        // cores keyed by root-local `module_idx`.
+        for (parsed.modules, 0..) |mod, i| {
+            pcs[i] = .{ .module_idx = mod.idx, .cwasm_bytes = cwasm_buffers[i] };
+        }
     }
 
     return .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -1195,6 +1195,8 @@ fn loadManifestErrorMessage(err: wamr.component_aot.LoadError) []const u8 {
         error.ManifestVersionMismatch => "manifest format version not understood by this build",
         error.ManifestBuildIdMismatch => "manifest was produced by a different wamr build (recompile with `wamrc compile-component`)",
         error.ManifestComponentMismatch => "manifest's component hash does not match this component (stale bundle — recompile with `wamrc compile-component`)",
+        error.ManifestCoreMismatch => "manifest references a core module that does not appear in this component (stale bundle — recompile with `wamrc compile-component`)",
+        error.ComponentParseFailed => "manifest is valid but the component bytes failed to re-parse for nested-core resolution",
         error.CwasmReadFailed => "could not read a .cwasm artifact referenced from the manifest",
         error.CwasmHashMismatch => "a .cwasm artifact's contents differ from the manifest's recorded hash (tampered or partial write)",
         error.OutOfMemory => "out of memory while loading the manifest",

--- a/src/tests/component_precompile_nested_test.zig
+++ b/src/tests/component_precompile_nested_test.zig
@@ -1,0 +1,175 @@
+//! #676 — precompile + loadManifest + instantiate round-trip for a
+//! composed component whose core module lives inside a nested
+//! sub-component (the dominant shape of `wabt component compose -d`
+//! / `wasm-tools compose` output).
+//!
+//! Builds a 2-level component in-process: the top-level component
+//! has zero of its own cores and contains a single sub-component
+//! (component section, id 4) which contains the `add42` core module
+//! plus a core-instance section instantiating it. The top-level
+//! instance section instantiates the sub-component.
+//!
+//! Validates that `precompileComponent` recurses into the
+//! sub-component (writing one `module<N>.cwasm` per leaf core) and
+//! that `loadManifest` resolves each entry to the live
+//! `core_modules[i].data` slice by `core_sha256`, stamping
+//! `core_wasm` so `Options.findPrecompiled` matches by slice
+//! identity through the parent-options-propagation path at
+//! `instance.zig:2292`.
+
+const std = @import("std");
+const wamr = @import("wamr");
+const aot_harness = @import("aot_harness.zig");
+
+const instance = wamr.component_instance;
+const core_types = wamr.types;
+const aot_runtime_mod = wamr.aot_runtime;
+const component_aot = wamr.component_aot;
+
+/// Same i32->i32 +42 module used by the phase-1 smoke test.
+const core_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    0x03, 0x02, 0x01, 0x00,
+    0x05, 0x03, 0x01, 0x00, 0x01,
+    0x07, 0x12, 0x02,
+    0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
+    0x05, 'a', 'd', 'd', '4', '2', 0x00, 0x00,
+    0x0a, 0x09, 0x01, 0x07, 0x00,
+    0x20, 0x00,
+    0x41, 0x2a,
+    0x6a,
+    0x0b,
+};
+
+fn writeLeb(out: *std.ArrayList(u8), allocator: std.mem.Allocator, v: u32) !void {
+    var x = v;
+    while (true) {
+        var b: u8 = @intCast(x & 0x7f);
+        x >>= 7;
+        if (x != 0) b |= 0x80;
+        try out.append(allocator, b);
+        if (x == 0) break;
+    }
+}
+
+/// Build a minimal sub-component containing one core module + one
+/// core-instance that instantiates it. Returned bytes are owned by
+/// the caller.
+fn buildSubComponent(allocator: std.mem.Allocator) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, &.{ 0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00 });
+
+    try out.append(allocator, 1);
+    try writeLeb(&out, allocator, @intCast(core_wasm.len));
+    try out.appendSlice(allocator, &core_wasm);
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(allocator);
+    try writeLeb(&body, allocator, 1);
+    try body.append(allocator, 0x00);
+    try writeLeb(&body, allocator, 0);
+    try writeLeb(&body, allocator, 0);
+
+    try out.append(allocator, 2);
+    try writeLeb(&out, allocator, @intCast(body.items.len));
+    try out.appendSlice(allocator, body.items);
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Build a top-level component that embeds the sub-component as
+/// section 4 (component) and instantiates it via section 5
+/// (instance, tag 0x00).
+fn buildNestedComponent(allocator: std.mem.Allocator) ![]u8 {
+    const sub_bytes = try buildSubComponent(allocator);
+    defer allocator.free(sub_bytes);
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, &.{ 0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00 });
+
+    try out.append(allocator, 4);
+    try writeLeb(&out, allocator, @intCast(sub_bytes.len));
+    try out.appendSlice(allocator, sub_bytes);
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(allocator);
+    try writeLeb(&body, allocator, 1);
+    try body.append(allocator, 0x00);
+    try writeLeb(&body, allocator, 0);
+    try writeLeb(&body, allocator, 0);
+
+    try out.append(allocator, 5);
+    try writeLeb(&out, allocator, @intCast(body.items.len));
+    try out.appendSlice(allocator, body.items);
+
+    return out.toOwnedSlice(allocator);
+}
+
+test "#676: precompile recurses into nested sub-components" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const component_bytes = try buildNestedComponent(allocator);
+    defer allocator.free(component_bytes);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    defer allocator.free(tmp_path);
+
+    var precomp = try component_aot.precompileComponent(allocator, component_bytes, tmp_path, .{});
+    defer precomp.deinit();
+    try std.testing.expectEqual(@as(usize, 1), precomp.manifest.modules.len);
+    try std.testing.expect(precomp.manifest.modules[0].core_sha256 != null);
+    try std.testing.expectEqual(@as(u32, 0), precomp.manifest.modules[0].idx);
+
+    var loaded = try component_aot.loadManifest(allocator, tmp_path, component_bytes);
+    defer loaded.deinit();
+
+    const pcs = loaded.precompiledCores();
+    try std.testing.expectEqual(@as(usize, 1), pcs.len);
+    try std.testing.expect(pcs[0].core_wasm != null);
+    try std.testing.expectEqual(@as(u32, 0), pcs[0].module_idx);
+
+    var parse_arena = std.heap.ArenaAllocator.init(allocator);
+    defer parse_arena.deinit();
+    const component = try wamr.component_loader.load(component_bytes, parse_arena.allocator());
+
+    try std.testing.expectEqual(@as(usize, 1), component.components.len);
+    try std.testing.expectEqual(@as(usize, 0), component.core_modules.len);
+    try std.testing.expectEqual(@as(usize, 1), component.components[0].core_modules.len);
+
+    const inst = try instance.instantiateWithOptions(&component, allocator, .{
+        .precompiled_cores = pcs,
+    });
+    defer inst.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), inst.sub_instances.len);
+    const sub = inst.sub_instances[0] orelse return error.TestFailed;
+    try std.testing.expectEqual(@as(usize, 1), sub.core_instances.len);
+    try std.testing.expect(sub.core_instances[0].module_inst == null);
+    const ai = sub.core_instances[0].aot_inst orelse return error.TestFailed;
+
+    const be = sub.core_instances[0].backend() orelse return error.TestFailed;
+    const fn_idx = be.findExportFunc("add42") orelse return error.TestFailed;
+
+    const param_types = [_]core_types.ValType{.i32};
+    const result_types = [_]core_types.ValType{.i32};
+    const args = [_]core_types.Value{.{ .i32 = 100 }};
+    var results_buf: [1]aot_runtime_mod.ScalarResult = .{.{ .i32 = 0 }};
+    const results = try aot_runtime_mod.callFuncScalar(
+        ai,
+        fn_idx,
+        &param_types,
+        &result_types,
+        &args,
+        &results_buf,
+    );
+    try std.testing.expectEqual(@as(usize, 1), results.len);
+    try std.testing.expectEqual(@as(i32, 142), results[0].i32);
+}

--- a/src/tests/component_precompile_test.zig
+++ b/src/tests/component_precompile_test.zig
@@ -13,7 +13,6 @@ const wamr = @import("wamr");
 const aot_harness = @import("aot_harness.zig");
 
 const instance = wamr.component_instance;
-const ctypes = wamr.component_types;
 const core_types = wamr.types;
 const aot_runtime_mod = wamr.aot_runtime;
 const component_aot = wamr.component_aot;
@@ -100,31 +99,19 @@ test "#625 phase 2: precompile + loadManifest + instantiate round-trip" {
     const pcs = loaded.precompiledCores();
     try std.testing.expectEqual(@as(usize, 1), pcs.len);
     try std.testing.expectEqual(@as(u32, 0), pcs[0].module_idx);
+    // v2 manifests stamp `core_wasm` for slice-identity matching
+    // across the runtime's separate parse of `component_bytes`.
+    try std.testing.expect(pcs[0].core_wasm != null);
 
-    // Hand the loaded artifacts to instantiateWithOptions. The
-    // component path should pick the AOT branch and skip the
-    // interpreter loader for this core.
-    //
-    // We build a Component literal here rather than parsing
-    // `component_bytes` again, because the test owns the component
-    // shape and there's no reason to round-trip through the loader
-    // (which is already exercised by the unit tests in loader.zig).
-    const core_modules = [_]ctypes.CoreModule{.{ .data = &core_wasm }};
-    const core_insts = [_]ctypes.CoreInstanceExpr{
-        .{ .instantiate = .{ .module_idx = 0, .args = &.{} } },
-    };
-    const component = ctypes.Component{
-        .core_modules = &core_modules,
-        .core_instances = &core_insts,
-        .core_types = &.{},
-        .components = &.{},
-        .instances = &.{},
-        .aliases = &.{},
-        .types = &.{},
-        .canons = &.{},
-        .imports = &.{},
-        .exports = &.{},
-    };
+    // Parse `component_bytes` (rather than building a `Component`
+    // literal here) so the `core_modules[i].data` slices the
+    // runtime sees come from the same backing buffer the loader's
+    // re-parse saw — matching slice identities are what
+    // `findPrecompiled` uses to resolve a `PrecompiledCore`
+    // produced from disk. (#676)
+    var parse_arena = std.heap.ArenaAllocator.init(allocator);
+    defer parse_arena.deinit();
+    const component = try wamr.component_loader.load(component_bytes, parse_arena.allocator());
 
     const inst = try instance.instantiateWithOptions(&component, allocator, .{
         .precompiled_cores = pcs,


### PR DESCRIPTION
## Summary

Fixes #676. `wamrc compile-component <composed.wasm>` now writes a non-empty manifest for components produced by `wabt component compose -d` / `wasm-tools compose` (the dominant compose flow), whose cores live inside nested sub-components rather than at the top level.

Before this PR the producer walked only `component.core_modules` (top-level), so the manifest was always `{ \"modules\": [] }` for composed components and `wamr run --precompiled-dir` found nothing — the runtime then fell back to in-memory AOT on every cold start (~252 s on the codegen-cli composed component).

## Producer

`precompileComponent` (`src/component/aot.zig`) now uses the same recursive walker shape `src/main.zig:542-555` already uses for the in-memory auto-precompile path. One \`module<N>.cwasm\` is written per leaf core, in gather order.

## Manifest schema (v1 → v2)

- `ManifestModuleEntry.core_sha256: ?[]const u8` — hex sha256 of the raw `core_mod.data` bytes. Primary cross-parse identity key.
- `idx` is preserved (now: leaf-local `module_idx`) — used by the v1 fallback loader and for human debugging.
- `loadManifest` accepts both v1 and v2; v1 manifests continue to match by root-local `module_idx`.

## Consumer

`loadManifest` (`src/component/aot.zig`) on v2:
1. Re-parses `expected_component_bytes` into a scratch arena (the parse bookkeeping is discarded; the borrowed `core_mod.data` slices reference the caller's component bytes).
2. Recursively walks the nested-component tree.
3. Computes `sha256(core_mod.data)` per visited core and looks up the matching manifest entry.
4. Emits `PrecompiledCore { module_idx, cwasm_bytes, core_wasm = core_mod.data }`.

The runtime's existing `Options.findPrecompiled` arm matches by slice identity (stable across re-parses of the same buffer per the `main.zig` precedent), and `instance.zig:2292` already propagates `Options` into sub-component instantiations — so nested cores resolve automatically. No changes needed in `core_backend.zig` or `instance.zig`.

## Tests

- Updated `src/tests/component_precompile_test.zig` to parse `component_bytes` via `component_loader.load` rather than constructing a `Component` literal, so the runtime sees the same `core_modules[i].data` slice the v2 loader saw.
- New `src/tests/component_precompile_nested_test.zig`: hand-rolls a 2-level component (top-level → section 4 nested → core module + core instance; top-level section 5 instance instantiates the sub-component), runs the full precompile → load → parse → instantiate → call \`add42(100) == 142\` round trip, and asserts the sub-component's core instance picked the AOT branch.

## Validation

```
Build Summary: 43/43 steps succeeded; 2931/2938 tests passed (7 skipped)
```

(`zig build test --summary all` from the repo root.)

## Acceptance (per the issue)

- ✅ `wamrc compile-component <composed.wasm>` now writes one cwasm per leaf core.
- ✅ `loadManifest` resolves nested cores to slice-identity-stable `core_wasm` entries.
- ✅ Existing top-level fixtures (`src/tests/component_precompile_test.zig`) continue to pass.
- ✅ New 2-level-nested fixture exercises the recursive path end-to-end.