### PR TITLE
#681: serialize locally-defined tables in the AOT format

### DIFF
--- a/src/compiler/emit_aot.zig
+++ b/src/compiler/emit_aot.zig
@@ -70,6 +70,12 @@ pub const MemoryEntry = struct {
     max_pages: ?u32,
 };
 
+pub const TableEntry = struct {
+    elem_type: types.ValType,
+    min: u32,
+    max: ?u32,
+};
+
 pub const GlobalEntry = struct {
     val_type: u8,
     mutability: u8,
@@ -117,6 +123,7 @@ pub fn emit(
     func_types: ?[]const FuncTypeEntry,
     local_func_type_indices: ?[]const u32,
     tags: ?[]const TagEntry,
+    tables: ?[]const TableEntry,
 ) ![]u8 {
     var buf: std.ArrayList(u8) = .empty;
     errdefer buf.deinit(allocator);
@@ -325,6 +332,31 @@ pub fn emit(
         }
     }
 
+    // Section 15: locally-defined tables (#681). Wire format mirrors the
+    // imported-table tail in section 8:
+    //   elem_type (u8), min (u32 LE), has_max (u8), max (u32 LE if has_max).
+    // Richer TableType fields (`elem_tidx`, `init_expr`, `is_table64`) are
+    // intentionally not round-tripped — imported tables don't carry them
+    // either, and the AOT runtime ignores them when allocating tables.
+    if (tables) |tbl_list| {
+        if (tbl_list.len > 0) {
+            var tmp: std.ArrayList(u8) = .empty;
+            defer tmp.deinit(allocator);
+            try appendU32Le(&tmp, allocator, @intCast(tbl_list.len));
+            for (tbl_list) |t| {
+                try tmp.append(allocator, @intFromEnum(t.elem_type));
+                try appendU32Le(&tmp, allocator, t.min);
+                if (t.max) |max| {
+                    try tmp.append(allocator, 1);
+                    try appendU32Le(&tmp, allocator, max);
+                } else {
+                    try tmp.append(allocator, 0);
+                }
+            }
+            try emitSection(allocator, &buf, 15, tmp.items);
+        }
+    }
+
     return buf.toOwnedSlice(allocator);
 }
 
@@ -360,7 +392,7 @@ fn buildTargetInfo(options: AotEmitOptions) [40]u8 {
 
 test "emit: minimal (no functions, no exports) has correct magic and version" {
     const allocator = std.testing.allocator;
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // At least header (8) + target_info section (8+40) + text section (8+0) + func section (8+4) + export section (8+4)
@@ -375,7 +407,7 @@ test "emit: one function offset produces valid function section" {
     const allocator = std.testing.allocator;
     const code = [_]u8{ 0xCC, 0xC3 }; // int3; ret
     const offsets = [_]u32{0};
-    const data = try emit(allocator, &code, &offsets, &.{}, .{}, null, null, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &code, &offsets, &.{}, .{}, null, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // Walk sections to find section type 3 (function)
@@ -406,7 +438,7 @@ test "emit: export section encodes name, kind, and index" {
         .kind = .function,
         .index = 7,
     }};
-    const data = try emit(allocator, &.{}, &.{}, &exports, .{}, null, null, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &exports, .{}, null, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // Walk sections to find section type 4 (export)
@@ -453,7 +485,7 @@ test "roundtrip: emit then load with AOT loader" {
     const data = try emit(allocator, &code, &offsets, &exports, .{
         .arch = arch_name,
         .e_machine = 0x3E,
-    }, null, null, null, null, null, null, null, null, null);
+    }, null, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // Parse back with the AOT loader
@@ -495,7 +527,7 @@ test "emit: import section round-trip" {
         .{ .module_name = "env", .field_name = "tbl", .kind = .table, .table_elem_type = .funcref, .table_min = 8, .table_max = 8 },
         .{ .module_name = "wasi_snapshot_preview1", .field_name = "clock_time_get", .kind = .function, .func_type_idx = 1 },
     };
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, &import_entries, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, &import_entries, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     const module = try aot_loader.load(data, allocator);
@@ -523,7 +555,7 @@ test "emit: memory section round-trip" {
         .{ .min_pages = 2, .max_pages = null },
         .{ .min_pages = 1, .max_pages = 256 },
     };
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, &mem_entries, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, &mem_entries, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     const module = try aot_loader.load(data, allocator);
@@ -536,6 +568,29 @@ test "emit: memory section round-trip" {
     try std.testing.expectEqual(@as(u64, 256), module.memories[1].limits.max.?);
 }
 
+test "emit: locally-defined table section round-trip (#681)" {
+    const allocator = std.testing.allocator;
+    const aot_loader = @import("../runtime/aot/loader.zig");
+
+    const tbl_entries = [_]TableEntry{
+        .{ .elem_type = .funcref, .min = 1, .max = null },
+        .{ .elem_type = .funcref, .min = 2, .max = 10 },
+    };
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, null, null, null, null, null, null, &tbl_entries);
+    defer allocator.free(data);
+
+    const module = try aot_loader.load(data, allocator);
+    defer aot_loader.unload(&module, allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), module.tables.len);
+    try std.testing.expectEqual(types.ValType.funcref, module.tables[0].elem_type);
+    try std.testing.expectEqual(@as(u64, 1), module.tables[0].limits.min);
+    try std.testing.expect(module.tables[0].limits.max == null);
+    try std.testing.expectEqual(types.ValType.funcref, module.tables[1].elem_type);
+    try std.testing.expectEqual(@as(u64, 2), module.tables[1].limits.min);
+    try std.testing.expectEqual(@as(u64, 10), module.tables[1].limits.max.?);
+}
+
 test "emit: v128 global init payload round-trip" {
     const allocator = std.testing.allocator;
     const aot_loader = @import("../runtime/aot/loader.zig");
@@ -545,7 +600,7 @@ test "emit: v128 global init payload round-trip" {
         .{ .val_type = 0x7F, .mutability = 0, .init_i64 = 0x1234 },
         .{ .val_type = 0x7B, .mutability = 1, .init_v128 = init_bits },
     };
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, &globals, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, &globals, null, null, null, null, null, null);
     defer allocator.free(data);
 
     const module = try aot_loader.load(data, allocator);
@@ -592,6 +647,7 @@ test "emit: type section and function type indices round-trip" {
         null,
         &ft_entries,
         &tidxs,
+        null,
         null,
     );
     defer allocator.free(data);
@@ -644,6 +700,7 @@ test "#672: tag imports and declared tags round-trip" {
         null,
         null,
         &tag_entries,
+        null,
     );
     defer allocator.free(data);
 

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -443,6 +443,20 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         });
     }
 
