### PR TITLE
fix #689: widen AOT host-trampoline dispatcher from 5 to 8 wasm args

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -5984,9 +5984,12 @@ pub export fn wamrAotDispatchComponentTrampoline(
     a3: u64,
     a4: u64,
     a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
 ) callconv(.c) host_trampolines.DispatchResult {
     const ctx: *const ComponentTrampolineCtx = @ptrCast(@alignCast(ctx_opaque));
-    const result = dispatchAotComponentTrampoline(ctx, lowered_sig.*, .{ a0, a1, a2, a3, a4, a5 }) catch |err| {
+    const result = dispatchAotComponentTrampoline(ctx, lowered_sig.*, .{ a0, a1, a2, a3, a4, a5, a6, a7, a8 }) catch |err| {
         if (debugAotEnabled()) {
             std.debug.print(
                 "[aot-dispatch] canon.lower trampoline failed: {s}\n",
@@ -6002,10 +6005,11 @@ pub export fn wamrAotDispatchComponentTrampoline(
 /// stub shifts caller regs right by one to inject `slot` as the first
 /// C-ABI arg, so when the AOT codegen calls a host import as
 /// `host_fn(vmctx, arg0, arg1, …)`, this dispatcher receives
-/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a5=arg4)`. We discard `a0`
+/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a8=arg7)`. We discard `a0`
 /// (importer's vmctx) and re-issue `dispatchAotComponentTrampoline` over
-/// `a1..a5`, matching the lowered wasm-arg shape the host trampoline
-/// already expects.
+/// `a1..a8`, matching the lowered wasm-arg shape the host trampoline
+/// already expects. Widened from a0..a5 in #689 so WASIp2 filesystem
+/// methods (`link-at` = 7 wasm params, etc.) fit.
 pub export fn wamrAotDispatchComponentTrampolineAot(
     ctx_opaque: *anyopaque,
     lowered_sig: *const host_trampolines.LoweredSig,
@@ -6015,10 +6019,13 @@ pub export fn wamrAotDispatchComponentTrampolineAot(
     a3: u64,
     a4: u64,
     a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
 ) callconv(.c) host_trampolines.DispatchResult {
     _ = a0;
     const ctx: *const ComponentTrampolineCtx = @ptrCast(@alignCast(ctx_opaque));
-    const result = dispatchAotComponentTrampoline(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, 0 }) catch |err| {
+    const result = dispatchAotComponentTrampoline(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, a6, a7, a8, 0 }) catch |err| {
         if (debugAotEnabled()) {
             std.debug.print(
                 "[aot-dispatch] canon.lower(aot) trampoline failed: {s}\n",
@@ -6050,11 +6057,12 @@ pub const CrossInstanceThunkCtx = struct {
 /// shifts caller regs right by one to inject `slot` as the first C-ABI arg,
 /// so when the AOT codegen calls a host import as
 /// `host_fn(vmctx, arg0, arg1, …)`, the dispatcher receives
-/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a5=arg4)`. We ignore `a0`
+/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a8=arg7)`. We ignore `a0`
 /// (importer's vmctx — the sibling AotInstance builds its own vmctx
-/// internally in `callFuncScalar`) and use `a1..a5` as lowered wasm args.
-/// Calls outside the trampoline pool's 5-arg-in-regs envelope return a
-/// failing status; richer signatures land in a follow-up.
+/// internally in `callFuncScalar`) and use `a1..a8` as lowered wasm args.
+/// Calls outside the trampoline pool's 8-arg-in-regs envelope return a
+/// failing status; richer signatures land in a follow-up. The 5 → 8 widening
+/// in #689 covers WASIp2 filesystem methods like `link-at` (7 wasm params).
 pub export fn wamrAotDispatchCrossInstance(
     ctx_opaque: *anyopaque,
     lowered_sig: *const host_trampolines.LoweredSig,
@@ -6064,10 +6072,13 @@ pub export fn wamrAotDispatchCrossInstance(
     a3: u64,
     a4: u64,
     a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
 ) callconv(.c) host_trampolines.DispatchResult {
     _ = a0; // importer's vmctx; the sibling AotInstance builds its own.
     const ctx: *const CrossInstanceThunkCtx = @ptrCast(@alignCast(ctx_opaque));
-    const result = dispatchAotCrossInstance(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, 0 }) catch |err| {
+    const result = dispatchAotCrossInstance(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, a6, a7, a8, 0 }) catch |err| {
         if (debugAotEnabled()) {
             std.debug.print(
                 "[aot-dispatch] cross-instance thunk '{s}' failed: {s}\n",
@@ -6082,20 +6093,20 @@ pub export fn wamrAotDispatchCrossInstance(
 fn dispatchAotCrossInstance(
     ctx: *const CrossInstanceThunkCtx,
     lowered_sig: host_trampolines.LoweredSig,
-    arg_regs: [6]u64,
+    arg_regs: [9]u64,
 ) !u64 {
-    // We support up to 5 args in registers (a1..a5 in the dispatcher's
+    // We support up to 8 args in registers (a1..a8 in the dispatcher's
     // frame, since a0 is the importer's vmctx). Spilled-arg / spilled-result
     // shapes route through the lift trampoline pathway, not this one.
     if (lowered_sig.has_retptr) return error.UnsupportedSignature;
-    if (lowered_sig.param_types.len > 5) return error.UnsupportedSignature;
+    if (lowered_sig.param_types.len > 8) return error.UnsupportedSignature;
     if (lowered_sig.result_types.len > 1) return error.UnsupportedSignature;
     if (lowered_sig.param_types.len != ctx.param_types.len) return error.UnsupportedSignature;
     if (lowered_sig.result_types.len != ctx.result_types.len) return error.UnsupportedSignature;
     for (lowered_sig.param_types, ctx.param_types) |a, b| if (a != b) return error.UnsupportedSignature;
     for (lowered_sig.result_types, ctx.result_types) |a, b| if (a != b) return error.UnsupportedSignature;
 
-    var args_buf: [5]core_types.Value = undefined;
+    var args_buf: [8]core_types.Value = undefined;
     for (ctx.param_types, 0..) |pt, i| {
         args_buf[i] = switch (pt) {
             .i32 => .{ .i32 = @bitCast(@as(u32, @truncate(arg_regs[i]))) },
@@ -6141,6 +6152,9 @@ pub export fn wamrAotDispatchTrapStub(
     a3: u64,
     a4: u64,
     a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
 ) callconv(.c) host_trampolines.DispatchResult {
     _ = lowered_sig;
     _ = a0;
@@ -6149,6 +6163,9 @@ pub export fn wamrAotDispatchTrapStub(
     _ = a3;
     _ = a4;
     _ = a5;
+    _ = a6;
+    _ = a7;
+    _ = a8;
     if (debugAotEnabled()) {
         const label_ptr: *const [*:0]const u8 = @ptrCast(@alignCast(ctx_opaque));
         std.debug.print("[aot-dispatch] trap-stub fired for unbridged import '{s}' (#662 follow-up)\n", .{label_ptr.*});
@@ -6160,7 +6177,7 @@ pub export fn wamrAotDispatchTrapStub(
 fn dispatchAotComponentTrampoline(
     ctx: *const ComponentTrampolineCtx,
     lowered_sig: host_trampolines.LoweredSig,
-    regs: [6]u64,
+    regs: [9]u64,
 ) !u64 {
     if (ctx.lower_opts.is_async or ctx.is_async_func) return error.UnsupportedSignature;
     if (lowered_sig.param_types.len + @intFromBool(lowered_sig.has_retptr) > regs.len)
@@ -6242,7 +6259,7 @@ fn liftAotDispatcherArg(
     t: ctypes.ValType,
     lowered_param_types: []const core_types.ValType,
     reg_index: *usize,
-    regs: *const [6]u64,
+    regs: *const [9]u64,
     registry: TypeRegistry,
     allocator: Allocator,
 ) !InterfaceValue {

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -3183,8 +3183,12 @@ fn installCrossInstanceThunk(
     const ft = module.func_types[imp.func_type_idx];
 
     // Only register-fit signatures land in this fast path. Anything else
-    // returns an error → the caller installs a trap stub instead.
-    if (ft.params.len > 5) return error.SignatureTooWide;
+    // returns an error → the caller installs a trap stub instead. The cap
+    // of 8 covers every WASIp2 method emitted by the public adapters
+    // (`link-at` = 7 wasm params is the widest seen in real binaries);
+    // widened from 5 in #689 so the WASIp1→WASIp2 adapter's filesystem
+    // methods stop trap-stubbing.
+    if (ft.params.len > 8) return error.SignatureTooWide;
     if (ft.results.len > 1) return error.MultipleResultsUnsupported;
     for (ft.params) |p| switch (p) {
         .i32, .i64, .f32, .f64 => {},

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -401,10 +401,10 @@ fn encodeAarch64Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
     // str x30, [sp, #-16]!  -- save LR, sp -= 16. Keeps sp 16-byte aligned.
     emitAarch64(bytes, &cursor, 0xF81F0FFE);
     // ldr x9, [sp, #16]     -- x9 = caller_a8 (was at [sp+0] pre-push).
-    emitAarch64(bytes, &cursor, 0xF94007E9);
+    emitAarch64(bytes, &cursor, 0xF9400BE9);
     // stp x7, x9, [sp, #-16]!  -- push caller_a7 + caller_a8.
     // After this: [sp+0]=a7, [sp+8]=a8 (dispatcher's stack args).
-    emitAarch64(bytes, &cursor, 0xA9BF93E7);
+    emitAarch64(bytes, &cursor, 0xA9BF27E7);
 
     // Shift x0..x7 right by one register (x7=x6, x6=x5, ..., x1=x0).
     inline for ([_]struct { dst: u5, src: u5 }{
@@ -434,7 +434,7 @@ fn encodeAarch64Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
     // add sp, sp, #16         -- pop the two pushed stack args.
     emitAarch64(bytes, &cursor, 0x910043FF);
     // ldr x30, [sp], #16      -- restore LR with post-increment.
-    emitAarch64(bytes, &cursor, 0xF84047FE);
+    emitAarch64(bytes, &cursor, 0xF84107FE);
     // ret                     -- branch to LR.
     emitAarch64(bytes, &cursor, 0xD65F03C0);
 
@@ -507,8 +507,8 @@ test "#648 phase 2: aarch64 trampoline encoder emits slot and dispatcher immedia
     // pushed args; restore LR; ret.
     const expected = [_]u32{
         0xF81F0FFE, // str x30, [sp, #-16]!
-        0xF94007E9, // ldr x9, [sp, #16]
-        0xA9BF93E7, // stp x7, x9, [sp, #-16]!
+        0xF9400BE9, // ldr x9, [sp, #16]
+        0xA9BF27E7, // stp x7, x9, [sp, #-16]!
         0xAA0603E7, // mov x7, x6
         0xAA0503E6, // mov x6, x5
         0xAA0403E5, // mov x5, x4
@@ -523,7 +523,7 @@ test "#648 phase 2: aarch64 trampoline encoder emits slot and dispatcher immedia
         0xF2E22450, // movk x16, #0x1122, lsl 48
         0xD63F0200, // blr x16
         0x910043FF, // add sp, sp, #16
-        0xF84047FE, // ldr x30, [sp], #16
+        0xF84107FE, // ldr x30, [sp], #16
         0xD65F03C0, // ret
     };
 

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -9,8 +9,13 @@ const platform = @import("../../platform/platform.zig");
 const core_types = @import("../common/types.zig");
 
 const page_size = std.heap.page_size_min;
-const x86_64_stub_bytes: usize = 39;
-const aarch64_stub_bytes: usize = 48;
+// Stubs forward up to 9 lowered C-ABI args (a0..a8) into `genericDispatcher`,
+// so the dispatcher kinds can carry up to 8 wasm-level params (after dropping
+// the importer's vmctx for the AOT-codegen variants). See #689 — the older
+// 6-arg shape couldn't lower WASIp2 filesystem methods like `link-at` (7
+// wasm params) and silently fell back to a trap stub.
+const x86_64_stub_bytes: usize = 57;
+const aarch64_stub_bytes: usize = 76;
 
 pub const STUB_BYTES: usize = switch (builtin.cpu.arch) {
     .x86_64 => x86_64_stub_bytes,
@@ -41,13 +46,16 @@ extern fn wamrAotDispatchComponentTrampoline(
     a3: u64,
     a4: u64,
     a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
 ) callconv(.c) DispatchResult;
 
 /// AOT-codegen-flavoured wrapper around `wamrAotDispatchComponentTrampoline`
 /// for canon.lower imports of an AOT core module. AOT-emitted host-import
 /// call sites pass the importer's vmctx as the first arg, so `a0` here is
-/// vmctx (which the host trampoline ignores) and `a1..a5` are the lowered
-/// wasm args. (#687.)
+/// vmctx (which the host trampoline ignores) and `a1..a8` are the lowered
+/// wasm args. (#687, widened in #689.)
 extern fn wamrAotDispatchComponentTrampolineAot(
     ctx_opaque: *anyopaque,
     lowered_sig: *const LoweredSig,
@@ -57,11 +65,14 @@ extern fn wamrAotDispatchComponentTrampolineAot(
     a3: u64,
     a4: u64,
     a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
 ) callconv(.c) DispatchResult;
 
 /// Cross-instance core-to-core fn-import dispatcher (#662). Implemented in
 /// `src/component/executor.zig`. The first slot (`a0`) is the importer's
-/// vmctx, which the dispatcher ignores; `a1..a5` are the lowered wasm args
+/// vmctx, which the dispatcher ignores; `a1..a8` are the lowered wasm args
 /// per the AOT codegen calling convention.
 extern fn wamrAotDispatchCrossInstance(
     ctx_opaque: *anyopaque,
@@ -72,6 +83,9 @@ extern fn wamrAotDispatchCrossInstance(
     a3: u64,
     a4: u64,
     a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
 ) callconv(.c) DispatchResult;
 
 /// Trap-on-call stub for non-WASI function imports that have no AOT-side
@@ -87,6 +101,9 @@ extern fn wamrAotDispatchTrapStub(
     a3: u64,
     a4: u64,
     a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
 ) callconv(.c) DispatchResult;
 
 pub const DispatchKind = enum(u8) {
@@ -114,17 +131,17 @@ pub fn setActivePool(pool: ?*TrampolinePool) void {
     g_active_pool = pool;
 }
 
-pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64) callconv(.c) u64 {
+pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64, a6: u64, a7: u64, a8: u64) callconv(.c) u64 {
     const pool = g_active_pool orelse return 0;
     if (slot >= pool.next_slot) return 0;
 
     const entry = pool.slots[slot];
     const ctx = entry.ctx orelse return 0;
     const dispatched = switch (entry.dispatch_kind) {
-        .canon_lower => wamrAotDispatchComponentTrampoline(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
-        .canon_lower_aot => wamrAotDispatchComponentTrampolineAot(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
-        .cross_instance => wamrAotDispatchCrossInstance(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
-        .trap_stub => wamrAotDispatchTrapStub(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5),
+        .canon_lower => wamrAotDispatchComponentTrampoline(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8),
+        .canon_lower_aot => wamrAotDispatchComponentTrampolineAot(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8),
+        .cross_instance => wamrAotDispatchCrossInstance(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8),
+        .trap_stub => wamrAotDispatchTrapStub(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8),
     };
     if (dispatched.status != 0) return 0;
     return dispatched.value;
@@ -314,28 +331,49 @@ fn dispatcherAddr() usize {
 fn encodeX8664Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
     std.debug.assert(bytes.len >= STUB_BYTES);
 
-    const prologue = [_]u8{
-        0x41, 0x51,
-        0x4D, 0x89,
-        0xC1, 0x49,
-        0x89, 0xC8,
-        0x48, 0x89,
-        0xD1, 0x48,
-        0x89, 0xF2,
-        0x48, 0x89,
-        0xFE, 0xBF,
+    // Caller passes up to 9 args (a0..a8): a0..a5 in regs (rdi, rsi, rdx,
+    // rcx, r8, r9), a6/a7/a8 on stack at [rsp+8/+16/+24]. We inject `slot`
+    // as the new first arg and forward a0..a8, so the dispatcher receives
+    // 10 args (slot + a0..a8): rdi=slot, rsi/rdx/rcx/r8/r9=a0..a4, and
+    // a5..a8 on stack at [rsp+8..+32] after `call rax` pushes the return
+    // address. We pre-push caller_a8/_a7/_a6 (read out of the caller's
+    // outgoing stack-arg region) and r9 (caller_a5) to land them at the
+    // right offsets.
+    //
+    // Prologue (20 bytes): read caller stack args into our frame, then
+    // push r9.
+    const prologue_stack = [_]u8{
+        0x48, 0x8B, 0x44, 0x24, 0x18, // mov rax, [rsp+24]  (caller_a8)
+        0x50, // push rax
+        0x48, 0x8B, 0x44, 0x24, 0x18, // mov rax, [rsp+24]  (caller_a7, shifted)
+        0x50, // push rax
+        0x48, 0x8B, 0x44, 0x24, 0x18, // mov rax, [rsp+24]  (caller_a6, shifted)
+        0x50, // push rax
+        0x41, 0x51, // push r9             (caller_a5)
+    };
+    // Register-shift + slot-inject (20 bytes), unchanged from the 6-arg
+    // version: r9..rsi each receive their lower neighbour, edi loads slot.
+    const shift = [_]u8{
+        0x4D, 0x89, 0xC1, // mov r9, r8
+        0x49, 0x89, 0xC8, // mov r8, rcx
+        0x48, 0x89, 0xD1, // mov rcx, rdx
+        0x48, 0x89, 0xF2, // mov rdx, rsi
+        0x48, 0x89, 0xFE, // mov rsi, rdi
+        0xBF, // mov edi, imm32 (slot)
     };
     const movabs = [_]u8{ 0x48, 0xB8 };
+    // Epilogue (7 bytes): call dispatcher, drop our 32-byte spill, return.
     const epilogue = [_]u8{
-        0xFF, 0xD0,
-        0x48, 0x83,
-        0xC4, 0x08,
-        0xC3,
+        0xFF, 0xD0, // call rax
+        0x48, 0x83, 0xC4, 0x20, // add rsp, 32
+        0xC3, // ret
     };
 
     var cursor: usize = 0;
-    @memcpy(bytes[cursor .. cursor + prologue.len], &prologue);
-    cursor += prologue.len;
+    @memcpy(bytes[cursor .. cursor + prologue_stack.len], &prologue_stack);
+    cursor += prologue_stack.len;
+    @memcpy(bytes[cursor .. cursor + shift.len], &shift);
+    cursor += shift.len;
     writeIntLittle(u32, bytes[cursor .. cursor + 4], slot);
     cursor += 4;
     @memcpy(bytes[cursor .. cursor + movabs.len], &movabs);
@@ -351,8 +389,26 @@ fn encodeX8664Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
 fn encodeAarch64Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
     std.debug.assert(bytes.len >= STUB_BYTES);
 
+    // AAPCS64: a0..a7 in x0..x7, a8 on stack at [sp+0]. We inject `slot`
+    // as x0 and forward a0..a8 to the dispatcher, so dispatcher sees
+    // (slot, a0..a8) = 10 args: x0=slot, x1..x7=a0..a6, [sp+0]=a7, [sp+8]=a8.
+    //
+    // Unlike the 6-arg version we can no longer tail-call: we own a stack
+    // frame for the dispatcher's stack args + a saved LR. So we use
+    // `blr x16` and restore LR/SP on return.
     var cursor: usize = 0;
+
+    // str x30, [sp, #-16]!  -- save LR, sp -= 16. Keeps sp 16-byte aligned.
+    emitAarch64(bytes, &cursor, 0xF81F0FFE);
+    // ldr x9, [sp, #16]     -- x9 = caller_a8 (was at [sp+0] pre-push).
+    emitAarch64(bytes, &cursor, 0xF94007E9);
+    // stp x7, x9, [sp, #-16]!  -- push caller_a7 + caller_a8.
+    // After this: [sp+0]=a7, [sp+8]=a8 (dispatcher's stack args).
+    emitAarch64(bytes, &cursor, 0xA9BF93E7);
+
+    // Shift x0..x7 right by one register (x7=x6, x6=x5, ..., x1=x0).
     inline for ([_]struct { dst: u5, src: u5 }{
+        .{ .dst = 7, .src = 6 },
         .{ .dst = 6, .src = 5 },
         .{ .dst = 5, .src = 4 },
         .{ .dst = 4, .src = 3 },
@@ -363,14 +419,24 @@ fn encodeAarch64Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
         emitAarch64(bytes, &cursor, 0xAA0003E0 | (@as(u32, move.src) << 16) | move.dst);
     }
 
+    // movz x0, #slot_low (slot fits in a single u16 since MAX_SLOTS=256).
     emitAarch64(bytes, &cursor, movz32(0, @truncate(slot), 0));
 
+    // movz/movk x16 = dispatcher address.
     const addr = @as(u64, @intCast(dispatcher));
     emitAarch64(bytes, &cursor, movz64(16, @truncate(addr), 0));
     emitAarch64(bytes, &cursor, movk64(16, @truncate(addr >> 16), 1));
     emitAarch64(bytes, &cursor, movk64(16, @truncate(addr >> 32), 2));
     emitAarch64(bytes, &cursor, movk64(16, @truncate(addr >> 48), 3));
-    emitAarch64(bytes, &cursor, 0xD61F0200);
+
+    // blr x16                 -- call dispatcher.
+    emitAarch64(bytes, &cursor, 0xD63F0200);
+    // add sp, sp, #16         -- pop the two pushed stack args.
+    emitAarch64(bytes, &cursor, 0x910043FF);
+    // ldr x30, [sp], #16      -- restore LR with post-increment.
+    emitAarch64(bytes, &cursor, 0xF84047FE);
+    // ret                     -- branch to LR.
+    emitAarch64(bytes, &cursor, 0xD65F03C0);
 
     std.debug.assert(cursor == aarch64_stub_bytes);
 }
@@ -402,29 +468,28 @@ test "#648 phase 2: x86_64 trampoline encoder emits slot and dispatcher immediat
 
     encodeX8664Stub(&bytes, 0x11223344, 0x1122334455667788);
 
+    // Stub layout (#689): pre-spill caller_a8/_a7/_a6 from [rsp+24], then
+    // push r9 (caller_a5); shift rdi..r9; mov edi, slot; movabs rax,
+    // dispatcher; call rax; add rsp, 32; ret.
     const expected = [_]u8{
+        0x48, 0x8B, 0x44, 0x24, 0x18, 0x50,
+        0x48, 0x8B, 0x44, 0x24, 0x18, 0x50,
+        0x48, 0x8B, 0x44, 0x24, 0x18, 0x50,
         0x41, 0x51,
-        0x4D, 0x89,
-        0xC1, 0x49,
-        0x89, 0xC8,
-        0x48, 0x89,
-        0xD1, 0x48,
-        0x89, 0xF2,
-        0x48, 0x89,
-        0xFE, 0xBF,
-        0x44, 0x33,
-        0x22, 0x11,
+        0x4D, 0x89, 0xC1,
+        0x49, 0x89, 0xC8,
+        0x48, 0x89, 0xD1,
+        0x48, 0x89, 0xF2,
+        0x48, 0x89, 0xFE,
+        0xBF, 0x44, 0x33, 0x22, 0x11,
         0x48, 0xB8,
-        0x88, 0x77,
-        0x66, 0x55,
-        0x44, 0x33,
-        0x22, 0x11,
+        0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11,
         0xFF, 0xD0,
-        0x48, 0x83,
-        0xC4, 0x08,
+        0x48, 0x83, 0xC4, 0x20,
         0xC3,
     };
 
+    try std.testing.expectEqual(@as(usize, x86_64_stub_bytes), expected.len);
     try std.testing.expectEqualSlices(u8, &expected, bytes[0..expected.len]);
     for (bytes[expected.len..]) |byte| {
         try std.testing.expectEqual(@as(u8, 0), byte);
@@ -437,21 +502,32 @@ test "#648 phase 2: aarch64 trampoline encoder emits slot and dispatcher immedia
 
     encodeAarch64Stub(&bytes, 0x1234, 0x1122334455667788);
 
+    // Stub layout (#689): save LR, read caller_a8, push x7+caller_a8;
+    // shift x0..x7; movz x0,slot; movz/movk x16,dispatcher; blr x16; pop
+    // pushed args; restore LR; ret.
     const expected = [_]u32{
-        0xAA0503E6,
-        0xAA0403E5,
-        0xAA0303E4,
-        0xAA0203E3,
-        0xAA0103E2,
-        0xAA0003E1,
-        0x52824680,
-        0xD28EF110,
-        0xF2AAACD0,
-        0xF2C66890,
-        0xF2E22450,
-        0xD61F0200,
+        0xF81F0FFE, // str x30, [sp, #-16]!
+        0xF94007E9, // ldr x9, [sp, #16]
+        0xA9BF93E7, // stp x7, x9, [sp, #-16]!
+        0xAA0603E7, // mov x7, x6
+        0xAA0503E6, // mov x6, x5
+        0xAA0403E5, // mov x5, x4
+        0xAA0303E4, // mov x4, x3
+        0xAA0203E3, // mov x3, x2
+        0xAA0103E2, // mov x2, x1
+        0xAA0003E1, // mov x1, x0
+        0x52824680, // movz w0, #0x1234
+        0xD28EF110, // movz x16, #0x7788
+        0xF2AAACD0, // movk x16, #0x5566, lsl 16
+        0xF2C66890, // movk x16, #0x3344, lsl 32
+        0xF2E22450, // movk x16, #0x1122, lsl 48
+        0xD63F0200, // blr x16
+        0x910043FF, // add sp, sp, #16
+        0xF84047FE, // ldr x30, [sp], #16
+        0xD65F03C0, // ret
     };
 
+    try std.testing.expectEqual(@as(usize, aarch64_stub_bytes), expected.len * @sizeOf(u32));
     for (expected, 0..) |word, idx| {
         const start = idx * @sizeOf(u32);
         try std.testing.expectEqual(word, std.mem.readInt(u32, bytes[start..][0..4], .little));

--- a/src/tests/aot_host_trampolines_test.zig
+++ b/src/tests/aot_host_trampolines_test.zig
@@ -112,7 +112,7 @@ test "#648 phase 1: trampoline pool allocates mmap-backed stub slots" {
     try std.testing.expectEqual(@as(u32, 4), pool.next_slot);
     try std.testing.expectEqual(@as(u32, 22), pool.slots[1].canon_lower_idx);
     try std.testing.expectEqual(@intFromPtr(&fake_component_2), @intFromPtr(pool.slots[2].component_inst));
-    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(3, 1, 2, 3, 4, 5, 6));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(3, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 
     host_trampolines.setActivePool(null);
     pool.deinit(allocator);
@@ -224,7 +224,7 @@ test "#648 phase 3: genericDispatcher handles (i32) -> ()" {
     const lowered_results = [_]core_types.ValType{};
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
 
-    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 41, 0, 0, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 41, 0, 0, 0, 0, 0, 0, 0, 0));
     try std.testing.expect(state.called);
     try std.testing.expectEqual(@as(i32, 41), state.arg);
 }
@@ -258,7 +258,7 @@ test "#648 phase 3: genericDispatcher handles () -> i32" {
     const lowered_results = [_]core_types.ValType{.i32};
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
 
-    try std.testing.expectEqual(@as(u64, 77), host_trampolines.genericDispatcher(0, 0, 0, 0, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 77), host_trampolines.genericDispatcher(0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 test "#648 phase 3: genericDispatcher handles (i32) -> i32" {
@@ -289,7 +289,7 @@ test "#648 phase 3: genericDispatcher handles (i32) -> i32" {
     const lowered_results = [_]core_types.ValType{.i32};
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
 
-    try std.testing.expectEqual(@as(u64, 17), host_trampolines.genericDispatcher(0, 12, 0, 0, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 17), host_trampolines.genericDispatcher(0, 12, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 test "#648 phase 3: genericDispatcher handles (i32 i32) -> () retptr" {
@@ -320,7 +320,7 @@ test "#648 phase 3: genericDispatcher handles (i32 i32) -> () retptr" {
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &.{}, .has_retptr = true });
 
     const retptr: u32 = 24;
-    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 9, retptr, 0, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 9, retptr, 0, 0, 0, 0, 0, 0, 0));
     const mem = inst.resolveTopLevelMemory(0).?.data;
     try expectStoredPtrLen(mem, retptr, 0x55, 7);
 }
@@ -355,7 +355,7 @@ test "#648 phase 3: genericDispatcher handles (i32 i32 i32 i32) -> ()" {
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &.{}, .has_retptr = true });
 
     const retptr: u32 = 40;
-    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 3, 0x40, 5, retptr, 0, 0));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 3, 0x40, 5, retptr, 0, 0, 0, 0, 0));
     const mem = inst.resolveTopLevelMemory(0).?.data;
     try expectStoredPtrLen(mem, retptr, 0x80, 5);
 }
@@ -389,7 +389,123 @@ test "#648 phase 3: genericDispatcher handles (i32 i64 i32) -> ()" {
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &.{}, .has_retptr = true });
 
     const retptr: u32 = 56;
-    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 4, 0x1_0000_0002, retptr, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 4, 0x1_0000_0002, retptr, 0, 0, 0, 0, 0, 0));
     const mem = inst.resolveTopLevelMemory(0).?.data;
     try expectStoredPtrLen(mem, retptr, 0x90, 2);
+}
+
+test "#689: trampoline stub forwards 7 i32 args (widest WASIp2 method shape)" {
+    if (builtin.os.tag == .windows or (builtin.os.tag == .macos and builtin.cpu.arch == .aarch64)) return error.SkipZigTest;
+    switch (builtin.cpu.arch) {
+        .x86_64, .aarch64 => {},
+        else => return error.SkipZigTest,
+    }
+
+    // 7 i32 wasm params is what wasi:filesystem/types.[method]descriptor.link-at
+    // lowers to: enough to push caller_a6 onto the dispatcher's stack frame on
+    // x86_64 SysV (only 6 reg args). On AArch64 all 7 fit in x0..x6 but the
+    // injected slot pushes x6 -> x7, exercising the widened shift sequence.
+    const Host = struct {
+        const State = struct { received: [7]i32 = [_]i32{0} ** 7, called: bool = false };
+
+        fn capture(ctx: ?*anyopaque, _: *instance.ComponentInstance, args: []const instance.InterfaceValue, results: []instance.InterfaceValue, _: std.mem.Allocator) !void {
+            const state: *State = @ptrCast(@alignCast(ctx.?));
+            try std.testing.expectEqual(@as(usize, 7), args.len);
+            try std.testing.expectEqual(@as(usize, 1), results.len);
+            var sum: i32 = 0;
+            for (args, 0..) |a, i| {
+                state.received[i] = a.s32;
+                sum +%= a.s32;
+            }
+            state.called = true;
+            results[0] = .{ .s32 = sum };
+        }
+    };
+
+    const inst = try instantiateMemoryComponent();
+    defer inst.deinit();
+    var pool = try host_trampolines.TrampolinePool.init(std.testing.allocator);
+    defer pool.deinit(std.testing.allocator);
+
+    const param_types = [_]ctypes.ValType{ .s32, .s32, .s32, .s32, .s32, .s32, .s32 };
+    const result_types = [_]ctypes.ValType{.s32};
+    const lowered_params = [_]core_types.ValType{ .i32, .i32, .i32, .i32, .i32, .i32, .i32 };
+    const lowered_results = [_]core_types.ValType{.i32};
+
+    var state = Host.State{};
+    var ctx = executor.ComponentTrampolineCtx{
+        .comp_inst = inst,
+        .host_func = .{ .context = @ptrCast(&state), .call = &Host.capture },
+        .param_types = &param_types,
+        .result_types = &result_types,
+        .lower_opts = .{},
+    };
+    const stub = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
+
+    const TrampolineFn = *const fn (u64, u64, u64, u64, u64, u64, u64) callconv(.c) u64;
+    const tramp: TrampolineFn = @ptrCast(stub);
+
+    const result = tramp(101, 202, 303, 404, 505, 606, 707);
+
+    try std.testing.expect(state.called);
+    try std.testing.expectEqualSlices(i32, &[_]i32{ 101, 202, 303, 404, 505, 606, 707 }, &state.received);
+    // 101+202+303+404+505+606+707 = 2828
+    try std.testing.expectEqual(@as(u64, 2828), result);
+}
+
+test "#689: trampoline stub forwards 8 i32 args (cap)" {
+    if (builtin.os.tag == .windows or (builtin.os.tag == .macos and builtin.cpu.arch == .aarch64)) return error.SkipZigTest;
+    switch (builtin.cpu.arch) {
+        .x86_64, .aarch64 => {},
+        else => return error.SkipZigTest,
+    }
+
+    // 8 i32 wasm params is the new cap installed by #689 — exercises both
+    // stack-arg slots on x86_64 (caller a6, a7) and the stack-spill arg on
+    // AArch64 (caller a7 lands at [sp+8] after the stub's push).
+    const Host = struct {
+        const State = struct { received: [8]i32 = [_]i32{0} ** 8, called: bool = false };
+
+        fn capture(ctx: ?*anyopaque, _: *instance.ComponentInstance, args: []const instance.InterfaceValue, results: []instance.InterfaceValue, _: std.mem.Allocator) !void {
+            const state: *State = @ptrCast(@alignCast(ctx.?));
+            try std.testing.expectEqual(@as(usize, 8), args.len);
+            try std.testing.expectEqual(@as(usize, 1), results.len);
+            var sum: i32 = 0;
+            for (args, 0..) |a, i| {
+                state.received[i] = a.s32;
+                sum +%= a.s32;
+            }
+            state.called = true;
+            results[0] = .{ .s32 = sum };
+        }
+    };
+
+    const inst = try instantiateMemoryComponent();
+    defer inst.deinit();
+    var pool = try host_trampolines.TrampolinePool.init(std.testing.allocator);
+    defer pool.deinit(std.testing.allocator);
+
+    const param_types = [_]ctypes.ValType{ .s32, .s32, .s32, .s32, .s32, .s32, .s32, .s32 };
+    const result_types = [_]ctypes.ValType{.s32};
+    const lowered_params = [_]core_types.ValType{ .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32 };
+    const lowered_results = [_]core_types.ValType{.i32};
+
+    var state = Host.State{};
+    var ctx = executor.ComponentTrampolineCtx{
+        .comp_inst = inst,
+        .host_func = .{ .context = @ptrCast(&state), .call = &Host.capture },
+        .param_types = &param_types,
+        .result_types = &result_types,
+        .lower_opts = .{},
+    };
+    const stub = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
+
+    const TrampolineFn = *const fn (u64, u64, u64, u64, u64, u64, u64, u64) callconv(.c) u64;
+    const tramp: TrampolineFn = @ptrCast(stub);
+
+    const result = tramp(1, 2, 4, 8, 16, 32, 64, 128);
+
+    try std.testing.expect(state.called);
+    try std.testing.expectEqualSlices(i32, &[_]i32{ 1, 2, 4, 8, 16, 32, 64, 128 }, &state.received);
+    try std.testing.expectEqual(@as(u64, 255), result);
 }


### PR DESCRIPTION
Fixes #689.

## Problem

`installCrossInstanceThunk` (`src/component/instance.zig:3187`) rejected any cross-instance / `canon.lower` thunk whose lowered signature had more than 5 wasm-level params, because the AOT host-trampoline pool only forwarded `a0..a5` (importer vmctx + 5 wasm args) into the dispatcher. The WASIp1→WASIp2 adapter's filesystem methods exceed that:

- `link-at` = 7 params
- `open-at` = 6 params
- `rename-at` = 6 params
- `symlink-at` ≈ 5 + retptr

All four got the silent trap-stub, and the guest's first `path_open` walked off the malformed result into wit-bindgen's `unreachable`.

## Fix (Option A from the issue)

Widen the dispatcher prototype end-to-end so up to **8 wasm flat args** survive the trip from the AOT-emitted call site into the dispatcher.

### `src/runtime/aot/host_trampolines.zig`
- All 4 `extern fn wamrAotDispatch*` declarations + `genericDispatcher` grow from `a0..a5` to `a0..a8` (9 u64 C-ABI args).
- `x86_64_stub_bytes`: 39 → 57. Pre-spill caller a6/a7/a8 from caller's outgoing stack-arg region (`[rsp+24]`, in order), then `push r9` (= caller a5), keep the existing 6 register shifts and `mov edi, slot`, end with `add rsp, 32 / ret`.
- `aarch64_stub_bytes`: 48 → 76. `str x30, [sp, #-16]!` to save LR (the old stub tail-called via `br x16` — no longer possible once we own a frame), `ldr x9, [sp, #16]` to grab caller a8, `stp x7, x9, [sp, #-16]!` so the dispatcher sees `[sp+0]=a7, [sp+8]=a8`. Shift now runs `x7=x6, x6=x5, …, x1=x0` (one more move). Tail: `blr x16 / add sp, sp, #16 / ldr x30, [sp], #16 / ret`.
- Both encoder unit tests rebaselined to the new instruction streams.

### `src/component/executor.zig`
- All 4 `pub export fn wamrAotDispatch*` definitions match the new 9-arg extern signature.
- `dispatchAotCrossInstance`: `arg_regs: [6]u64 → [9]u64`, cap `> 5` → `> 8`, `args_buf: [5] → [8]`.
- `dispatchAotComponentTrampoline`: `regs: [6]u64 → [9]u64`.
- `liftAotDispatcherArg`: `regs: *const [6]u64 → *const [9]u64`.

### `src/component/instance.zig`
- `installCrossInstanceThunk` cap `> 5` → `> 8` (covers every public WASIp2 method shape).

### `src/tests/aot_host_trampolines_test.zig`
- Existing direct `genericDispatcher(...)` test calls extended to the new 10-u64 signature.
- Two new regression tests:
  - 7 i32 args through the real compiled stub (exercises x86_64 caller-stack spill at `[rsp+24]` for a6 and AArch64 `mov x7,x6` shift).
  - 8 i32 args at the cap (exercises both x86_64 stack args a6+a7 and the AArch64 `stp x7,x9,[sp,#-16]!` push so a7 lands at `[sp+8]`).

## ABI notes

- **x86_64 SysV**: stub entry has `rsp ≡ 8 (mod 16)`. 4 pushes (32 B) → still 8 mod 16; `call` (8 B) → 16-aligned. After `call`, dispatcher sees `[rsp+0]=retaddr, [rsp+8]=a5, +16=a6, +24=a7, +32=a8`. ✓
- **AAPCS64**: `str x30,[sp,#-16]!` + `stp x7,x9,[sp,#-16]!` keep SP 16-byte aligned. Caller's a8 (originally at `[sp+0]`) becomes `[sp+16]` after the LR push.

## Validation

Full `zig build test --summary failures` passes with the two new regression tests included.

## Out of scope

- Option B (spill-args trampoline kind for > 8 flat args) and Option C (detour-to-interp fallback) — both deferred. No public WASIp2 import needs more than 8.