### PR TITLE
fix #687: bridge canon-lower sibling exports across AOT cores

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -5998,6 +5998,38 @@ pub export fn wamrAotDispatchComponentTrampoline(
     return .{ .status = 0, .value = result };
 }
 
+/// AOT-codegen-flavoured canon.lower dispatcher (#687). The trampoline pool
+/// stub shifts caller regs right by one to inject `slot` as the first
+/// C-ABI arg, so when the AOT codegen calls a host import as
+/// `host_fn(vmctx, arg0, arg1, …)`, this dispatcher receives
+/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a5=arg4)`. We discard `a0`
+/// (importer's vmctx) and re-issue `dispatchAotComponentTrampoline` over
+/// `a1..a5`, matching the lowered wasm-arg shape the host trampoline
+/// already expects.
+pub export fn wamrAotDispatchComponentTrampolineAot(
+    ctx_opaque: *anyopaque,
+    lowered_sig: *const host_trampolines.LoweredSig,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+) callconv(.c) host_trampolines.DispatchResult {
+    _ = a0;
+    const ctx: *const ComponentTrampolineCtx = @ptrCast(@alignCast(ctx_opaque));
+    const result = dispatchAotComponentTrampoline(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, 0 }) catch |err| {
+        if (debugAotEnabled()) {
+            std.debug.print(
+                "[aot-dispatch] canon.lower(aot) trampoline failed: {s}\n",
+                .{@errorName(err)},
+            );
+        }
+        return .{ .status = 1, .value = 0 };
+    };
+    return .{ .status = 0, .value = result };
+}
+
 /// Per-import context for the cross-instance core-to-core thunk (#662).
 /// Owned by `ComponentInstance.cross_instance_thunk_ctxs`; the trampoline
 /// pool slot stores `*CrossInstanceThunkCtx` as its `ctx`.

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -3355,11 +3355,24 @@ fn installCanonLowerBackedCrossInstanceThunk(
     imp: aot_loader.AotImportDesc,
     module: *const aot_loader.AotModule,
 ) !*const anyopaque {
+    // Probe the pool first so failures on platforms that don't support
+    // RWX trampoline pages (Windows, macOS aarch64, non-x86_64/aarch64
+    // arches) bail before we allocate or publish the ctx — the caller
+    // installs a trap stub instead. Doing this up front also keeps the
+    // failure-cleanup path trivially correct.
+    const pool = try ensureAotTrampolinePool(inst);
+
     const ctx_ptr = try buildLoweredComponentTrampolineCtx(allocator, inst, component, canon_lower_idx);
-    // Once registered on inst.trampoline_ctxs, ownership is the
-    // ComponentInstance's; pop on subsequent failure to avoid leaking
-    // a published-but-unused entry.
-    errdefer _ = inst.trampoline_ctxs.pop();
+    // `buildLoweredComponentTrampolineCtx` publishes `ctx_ptr` on
+    // `inst.trampoline_ctxs` as its final step, so a failure below has
+    // to pop the entry AND release the ctx's owned memory (param/result
+    // type slices + extension storage). `ComponentInstance.deinit` is
+    // the only other place that does this teardown.
+    errdefer {
+        _ = inst.trampoline_ctxs.pop();
+        ctx_ptr.deinit(allocator);
+        allocator.destroy(ctx_ptr);
+    }
 
     // Attempt to bind the HostFunc eagerly so calls that fire before
     // `linkImports` (e.g. AOT start-section that calls back through
@@ -3381,7 +3394,6 @@ fn installCanonLowerBackedCrossInstanceThunk(
     const lowered_results = try arena.alloc(core_types.ValType, ft.results.len);
     for (ft.results, 0..) |r, i| lowered_results[i] = r;
 
-    const pool = try ensureAotTrampolinePool(inst);
     const stub = try pool.allocCanonLowerAotSlot(@ptrCast(ctx_ptr), .{
         .param_types = lowered_params,
         .result_types = lowered_results,

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -3060,13 +3060,51 @@ fn resolveAotImportedFunctionOverrides(
 
         var thunk: ?*const anyopaque = null;
         if (source_inst_idx != std.math.maxInt(u32) and source_inst_idx < ci_idx) {
-            thunk = installCrossInstanceThunk(allocator, inst, component, cis[source_inst_idx], imp, module) catch |err| blk: {
-                std.log.warn(
-                    "[aot reject] core module {d}: cross-instance thunk for '{s}.{s}' failed ({s}); installing trap-on-call stub",
-                    .{ module_idx, imp.module_name, imp.field_name, @errorName(err) },
-                );
-                break :blk null;
-            };
+            const src_entry = cis[source_inst_idx];
+
+            // Wit-component adapter pattern: the sibling is an inline-
+            // exports synthetic core instance whose `imp.field_name`
+            // member is a `canon.lower` contributor bridging a parent
+            // WASIp2 import. Build a ComponentTrampolineCtx and route
+            // through the canon-lower dispatcher rather than the
+            // sibling-AOT cross-instance path (which only handles
+            // alias-of-AOT-export sources).
+            if (resolveInlineExportCanonRef(component, src_entry, imp.field_name)) |canon_ref| {
+                switch (canon_ref) {
+                    .lowered => |cl_idx| {
+                        thunk = installCanonLowerBackedCrossInstanceThunk(
+                            allocator,
+                            inst,
+                            component,
+                            cl_idx,
+                            imp,
+                            module,
+                        ) catch |err| blk: {
+                            std.log.warn(
+                                "[aot reject] core module {d}: canon-lower thunk for '{s}.{s}' failed ({s}); falling back to cross-instance / trap-stub",
+                                .{ module_idx, imp.module_name, imp.field_name, @errorName(err) },
+                            );
+                            break :blk null;
+                        };
+                    },
+                    // Resource-drop / new / rep and other canon-builtin
+                    // contributors still fall through to the trap stub.
+                    // Bridging them requires a separate canon-builtin
+                    // dispatch kind in the trampoline pool; tracked as a
+                    // follow-up to #687.
+                    else => {},
+                }
+            }
+
+            if (thunk == null) {
+                thunk = installCrossInstanceThunk(allocator, inst, component, src_entry, imp, module) catch |err| blk: {
+                    std.log.warn(
+                        "[aot reject] core module {d}: cross-instance thunk for '{s}.{s}' failed ({s}); installing trap-on-call stub",
+                        .{ module_idx, imp.module_name, imp.field_name, @errorName(err) },
+                    );
+                    break :blk null;
+                };
+            }
         }
 
         if (thunk == null) {
@@ -3183,6 +3221,170 @@ fn installCrossInstanceThunk(
     const stub = try pool.allocCrossInstanceSlot(@ptrCast(ctx), .{
         .param_types = param_types,
         .result_types = result_types,
+        .has_retptr = false,
+    });
+    return @ptrCast(stub);
+}
+
+/// Walk a sibling core instance's `inline_exports` and, if `export_name`
+/// names a member backed directly by a canon contributor (rather than an
+/// alias of a sibling-instance export), return that canon-func reference.
+/// Returns `null` for non-canon backings (the caller should fall back to
+/// the alias-walking path in `resolveCoreInstanceFuncToAi`).
+///
+/// wit-component adapter outputs use this pattern: the synthetic
+/// `(core instance (exports ...))` instance the adapter produces names
+/// each parent-component WASIp2 import via a `canon.lower` contributor.
+fn resolveInlineExportCanonRef(
+    component: *const ctypes.Component,
+    entry: ComponentInstance.CoreInstanceEntry,
+    export_name: []const u8,
+) ?indexspace.CoreFuncRef {
+    if (entry.module_inst != null) return null;
+    if (entry.aot_inst != null) return null;
+    for (entry.inline_exports) |mem| {
+        if (!std.mem.eql(u8, mem.name, export_name)) continue;
+        if (mem.sort_idx.sort != .func) return null;
+        return indexspace.resolveCoreFunc(component, mem.sort_idx.idx);
+    }
+    return null;
+}
+
+/// Build a `ComponentTrampolineCtx` for a `canon.lower` decl, mirroring the
+/// interp path's ctx-population at the bottom of `instantiateWithOptions`'s
+/// inline-exports walk. The resulting ctx has `host_func = .{}` (empty);
+/// `linkImports` rebinds it later by walking `inst.trampoline_ctxs`.
+///
+/// The ctx is registered on `inst.trampoline_ctxs` (which owns destruction)
+/// before returning. On error, the partially-built ctx is fully cleaned up.
+fn buildLoweredComponentTrampolineCtx(
+    allocator: std.mem.Allocator,
+    inst: *ComponentInstance,
+    component: *const ctypes.Component,
+    canon_lower_idx: u32,
+) !*executor_mod.ComponentTrampolineCtx {
+    if (canon_lower_idx >= component.canons.len) return error.UnsupportedCrossInstanceSource;
+    const lower = switch (component.canons[canon_lower_idx]) {
+        .lower => |l| l,
+        else => return error.UnsupportedCrossInstanceSource,
+    };
+
+    const ctx_ptr = try allocator.create(executor_mod.ComponentTrampolineCtx);
+    errdefer allocator.destroy(ctx_ptr);
+
+    const rft_opt: ?ResolvedFuncType = resolveCompFuncType(component, lower.func_idx) orelse blk: {
+        if (lower.func_idx >= component.types.len) break :blk null;
+        break :blk switch (component.types[lower.func_idx]) {
+            .func => |f| ResolvedFuncType{ .ft = f },
+            else => null,
+        };
+    };
+    const rft = rft_opt orelse return error.UnsupportedCrossInstanceSource;
+
+    const ext_base: u32 = if (component.type_indexspace.len > 0)
+        @intCast(component.type_indexspace.len)
+    else
+        @intCast(component.types.len);
+
+    const ext: InstanceTypeExtension = if (rft.decls) |decls|
+        try buildInstanceTypeExtension(allocator, decls, ext_base, component)
+    else
+        InstanceTypeExtension.empty();
+    // Once `ctx_ptr.*` is initialized with `extended_types/indexspace`,
+    // the ComponentTrampolineCtx.deinit path owns those slices; before
+    // that, the local errdefer below frees them.
+    var ext_owned_by_ctx = false;
+    errdefer if (!ext_owned_by_ctx) ext.deinit(allocator, true);
+
+    const ft = rft.ft;
+    const params = try allocator.alloc(ctypes.ValType, ft.params.len);
+    errdefer allocator.free(params);
+    for (ft.params, 0..) |p, i| {
+        params[i] = if (rft.decls != null) rewriteValTypeAbsolute(ext_base, p.type) else p.type;
+    }
+    const results = switch (ft.results) {
+        .none => try allocator.alloc(ctypes.ValType, 0),
+        .unnamed => |t| blk: {
+            const r = try allocator.alloc(ctypes.ValType, 1);
+            r[0] = if (rft.decls != null) rewriteValTypeAbsolute(ext_base, t) else t;
+            break :blk r;
+        },
+        .named => |named| blk: {
+            const r = try allocator.alloc(ctypes.ValType, named.len);
+            for (named, 0..) |n, i| {
+                r[i] = if (rft.decls != null) rewriteValTypeAbsolute(ext_base, n.type) else n.type;
+            }
+            break :blk r;
+        },
+    };
+    errdefer allocator.free(results);
+
+    ctx_ptr.* = .{
+        .comp_inst = inst,
+        .host_func = .{},
+        .component_func_idx = lower.func_idx,
+        .param_types = params,
+        .result_types = results,
+        .lower_opts = executor_mod.LowerOptions.fromOpts(lower.opts),
+        .extended_types = ext.extension_types,
+        .extended_indexspace = ext.extension_indexspace,
+        .is_async_func = ft.is_async,
+    };
+    ext_owned_by_ctx = true;
+
+    try inst.trampoline_ctxs.append(allocator, ctx_ptr);
+    return ctx_ptr;
+}
+
+/// Install a cross-instance thunk for an AOT core module's import whose
+/// sibling source is a `canon.lower` contributor (the wit-component
+/// adapter pattern). Builds a `ComponentTrampolineCtx` keyed off the
+/// canon-lower's component-func index and allocates a pool slot that
+/// dispatches via `wamrAotDispatchComponentTrampoline` →
+/// `dispatchAotComponentTrampoline`. The dispatcher invokes the bound
+/// `HostFunc` directly, so the standard WASIp2 host implementations work
+/// without any further bridge.
+///
+/// The `HostFunc` is left empty here; `linkImports` later walks
+/// `inst.trampoline_ctxs` and binds via `resolveComponentFuncToHostFunc`.
+fn installCanonLowerBackedCrossInstanceThunk(
+    allocator: std.mem.Allocator,
+    inst: *ComponentInstance,
+    component: *const ctypes.Component,
+    canon_lower_idx: u32,
+    imp: aot_loader.AotImportDesc,
+    module: *const aot_loader.AotModule,
+) !*const anyopaque {
+    const ctx_ptr = try buildLoweredComponentTrampolineCtx(allocator, inst, component, canon_lower_idx);
+    // Once registered on inst.trampoline_ctxs, ownership is the
+    // ComponentInstance's; pop on subsequent failure to avoid leaking
+    // a published-but-unused entry.
+    errdefer _ = inst.trampoline_ctxs.pop();
+
+    // Attempt to bind the HostFunc eagerly so calls that fire before
+    // `linkImports` (e.g. AOT start-section that calls back through
+    // a canon.lower import) still dispatch correctly. linkImports's
+    // later sweep is idempotent.
+    if (resolveComponentFuncToHostFunc(inst, component, ctx_ptr.component_func_idx)) |hf| {
+        ctx_ptr.host_func = hf;
+    }
+
+    // Lowered (core-level) signature for the trampoline pool slot. We
+    // take the AOT importer's view of the import's signature — that's
+    // what the AOT codegen's call site emits, and it must match what
+    // `dispatchAotComponentTrampoline` lifts off the register file.
+    if (imp.func_type_idx >= module.func_types.len) return error.InvalidFuncType;
+    const ft = module.func_types[imp.func_type_idx];
+    const arena = inst.module_arena.allocator();
+    const lowered_params = try arena.alloc(core_types.ValType, ft.params.len);
+    for (ft.params, 0..) |p, i| lowered_params[i] = p;
+    const lowered_results = try arena.alloc(core_types.ValType, ft.results.len);
+    for (ft.results, 0..) |r, i| lowered_results[i] = r;
+
+    const pool = try ensureAotTrampolinePool(inst);
+    const stub = try pool.allocCanonLowerAotSlot(@ptrCast(ctx_ptr), .{
+        .param_types = lowered_params,
+        .result_types = lowered_results,
         .has_retptr = false,
     });
     return @ptrCast(stub);

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -43,6 +43,22 @@ extern fn wamrAotDispatchComponentTrampoline(
     a5: u64,
 ) callconv(.c) DispatchResult;
 
+/// AOT-codegen-flavoured wrapper around `wamrAotDispatchComponentTrampoline`
+/// for canon.lower imports of an AOT core module. AOT-emitted host-import
+/// call sites pass the importer's vmctx as the first arg, so `a0` here is
+/// vmctx (which the host trampoline ignores) and `a1..a5` are the lowered
+/// wasm args. (#687.)
+extern fn wamrAotDispatchComponentTrampolineAot(
+    ctx_opaque: *anyopaque,
+    lowered_sig: *const LoweredSig,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+) callconv(.c) DispatchResult;
+
 /// Cross-instance core-to-core fn-import dispatcher (#662). Implemented in
 /// `src/component/executor.zig`. The first slot (`a0`) is the importer's
 /// vmctx, which the dispatcher ignores; `a1..a5` are the lowered wasm args
@@ -75,6 +91,7 @@ extern fn wamrAotDispatchTrapStub(
 
 pub const DispatchKind = enum(u8) {
     canon_lower,
+    canon_lower_aot,
     cross_instance,
     trap_stub,
 };
@@ -105,6 +122,7 @@ pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64,
     const ctx = entry.ctx orelse return 0;
     const dispatched = switch (entry.dispatch_kind) {
         .canon_lower => wamrAotDispatchComponentTrampoline(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
+        .canon_lower_aot => wamrAotDispatchComponentTrampolineAot(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
         .cross_instance => wamrAotDispatchCrossInstance(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
         .trap_stub => wamrAotDispatchTrapStub(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
     };
@@ -180,6 +198,30 @@ pub const TrampolinePool = struct {
         self.slots[slot] = .{
             .component_inst = component_inst,
             .canon_lower_idx = canon_lower_idx,
+        };
+        self.next_slot += 1;
+        writeStub(self.stubBytes(slot), slot);
+        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
+        g_active_pool = self;
+
+        return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
+    }
+
+    /// Allocate a slot for a canon-lower-backed cross-instance thunk where
+    /// the *importer* is an AOT-compiled core module. Same shape as
+    /// `allocSlotWithCtx` but routes through `wamrAotDispatchComponentTrampolineAot`
+    /// so the dispatcher skips the AOT codegen's leading vmctx argument
+    /// before treating the remaining registers as lowered wasm args. (#687.)
+    pub fn allocCanonLowerAotSlot(self: *TrampolinePool, ctx: *anyopaque, lowered_sig: LoweredSig) !StubFn {
+        const slot = self.next_slot;
+        if (slot >= MAX_SLOTS) return error.OutOfTrampolineSlots;
+
+        self.slots[slot] = .{
+            .component_inst = ctx,
+            .canon_lower_idx = 0,
+            .ctx = ctx,
+            .lowered_sig = lowered_sig,
+            .dispatch_kind = .canon_lower_aot,
         };
         self.next_slot += 1;
         writeStub(self.stubBytes(slot), slot);

--- a/src/tests/component_aot_canonlift_test.zig
+++ b/src/tests/component_aot_canonlift_test.zig
@@ -13,6 +13,7 @@
 //! `module_inst orelse` guard refused AOT-only cores.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const wamr = @import("wamr");
 const aot_harness = @import("aot_harness.zig");
 
@@ -712,6 +713,13 @@ const Incr687Ctx = struct {
 
 test "#687: AOT core imports a canon-lower-bridged sibling export" {
     if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+    // Cross-instance AOT bridging needs `TrampolinePool` (RWX page
+    // allocator). Skip on platforms where the pool ctor is comptime-
+    // disabled (`runtime/aot/host_trampolines.zig:144-151`): Windows
+    // and macOS aarch64. On those targets the runtime falls back to
+    // the trap-on-call stub, which the fixture intentionally exercises.
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+    if (comptime builtin.os.tag == .macos and builtin.cpu.arch == .aarch64) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
     const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, &aot_forwarder_wasm);

--- a/src/tests/component_aot_canonlift_test.zig
+++ b/src/tests/component_aot_canonlift_test.zig
@@ -660,3 +660,155 @@ test "#650 commit 2: AOT lifts func(list<u8>) -> string (acceptance)" {
     try std.testing.expectEqual(@as(u32, 0x100), results[0].string.ptr);
     try std.testing.expectEqual(@as(u32, 5), results[0].string.len);
 }
+
+// ── #687: canon-lower-backed cross-instance bridging ─────────────────────
+
+/// AOT module that imports `env.increment: (i32) -> i32` and exports
+/// `go: (i32) -> i32` which simply forwards to the import. Used by the
+/// #687 fixture to exercise the canon-lower-backed cross-instance thunk.
+const aot_forwarder_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    // type section: 1 type, (i32)->i32
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    // import section: "env"."increment" (func type 0)
+    0x02, 0x11, 0x01,
+    0x03, 'e', 'n', 'v',
+    0x09, 'i', 'n', 'c', 'r', 'e', 'm', 'e', 'n', 't',
+    0x00, 0x00,
+    // function section: 1 func of type 0
+    0x03, 0x02, 0x01, 0x00,
+    // memory section: 1 memory min 1
+    0x05, 0x03, 0x01, 0x00, 0x01,
+    // export section: "memory" (mem 0) + "go" (func 1)
+    0x07, 0x0f, 0x02,
+    0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
+    0x02, 'g', 'o', 0x00, 0x01,
+    // code section: 1 func body — local.get 0; call 0; end (6 body bytes)
+    0x0a, 0x08, 0x01,
+    0x06,
+    0x00,
+    0x20, 0x00,
+    0x10, 0x00,
+    0x0b,
+};
+
+const Incr687Ctx = struct {
+    observed: i32 = 0,
+    return_value: i32 = 0,
+
+    fn call(
+        ctx: ?*anyopaque,
+        _: *instance.ComponentInstance,
+        args: []const abi.InterfaceValue,
+        results: []abi.InterfaceValue,
+        _: std.mem.Allocator,
+    ) anyerror!void {
+        const self: *Incr687Ctx = @ptrCast(@alignCast(ctx.?));
+        self.observed = args[0].s32;
+        self.return_value = args[0].s32 + 1;
+        results[0] = .{ .s32 = self.return_value };
+    }
+};
+
+test "#687: AOT core imports a canon-lower-bridged sibling export" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, &aot_forwarder_wasm);
+    defer allocator.free(cwasm_bytes);
+
+    // Component shape:
+    //   import "incr": (i32)->i32   = comp-func 0
+    //   core_inst 0 = (exports "increment" -> core-func 0 (the lower))
+    //   core_inst 1 = (instantiate $aot (with "env" $core_inst_0))
+    //   alias core-func ("go" of core_inst 1)            = core-func 1
+    //   canons[0] = lower(comp-func 0)                    -> core-func 0
+    //   canons[1] = lift(core-func 1, type 0)             = comp-func 1
+    //   export "go" = sort_idx{ .func, 1 }
+    //
+    // Without #687, the AOT import "env.increment" cannot be resolved
+    // (its sibling source is a canon.lower, not an alias-of-AOT-export),
+    // so the core call traps. With the fix, the import is bridged
+    // through `dispatchAotComponentTrampoline` to the bound HostFunc.
+
+    const core_modules = [_]ctypes.CoreModule{.{ .data = &aot_forwarder_wasm }};
+
+    const inst0_exports = [_]ctypes.CoreInlineExport{
+        .{ .name = "increment", .sort_idx = .{ .sort = .func, .idx = 0 } },
+    };
+    const inst1_args = [_]ctypes.CoreInstantiateArg{
+        .{ .name = "env", .instance_idx = 0 },
+    };
+    const core_insts = [_]ctypes.CoreInstanceExpr{
+        .{ .exports = &inst0_exports },
+        .{ .instantiate = .{ .module_idx = 0, .args = &inst1_args } },
+    };
+
+    const aliases = [_]ctypes.Alias{
+        .{ .instance_export = .{ .sort = .{ .core = .func }, .instance_idx = 1, .name = "go" } },
+    };
+
+    const params = [_]ctypes.NamedValType{.{ .name = "x", .type = .s32 }};
+    const types = [_]ctypes.TypeDef{
+        .{ .func = .{ .params = &params, .results = .{ .unnamed = .s32 } } },
+    };
+
+    const empty_opts = [_]ctypes.CanonOpt{};
+    const canons = [_]ctypes.Canon{
+        .{ .lower = .{ .func_idx = 0, .opts = &empty_opts } },
+        .{ .lift = .{ .core_func_idx = 1, .type_idx = 0, .opts = &empty_opts } },
+    };
+
+    const imports = [_]ctypes.ImportDecl{
+        .{ .name = "incr", .desc = .{ .func = 0 } },
+    };
+    const exports = [_]ctypes.ExportDecl{
+        .{ .name = "go", .desc = .{ .func = 0 }, .sort_idx = .{ .sort = .func, .idx = 1 } },
+    };
+
+    const component = ctypes.Component{
+        .core_modules = &core_modules,
+        .core_instances = &core_insts,
+        .core_types = &.{},
+        .components = &.{},
+        .instances = &.{},
+        .aliases = &aliases,
+        .types = &types,
+        .canons = &canons,
+        .imports = &imports,
+        .exports = &exports,
+    };
+
+    const pcs = [_]instance.PrecompiledCore{
+        .{ .module_idx = 0, .cwasm_bytes = cwasm_bytes },
+    };
+    const inst = try instance.instantiateWithOptions(&component, allocator, .{
+        .precompiled_cores = &pcs,
+    });
+    defer inst.deinit();
+
+    try std.testing.expect(inst.core_instances[1].aot_inst != null);
+
+    // Bind the parent "incr" import to a host function that increments
+    // its argument. linkImports walks `inst.trampoline_ctxs` and rebinds
+    // the canon-lower ctx that #687 registered there.
+    var host_ctx = Incr687Ctx{};
+    var providers: std.StringHashMapUnmanaged(instance.ImportBinding) = .{};
+    defer providers.deinit(allocator);
+    try providers.put(allocator, "incr", .{
+        .host_func = .{ .context = &host_ctx, .call = Incr687Ctx.call },
+    });
+    try inst.linkImports(providers);
+
+    const ef = inst.getExport("go") orelse return error.TestFailed;
+    const local = switch (ef) {
+        .local => |l| l,
+        else => return error.TestFailed,
+    };
+
+    const args = [_]abi.InterfaceValue{.{ .s32 = 41 }};
+    var results: [1]abi.InterfaceValue = .{.{ .s32 = 0 }};
+    try executor.callComponentFuncByLocal(inst, local, &args, &results, allocator);
+    try std.testing.expectEqual(@as(i32, 41), host_ctx.observed);
+    try std.testing.expectEqual(@as(i32, 42), results[0].s32);
+}


### PR DESCRIPTION
Fixes #687.

## Problem

When an AOT-compiled core module imports from a sibling synthetic `(core instance (exports …))` whose members come from `canon.lower` contributors (the wit-component adapter pattern), the previous cross-instance path returned `UnsupportedCrossInstanceSource` because `resolveCoreInstanceFuncToAi` only follows `.aliased` sources. The caller installed a trap-on-call stub, so the first guest WASIp2 call traps. The issue reports 50+ such `[aot reject]` warnings on `codegen-cli.composed.wasm`.

## Fix

Adds a parallel cross-instance install path that handles the `.lowered` canon contributor (option 1 from the issue):

- New helper `resolveInlineExportCanonRef` returns the raw `CoreFuncRef` from a sibling's inline-exports walk (without throwing the canon ref away the way `resolveCoreInstanceFuncToAi` does).
- New helper `installCanonLowerBackedCrossInstanceThunk` builds a `ComponentTrampolineCtx` keyed off the lower's component-func index (mirroring the interpreter's `.lowered` arm) and allocates a trampoline-pool slot routed through a new `canon_lower_aot` dispatch kind.
- New `wamrAotDispatchComponentTrampolineAot` export discards the AOT codegen's leading vmctx arg before passing the remaining registers to `dispatchAotComponentTrampoline`, which already invokes the bound `HostFunc` when `lift_target == null`.
- The ctx is registered on `inst.trampoline_ctxs`, so `linkImports`'s existing sweep binds the `HostFunc` via `resolveComponentFuncToHostFunc` without extra plumbing. The install path also tries an eager bind so a deferred start that fires before `linkImports` still dispatches correctly.

## Scope

Resource-drop / new / rep contributors still fall through to the trap stub; bridging those needs a separate canon-builtin dispatch kind and is tracked as a follow-up. The keyvault repro in the issue traps on a canon.lower (not a resource-drop), so this lower-only fix unblocks it.

## Test

`component_aot_canonlift_test.zig` gets a new fixture: a two-core component literal — one AOT module forwarding `env.increment` to its `go` export, plus a synthetic inline-exports core instance whose `increment` member is the parent's `canon.lower` of an imported func — and asserts the host implementation observes the correct argument and result. Without the fix the install path returns `UnsupportedCrossInstanceSource` and the first call traps.

Full suite: `2936/2943 tests passed (7 skipped)` (was 2935/2942; +1 for the new fixture).

## Files

- `src/component/instance.zig` — new `installCanonLowerBackedCrossInstanceThunk` + `buildLoweredComponentTrampolineCtx` + `resolveInlineExportCanonRef`; wired into `resolveAotImportedFunctionOverrides` ahead of the existing trap-stub fallback.
- `src/component/executor.zig` — new `wamrAotDispatchComponentTrampolineAot` export.
- `src/runtime/aot/host_trampolines.zig` — new `DispatchKind.canon_lower_aot` + `allocCanonLowerAotSlot`.
- `src/tests/component_aot_canonlift_test.zig` — new fixture.