### PR TITLE
#685: resolveLiftedCoreFunc handles AOT-backed core instances

### DIFF
--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -3726,12 +3726,21 @@ fn resolveLiftedCoreFunc(
             const ie = a.instance_export;
             if (ie.instance_idx >= inst.core_instances.len) return null;
             const target = inst.core_instances[ie.instance_idx];
-            const mi = target.module_inst orelse return null;
-            const local = mi.getExportFunc(ie.name) orelse return null;
-            return .{
-                .core_instance_idx = ie.instance_idx,
-                .local_func_idx = local,
-            };
+            if (target.module_inst) |mi| {
+                const local = mi.getExportFunc(ie.name) orelse return null;
+                return .{
+                    .core_instance_idx = ie.instance_idx,
+                    .local_func_idx = local,
+                };
+            }
+            if (target.aot_inst) |ai| {
+                const exp = ai.module.findExport(ie.name, .function) orelse return null;
+                return .{
+                    .core_instance_idx = ie.instance_idx,
+                    .local_func_idx = exp.index,
+                };
+            }
+            return null;
         },
     }
 }


### PR DESCRIPTION
Closes #685.

## Problem

`resolveLiftedCoreFunc` (`src/component/instance.zig:3704-3737`) only inspected `target.module_inst` in its `.aliased` arm and returned `null` when the canon.lift target lived in an **AOT-backed** core instance (`module_inst == null`, `aot_inst != null`). Both callers (`instance.zig:1190-1193`, `2374-2377`) silently fell back to `(core_instance_idx = 0, core_func_idx = lift.core_func_idx)` — feeding the executor a component-level core-func index against AOT core_instance[0] and producing `error.FunctionNotFound` / `TrapInCoreFunction`.

Repro from the issue (codegen-cli bundle after `wamrc compile-component`):

```
[aot-debug] callComponentFuncByLocal -> AOT core_inst_idx=0 core_func_idx=170 func_type_idx=29
[diag] callFuncScalar: func_idx=170 not found. import_count=0 func_count=74 funcptrs.len=74
```

## Fix

Mirror the existing `module_inst` branch with an `aot_inst` branch that resolves the export via `AotModule.findExport(ie.name, .function)`. `ExportDesc.index` is the wasm-level (imports + locals) function index, which is what `getFuncAddr` / `callFuncScalar` expect (`src/runtime/aot/runtime.zig:1383-1402`).

```zig
if (target.module_inst) |mi| {
    const local = mi.getExportFunc(ie.name) orelse return null;
    return .{ .core_instance_idx = ie.instance_idx, .local_func_idx = local };
}
if (target.aot_inst) |ai| {
    const exp = ai.module.findExport(ie.name, .function) orelse return null;
    return .{ .core_instance_idx = ie.instance_idx, .local_func_idx = exp.index };
}
return null;
```

## Scope notes

- The issue's note #1 (replace the silent caller fallbacks with warn-or-error) was prototyped but reverted: every hand-authored fixture in `component_aot_canonlift_test.zig` uses `.aliases = &.{}` (so `resolveCoreFunc` returns null and the fallback fires by design), which made the warn variant chatty without surfacing real bugs. Note #1 is explicitly "not strictly required for #685" — leaving that for a follow-up that also teaches fixtures to populate the indexspace.
- Note #2 (`inline_exports` synthetic backing) is out of scope per the issue text.

## Validation

`zig build test --summary all` from the worktree: **Build Summary: 43/43 steps succeeded; 2935/2942 tests passed (7 skipped)**.