+    // Locally-defined tables (#681). Imported tables already round-trip
+    // through `import_entries`; without this section the loader can't
+    // recover `module.tables`, leaving exported local tables
+    // (e.g. wit-component's `(table $imports)`) unallocated at runtime.
+    var table_entries: std.ArrayList(emit_aot.TableEntry) = .empty;
+    defer table_entries.deinit(allocator);
+    for (module.tables) |t| {
+        try table_entries.append(allocator, .{
+            .elem_type = t.elem_type,
+            .min = @intCast(t.limits.min),
+            .max = if (t.limits.max) |m| @as(?u32, @intCast(m)) else null,
+        });
+    }
+
     // Build global entries in wasm-flat order (imported globals first, then
     // local globals) so codegen offsets match runtime storage.
     var global_entries: std.ArrayList(emit_aot.GlobalEntry) = .empty;
@@ -553,6 +567,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         if (func_type_entries.items.len > 0) func_type_entries.items else null,
         if (local_func_tidx_list.items.len > 0) local_func_tidx_list.items else null,
         if (tag_entries.items.len > 0) tag_entries.items else null,
+        if (table_entries.items.len > 0) table_entries.items else null,
     );
     defer allocator.free(aot_binary);
 

--- a/src/component/aot.zig
+++ b/src/component/aot.zig
@@ -305,6 +305,20 @@ pub fn compileCoreWasm(
         }) catch return error.OutOfMemory;
     }
 
+    // Locally-defined tables (#681). Imported tables already round-trip
+    // via `import_entries`; local tables need section 15 so the loader
+    // populates `module.tables` and `allocateTables` creates the matching
+    // `TableInstance`s. wit-component cores rely on this for
+    // `(table $imports)`.
+    var table_entries: std.ArrayList(emit_aot.TableEntry) = .empty;
+    for (module.tables) |t| {
+        table_entries.append(ea, .{
+            .elem_type = t.elem_type,
+            .min = @intCast(t.limits.min),
+            .max = if (t.limits.max) |m| @as(?u32, @intCast(m)) else null,
+        }) catch return error.OutOfMemory;
+    }
+
     var data_segs: std.ArrayList(emit_aot.DataSegmentEntry) = .empty;
     for (module.data_segments) |seg| {
         if (seg.is_passive) continue;
@@ -437,6 +451,7 @@ pub fn compileCoreWasm(
         if (func_type_entries.items.len > 0) func_type_entries.items else null,
         if (local_func_tidx_list.items.len > 0) local_func_tidx_list.items else null,
         if (tag_entries.items.len > 0) tag_entries.items else null,
+        if (table_entries.items.len > 0) table_entries.items else null,
     ) catch return error.CoreCompileFailed;
 }
 

--- a/src/runtime/aot/loader.zig
+++ b/src/runtime/aot/loader.zig
@@ -30,6 +30,7 @@ pub const AotSectionType = enum(u32) {
     start = 12,
     type = 13,
     tag = 14,
+    table = 15,
     _,
 };
 
