### PR TITLE
#683: forward aggregate TypeDef indirection through coreFlatSlotType

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -478,15 +478,33 @@ fn coreFlatSlotType(t: ctypes.ValType, registry: TypeRegistry) !core_types.ValTy
         .f64 => .f64,
         .enum_ => .i32,
         .own, .borrow, .future, .stream, .error_context => .i32,
-        .result, .variant, .option, .flags => blk: {
+        .result, .variant, .option, .flags, .tuple, .record => blk: {
             if (abi.flattenCount(registry, t) != 1) return error.AotPathUnsupported;
             break :blk .i32;
         },
         .type_idx => |idx| blk: {
             const td = registry.get(idx) orelse return error.AotPathUnsupported;
+            // Forward aggregate TypeDefs to the matching inline ValType so
+            // the recursion lands in the inline arm above (which enforces
+            // the `flattenCount == 1 → .i32` guard) or the direct `.enum_`
+            // arm. The `u32` payload of each ValType aggregate variant is
+            // itself a typeidx, and `flattenCount` collapses `type_idx`
+            // indirection identically to the inline form (see
+            // `canonical_abi.flattenCount` / `flattenCountDef`). So this
+            // is a pure reify-table extension — no semantic change.
+            // Without it, `wasi:cli/run.run`'s `result<unit,unit>`
+            // declared as a stand-alone TypeDef traps every AOT-backed
+            // export with `AotPathUnsupported` (issue #683).
             const reified: ctypes.ValType = switch (td) {
                 .val => |inner| inner,
                 .resource => .{ .own = idx },
+                .result => .{ .result = idx },
+                .variant => .{ .variant = idx },
+                .option => .{ .option = idx },
+                .flags => .{ .flags = idx },
+                .enum_ => .{ .enum_ = idx },
+                .tuple => .{ .tuple = idx },
+                .record => .{ .record = idx },
                 else => return error.AotPathUnsupported,
             };
             break :blk try coreFlatSlotType(reified, registry);
@@ -2996,6 +3014,35 @@ test "dispatchCanonBuiltin: waitable.join late-arrival on a cancelled subtask ca
     try testing.expectEqual(@as(usize, 1), ws.items.items.len);
     try testing.expect(ws.items.items[0].ready);
     try testing.expectEqual(STATUS_STARTED_CANCELLED, ws.items.items[0].code);
+}
+
+test "coreFlatSlotType: TypeDef indirection to single-slot result reifies to .i32 (#683)" {
+    // type 0: result<unit, unit> — discriminant only, flattens to 1 slot.
+    const result_unit = ctypes.TypeDef{ .result = .{ .ok = null, .err = null } };
+    const reg = TypeRegistry.fromTypes(&.{result_unit});
+    const slot = try coreFlatSlotType(.{ .type_idx = 0 }, reg);
+    try std.testing.expectEqual(core_types.ValType.i32, slot);
+}
+
+test "coreFlatSlotType: TypeDef indirection to multi-slot variant traps AotPathUnsupported (#683)" {
+    // type 0: variant { a, b(s64) } — 1 disc + 1 payload = 2 slots.
+    const variant_two_slot = ctypes.TypeDef{ .variant = .{ .cases = &.{
+        .{ .name = "a", .type = null },
+        .{ .name = "b", .type = .s64 },
+    } } };
+    const reg = TypeRegistry.fromTypes(&.{variant_two_slot});
+    const got = coreFlatSlotType(.{ .type_idx = 0 }, reg);
+    try std.testing.expectError(error.AotPathUnsupported, got);
+}
+
+test "coreFlatSlotType: TypeDef indirection to single-field record reifies to .i32 (#683)" {
+    // type 0: record { x: u32 } — flattens to 1 slot.
+    const record_one_slot = ctypes.TypeDef{ .record = .{ .fields = &.{
+        .{ .name = "x", .type = .u32 },
+    } } };
+    const reg = TypeRegistry.fromTypes(&.{record_one_slot});
+    const slot = try coreFlatSlotType(.{ .type_idx = 0 }, reg);
+    try std.testing.expectEqual(core_types.ValType.i32, slot);
 }
 
 test "countFlatTypes: primitives" {


### PR DESCRIPTION
Closes #683.

## Problem

`callComponentFuncByLocal` trapped with `error.AotPathUnsupported` whenever
an AOT-backed export's interface result type was a `TypeDef` indirection to
an aggregate — e.g. every `wasi:cli/run.run` export (`result<unit, unit>`
declared as a stand-alone TypeDef and aliased into the run instance), which
is the only entry point for nearly all `wasm-tools component new` outputs.

Diagnostic from the issue (with #681 landed):

```
[aot-debug] callComponentFuncByLocal -> AOT core_inst_idx=0 core_func_idx=170 func_type_idx=29
[aot-debug] runComponent_2 trap from callComponentFunc("run"): AotPathUnsupported
[diag-aot] coreFlatSlotType: type_idx=28 td-tag=result → AotPathUnsupported
```

The same shape inlined as `ValType.result` already worked: the inline arm at
`executor.zig:481` checks `flattenCount == 1` and returns `.i32`. The
`.type_idx` arm's reify switch at `:485-493` only forwarded `.val` and
`.resource`, so every aggregate TypeDef fell into the catch-all.

## Change

Extend the reify switch in the `.type_idx` arm of `coreFlatSlotType` to
forward each aggregate `TypeDef` variant to the matching synthetic
`ValType.<variant> = idx`:

```zig
const reified: ctypes.ValType = switch (td) {
    .val => |inner| inner,
    .resource => .{ .own = idx },
    .result => .{ .result = idx },
    .variant => .{ .variant = idx },
    .option => .{ .option = idx },
    .flags => .{ .flags = idx },
    .enum_ => .{ .enum_ = idx },
    .tuple => .{ .tuple = idx },
    .record => .{ .record = idx },
    else => return error.AotPathUnsupported,
};
```

The `u32` payload of each aggregate `ValType` variant is itself a typeidx
and `flattenCount` collapses both forms identically (canonical_abi.zig:446-531
delegates `type_idx` to `flattenCountDef`). So this is a pure reify-table
extension — no semantic change for any input that was previously accepted,
and no permissive widening: the existing `flattenCount == 1` guard in the
inline arm still gates everything multi-slot to `AotPathUnsupported`.

Also extend the inline aggregate arm to include `.tuple` and `.record` so
the recursion has a defined landing site for single-field shapes (matches
`flattenCountDef`'s treatment).

## Tests

Three focused unit tests using `TypeRegistry.fromTypes` (executor.zig):

- `result<unit, unit>` via `.{ .type_idx = 0 }` → `.i32` (the
  `wasi:cli/run.run` shape)
- `variant { a, b(s64) }` (2 slots) via `.{ .type_idx = 0 }` →
  `error.AotPathUnsupported` (negative guard)
- `record { x: u32 }` (1 slot) via `.{ .type_idx = 0 }` → `.i32`

## Validation

```
unset ZIG_LOCAL_CACHE_DIR
export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
zig build test --summary all
# → 2935/2942 tests passed (7 skipped) — +3 new tests over the #682 baseline
```

End-to-end `codegen-cli.composed.wasm` parity (the issue's acceptance
criterion) needs the azure-sdk-for-zig bundle on the user's host and isn't
runnable in this environment.

## Out of scope

`list`, `string`, `func`, `component`, `instance` TypeDef indirection —
these can never flatten to one slot, so the catch-all in the reify switch
remains correct for them.