@@ -293,6 +294,9 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!AotModule 
             },
             .tag => {
                 try parseTagSection(&reader, section_size, &module, allocator);
+            },
+            .table => {
+                try parseTableSection(&reader, section_size, &module, allocator);
             },
             else => {
                 // Skip unknown/unhandled sections
@@ -636,6 +640,28 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
     module.imported_memories = memory_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
     module.imported_globals = global_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
     module.imported_tags = tag_descs.toOwnedSlice(allocator) catch return error.OutOfMemory;
+}
+
+fn parseTableSection(reader: *BinaryReader, section_size: u32, module: *AotModule, allocator: std.mem.Allocator) LoadError!void {
+    if (section_size < 4) return error.InvalidSection;
+    const count = try reader.readU32Le();
+    if (count == 0) return;
+
+    const tbl_types = allocator.alloc(types.TableType, count) catch return error.OutOfMemory;
+    errdefer allocator.free(tbl_types);
+
+    for (0..count) |i| {
+        const elem_type: types.ValType = @enumFromInt(try reader.readByte());
+        const min = try reader.readU32Le();
+        const has_max = try reader.readByte();
+        const max: ?u64 = if (has_max != 0) @as(u64, try reader.readU32Le()) else null;
+        tbl_types[i] = .{
+            .elem_type = elem_type,
+            .limits = .{ .min = min, .max = max },
+        };
+    }
+
+    module.tables = tbl_types;
 }
 
 fn parseMemorySection(reader: *BinaryReader, section_size: u32, module: *AotModule, allocator: std.mem.Allocator) LoadError!void {

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -1139,6 +1139,20 @@ fn compileToAot(
         });
     }
 
+    // Locally-defined tables (#681) — imported tables round-trip via
+    // `import_entries`/`ImportedTableDesc`, while local tables need the
+    // dedicated section 15 added by #681. Without this, `module.tables`
+    // is empty on the loader side and `findExport(name, .table)` against
+    // a local table resolves to an unallocated `tables[i]` slot.
+    var table_entries: std.ArrayList(emit_aot.TableEntry) = .empty;
+    for (module.tables) |t| {
+        try table_entries.append(a, .{
+            .elem_type = t.elem_type,
+            .min = @intCast(t.limits.min),
+            .max = if (t.limits.max) |m| @as(?u32, @intCast(m)) else null,
+        });
+    }
+
     // Build the global entries with wasm-flat indexing. Imported globals
     // are now emitted via `import_entries` (the #649-phase-4 path) so the
     // runtime owns their slots at `inst.globals[0..import_count]`. Only
@@ -1299,6 +1313,7 @@ fn compileToAot(
         if (ft_entries.items.len > 0) ft_entries.items else null,
         if (tidxs.len > 0) tidxs else null,
         if (tag_entries.items.len > 0) tag_entries.items else null,
+        if (table_entries.items.len > 0) table_entries.items else null,
     );
 }
 


### PR DESCRIPTION
Closes #681.

## Problem

`AotModule.tables` was always empty across an AOT round-trip even when the
core wasm module defined a local table. `emit_aot.zig` had no section for
locally-defined tables and `loader.zig` had no section ID, so wit-component
cores' `(table $imports)` was silently lost. With #680's diagnostics in
place, this surfaces as:

    imported table '*.$imports' — source core_instance does not export
    a table named '$imports'

even though `findExport("$imports", .table)` succeeds on the producer side.

## Change

Add **section type 15** mirroring the imported-table tail in
`parseImportSection`:

    count   (u32 LE)
    repeat:
      elem_type (u8)
      min       (u32 LE)
      has_max   (u8)
      max       (u32 LE, only when has_max != 0)

- `src/runtime/aot/loader.zig`: `AotSectionType.table = 15`, dispatch
  case, `parseTableSection`.
- `src/compiler/emit_aot.zig`: `TableEntry`, 15th `tables` param on
  `emit()`, section-15 emit, round-trip unit test.
- `src/component/aot.zig`, `src/compiler/main.zig`,
  `src/tests/aot_harness.zig`: build `table_entries` from
  `module.tables` and pass it to `emit_aot.emit`.

`allocateTables` in `runtime.zig` requires no change; its existing
`module.tables` loop allocates the matching `TableInstance` once the loader
populates the field.

## Out of scope

- `init_expr` / `elem_tidx` / `is_table64` are deliberately omitted —
  imported tables don't round-trip them either, so the format stays
  symmetric and decode-safe. Follow-up if a producer needs them.
- The `elem_segments`-derived default-table fallback at
  `runtime.zig:1144` stays as defensive code per issue body.

## Validation

```
unset ZIG_LOCAL_CACHE_DIR
export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
zig build test --summary all
# → 2932/2939 tests passed (7 skipped)
```

End-to-end componentize-js parity (the acceptance criterion from #681's
body) needs the azure-sdk-for-zig bundle on the user's host and isn't
runnable in CI.