### PR TITLE
Split AOT compiler from wamr runtime; add 'wamrc run'; flat component layout

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -412,6 +412,29 @@ pub fn build(b: *std.Build) void {
         wamrc_help_compile.addArgs(&.{ "help", "compile" });
         wamrc_help_compile.expectExitCode(0);
         test_step.dependOn(&wamrc_help_compile.step);
+
+        const wamrc_help_run = b.addRunArtifact(wamrc);
+        wamrc_help_run.addArgs(&.{ "help", "run" });
+        wamrc_help_run.expectExitCode(0);
+        test_step.dependOn(&wamrc_help_run.step);
+    }
+
+    // `wamrc run` smoke (#665): compile + spawn the just-built `wamr`
+    // against the 36-byte noop core wasm. Exercises the full subprocess
+    // pipeline (sibling-output → freshness sidecar → wamr discovery via
+    // `WAMR_BIN` → exit-code propagation). Output goes to a build-cache
+    // file via `-o` so the source tree stays clean.
+    if (aot_executable_target) {
+        const wamrc_run_smoke = b.addRunArtifact(wamrc);
+        wamrc_run_smoke.addArg("run");
+        wamrc_run_smoke.addArg("-o");
+        const smoke_out = wamrc_run_smoke.addOutputFileArg("noop.cwasm");
+        _ = smoke_out;
+        wamrc_run_smoke.addFileArg(b.path("tests/coldstart/noop.wasm"));
+        wamrc_run_smoke.setEnvironmentVariable("WAMR_BIN", b.getInstallPath(.bin, "wamr"));
+        wamrc_run_smoke.step.dependOn(b.getInstallStep());
+        wamrc_run_smoke.expectExitCode(0);
+        test_step.dependOn(&wamrc_run_smoke.step);
     }
 
     // Compiler IR passes tests (separate module to avoid root/wamr conflict)
@@ -1150,12 +1173,14 @@ const ComponentRunSteps = struct {
     wasmtime: *std.Build.Step,
 };
 
-/// Register one component fixture against both run parents. Wires
-/// up the wamr arm via `b.addRunArtifact(wamr_exe)` and the wasmtime
-/// arm via `b.addSystemCommand({"wasmtime", "run", "-S",
-/// "cli-exit-with-code"})`. Both arms assert the same expected
-/// stdout + exit code, so byte-equivalent output across runtimes is
-/// the parity invariant the CI cross-validation job enforces
+/// Register one component fixture against both run parents. The wamr
+/// arm spawns the freshly-built `wamrc run` (which compiles the
+/// component into sibling `<stem>.cwasm.json` + `<stem>.<N>.cwasm`
+/// files if missing or stale and then spawns `wamr run` itself with
+/// stdio inherited). The wasmtime arm uses `wasmtime run -S
+/// cli-exit-with-code`. Both arms assert the same expected stdout
+/// + exit code, so byte-equivalent output across runtimes is the
+/// parity invariant the CI cross-validation job enforces
 /// (cataggar/wamr#457).
 fn wireComponentRun(
     b: *std.Build,
@@ -1166,10 +1191,14 @@ fn wireComponentRun(
     expected_exit: u8,
     opts: WireRunOptions,
 ) void {
+    _ = wamr_exe;
     if (!opts.skip_wamr) {
-        const run = b.addRunArtifact(wamr_exe);
-        run.addArg("run");
+        const wamrc_path = b.getInstallPath(.bin, "wamrc");
+        const wamr_path = b.getInstallPath(.bin, "wamr");
+        const run = b.addSystemCommand(&.{ wamrc_path, "run" });
         run.addFileArg(component);
+        run.setEnvironmentVariable("WAMR_BIN", wamr_path);
+        run.step.dependOn(b.getInstallStep());
         run.expectExitCode(expected_exit);
         run.expectStdOutEqual(expected_stdout);
         runs.wamr.dependOn(&run.step);

--- a/build.zig
+++ b/build.zig
@@ -247,6 +247,7 @@ pub fn build(b: *std.Build) void {
     // Point the adapter at the freshly-installed wamr binary so we don't pick
     // up a stale system iwasm.
     wasi_runner.setEnvironmentVariable("WAMR", b.getInstallPath(.bin, "wamr"));
+    wasi_runner.setEnvironmentVariable("WAMRC", b.getInstallPath(.bin, "wamrc"));
     wasi_runner.step.dependOn(b.getInstallStep());
     const wasi_testsuite_step = b.step(
         "wasi-testsuite",
@@ -276,6 +277,7 @@ pub fn build(b: *std.Build) void {
         "tests/wasi-p3-testsuite-skip.json",
     });
     wasi_p3_runner.setEnvironmentVariable("WAMR", b.getInstallPath(.bin, "wamr"));
+    wasi_p3_runner.setEnvironmentVariable("WAMRC", b.getInstallPath(.bin, "wamrc"));
     wasi_p3_runner.step.dependOn(b.getInstallStep());
     const wasi_p3_testsuite_step = b.step(
         "wasi-p3-testsuite",

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -15,11 +15,12 @@ const ir = wamr.ir;
 
 const TargetArch = passes.TargetArch;
 
-const Subcommand = enum { compile, compile_component, version, help };
+const Subcommand = enum { compile, compile_component, run, version, help };
 
 fn parseSubcommand(s: []const u8) ?Subcommand {
     if (std.mem.eql(u8, s, "compile")) return .compile;
     if (std.mem.eql(u8, s, "compile-component")) return .compile_component;
+    if (std.mem.eql(u8, s, "run")) return .run;
     if (std.mem.eql(u8, s, "version")) return .version;
     if (std.mem.eql(u8, s, "help")) return .help;
     return null;
@@ -44,6 +45,7 @@ pub fn main(init: std.process.Init) !void {
         .help => runHelp(init.io, args[2..]),
         .compile => try runCompile(init, allocator, args[2..]),
         .compile_component => try runCompileComponent(init, allocator, args[2..]),
+        .run => try runRun(init, allocator, args[2..]),
     }
 }
 
@@ -630,7 +632,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
         return;
     }
     var input_path: ?[]const u8 = null;
-    var output_dir: ?[]const u8 = null;
+    var output_manifest: ?[]const u8 = null;
     var target_arch: TargetArch = switch (builtin.cpu.arch) {
         .aarch64 => .aarch64,
         else => .x86_64,
@@ -645,7 +647,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
                 std.debug.print("error: -o requires an argument\n", .{});
                 std.process.exit(1);
             }
-            output_dir = sub_args[i];
+            output_manifest = sub_args[i];
         } else if (std.mem.startsWith(u8, a, "--target=")) {
             const v = a["--target=".len..];
             if (std.mem.eql(u8, v, "x86_64") or std.mem.eql(u8, v, "x86-64")) {
@@ -671,8 +673,8 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
         std.debug.print("error: missing input component path\n", .{});
         std.process.exit(1);
     };
-    const out_dir = output_dir orelse blk: {
-        break :blk try wamr.component_aot.defaultPrecompiledDirFor(allocator, in_path);
+    const manifest_path: []const u8 = if (output_manifest) |o| o else blk: {
+        break :blk try wamr.component_aot.defaultManifestPathFor(allocator, in_path);
     };
 
     const io = init.io;
@@ -693,7 +695,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
         std.process.exit(1);
     }
 
-    var result = wamr.component_aot.precompileComponent(allocator, component_data, out_dir, .{
+    var result = wamr.component_aot_compile.precompileComponent(allocator, component_data, manifest_path, .{
         .target_arch = target_arch,
     }) catch |err| {
         std.debug.print("error: precompile failed: {s}\n", .{@errorName(err)});
@@ -701,10 +703,393 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
     };
     defer result.deinit();
 
-    std.debug.print("Wrote {d} core module(s) + manifest.json to {s}\n", .{
-        result.manifest.modules.len, out_dir,
+    std.debug.print("Wrote {d} core module(s) + {s}\n", .{
+        result.manifest.modules.len, manifest_path,
     });
 }
+
+/// `wamrc run` — compile (if needed) and then execute via the `wamr`
+/// runtime as a subprocess. Default output lives next to the input:
+/// `foo.wasm` → `foo.cwasm` (core) or `foo.cwasm.json` + `foo.<N>.cwasm`
+/// (component). The existing artifact is reused when a "target format"
+/// check passes (see `coreArtifactFresh` / component manifest
+/// verification); otherwise it is recompiled in place.
+fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
+    if (sub_args.len == 1 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, run_usage);
+        return;
+    }
+
+    var input_path: ?[]const u8 = null;
+    var output_path: ?[]const u8 = null;
+    var force = false;
+    var target_arch: TargetArch = switch (builtin.cpu.arch) {
+        .aarch64 => .aarch64,
+        else => .x86_64,
+    };
+
+    // After we encounter `--` or the first non-option positional, every
+    // remaining token is forwarded verbatim to `wamr run`. We split the
+    // input on `--` so users can disambiguate `wamrc run -O0 foo.wasm`
+    // (still our flag) from `wamrc run foo.wasm -- --listen ...`
+    // (`--listen` belongs to `wamr`).
+    var forward_args: std.ArrayList([]const u8) = .empty;
+    defer forward_args.deinit(allocator);
+
+    var i: usize = 0;
+    var saw_dashdash = false;
+    while (i < sub_args.len) : (i += 1) {
+        const a = sub_args[i];
+        if (saw_dashdash) {
+            try forward_args.append(allocator, a);
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--")) {
+            saw_dashdash = true;
+            continue;
+        }
+        if (std.mem.eql(u8, a, "-o") and i + 1 < sub_args.len) {
+            i += 1;
+            output_path = sub_args[i];
+        } else if (std.mem.eql(u8, a, "--force")) {
+            force = true;
+        } else if (std.mem.eql(u8, a, "--target") and i + 1 < sub_args.len) {
+            i += 1;
+            target_arch = parseTargetArchOrDie(sub_args[i]);
+        } else if (std.mem.startsWith(u8, a, "--target=")) {
+            target_arch = parseTargetArchOrDie(a["--target=".len..]);
+        } else if (a.len > 0 and a[0] == '-' and input_path == null) {
+            std.debug.print("error: unknown option '{s}' — try `wamrc run help`\n", .{a});
+            std.process.exit(1);
+        } else if (input_path == null) {
+            input_path = a;
+        } else {
+            // Implicit forward: positionals after the input wasm go to
+            // `wamr run` without requiring `--`.
+            try forward_args.append(allocator, a);
+        }
+    }
+
+    const in_path = input_path orelse {
+        std.debug.print("error: missing input wasm file — usage: wamrc run <input.wasm> [-- args...]\n", .{});
+        std.process.exit(1);
+    };
+
+    const io = init.io;
+    const cwd = std.Io.Dir.cwd();
+    const wasm_data = cwd.readFileAlloc(io, in_path, allocator, @enumFromInt(256 * 1024 * 1024)) catch |err| {
+        wamr.utils.read_file.dieReadFileError(in_path, err);
+    };
+    defer allocator.free(wasm_data);
+
+    const is_comp = wamr.component_aot.isComponent(wasm_data) catch {
+        std.debug.print("error: '{s}' is not a valid wasm module or component\n", .{in_path});
+        std.process.exit(1);
+    };
+
+    // Resolve the artifact path. For components this is a manifest
+    // sidecar (`<stem>.cwasm.json`); for core wasm it's the `.cwasm`
+    // itself. Default lives next to the input.
+    var derived_output: ?[]u8 = null;
+    defer if (derived_output) |d| allocator.free(d);
+
+    const artifact_path: []const u8 = if (is_comp) blk: {
+        if (output_path) |p| break :blk p;
+        const d = try wamr.component_aot.defaultManifestPathFor(allocator, in_path);
+        derived_output = d;
+        break :blk d;
+    } else blk: {
+        if (output_path) |p| break :blk p;
+        const d = try deriveOutputPath(allocator, in_path);
+        derived_output = d;
+        break :blk d;
+    };
+
+    // Freshness check. On a hit we skip compilation entirely; on a miss
+    // (or `--force`) we (re)compile in place.
+    var did_compile = false;
+    if (is_comp) {
+        const fresh = !force and componentArtifactFresh(allocator, artifact_path, wasm_data);
+        if (!fresh) {
+            std.debug.print("wamrc: compiling {s} → {s}\n", .{ in_path, artifact_path });
+            var result = wamr.component_aot_compile.precompileComponent(allocator, wasm_data, artifact_path, .{
+                .target_arch = target_arch,
+            }) catch |err| {
+                std.debug.print("error: precompile failed: {s}\n", .{@errorName(err)});
+                std.process.exit(1);
+            };
+            result.deinit();
+            did_compile = true;
+        }
+    } else {
+        const fresh = !force and coreArtifactFresh(allocator, artifact_path, wasm_data, target_arch, in_path);
+        if (!fresh) {
+            std.debug.print("wamrc: compiling {s} → {s}\n", .{ in_path, artifact_path });
+            const cwasm = wamr.component_aot_compile.compileCoreWasm(allocator, wasm_data, .{
+                .target_arch = target_arch,
+            }) catch |err| {
+                std.debug.print("error: compile failed: {s}\n", .{@errorName(err)});
+                std.process.exit(1);
+            };
+            defer allocator.free(cwasm);
+            writeFileAtomic(io, artifact_path, cwasm) catch |err| {
+                std.debug.print("error: failed to write '{s}': {s}\n", .{ artifact_path, @errorName(err) });
+                std.process.exit(1);
+            };
+            writeCoreSidecar(allocator, io, artifact_path, wasm_data, target_arch) catch |err| {
+                std.debug.print("warning: failed to write fingerprint sidecar for '{s}': {s}\n", .{ artifact_path, @errorName(err) });
+            };
+            did_compile = true;
+        }
+    }
+    if (!did_compile) {
+        std.debug.print("wamrc: reusing {s} (up to date)\n", .{artifact_path});
+    }
+
+    // Build the argv for `wamr run`. Layout:
+    //   wamr run <artifact> [forwarded args...]
+    const wamr_bin = findWamrBinary(allocator, io, init.environ_map) catch |err| {
+        std.debug.print("error: could not locate `wamr` binary: {s}\n" ++
+            "  Set WAMR_BIN, install `wamr` on PATH, or place it next to wamrc.\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+    defer allocator.free(wamr_bin);
+
+    var child_argv: std.ArrayList([]const u8) = .empty;
+    defer child_argv.deinit(allocator);
+    try child_argv.append(allocator, wamr_bin);
+    try child_argv.append(allocator, "run");
+    // For components, `wamr run` takes the source `.wasm` and
+    // auto-discovers the sibling `<stem>.cwasm.json` (or honours
+    // `--precompiled-manifest` if the user picked a non-default
+    // location). For core wasm we hand it the freshly-written
+    // `.cwasm` directly.
+    if (is_comp) {
+        if (output_path != null) {
+            try child_argv.append(allocator, "--precompiled-manifest");
+            try child_argv.append(allocator, artifact_path);
+        }
+        try child_argv.append(allocator, in_path);
+    } else {
+        try child_argv.append(allocator, artifact_path);
+    }
+    for (forward_args.items) |fa| try child_argv.append(allocator, fa);
+
+    var child = std.process.spawn(io, .{
+        .argv = child_argv.items,
+        .stdin = .inherit,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    }) catch |err| {
+        std.debug.print("error: failed to spawn '{s}': {s}\n", .{ wamr_bin, @errorName(err) });
+        std.process.exit(1);
+    };
+
+    const term = child.wait(io) catch |err| {
+        std.debug.print("error: failed waiting for `wamr` subprocess: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+
+    switch (term) {
+        .exited => |code| std.process.exit(code),
+        .signal => |sig| {
+            std.debug.print("error: `wamr` was killed by signal {d}\n", .{@intFromEnum(sig)});
+            std.process.exit(1);
+        },
+        .stopped => |sig| {
+            std.debug.print("error: `wamr` was stopped by signal {d}\n", .{@intFromEnum(sig)});
+            std.process.exit(1);
+        },
+        .unknown => |code| {
+            std.debug.print("error: `wamr` terminated with unknown status {d}\n", .{code});
+            std.process.exit(1);
+        },
+    }
+}
+
+fn parseTargetArchOrDie(s: []const u8) TargetArch {
+    if (std.mem.eql(u8, s, "aarch64")) return .aarch64;
+    if (std.mem.eql(u8, s, "x86_64") or std.mem.eql(u8, s, "x86-64")) return .x86_64;
+    std.debug.print("error: unknown target '{s}' (supported: x86_64, aarch64)\n", .{s});
+    std.process.exit(1);
+}
+
+fn targetArchName(arch: TargetArch) []const u8 {
+    return switch (arch) {
+        .aarch64 => "aarch64",
+        .x86_64 => "x86_64",
+    };
+}
+
+/// Fingerprint persisted next to a `<input>.cwasm` so `wamrc run` can
+/// decide whether to reuse the artifact. The cwasm header alone only
+/// stores `aot_magic + aot_version`; the sidecar adds the bits we
+/// otherwise can't recover (target arch, wamr build id, source hash).
+const CoreSidecar = struct {
+    aot_version: u32,
+    wamr_build_id: []const u8,
+    target_arch: []const u8,
+    wasm_sha256: []const u8,
+};
+
+fn coreSidecarPathAlloc(allocator: std.mem.Allocator, artifact_path: []const u8) ![]u8 {
+    return std.mem.concat(allocator, u8, &.{ artifact_path, ".id" });
+}
+
+fn writeCoreSidecar(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    artifact_path: []const u8,
+    wasm_data: []const u8,
+    target_arch: TargetArch,
+) !void {
+    var hex_hash: [64]u8 = undefined;
+    hexSha256Into(wasm_data, &hex_hash);
+
+    const sidecar: CoreSidecar = .{
+        .aot_version = emit_aot.aot_version,
+        .wamr_build_id = wamr.version.string,
+        .target_arch = targetArchName(target_arch),
+        .wasm_sha256 = &hex_hash,
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    var sw: std.json.Stringify = .{ .writer = &aw.writer };
+    try sw.write(sidecar);
+
+    const sidecar_path = try coreSidecarPathAlloc(allocator, artifact_path);
+    defer allocator.free(sidecar_path);
+    try writeFileAtomic(io, sidecar_path, aw.written());
+}
+
+fn hexSha256Into(data: []const u8, out: *[64]u8) void {
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(data, &digest, .{});
+    const hex = "0123456789abcdef";
+    for (digest, 0..) |b, j| {
+        out[j * 2] = hex[b >> 4];
+        out[j * 2 + 1] = hex[b & 0x0f];
+    }
+}
+
+fn writeFileAtomic(io: std.Io, path: []const u8, bytes: []const u8) !void {
+    // Write to `<path>.tmp` then rename for crash safety. Falls back
+    // to a plain overwrite if the rename fails (e.g. cross-device).
+    var tmp_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cwd = std.Io.Dir.cwd();
+    if (path.len + 4 > tmp_buf.len) {
+        // Path too long for the buffer — just overwrite directly.
+        try cwd.writeFile(io, .{ .sub_path = path, .data = bytes });
+        return;
+    }
+    @memcpy(tmp_buf[0..path.len], path);
+    @memcpy(tmp_buf[path.len..][0..4], ".tmp");
+    const tmp_path = tmp_buf[0 .. path.len + 4];
+    try cwd.writeFile(io, .{ .sub_path = tmp_path, .data = bytes });
+    cwd.rename(tmp_path, cwd, path, io) catch {
+        // Best-effort: overwrite directly, then clean up the tmp.
+        try cwd.writeFile(io, .{ .sub_path = path, .data = bytes });
+        cwd.deleteFile(io, tmp_path) catch {};
+    };
+}
+
+/// True iff `artifact_path` is a `.cwasm` whose magic + version match
+/// the current `emit_aot.aot_version` AND whose sidecar matches the
+/// current wamr build id, target arch, and source wasm hash.
+fn coreArtifactFresh(
+    allocator: std.mem.Allocator,
+    artifact_path: []const u8,
+    wasm_data: []const u8,
+    target_arch: TargetArch,
+    in_path: []const u8,
+) bool {
+    _ = in_path;
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const cwd = std.Io.Dir.cwd();
+
+    // 1. Read enough of the cwasm to validate the header.
+    var header: [8]u8 = undefined;
+    const got = cwd.readFile(io, artifact_path, &header) catch return false;
+    if (got.len < 8) return false;
+    const magic = std.mem.readInt(u32, header[0..4], .little);
+    const version = std.mem.readInt(u32, header[4..8], .little);
+    if (magic != emit_aot.aot_magic) return false;
+    if (version != emit_aot.aot_version) return false;
+
+    // 2. Read + parse the sidecar.
+    const sidecar_path = coreSidecarPathAlloc(allocator, artifact_path) catch return false;
+    defer allocator.free(sidecar_path);
+    const json_bytes = cwd.readFileAlloc(io, sidecar_path, allocator, @enumFromInt(64 * 1024)) catch return false;
+    defer allocator.free(json_bytes);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const parsed = std.json.parseFromSliceLeaky(
+        CoreSidecar,
+        arena.allocator(),
+        json_bytes,
+        .{ .ignore_unknown_fields = true },
+    ) catch return false;
+
+    if (parsed.aot_version != emit_aot.aot_version) return false;
+    if (!std.mem.eql(u8, parsed.wamr_build_id, wamr.version.string)) return false;
+    if (!std.mem.eql(u8, parsed.target_arch, targetArchName(target_arch))) return false;
+
+    var hex_hash: [64]u8 = undefined;
+    hexSha256Into(wasm_data, &hex_hash);
+    if (!std.mem.eql(u8, parsed.wasm_sha256, &hex_hash)) return false;
+
+    return true;
+}
+
+/// True iff `manifest_path` holds a manifest that loads cleanly
+/// against the supplied component bytes. `loadManifest` already
+/// validates `wamr_build_id`, `component_sha256`, and every per-core
+/// `sha256`, so a successful load *is* the freshness signal.
+fn componentArtifactFresh(
+    allocator: std.mem.Allocator,
+    manifest_path: []const u8,
+    wasm_data: []const u8,
+) bool {
+    var loaded = wamr.component_aot.loadManifest(allocator, manifest_path, wasm_data) catch return false;
+    loaded.deinit();
+    return true;
+}
+
+/// Resolve a path to a sibling `wamr` binary. Resolution order:
+///   1. `WAMR_BIN` environment variable (caller's responsibility to
+///      point at a real file).
+///   2. `<dir-of-wamrc>/wamr` — covers `zig build` (both binaries land
+///      in `zig-out/bin/`) and most install layouts.
+///   3. PATH lookup of `wamr` (we let `process.spawn` do this implicitly
+///      by returning the bare name `"wamr"`).
+fn findWamrBinary(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    environ_map: *const std.process.Environ.Map,
+) ![]u8 {
+    if (environ_map.get("WAMR_BIN")) |env_path| {
+        if (env_path.len > 0) return allocator.dupe(u8, env_path);
+    }
+
+    // Locate sibling next to wamrc.
+    var exe_buf: [std.fs.max_path_bytes]u8 = undefined;
+    if (std.process.executablePath(io, &exe_buf)) |n| {
+        const exe_path = exe_buf[0..n];
+        const dir = std.fs.path.dirname(exe_path) orelse "";
+        if (dir.len > 0) {
+            const candidate = try std.fs.path.join(allocator, &.{ dir, "wamr" });
+            // Don't access() here — let spawn surface a clearer error
+            // (e.g. "FileNotFound") with the candidate path baked in.
+            return candidate;
+        }
+    } else |_| {}
+
+    // Final fallback: let the OS look up "wamr" on PATH.
+    return allocator.dupe(u8, "wamr");
+}
+
 
 const top_usage =
     \\wamrc - WebAssembly AOT Compiler
@@ -714,6 +1099,7 @@ const top_usage =
     \\Subcommands:
     \\  compile             Compile a .wasm module to a .cwasm AOT binary
     \\  compile-component   Precompile every embedded core of a component
+    \\  run                 Compile (if needed) and execute via the wamr runtime
     \\  version             Print version and exit
     \\  help                Print this help
     \\
@@ -777,19 +1163,54 @@ const compile_usage =
 ;
 
 const compile_component_usage =
-    \\Usage: wamrc compile-component [options] <component.wasm> [-o <out_dir>]
+    \\Usage: wamrc compile-component [options] <component.wasm> [-o <manifest.json>]
     \\
-    \\Precompile every embedded core module of a component into a directory
-    \\containing one `module<N>.cwasm` per core plus a `manifest.json`
-    \\(versioned, with build-id and component-hash, rejected on mismatch).
-    \\If `-o` is omitted, the directory is derived from the input path with
-    \\suffix `.cwasm.d`.
+    \\Precompile every embedded core module of a component, writing each
+    \\as `<stem>.<N>.cwasm` next to the source `.wasm` and a versioned
+    \\`<stem>.cwasm.json` manifest sidecar (with build-id and component
+    \\sha256; rejected on mismatch). If `-o` is omitted, the manifest
+    \\path is derived from the input by stripping `.wasm` and appending
+    \\`.cwasm.json`; per-core artifacts land in the manifest's directory.
     \\
     \\Options:
-    \\  -o <dir>                      Output directory (default: <input>.cwasm.d)
+    \\  -o <manifest.json>            Manifest path (default: <input>.cwasm.json)
     \\  --target=<x86_64|aarch64>     Target architecture (default: host)
     \\
 ;
+
+const run_usage =
+    \\Usage: wamrc run [options] <input.wasm> [-- <wamr args...>]
+    \\
+    \\Compile <input.wasm> if the existing artifact is missing or stale,
+    \\then spawn `wamr run <artifact>` with stdin/stdout/stderr inherited
+    \\and propagate its exit code. By default the artifact is written
+    \\next to the source:
+    \\
+    \\  core wasm  : foo.wasm  ->  foo.cwasm          (+ foo.cwasm.id sidecar)
+    \\  component  : foo.wasm  ->  foo.cwasm.json     (+ foo.<N>.cwasm per core)
+    \\
+    \\The artifact is reused only when the target-format check passes:
+    \\
+    \\  * core     : cwasm magic + aot_version match, plus the sidecar
+    \\               records the current wamr build id, target arch, and
+    \\               the source's sha256.
+    \\  * component: `loadManifest` accepts the manifest sidecar (it
+    \\               already checks wamr_build_id, the component sha256,
+    \\               and every per-core sha256).
+    \\
+    \\Anything after `--` (or any positional after the input) is forwarded
+    \\verbatim to `wamr run`. The `wamr` binary is located via
+    \\$WAMR_BIN, then a sibling of wamrc, then PATH.
+    \\
+    \\Options:
+    \\  -o <file>                     Override the artifact path (a `.cwasm`
+    \\                                 for core wasm, a `.cwasm.json` manifest
+    \\                                 for components)
+    \\  --force                       Recompile even if the artifact is fresh
+    \\  --target=<x86_64|aarch64>     Target architecture (default: host)
+    \\
+;
+
 
 const version_usage =
     \\Usage: wamrc version

--- a/src/component/aot.zig
+++ b/src/component/aot.zig
@@ -2,24 +2,25 @@
 //!
 //! Walks every embedded core module in a parsed `Component` and AOT-
 //! compiles it via the existing `src/compiler` pipeline, writing each
-//! result to `<out_dir>/module<N>.cwasm` alongside a versioned
-//! `manifest.json`. The manifest records the component's sha256 and
-//! the wamr build id so a stale or wrong-component artifact is
-//! rejected on load.
+//! result next to the source `.wasm` as `<stem>.<idx>.cwasm`, with a
+//! versioned `<stem>.cwasm.json` manifest sidecar. The manifest
+//! records the component's sha256 and the wamr build id so a stale
+//! or wrong-component artifact is rejected on load.
 //!
 //! Mirrors `wasmtime::Engine::precompile_component`. The on-disk
-//! layout is:
+//! layout for `foo.wasm` is:
 //!
 //! ```text
-//! <out_dir>/manifest.json
-//! <out_dir>/module0.cwasm
-//! <out_dir>/module1.cwasm
+//! foo.wasm            (source component)
+//! foo.cwasm.json      (manifest sidecar)
+//! foo.0.cwasm         (per-core AOT artifacts)
+//! foo.1.cwasm
 //! …
 //! ```
 //!
-//! `loadManifest` is the inverse: parse `manifest.json`, mmap each
-//! referenced `.cwasm`, verify the embedded sha256s, and return a
-//! `LoadedManifest` whose `precompiledCores()` hands the slice
+//! `loadManifest` is the inverse: parse `<stem>.cwasm.json`, mmap
+//! each referenced `.cwasm`, verify the embedded sha256s, and return
+//! a `LoadedManifest` whose `precompiledCores()` hands the slice
 //! directly to `instance.instantiateWithOptions`.
 //!
 //! Out of scope (per issue #625):
@@ -27,29 +28,11 @@
 //!   * Cache invalidation beyond build-id + content-hash comparison.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const ctypes = @import("types.zig");
 const component_loader = @import("loader.zig");
 const core_backend = @import("core_backend.zig");
-const core_loader = @import("../runtime/interpreter/loader.zig");
-const frontend = @import("../compiler/frontend.zig");
-const passes = @import("../compiler/ir/passes.zig");
-const x86_64_compile = @import("../compiler/codegen/x86_64/compile.zig");
-const aarch64_compile = @import("../compiler/codegen/aarch64/compile.zig");
-const emit_aot = @import("../compiler/emit_aot.zig");
 const core_types = @import("../runtime/common/types.zig");
-const interp_instance = @import("../runtime/interpreter/instance.zig");
-const instance_mod = @import("instance.zig");
 const config = @import("../config.zig");
-
-pub const PrecompileError = error{
-    InvalidComponent,
-    CoreCompileFailed,
-    WriteFailed,
-    OutOfMemory,
-    OpenDirFailed,
-    JsonSerializationFailed,
-};
 
 pub const LoadError = error{
     ManifestNotFound,
@@ -70,17 +53,17 @@ pub const LoadError = error{
     OutOfMemory,
 };
 
-/// Convention for the default precompiled-bundle directory next to a
+/// Convention for the default manifest sidecar path next to a
 /// component file: strip a trailing `.wasm` (if present) and append
-/// `.cwasm.d`. Used both by `wamrc compile-component` (default `-o`)
-/// and by `wamr run`'s auto-detect probe — they must stay in sync
-/// (issue #645). Caller owns the returned slice.
-pub fn defaultPrecompiledDirFor(allocator: std.mem.Allocator, in_path: []const u8) ![]u8 {
+/// `.cwasm.json`. Used both by `wamrc compile-component` (default
+/// `-o`) and by `wamr run`'s auto-detect probe — they must stay in
+/// sync (issue #645). Caller owns the returned slice.
+pub fn defaultManifestPathFor(allocator: std.mem.Allocator, in_path: []const u8) ![]u8 {
     const stem = if (std.mem.endsWith(u8, in_path, ".wasm"))
         in_path[0 .. in_path.len - ".wasm".len]
     else
         in_path;
-    return std.mem.concat(allocator, u8, &.{ stem, ".cwasm.d" });
+    return std.mem.concat(allocator, u8, &.{ stem, ".cwasm.json" });
 }
 
 /// Manifest schema version. Bump when the on-disk layout or
@@ -119,7 +102,7 @@ pub const ManifestModuleEntry = struct {
     core_sha256: ?[]const u8 = null,
 };
 
-/// Top-level manifest. Serialized to / parsed from `manifest.json`.
+/// Top-level manifest. Serialized to / parsed from `<stem>.cwasm.json`.
 pub const Manifest = struct {
     /// `manifest_format_version` at write time. Refused on load when
     /// it doesn't match the current loader's expected value.
@@ -165,505 +148,48 @@ pub const LoadedManifest = struct {
     }
 };
 
+
 /// Options controlling `precompileComponent`. Today only the target
 /// arch is exposed; future options (opt level, dump-ir hooks, …) slot
 /// in here without breaking the API.
-pub const PrecompileOptions = struct {
-    target_arch: passes.TargetArch = switch (builtin.cpu.arch) {
-        .aarch64 => .aarch64,
-        else => .x86_64,
-    },
-};
-
-/// AOT-compile a single core wasm module. Returns freshly-allocated
-/// `.cwasm` bytes owned by the caller (free with `allocator.free`).
 ///
-/// Pure data in / data out — no filesystem I/O — so the same helper
-/// services both `precompileComponent` and any future programmatic
-/// caller that wants per-core artifacts in memory.
-pub fn compileCoreWasm(
-    allocator: std.mem.Allocator,
-    wasm_bytes: []const u8,
-    opts: PrecompileOptions,
-) PrecompileError![]u8 {
-    // Lifetime split mirrors `src/compiler/main.zig` (`wamrc compile`)
-    // to bound peak memory on large modules (issue #640). The parsed
-    // module lives in a transient `module_arena`; IR + passes +
-    // codegen go on the outer GPA so per-function intermediates are
-    // freed back as each pass completes; emit-side field tables live
-    // in a short-lived `emit_arena`. Lumping everything on one arena
-    // (the previous implementation) retained tens of GB on a
-    // 12 610-function core.
-    var module_arena = std.heap.ArenaAllocator.init(allocator);
-    defer module_arena.deinit();
-    const ma = module_arena.allocator();
+/// Lives in `aot_compile.zig`; aliased here for callers that only
+/// hold a `wamr.component_aot` import.
+pub const PrecompileOptions = @import("aot_compile.zig").PrecompileOptions;
 
-    // Don't dupe `wasm_bytes`: `core_loader.load` only borrows from
-    // the slice (returned `module` fields are slices into it), and
-    // the caller's bytes outlive this call.
-    const module = core_loader.load(wasm_bytes, ma) catch return error.CoreCompileFailed;
-
-    var ir_module = frontend.lowerModule(&module, allocator) catch return error.CoreCompileFailed;
-    defer ir_module.deinit();
-
-    _ = passes.runPassesWithOptions(
-        &ir_module,
-        passes.defaultPassesForTarget(opts.target_arch),
-        allocator,
-        .{ .verify_mode = .off },
-    ) catch return error.CoreCompileFailed;
-
-    const code: []u8, const offsets: []u32 = switch (opts.target_arch) {
-        .aarch64 => blk: {
-            const r = aarch64_compile.compileModule(&ir_module, allocator) catch return error.CoreCompileFailed;
-            break :blk .{ r.code, r.offsets };
-        },
-        .x86_64 => blk: {
-            const r = x86_64_compile.compileModule(&ir_module, allocator) catch return error.CoreCompileFailed;
-            break :blk .{ r.code, r.offsets };
-        },
-    };
-    defer allocator.free(code);
-    defer allocator.free(offsets);
-
-    // Short-lived arena for the emit-side field tables. `emit_aot.emit`
-    // copies what it needs into its caller-owned output buffer, so
-    // everything in here (and in `module_arena`) is safe to drop on
-    // return.
-    var emit_arena = std.heap.ArenaAllocator.init(allocator);
-    defer emit_arena.deinit();
-    const ea = emit_arena.allocator();
-
-    var exports: std.ArrayList(emit_aot.ExportEntry) = .empty;
-    for (module.exports) |exp| {
-        if (exp.kind == .tag) continue;
-        exports.append(ea, .{
-            .name = exp.name,
-            .kind = @enumFromInt(@intFromEnum(exp.kind)),
-            .index = exp.index,
-        }) catch return error.OutOfMemory;
-    }
-
-    var imports: std.ArrayList(emit_aot.ImportEntry) = .empty;
-    for (module.imports) |imp| {
-        switch (imp.kind) {
-            .function => imports.append(ea, .{
-                .module_name = imp.module_name,
-                .field_name = imp.field_name,
-                .kind = .function,
-                .func_type_idx = imp.func_type_idx orelse 0,
-            }) catch return error.OutOfMemory,
-            .table => {
-                const table_type = imp.table_type orelse continue;
-                imports.append(ea, .{
-                    .module_name = imp.module_name,
-                    .field_name = imp.field_name,
-                    .kind = .table,
-                    .table_elem_type = table_type.elem_type,
-                    .table_min = @intCast(table_type.limits.min),
-                    .table_max = if (table_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
-                }) catch return error.OutOfMemory;
-            },
-            .memory => {
-                const memory_type = imp.memory_type orelse continue;
-                imports.append(ea, .{
-                    .module_name = imp.module_name,
-                    .field_name = imp.field_name,
-                    .kind = .memory,
-                    .memory_min = @intCast(memory_type.limits.min),
-                    .memory_max = if (memory_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
-                    .memory_is64 = memory_type.is_memory64,
-                }) catch return error.OutOfMemory;
-            },
-            .global => {
-                const global_type = imp.global_type orelse continue;
-                imports.append(ea, .{
-                    .module_name = imp.module_name,
-                    .field_name = imp.field_name,
-                    .kind = .global,
-                    .global_val_type = global_type.val_type,
-                    .global_mutable = global_type.mutability == .mutable,
-                }) catch return error.OutOfMemory;
-            },
-            .tag => {
-                const type_idx = imp.tag_type_idx orelse continue;
-                imports.append(ea, .{
-                    .module_name = imp.module_name,
-                    .field_name = imp.field_name,
-                    .kind = .tag,
-                    .tag_type_idx = type_idx,
-                }) catch return error.OutOfMemory;
-            },
-        }
-    }
-
-    var mem_entries: std.ArrayList(emit_aot.MemoryEntry) = .empty;
-    for (module.memories) |mem| {
-        mem_entries.append(ea, .{
-            .min_pages = @intCast(mem.limits.min),
-            .max_pages = if (mem.limits.max) |m| @as(?u32, @intCast(m)) else null,
-        }) catch return error.OutOfMemory;
-    }
-
-    // Locally-defined tables (#681). Imported tables already round-trip
-    // via `import_entries`; local tables need section 15 so the loader
-    // populates `module.tables` and `allocateTables` creates the matching
-    // `TableInstance`s. wit-component cores rely on this for
-    // `(table $imports)`.
-    var table_entries: std.ArrayList(emit_aot.TableEntry) = .empty;
-    for (module.tables) |t| {
-        table_entries.append(ea, .{
-            .elem_type = t.elem_type,
-            .min = @intCast(t.limits.min),
-            .max = if (t.limits.max) |m| @as(?u32, @intCast(m)) else null,
-        }) catch return error.OutOfMemory;
-    }
-
-    var data_segs: std.ArrayList(emit_aot.DataSegmentEntry) = .empty;
-    for (module.data_segments) |seg| {
-        if (seg.is_passive) continue;
-        const offset: u32 = switch (seg.offset) {
-            .i32_const => |v| @bitCast(v),
-            else => continue,
-        };
-        data_segs.append(ea, .{
-            .memory_idx = seg.memory_idx,
-            .offset = offset,
-            .data = seg.data,
-        }) catch return error.OutOfMemory;
-    }
-
-    var func_type_entries: std.ArrayList(emit_aot.FuncTypeEntry) = .empty;
-    for (module.types) |ft| {
-        if (ft.kind != .func) {
-            func_type_entries.append(ea, .{ .params = &.{}, .results = &.{} }) catch return error.OutOfMemory;
-            continue;
-        }
-        const params_bytes = ea.alloc(u8, ft.params.len) catch return error.OutOfMemory;
-        for (ft.params, 0..) |p, j| params_bytes[j] = @intFromEnum(p);
-        const results_bytes = ea.alloc(u8, ft.results.len) catch return error.OutOfMemory;
-        for (ft.results, 0..) |r, j| results_bytes[j] = @intFromEnum(r);
-        func_type_entries.append(ea, .{ .params = params_bytes, .results = results_bytes }) catch return error.OutOfMemory;
-    }
-
-    var local_func_tidx_list: std.ArrayList(u32) = .empty;
-    for (module.functions) |f| {
-        local_func_tidx_list.append(ea, f.type_idx) catch return error.OutOfMemory;
-    }
-
-    // Locally-declared tags (#672). `module.tag_types` is parallel to the
-    // wasm tag section: each entry is a function-type index describing the
-    // exception parameters.
-    var tag_entries: std.ArrayList(emit_aot.TagEntry) = .empty;
-    for (module.tag_types) |type_idx| {
-        tag_entries.append(ea, .{ .type_idx = type_idx }) catch return error.OutOfMemory;
-    }
-
-    // Build global entries in wasm-flat order (imported globals first,
-    // then local globals). `evalInitExpr` is shared with the on-disk
-    // wamrc path so the resulting `.cwasm` is byte-identical for this
-    // section. `tmp_globals` is the running prefix `evalInitExpr` uses
-    // to resolve `global.get` in a `global` init expression.
-    var global_entries: std.ArrayList(emit_aot.GlobalEntry) = .empty;
-    var tmp_globals: std.ArrayList(*core_types.GlobalInstance) = .empty;
-    defer {
-        for (tmp_globals.items) |g| allocator.destroy(g);
-        tmp_globals.deinit(allocator);
-    }
-    for (module.imports) |imp| {
-        if (imp.kind != .global) continue;
-        const gt = imp.global_type orelse continue;
-        const val = defaultZeroValue(gt.val_type);
-        const gi = allocator.create(core_types.GlobalInstance) catch return error.OutOfMemory;
-        gi.* = .{ .global_type = gt, .value = val };
-        tmp_globals.append(allocator, gi) catch return error.OutOfMemory;
-        global_entries.append(ea, .{
-            .val_type = @intFromEnum(gt.val_type),
-            .mutability = if (gt.mutability == .mutable) @as(u8, 1) else @as(u8, 0),
-            .init_i64 = valueToI64(val),
-            .init_v128 = valueToV128(val),
-        }) catch return error.OutOfMemory;
-    }
-    for (module.globals) |g| {
-        const val = interp_instance.evalInitExpr(g.init_expr, tmp_globals.items, null) catch defaultZeroValue(g.global_type.val_type);
-        const gi = allocator.create(core_types.GlobalInstance) catch return error.OutOfMemory;
-        gi.* = .{ .global_type = g.global_type, .value = val };
-        tmp_globals.append(allocator, gi) catch return error.OutOfMemory;
-        global_entries.append(ea, .{
-            .val_type = @intFromEnum(g.global_type.val_type),
-            .mutability = if (g.global_type.mutability == .mutable) @as(u8, 1) else @as(u8, 0),
-            .init_i64 = valueToI64(val),
-            .init_v128 = valueToV128(val),
-        }) catch return error.OutOfMemory;
-    }
-
-    // Build element segment entries. Declarative segments contribute
-    // nothing at runtime; passive segments emit with offset = 0 and
-    // `is_passive = true` (only usable via `table.init`). Funcidx
-    // null sentinels are encoded as `0xFFFFFFFF`, matching the loader.
-    var elem_entries: std.ArrayList(emit_aot.ElemEntry) = .empty;
-    for (module.elements) |seg| {
-        if (seg.is_declarative) continue;
-        const offset: u32 = if (seg.is_passive) 0 else blk: {
-            const off = seg.offset orelse continue;
-            break :blk switch (off) {
-                .i32_const => |v| @as(u32, @bitCast(v)),
-                else => continue,
-            };
-        };
-        const indices = ea.alloc(u32, seg.func_indices.len) catch return error.OutOfMemory;
-        for (seg.func_indices, 0..) |fi, j| {
-            indices[j] = fi orelse 0xFFFFFFFF;
-        }
-        elem_entries.append(ea, .{
-            .table_idx = seg.table_idx,
-            .offset = offset,
-            .func_indices = indices,
-            .is_passive = seg.is_passive,
-        }) catch return error.OutOfMemory;
-    }
-
-    var arch_name = std.mem.zeroes([16]u8);
-    switch (opts.target_arch) {
-        .x86_64 => @memcpy(arch_name[0..6], "x86-64"),
-        .aarch64 => @memcpy(arch_name[0..7], "aarch64"),
-    }
-
-    return emit_aot.emit(
-        allocator,
-        code,
-        offsets,
-        exports.items,
-        .{ .arch = arch_name },
-        if (data_segs.items.len > 0) data_segs.items else null,
-        if (imports.items.len > 0) imports.items else null,
-        if (mem_entries.items.len > 0) mem_entries.items else null,
-        // Plain wasm32-wasip1 modules (AssemblyScript / Rust / clang
-        // wasi-libc) carry a mutable `i32` shadow stack pointer global
-        // that every function prologue reads/writes; failing to emit it
-        // leaves SP=0 at startup and AS aborts inside its runtime with
-        // `abort:  in (1:1)`. Componentize-js cores tolerate empty
-        // globals/elems because canon-lift wraps them; standalone cores
-        // do not. See `phase-b-diagnosis.md` (#662 Phase B).
-        if (global_entries.items.len > 0) global_entries.items else null,
-        if (elem_entries.items.len > 0) elem_entries.items else null,
-        module.start_function,
-        if (func_type_entries.items.len > 0) func_type_entries.items else null,
-        if (local_func_tidx_list.items.len > 0) local_func_tidx_list.items else null,
-        if (tag_entries.items.len > 0) tag_entries.items else null,
-        if (table_entries.items.len > 0) table_entries.items else null,
-    ) catch return error.CoreCompileFailed;
+/// Sniff the first 8 bytes of `data` for the component magic +
+/// version pair. Returns `true` for a component, `false` for a core
+/// module, `error.InvalidMagic` for anything else.
+pub fn isComponent(data: []const u8) error{InvalidMagic}!bool {
+    if (data.len < 8) return error.InvalidMagic;
+    const magic = std.mem.readInt(u32, data[0..4], .little);
+    if (magic != core_types.wasm_magic) return error.InvalidMagic;
+    const version = std.mem.readInt(u32, data[4..8], .little);
+    if (version == core_types.component_version) return true;
+    if (version == core_types.wasm_version) return false;
+    return error.InvalidMagic;
 }
 
-// ── Global / element entry builders ─────────────────────────────────────
-//
-// Mirrors `src/compiler/main.zig`'s `runCompile` so the in-process AOT
-// compile produces the same `.cwasm` layout the on-disk path does. The
-// helpers here are deliberately self-contained (no cross-imports of
-// file-private functions in `compiler/main.zig`) to keep this fix
-// surgical; the duplication can be deduplicated in a follow-up by
-// hoisting them into `emit_aot.zig` or a new shared file.
-
-fn defaultZeroValue(vt: core_types.ValType) core_types.Value {
-    return switch (vt) {
-        .i32 => .{ .i32 = 0 },
-        .i64 => .{ .i64 = 0 },
-        .f32 => .{ .f32 = 0 },
-        .f64 => .{ .f64 = 0 },
-        .v128 => .{ .v128 = 0 },
-        .funcref => .{ .funcref = null },
-        .externref => .{ .externref = null },
-        .nonfuncref => .{ .nonfuncref = null },
-        .nonexternref => .{ .nonexternref = null },
-        else => .{ .i64 = 0 },
-    };
-}
-
-fn valueToI64(v: core_types.Value) i64 {
-    return switch (v) {
-        .i32 => |x| @as(i64, @as(u32, @bitCast(x))),
-        .i64 => |x| x,
-        .f32 => |x| @as(i64, @as(u32, @bitCast(x))),
-        .f64 => |x| @as(i64, @bitCast(x)),
-        .funcref, .nonfuncref => |maybe| if (maybe) |x| @as(i64, @as(u32, x)) + 1 else 0,
-        .externref, .nonexternref => |maybe| if (maybe) |x| @as(i64, @as(u32, x)) + 1 else 0,
-        else => 0,
-    };
-}
-
-fn valueToV128(v: core_types.Value) u128 {
-    return switch (v) {
-        .v128 => |x| x,
-        else => 0,
-    };
-}
-
-/// Hex-encode a sha256 digest into a fresh allocator-owned string.
-fn hexSha256(allocator: std.mem.Allocator, bytes: []const u8) ![]u8 {
-    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
-    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
-    const hex = try allocator.alloc(u8, digest.len * 2);
-    const hex_chars = "0123456789abcdef";
-    for (digest, 0..) |b, i| {
-        hex[i * 2] = hex_chars[b >> 4];
-        hex[i * 2 + 1] = hex_chars[b & 0x0f];
-    }
-    return hex;
-}
-
-/// Result of `precompileComponent`. The returned `Manifest`'s strings
-/// are arena-allocated and freed by `deinit` together with the arena.
-pub const PrecompileResult = struct {
-    manifest: Manifest,
-    arena: *std.heap.ArenaAllocator,
-    allocator: std.mem.Allocator,
-
-    pub fn deinit(self: *PrecompileResult) void {
-        self.arena.deinit();
-        self.allocator.destroy(self.arena);
-    }
-};
-
-/// Precompile every embedded core module of `component_bytes` to
-/// `<out_dir>/module<N>.cwasm` and write `<out_dir>/manifest.json`.
-///
-/// `out_dir` is created if it doesn't exist. Existing files at the
-/// target paths are overwritten — callers responsible for stale-cache
-/// management beyond the manifest's build-id check.
-pub fn precompileComponent(
-    allocator: std.mem.Allocator,
-    component_bytes: []const u8,
-    out_dir: []const u8,
-    opts: PrecompileOptions,
-) PrecompileError!PrecompileResult {
-    // Snapshot per-core byte slices off the parsed component, then
-    // drop `load_arena` before the compile loop so the parsed
-    // component (large for componentize-js workloads) isn't live in
-    // memory while each core is being AOT-compiled. The `core_mod.data`
-    // slices borrow from `component_bytes` (owned by the caller), so
-    // they remain valid after `load_arena.deinit()`.
-    //
-    // Recurses into `component.components` so cores inside nested
-    // sub-components (the dominant shape of `wabt component compose -d`
-    // / `wasm-tools compose` output) are precompiled too — without
-    // this the manifest is always empty for composed components and
-    // `--precompiled-dir` falls back to in-memory AOT on every cold
-    // start. (#676)
-    const CoreRef = struct {
-        data: []const u8,
-        /// Position within the `core_modules[]` of the (sub-)component
-        /// that directly contains this core. Persisted as
-        /// `ManifestModuleEntry.idx` for human debugging and for the
-        /// v1-fallback loader path.
-        local_idx: u32,
-    };
-    var core_data_list: std.ArrayList(CoreRef) = .empty;
-    defer core_data_list.deinit(allocator);
-    {
-        var load_arena = std.heap.ArenaAllocator.init(allocator);
-        defer load_arena.deinit();
-        const component = component_loader.load(component_bytes, load_arena.allocator()) catch
-            return error.InvalidComponent;
-        const Walker = struct {
-            fn walk(
-                comp: *const ctypes.Component,
-                list: *std.ArrayList(CoreRef),
-                alloc: std.mem.Allocator,
-            ) PrecompileError!void {
-                for (comp.core_modules, 0..) |cm, mi| {
-                    list.append(alloc, .{ .data = cm.data, .local_idx = @intCast(mi) }) catch
-                        return error.OutOfMemory;
-                }
-                for (comp.components) |child| {
-                    try walk(child, list, alloc);
-                }
-            }
-        };
-        try Walker.walk(&component, &core_data_list, allocator);
-    }
-
-    // Result-owned arena holds all strings the caller might read off
-    // the returned Manifest (paths, hex hashes, build id).
-    const result_arena = allocator.create(std.heap.ArenaAllocator) catch return error.OutOfMemory;
-    errdefer allocator.destroy(result_arena);
-    result_arena.* = std.heap.ArenaAllocator.init(allocator);
-    errdefer result_arena.deinit();
-    const ra = result_arena.allocator();
-
-    const cwd = std.Io.Dir.cwd();
-    const io = std.Io.Threaded.global_single_threaded.io();
-    cwd.createDirPath(io, out_dir) catch return error.OpenDirFailed;
-    var dir = cwd.openDir(io, out_dir, .{}) catch return error.OpenDirFailed;
-    defer dir.close(io);
-
-    var entries: std.ArrayList(ManifestModuleEntry) = .empty;
-    entries.ensureTotalCapacity(ra, core_data_list.items.len) catch return error.OutOfMemory;
-
-    for (core_data_list.items, 0..) |core_ref, idx| {
-        const cwasm = compileCoreWasm(allocator, core_ref.data, opts) catch |err| {
-            std.log.err("precompileComponent: core {d} compile failed: {s}", .{ idx, @errorName(err) });
-            return err;
-        };
-        defer allocator.free(cwasm);
-
-        const rel_path = std.fmt.allocPrint(ra, "module{d}.cwasm", .{idx}) catch return error.OutOfMemory;
-
-        dir.writeFile(io, .{ .sub_path = rel_path, .data = cwasm }) catch |err| {
-            std.log.err("precompileComponent: write {s}/{s} failed: {s}", .{ out_dir, rel_path, @errorName(err) });
-            return error.WriteFailed;
-        };
-
-        const hex = hexSha256(ra, cwasm) catch return error.OutOfMemory;
-        const core_hex = hexSha256(ra, core_ref.data) catch return error.OutOfMemory;
-        entries.append(ra, .{
-            .idx = core_ref.local_idx,
-            .path = rel_path,
-            .sha256 = hex,
-            .core_sha256 = core_hex,
-        }) catch return error.OutOfMemory;
-    }
-
-    const component_hex = hexSha256(ra, component_bytes) catch return error.OutOfMemory;
-    const build_id = ra.dupe(u8, config.version) catch return error.OutOfMemory;
-
-    const manifest = Manifest{
-        .version = manifest_format_version,
-        .wamr_build_id = build_id,
-        .component_sha256 = component_hex,
-        .modules = entries.items,
-    };
-
-    // Serialize manifest.json.
-    var aw: std.Io.Writer.Allocating = .init(allocator);
-    defer aw.deinit();
-    var stringify: std.json.Stringify = .{ .writer = &aw.writer, .options = .{ .whitespace = .indent_2 } };
-    stringify.write(manifest) catch return error.JsonSerializationFailed;
-    dir.writeFile(io, .{ .sub_path = "manifest.json", .data = aw.written() }) catch return error.WriteFailed;
-
-    return .{
-        .manifest = manifest,
-        .arena = result_arena,
-        .allocator = allocator,
-    };
-}
-
-/// Read + validate a `manifest.json` and its referenced `.cwasm`
-/// artifacts from `manifest_dir`, cross-checking the recorded
+/// Read + validate a `<stem>.cwasm.json` manifest sidecar and its
+/// referenced `.cwasm` artifacts (resolved relative to the manifest
+/// file's parent directory), cross-checking the recorded
 /// `component_sha256` against `expected_component_bytes`.
 ///
 /// The returned `LoadedManifest.precompiledCores()` slice can be
 /// handed straight to `instance.instantiateWithOptions`.
 pub fn loadManifest(
     allocator: std.mem.Allocator,
-    manifest_dir: []const u8,
+    manifest_path: []const u8,
     expected_component_bytes: []const u8,
 ) LoadError!LoadedManifest {
     const cwd = std.Io.Dir.cwd();
     const io = std.Io.Threaded.global_single_threaded.io();
-    var dir = cwd.openDir(io, manifest_dir, .{}) catch return error.ManifestNotFound;
+    const parent = std.fs.path.dirname(manifest_path) orelse ".";
+    const filename = std.fs.path.basename(manifest_path);
+    var dir = cwd.openDir(io, parent, .{}) catch return error.ManifestNotFound;
     defer dir.close(io);
 
-    const json_bytes = dir.readFileAlloc(io, "manifest.json", allocator, @enumFromInt(4 * 1024 * 1024)) catch
+    const json_bytes = dir.readFileAlloc(io, filename, allocator, @enumFromInt(4 * 1024 * 1024)) catch
         return error.ManifestNotFound;
     defer allocator.free(json_bytes);
 
@@ -809,19 +335,6 @@ pub fn loadManifest(
     };
 }
 
-/// Sniff the first 8 bytes of `data` for the component magic +
-/// version pair. Returns `true` for a component, `false` for a core
-/// module, `error.InvalidMagic` for anything else.
-pub fn isComponent(data: []const u8) error{InvalidMagic}!bool {
-    if (data.len < 8) return error.InvalidMagic;
-    const magic = std.mem.readInt(u32, data[0..4], .little);
-    if (magic != core_types.wasm_magic) return error.InvalidMagic;
-    const version = std.mem.readInt(u32, data[4..8], .little);
-    if (version == core_types.component_version) return true;
-    if (version == core_types.wasm_version) return false;
-    return error.InvalidMagic;
-}
-
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 test "isComponent: core module vs component" {
@@ -834,20 +347,20 @@ test "isComponent: core module vs component" {
     try std.testing.expectError(error.InvalidMagic, isComponent(&.{}));
 }
 
-test "defaultPrecompiledDirFor: strips .wasm and appends .cwasm.d (#645)" {
+test "defaultManifestPathFor: strips .wasm and appends .cwasm.json (#645)" {
     const alloc = std.testing.allocator;
 
-    const a = try defaultPrecompiledDirFor(alloc, "/tmp/stdio-echo.wasm");
+    const a = try defaultManifestPathFor(alloc, "/tmp/stdio-echo.wasm");
     defer alloc.free(a);
-    try std.testing.expectEqualStrings("/tmp/stdio-echo.cwasm.d", a);
+    try std.testing.expectEqualStrings("/tmp/stdio-echo.cwasm.json", a);
 
     // No .wasm suffix → append directly (preserves the prior fallback).
-    const b = try defaultPrecompiledDirFor(alloc, "/tmp/stdio-echo");
+    const b = try defaultManifestPathFor(alloc, "/tmp/stdio-echo");
     defer alloc.free(b);
-    try std.testing.expectEqualStrings("/tmp/stdio-echo.cwasm.d", b);
+    try std.testing.expectEqualStrings("/tmp/stdio-echo.cwasm.json", b);
 
     // .wasm appears mid-path but not as suffix → don't strip.
-    const c = try defaultPrecompiledDirFor(alloc, "/tmp/a.wasm.bak");
+    const c = try defaultManifestPathFor(alloc, "/tmp/a.wasm.bak");
     defer alloc.free(c);
-    try std.testing.expectEqualStrings("/tmp/a.wasm.bak.cwasm.d", c);
+    try std.testing.expectEqualStrings("/tmp/a.wasm.bak.cwasm.json", c);
 }

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -1,0 +1,536 @@
+//! Component / core-module AOT precompilation (compile-only half).
+//!
+//! Split out of `src/component/aot.zig` so the runtime CLI (`wamr`)
+//! can link against the manifest loader without dragging in the
+//! compiler crate. The runtime-only declarations
+//! (`LoadedManifest`, `loadManifest`, `defaultManifestPathFor`,
+//! manifest JSON schema, `isComponent`) live in `aot.zig`; this file
+//! owns `compileCoreWasm`, `precompileComponent`, and the
+//! `emit_aot` field-table builders that only the compile side uses.
+//!
+//! `Manifest` / `ManifestModuleEntry` / `manifest_format_version` are
+//! re-exported from `aot.zig` here so the on-disk JSON shape stays
+//! single-source-of-truth in `aot.zig`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const ctypes = @import("types.zig");
+const component_loader = @import("loader.zig");
+const aot = @import("aot.zig");
+const core_loader = @import("../runtime/interpreter/loader.zig");
+const frontend = @import("../compiler/frontend.zig");
+const passes = @import("../compiler/ir/passes.zig");
+const x86_64_compile = @import("../compiler/codegen/x86_64/compile.zig");
+const aarch64_compile = @import("../compiler/codegen/aarch64/compile.zig");
+const emit_aot = @import("../compiler/emit_aot.zig");
+const core_types = @import("../runtime/common/types.zig");
+const interp_instance = @import("../runtime/interpreter/instance.zig");
+const config = @import("../config.zig");
+
+// Re-export the on-disk JSON schema from `aot.zig` so `precompileComponent`
+// and `loadManifest` agree on layout without duplicating the schema.
+pub const Manifest = aot.Manifest;
+pub const ManifestModuleEntry = aot.ManifestModuleEntry;
+pub const manifest_format_version = aot.manifest_format_version;
+
+pub const PrecompileError = error{
+    InvalidComponent,
+    CoreCompileFailed,
+    WriteFailed,
+    OutOfMemory,
+    OpenDirFailed,
+    JsonSerializationFailed,
+};
+
+/// Options controlling `precompileComponent`. Today only the target
+/// arch is exposed; future options (opt level, dump-ir hooks, …) slot
+/// in here without breaking the API.
+pub const PrecompileOptions = struct {
+    target_arch: passes.TargetArch = switch (builtin.cpu.arch) {
+        .aarch64 => .aarch64,
+        else => .x86_64,
+    },
+};
+
+/// AOT-compile a single core wasm module. Returns freshly-allocated
+/// `.cwasm` bytes owned by the caller (free with `allocator.free`).
+///
+/// Pure data in / data out — no filesystem I/O — so the same helper
+/// services both `precompileComponent` and any future programmatic
+/// caller that wants per-core artifacts in memory.
+pub fn compileCoreWasm(
+    allocator: std.mem.Allocator,
+    wasm_bytes: []const u8,
+    opts: PrecompileOptions,
+) PrecompileError![]u8 {
+    // Lifetime split mirrors `src/compiler/main.zig` (`wamrc compile`)
+    // to bound peak memory on large modules (issue #640). The parsed
+    // module lives in a transient `module_arena`; IR + passes +
+    // codegen go on the outer GPA so per-function intermediates are
+    // freed back as each pass completes; emit-side field tables live
+    // in a short-lived `emit_arena`. Lumping everything on one arena
+    // (the previous implementation) retained tens of GB on a
+    // 12 610-function core.
+    var module_arena = std.heap.ArenaAllocator.init(allocator);
+    defer module_arena.deinit();
+    const ma = module_arena.allocator();
+
+    // Don't dupe `wasm_bytes`: `core_loader.load` only borrows from
+    // the slice (returned `module` fields are slices into it), and
+    // the caller's bytes outlive this call.
+    const module = core_loader.load(wasm_bytes, ma) catch return error.CoreCompileFailed;
+
+    var ir_module = frontend.lowerModule(&module, allocator) catch return error.CoreCompileFailed;
+    defer ir_module.deinit();
+
+    _ = passes.runPassesWithOptions(
+        &ir_module,
+        passes.defaultPassesForTarget(opts.target_arch),
+        allocator,
+        .{ .verify_mode = .off },
+    ) catch return error.CoreCompileFailed;
+
+    const code: []u8, const offsets: []u32 = switch (opts.target_arch) {
+        .aarch64 => blk: {
+            const r = aarch64_compile.compileModule(&ir_module, allocator) catch return error.CoreCompileFailed;
+            break :blk .{ r.code, r.offsets };
+        },
+        .x86_64 => blk: {
+            const r = x86_64_compile.compileModule(&ir_module, allocator) catch return error.CoreCompileFailed;
+            break :blk .{ r.code, r.offsets };
+        },
+    };
+    defer allocator.free(code);
+    defer allocator.free(offsets);
+
+    // Short-lived arena for the emit-side field tables. `emit_aot.emit`
+    // copies what it needs into its caller-owned output buffer, so
+    // everything in here (and in `module_arena`) is safe to drop on
+    // return.
+    var emit_arena = std.heap.ArenaAllocator.init(allocator);
+    defer emit_arena.deinit();
+    const ea = emit_arena.allocator();
+
+    var exports: std.ArrayList(emit_aot.ExportEntry) = .empty;
+    for (module.exports) |exp| {
+        if (exp.kind == .tag) continue;
+        exports.append(ea, .{
+            .name = exp.name,
+            .kind = @enumFromInt(@intFromEnum(exp.kind)),
+            .index = exp.index,
+        }) catch return error.OutOfMemory;
+    }
+
+    var imports: std.ArrayList(emit_aot.ImportEntry) = .empty;
+    for (module.imports) |imp| {
+        switch (imp.kind) {
+            .function => imports.append(ea, .{
+                .module_name = imp.module_name,
+                .field_name = imp.field_name,
+                .kind = .function,
+                .func_type_idx = imp.func_type_idx orelse 0,
+            }) catch return error.OutOfMemory,
+            .table => {
+                const table_type = imp.table_type orelse continue;
+                imports.append(ea, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .table,
+                    .table_elem_type = table_type.elem_type,
+                    .table_min = @intCast(table_type.limits.min),
+                    .table_max = if (table_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
+                }) catch return error.OutOfMemory;
+            },
+            .memory => {
+                const memory_type = imp.memory_type orelse continue;
+                imports.append(ea, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .memory,
+                    .memory_min = @intCast(memory_type.limits.min),
+                    .memory_max = if (memory_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
+                    .memory_is64 = memory_type.is_memory64,
+                }) catch return error.OutOfMemory;
+            },
+            .global => {
+                const global_type = imp.global_type orelse continue;
+                imports.append(ea, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .global,
+                    .global_val_type = global_type.val_type,
+                    .global_mutable = global_type.mutability == .mutable,
+                }) catch return error.OutOfMemory;
+            },
+            .tag => {
+                const type_idx = imp.tag_type_idx orelse continue;
+                imports.append(ea, .{
+                    .module_name = imp.module_name,
+                    .field_name = imp.field_name,
+                    .kind = .tag,
+                    .tag_type_idx = type_idx,
+                }) catch return error.OutOfMemory;
+            },
+        }
+    }
+
+    var mem_entries: std.ArrayList(emit_aot.MemoryEntry) = .empty;
+    for (module.memories) |mem| {
+        mem_entries.append(ea, .{
+            .min_pages = @intCast(mem.limits.min),
+            .max_pages = if (mem.limits.max) |m| @as(?u32, @intCast(m)) else null,
+        }) catch return error.OutOfMemory;
+    }
+
+    // Locally-defined tables (#681). Imported tables already round-trip
+    // via `import_entries`; local tables need section 15 so the loader
+    // populates `module.tables` and `allocateTables` creates the matching
+    // `TableInstance`s. wit-component cores rely on this for
+    // `(table $imports)`.
+    var table_entries: std.ArrayList(emit_aot.TableEntry) = .empty;
+    for (module.tables) |t| {
+        table_entries.append(ea, .{
+            .elem_type = t.elem_type,
+            .min = @intCast(t.limits.min),
+            .max = if (t.limits.max) |m| @as(?u32, @intCast(m)) else null,
+        }) catch return error.OutOfMemory;
+    }
+
+    var data_segs: std.ArrayList(emit_aot.DataSegmentEntry) = .empty;
+    for (module.data_segments) |seg| {
+        if (seg.is_passive) continue;
+        const offset: u32 = switch (seg.offset) {
+            .i32_const => |v| @bitCast(v),
+            else => continue,
+        };
+        data_segs.append(ea, .{
+            .memory_idx = seg.memory_idx,
+            .offset = offset,
+            .data = seg.data,
+        }) catch return error.OutOfMemory;
+    }
+
+    var func_type_entries: std.ArrayList(emit_aot.FuncTypeEntry) = .empty;
+    for (module.types) |ft| {
+        if (ft.kind != .func) {
+            func_type_entries.append(ea, .{ .params = &.{}, .results = &.{} }) catch return error.OutOfMemory;
+            continue;
+        }
+        const params_bytes = ea.alloc(u8, ft.params.len) catch return error.OutOfMemory;
+        for (ft.params, 0..) |p, j| params_bytes[j] = @intFromEnum(p);
+        const results_bytes = ea.alloc(u8, ft.results.len) catch return error.OutOfMemory;
+        for (ft.results, 0..) |r, j| results_bytes[j] = @intFromEnum(r);
+        func_type_entries.append(ea, .{ .params = params_bytes, .results = results_bytes }) catch return error.OutOfMemory;
+    }
+
+    var local_func_tidx_list: std.ArrayList(u32) = .empty;
+    for (module.functions) |f| {
+        local_func_tidx_list.append(ea, f.type_idx) catch return error.OutOfMemory;
+    }
+
+    // Locally-declared tags (#672). `module.tag_types` is parallel to the
+    // wasm tag section: each entry is a function-type index describing the
+    // exception parameters.
+    var tag_entries: std.ArrayList(emit_aot.TagEntry) = .empty;
+    for (module.tag_types) |type_idx| {
+        tag_entries.append(ea, .{ .type_idx = type_idx }) catch return error.OutOfMemory;
+    }
+
+    // Build global entries in wasm-flat order (imported globals first,
+    // then local globals). `evalInitExpr` is shared with the on-disk
+    // wamrc path so the resulting `.cwasm` is byte-identical for this
+    // section. `tmp_globals` is the running prefix `evalInitExpr` uses
+    // to resolve `global.get` in a `global` init expression.
+    var global_entries: std.ArrayList(emit_aot.GlobalEntry) = .empty;
+    var tmp_globals: std.ArrayList(*core_types.GlobalInstance) = .empty;
+    defer {
+        for (tmp_globals.items) |g| allocator.destroy(g);
+        tmp_globals.deinit(allocator);
+    }
+    for (module.imports) |imp| {
+        if (imp.kind != .global) continue;
+        const gt = imp.global_type orelse continue;
+        const val = defaultZeroValue(gt.val_type);
+        const gi = allocator.create(core_types.GlobalInstance) catch return error.OutOfMemory;
+        gi.* = .{ .global_type = gt, .value = val };
+        tmp_globals.append(allocator, gi) catch return error.OutOfMemory;
+        global_entries.append(ea, .{
+            .val_type = @intFromEnum(gt.val_type),
+            .mutability = if (gt.mutability == .mutable) @as(u8, 1) else @as(u8, 0),
+            .init_i64 = valueToI64(val),
+            .init_v128 = valueToV128(val),
+        }) catch return error.OutOfMemory;
+    }
+    for (module.globals) |g| {
+        const val = interp_instance.evalInitExpr(g.init_expr, tmp_globals.items, null) catch defaultZeroValue(g.global_type.val_type);
+        const gi = allocator.create(core_types.GlobalInstance) catch return error.OutOfMemory;
+        gi.* = .{ .global_type = g.global_type, .value = val };
+        tmp_globals.append(allocator, gi) catch return error.OutOfMemory;
+        global_entries.append(ea, .{
+            .val_type = @intFromEnum(g.global_type.val_type),
+            .mutability = if (g.global_type.mutability == .mutable) @as(u8, 1) else @as(u8, 0),
+            .init_i64 = valueToI64(val),
+            .init_v128 = valueToV128(val),
+        }) catch return error.OutOfMemory;
+    }
+
+    // Build element segment entries. Declarative segments contribute
+    // nothing at runtime; passive segments emit with offset = 0 and
+    // `is_passive = true` (only usable via `table.init`). Funcidx
+    // null sentinels are encoded as `0xFFFFFFFF`, matching the loader.
+    var elem_entries: std.ArrayList(emit_aot.ElemEntry) = .empty;
+    for (module.elements) |seg| {
+        if (seg.is_declarative) continue;
+        const offset: u32 = if (seg.is_passive) 0 else blk: {
+            const off = seg.offset orelse continue;
+            break :blk switch (off) {
+                .i32_const => |v| @as(u32, @bitCast(v)),
+                else => continue,
+            };
+        };
+        const indices = ea.alloc(u32, seg.func_indices.len) catch return error.OutOfMemory;
+        for (seg.func_indices, 0..) |fi, j| {
+            indices[j] = fi orelse 0xFFFFFFFF;
+        }
+        elem_entries.append(ea, .{
+            .table_idx = seg.table_idx,
+            .offset = offset,
+            .func_indices = indices,
+            .is_passive = seg.is_passive,
+        }) catch return error.OutOfMemory;
+    }
+
+    var arch_name = std.mem.zeroes([16]u8);
+    switch (opts.target_arch) {
+        .x86_64 => @memcpy(arch_name[0..6], "x86-64"),
+        .aarch64 => @memcpy(arch_name[0..7], "aarch64"),
+    }
+
+    return emit_aot.emit(
+        allocator,
+        code,
+        offsets,
+        exports.items,
+        .{ .arch = arch_name },
+        if (data_segs.items.len > 0) data_segs.items else null,
+        if (imports.items.len > 0) imports.items else null,
+        if (mem_entries.items.len > 0) mem_entries.items else null,
+        // Plain wasm32-wasip1 modules (AssemblyScript / Rust / clang
+        // wasi-libc) carry a mutable `i32` shadow stack pointer global
+        // that every function prologue reads/writes; failing to emit it
+        // leaves SP=0 at startup and AS aborts inside its runtime with
+        // `abort:  in (1:1)`. Componentize-js cores tolerate empty
+        // globals/elems because canon-lift wraps them; standalone cores
+        // do not. See `phase-b-diagnosis.md` (#662 Phase B).
+        if (global_entries.items.len > 0) global_entries.items else null,
+        if (elem_entries.items.len > 0) elem_entries.items else null,
+        module.start_function,
+        if (func_type_entries.items.len > 0) func_type_entries.items else null,
+        if (local_func_tidx_list.items.len > 0) local_func_tidx_list.items else null,
+        if (tag_entries.items.len > 0) tag_entries.items else null,
+        if (table_entries.items.len > 0) table_entries.items else null,
+    ) catch return error.CoreCompileFailed;
+}
+
+// ── Global / element entry builders ─────────────────────────────────────
+//
+// Mirrors `src/compiler/main.zig`'s `runCompile` so the in-process AOT
+// compile produces the same `.cwasm` layout the on-disk path does. The
+// helpers here are deliberately self-contained (no cross-imports of
+// file-private functions in `compiler/main.zig`) to keep this fix
+// surgical; the duplication can be deduplicated in a follow-up by
+// hoisting them into `emit_aot.zig` or a new shared file.
+
+fn defaultZeroValue(vt: core_types.ValType) core_types.Value {
+    return switch (vt) {
+        .i32 => .{ .i32 = 0 },
+        .i64 => .{ .i64 = 0 },
+        .f32 => .{ .f32 = 0 },
+        .f64 => .{ .f64 = 0 },
+        .v128 => .{ .v128 = 0 },
+        .funcref => .{ .funcref = null },
+        .externref => .{ .externref = null },
+        .nonfuncref => .{ .nonfuncref = null },
+        .nonexternref => .{ .nonexternref = null },
+        else => .{ .i64 = 0 },
+    };
+}
+
+fn valueToI64(v: core_types.Value) i64 {
+    return switch (v) {
+        .i32 => |x| @as(i64, @as(u32, @bitCast(x))),
+        .i64 => |x| x,
+        .f32 => |x| @as(i64, @as(u32, @bitCast(x))),
+        .f64 => |x| @as(i64, @bitCast(x)),
+        .funcref, .nonfuncref => |maybe| if (maybe) |x| @as(i64, @as(u32, x)) + 1 else 0,
+        .externref, .nonexternref => |maybe| if (maybe) |x| @as(i64, @as(u32, x)) + 1 else 0,
+        else => 0,
+    };
+}
+
+fn valueToV128(v: core_types.Value) u128 {
+    return switch (v) {
+        .v128 => |x| x,
+        else => 0,
+    };
+}
+
+/// Hex-encode a sha256 digest into a fresh allocator-owned string.
+fn hexSha256(allocator: std.mem.Allocator, bytes: []const u8) ![]u8 {
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    const hex = try allocator.alloc(u8, digest.len * 2);
+    const hex_chars = "0123456789abcdef";
+    for (digest, 0..) |b, i| {
+        hex[i * 2] = hex_chars[b >> 4];
+        hex[i * 2 + 1] = hex_chars[b & 0x0f];
+    }
+    return hex;
+}
+
+/// Result of `precompileComponent`. The returned `Manifest`'s strings
+/// are arena-allocated and freed by `deinit` together with the arena.
+pub const PrecompileResult = struct {
+    manifest: Manifest,
+    arena: *std.heap.ArenaAllocator,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *PrecompileResult) void {
+        self.arena.deinit();
+        self.allocator.destroy(self.arena);
+    }
+};
+
+/// Precompile every embedded core module of `component_bytes` and
+/// write them as `<stem>.<idx>.cwasm` next to `manifest_path`, with
+/// the manifest JSON itself at `manifest_path`. The "stem" is the
+/// basename of `manifest_path` with the `.cwasm.json` suffix stripped
+/// (or the whole basename if the suffix is absent); cores share that
+/// stem so multiple components can coexist in the same directory.
+///
+/// The parent directory of `manifest_path` is created if missing.
+/// Existing files at the target paths are overwritten — callers
+/// responsible for stale-cache management beyond the manifest's
+/// build-id check.
+pub fn precompileComponent(
+    allocator: std.mem.Allocator,
+    component_bytes: []const u8,
+    manifest_path: []const u8,
+    opts: PrecompileOptions,
+) PrecompileError!PrecompileResult {
+    // Snapshot per-core byte slices off the parsed component, then
+    // drop `load_arena` before the compile loop so the parsed
+    // component (large for componentize-js workloads) isn't live in
+    // memory while each core is being AOT-compiled. The `core_mod.data`
+    // slices borrow from `component_bytes` (owned by the caller), so
+    // they remain valid after `load_arena.deinit()`.
+    //
+    // Recurses into `component.components` so cores inside nested
+    // sub-components (the dominant shape of `wabt component compose -d`
+    // / `wasm-tools compose` output) are precompiled too — without
+    // this the manifest is always empty for composed components and
+    // `--precompiled-manifest` falls back to in-memory AOT on every
+    // cold start. (#676)
+    const CoreRef = struct {
+        data: []const u8,
+        /// Position within the `core_modules[]` of the (sub-)component
+        /// that directly contains this core. Persisted as
+        /// `ManifestModuleEntry.idx` for human debugging and for the
+        /// v1-fallback loader path.
+        local_idx: u32,
+    };
+    var core_data_list: std.ArrayList(CoreRef) = .empty;
+    defer core_data_list.deinit(allocator);
+    {
+        var load_arena = std.heap.ArenaAllocator.init(allocator);
+        defer load_arena.deinit();
+        const component = component_loader.load(component_bytes, load_arena.allocator()) catch
+            return error.InvalidComponent;
+        const Walker = struct {
+            fn walk(
+                comp: *const ctypes.Component,
+                list: *std.ArrayList(CoreRef),
+                alloc: std.mem.Allocator,
+            ) PrecompileError!void {
+                for (comp.core_modules, 0..) |cm, mi| {
+                    list.append(alloc, .{ .data = cm.data, .local_idx = @intCast(mi) }) catch
+                        return error.OutOfMemory;
+                }
+                for (comp.components) |child| {
+                    try walk(child, list, alloc);
+                }
+            }
+        };
+        try Walker.walk(&component, &core_data_list, allocator);
+    }
+
+    // Result-owned arena holds all strings the caller might read off
+    // the returned Manifest (paths, hex hashes, build id).
+    const result_arena = allocator.create(std.heap.ArenaAllocator) catch return error.OutOfMemory;
+    errdefer allocator.destroy(result_arena);
+    result_arena.* = std.heap.ArenaAllocator.init(allocator);
+    errdefer result_arena.deinit();
+    const ra = result_arena.allocator();
+
+    const cwd = std.Io.Dir.cwd();
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const parent_dir_path = std.fs.path.dirname(manifest_path) orelse ".";
+    const manifest_filename = std.fs.path.basename(manifest_path);
+    const core_stem = if (std.mem.endsWith(u8, manifest_filename, ".cwasm.json"))
+        manifest_filename[0 .. manifest_filename.len - ".cwasm.json".len]
+    else
+        manifest_filename;
+    cwd.createDirPath(io, parent_dir_path) catch return error.OpenDirFailed;
+    var dir = cwd.openDir(io, parent_dir_path, .{}) catch return error.OpenDirFailed;
+    defer dir.close(io);
+
+    var entries: std.ArrayList(ManifestModuleEntry) = .empty;
+    entries.ensureTotalCapacity(ra, core_data_list.items.len) catch return error.OutOfMemory;
+
+    for (core_data_list.items, 0..) |core_ref, idx| {
+        const cwasm = compileCoreWasm(allocator, core_ref.data, opts) catch |err| {
+            std.log.err("precompileComponent: core {d} compile failed: {s}", .{ idx, @errorName(err) });
+            return err;
+        };
+        defer allocator.free(cwasm);
+
+        const rel_path = std.fmt.allocPrint(ra, "{s}.{d}.cwasm", .{ core_stem, idx }) catch return error.OutOfMemory;
+
+        dir.writeFile(io, .{ .sub_path = rel_path, .data = cwasm }) catch |err| {
+            std.log.err("precompileComponent: write {s}/{s} failed: {s}", .{ parent_dir_path, rel_path, @errorName(err) });
+            return error.WriteFailed;
+        };
+
+        const hex = hexSha256(ra, cwasm) catch return error.OutOfMemory;
+        const core_hex = hexSha256(ra, core_ref.data) catch return error.OutOfMemory;
+        entries.append(ra, .{
+            .idx = core_ref.local_idx,
+            .path = rel_path,
+            .sha256 = hex,
+            .core_sha256 = core_hex,
+        }) catch return error.OutOfMemory;
+    }
+
+    const component_hex = hexSha256(ra, component_bytes) catch return error.OutOfMemory;
+    const build_id = ra.dupe(u8, config.version) catch return error.OutOfMemory;
+
+    const manifest = Manifest{
+        .version = manifest_format_version,
+        .wamr_build_id = build_id,
+        .component_sha256 = component_hex,
+        .modules = entries.items,
+    };
+
+    // Serialize the manifest sidecar.
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    var stringify: std.json.Stringify = .{ .writer = &aw.writer, .options = .{ .whitespace = .indent_2 } };
+    stringify.write(manifest) catch return error.JsonSerializationFailed;
+    dir.writeFile(io, .{ .sub_path = manifest_filename, .data = aw.written() }) catch return error.WriteFailed;
+
+    return .{
+        .manifest = manifest,
+        .arena = result_arena,
+        .allocator = allocator,
+    };
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -102,13 +102,12 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     // rewrites synchronously after every mutation. Null ⇒ in-memory
     // only (default, behaviour-compatible with PR #601).
     var keyvalue_store_path: ?[]const u8 = null;
-    // `--precompiled-dir=<path>` (#642): explicit path to a
-    // `wamrc compile-component` output bundle (manifest.json + per-core
-    // .cwasm artifacts). When unset, `runRun` probes for a sibling
-    // `<input>.cwasm.d/manifest.json` next to the component file and
-    // uses it on a best-effort basis (mismatch → warning + interpreter
-    // fallback). When set, the bundle is mandatory: any error is fatal.
-    var precompiled_dir: ?[]const u8 = null;
+    // `--precompiled-manifest=<path>` (#642, #680): explicit path to a
+    // `wamrc compile-component` manifest sidecar (`<stem>.cwasm.json`).
+    // When unset, `runRun` probes for a sibling `<input>.cwasm.json`
+    // next to the component file. Missing/stale bundle is fatal — the
+    // `wamr` CLI no longer embeds the AOT compiler.
+    var precompiled_manifest: ?[]const u8 = null;
     var listen_address: ?std.Io.net.IpAddress = null;
     // `--tls-cert=<path>` + `--tls-key=<path>` (or the combined
     // `--tls-pem=<path>`) (#583 follow-up to #595): when both cert
@@ -306,31 +305,29 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                     return 2;
                 }
                 keyvalue_store_path = spec;
-            } else if (std.mem.eql(u8, arg, "--precompiled-dir") or std.mem.startsWith(u8, arg, "--precompiled-dir=")) {
-                // `--precompiled-dir <path>` (#642): explicit path to a
-                // `wamrc compile-component` output directory containing
-                // `manifest.json` + `module<N>.cwasm`. Cores in the bundle
-                // are loaded as AOT; cores missing from the manifest fall
-                // back to the interpreter. A mismatched / stale manifest
-                // is a hard error (vs. the silent fallback used by the
-                // sibling auto-detect path below).
-                if (precompiled_dir != null) {
-                    std.debug.print("error: --precompiled-dir specified more than once\n", .{});
+            } else if (std.mem.eql(u8, arg, "--precompiled-manifest") or std.mem.startsWith(u8, arg, "--precompiled-manifest=")) {
+                // `--precompiled-manifest <path>` (#642, #680): explicit
+                // path to a `wamrc compile-component` manifest sidecar
+                // (`<stem>.cwasm.json`). Per-core `.cwasm` files
+                // resolve relative to the manifest's directory. A
+                // mismatched / stale manifest is a hard error.
+                if (precompiled_manifest != null) {
+                    std.debug.print("error: --precompiled-manifest specified more than once\n", .{});
                     return 2;
                 }
-                const spec = if (std.mem.eql(u8, arg, "--precompiled-dir")) blk: {
+                const spec = if (std.mem.eql(u8, arg, "--precompiled-manifest")) blk: {
                     i += 1;
                     if (i >= run_args.len) {
-                        std.debug.print("error: --precompiled-dir requires a path to a wamrc compile-component output dir\n", .{});
+                        std.debug.print("error: --precompiled-manifest requires a path to a wamrc compile-component manifest\n", .{});
                         return 2;
                     }
                     break :blk run_args[i];
-                } else arg["--precompiled-dir=".len..];
+                } else arg["--precompiled-manifest=".len..];
                 if (spec.len == 0) {
-                    std.debug.print("error: --precompiled-dir path is empty\n", .{});
+                    std.debug.print("error: --precompiled-manifest path is empty\n", .{});
                     return 2;
                 }
-                precompiled_dir = spec;
+                precompiled_manifest = spec;
             } else if (std.mem.eql(u8, arg, "--trace-aot-wasi")) {
                 wamr.aot_host_bridge.trace_enabled = true;
             } else if (std.mem.eql(u8, arg, "--")) {
@@ -440,154 +437,80 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                 std.debug.print("Error: --config-store '{s}': {}\n", .{ config_store_path orelse "", err });
                 return 2;
             };
-            // #642 / #644: resolve the AOT precompiled-cores bundle. The
-            // `wamr` CLI is AOT-only — every component core must be
+            // #644 / #680: resolve the AOT precompiled-cores manifest.
+            // The `wamr` CLI is AOT-only and the runtime no longer
+            // embeds the compiler — every component core must be
             // available as a precompiled `.cwasm`, or instantiation
-            // fails hard with `error.AotImportUnresolvable` (the
-            // interp fallback is disabled at the CLI surface; library
-            // callers still get the legacy silent demotion by leaving
+            // fails hard with `error.AotImportUnresolvable` (the interp
+            // fallback is disabled at the CLI surface; library callers
+            // still get the legacy silent demotion by leaving
             // `Options.aot_only` unset).
             //
-            //  * `--precompiled-dir <path>` (explicit): any error
+            //  * `--precompiled-manifest <path>` (explicit): any error
             //    opening / validating the manifest is fatal so the user
             //    knows the AOT path isn't being taken.
-            //  * sibling `<input>.cwasm.d/manifest.json` (auto-detect):
-            //    used when present and valid; mismatch / stale → one
-            //    `warning: ...` line on stderr and we fall through to
-            //    the in-memory auto-precompile path below.
-            //  * neither found → AOT-compile each core to memory on
-            //    the fly. Single-run cost; users who care about
-            //    cold-start should `wamrc compile-component` once and
-            //    pass `--precompiled-dir` or use a sibling
-            //    `<input>.cwasm.d`.
+            //  * sibling `<input>.cwasm.json` (auto-detect):
+            //    used when present and valid.
+            //  * neither found → hard error. The `wamr` binary no
+            //    longer embeds the AOT compiler (issue #680); users
+            //    must run `wamrc compile-component <component.wasm>`
+            //    or `wamrc run <component.wasm>` first.
             //
             // The `LoadedManifest`'s lifetime must outlive
             // `runComponent` / `runHttpComponent` because the mmapped
             // `.cwasm` buffers it owns are borrowed by the
             // `PrecompiledCore` slice handed to the instance loader.
-            // The in-memory auto-precompile path owns its `.cwasm`
-            // slices on `allocator`; the defer below frees them.
             var loaded_manifest: ?wamr.component_aot.LoadedManifest = null;
             defer if (loaded_manifest) |*lm| lm.deinit();
 
-            var auto_cores: std.ArrayListUnmanaged(wamr.component_core_backend.PrecompiledCore) = .empty;
-            defer {
-                for (auto_cores.items) |pc| allocator.free(pc.cwasm_bytes);
-                auto_cores.deinit(allocator);
-            }
-
-            if (precompiled_dir) |dir| {
-                loaded_manifest = wamr.component_aot.loadManifest(allocator, dir, wasm_data) catch |err| {
-                    std.debug.print("Error: --precompiled-dir '{s}': {s}\n", .{ dir, loadManifestErrorMessage(err) });
+            if (precompiled_manifest) |mp| {
+                loaded_manifest = wamr.component_aot.loadManifest(allocator, mp, wasm_data) catch |err| {
+                    std.debug.print("Error: --precompiled-manifest '{s}': {s}\n", .{ mp, loadManifestErrorMessage(err) });
                     return 2;
                 };
                 const n = loaded_manifest.?.precompiledCores().len;
-                std.debug.print("wamr: loaded AOT bundle from {s} ({d} core{s} precompiled)\n", .{ dir, n, if (n == 1) @as([]const u8, "") else "s" });
+                std.debug.print("wamr: loaded AOT manifest from {s} ({d} core{s} precompiled)\n", .{ mp, n, if (n == 1) @as([]const u8, "") else "s" });
             } else {
-                // Auto-probe `<input>.cwasm.d/manifest.json`. Don't
-                // fail the run if the bundle is absent / stale — fall
-                // through to the in-memory auto-precompile path
-                // below.
-                const sibling = wamr.component_aot.defaultPrecompiledDirFor(allocator, path) catch return 1;
+                // Auto-probe `<input>.cwasm.json`. Without an embedded
+                // compiler the absence of a sibling manifest is fatal —
+                // direct the user at `wamrc`.
+                const sibling = wamr.component_aot.defaultManifestPathFor(allocator, path) catch return 1;
                 defer allocator.free(sibling);
-                const probe = std.fs.path.join(allocator, &.{ sibling, "manifest.json" }) catch return 1;
-                defer allocator.free(probe);
                 const io_probe = init.io;
                 const cwd_probe = std.Io.Dir.cwd();
                 const exists = blk: {
-                    var f = cwd_probe.openFile(io_probe, probe, .{}) catch break :blk false;
+                    var f = cwd_probe.openFile(io_probe, sibling, .{}) catch break :blk false;
                     f.close(io_probe);
                     break :blk true;
                 };
-                if (exists) {
-                    if (wamr.component_aot.loadManifest(allocator, sibling, wasm_data)) |lm| {
-                        loaded_manifest = lm;
-                        const n = lm.precompiledCores().len;
-                        std.debug.print("wamr: loaded AOT bundle from {s} ({d} core{s} precompiled)\n", .{ sibling, n, if (n == 1) @as([]const u8, "") else "s" });
-                    } else |err| {
-                        std.debug.print("warning: ignoring AOT bundle at {s}: {s}\n", .{ sibling, loadManifestErrorMessage(err) });
-                    }
-                }
-
-                // #644: no on-disk bundle → AOT-compile every core to
-                // memory now. The cwasm slices live on `allocator`
-                // (freed by the outer defer) so they outlive both the
-                // parser arena and the `runComponent` call.
-                if (loaded_manifest == null) {
-                    var load_arena = std.heap.ArenaAllocator.init(allocator);
-                    defer load_arena.deinit();
-                    const parsed = wamr.component_loader.load(wasm_data, load_arena.allocator()) catch |err| {
-                        std.debug.print("Error: failed to parse component for auto-precompile: {s}\n", .{@errorName(err)});
-                        return 1;
-                    };
-                    // Recursively collect every core module from the
-                    // top level *and* every nested sub-component. The
-                    // top level of a `wabt component compose -d`
-                    // composed component has zero cores of its own —
-                    // the actual command + adder cores live inside
-                    // its two nested sub-components (#662 phase D).
-                    // Each entry pairs the core's raw module bytes
-                    // (a stable cross-parse identity) with its
-                    // *local* `module_idx` within the component that
-                    // contains it; `Options.findPrecompiled` matches
-                    // on the bytes-slice so sub-component
-                    // instantiations don't collide on shared local
-                    // indices.
-                    const CoreRef = struct {
-                        data: []const u8,
-                        local_idx: u32,
-                    };
-                    var all_cores: std.ArrayListUnmanaged(CoreRef) = .empty;
-                    defer all_cores.deinit(load_arena.allocator());
-                    const Walker = struct {
-                        fn walk(
-                            comp: *const wamr.component_types.Component,
-                            list: *std.ArrayListUnmanaged(CoreRef),
-                            arena: std.mem.Allocator,
-                        ) !void {
-                            for (comp.core_modules, 0..) |cm, mi| {
-                                try list.append(arena, .{ .data = cm.data, .local_idx = @intCast(mi) });
-                            }
-                            for (comp.components) |child| {
-                                try walk(child, list, arena);
-                            }
-                        }
-                    };
-                    Walker.walk(&parsed, &all_cores, load_arena.allocator()) catch return 1;
-                    const ncore = all_cores.items.len;
-                    if (ncore == 0) {
-                        std.debug.print("Error: component contains no core modules\n", .{});
-                        return 1;
-                    }
+                if (!exists) {
                     std.debug.print(
-                        "wamr: auto-precompiling {d} core{s} in memory (no on-disk bundle; pass --precompiled-dir or run `wamrc compile-component` to persist)\n",
-                        .{ ncore, if (ncore == 1) @as([]const u8, "") else "s" },
+                        "Error: no AOT manifest found for '{s}'. The `wamr` runtime no longer embeds the compiler (#680).\n" ++
+                            "  Run `wamrc compile-component {s}` to produce '{s}', or\n" ++
+                            "  run `wamrc run {s} [-- args...]` to compile and execute in one step.\n",
+                        .{ path, path, sibling, path },
                     );
-                    auto_cores.ensureTotalCapacity(allocator, ncore) catch return 1;
-                    for (all_cores.items, 0..) |ref, idx| {
-                        const cwasm = wamr.component_aot.compileCoreWasm(allocator, ref.data, .{}) catch |err| {
-                            std.debug.print(
-                                "Error: auto-precompile failed for core module {d}: {s} (issue #644)\n",
-                                .{ idx, @errorName(err) },
-                            );
-                            return 1;
-                        };
-                        auto_cores.appendAssumeCapacity(.{
-                            .module_idx = ref.local_idx,
-                            .cwasm_bytes = cwasm,
-                            .core_wasm = ref.data,
-                        });
-                    }
+                    return 2;
                 }
+                loaded_manifest = wamr.component_aot.loadManifest(allocator, sibling, wasm_data) catch |err| {
+                    std.debug.print(
+                        "Error: AOT manifest at '{s}' is stale or invalid: {s}.\n" ++
+                            "  Rebuild it with `wamrc compile-component {s}` or run `wamrc run {s}`.\n",
+                        .{ sibling, loadManifestErrorMessage(err), path, path },
+                    );
+                    return 2;
+                };
+                const n = loaded_manifest.?.precompiledCores().len;
+                std.debug.print("wamr: loaded AOT manifest from {s} ({d} core{s} precompiled)\n", .{ sibling, n, if (n == 1) @as([]const u8, "") else "s" });
             }
             const precompiled_cores: []const wamr.component_core_backend.PrecompiledCore =
-                if (loaded_manifest) |lm| lm.precompiledCores() else auto_cores.items;
+                loaded_manifest.?.precompiledCores();
 
             // #644: AOT-only policy. `wamr run` requires a precompiled
             // bundle for every component — there is no interp fallback
-            // at the CLI surface. With auto-precompile above this
-            // should only fire when the component had no core modules
-            // (an empty / malformed input that survived parsing).
+            // at the CLI surface and no in-process compiler. An empty
+            // bundle means the component had no core modules (an
+            // empty / malformed input that survived parsing).
             if (precompiled_cores.len == 0) {
                 std.debug.print(
                     "Error: component has no AOT-compiled cores and `wamr run` is AOT-only.\n" ++
@@ -622,146 +545,22 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
         }
     }
 
-    // Plain core wasm. The `wamr` CLI is AOT-only as of #644 — there
-    // is no interp fallback at the CLI surface. Auto-compile the
-    // module in-process to AOT and run it through the AOT runtime
-    // with WASI preview1 wired up via `src/runtime/aot/host_bridge.zig`.
-    if (comptime !aot_supported) {
-        std.debug.print(
-            "Error: AOT execution is not supported on this architecture, and `wamr run` is AOT-only.\n" ++
-                "  See issue #644.\n",
-            .{},
-        );
-        return 1;
-    }
+    // Plain core wasm. The `wamr` runtime no longer embeds the AOT
+    // compiler (#680) — users must precompile with `wamrc compile`
+    // (or use `wamrc run` for one-shot test execution).
+    _ = aot_supported;
     if (listen_address != null) {
         std.debug.print("Error: --listen is not supported for plain core wasm modules (use a component)\n", .{});
         return 2;
     }
-    return runCoreAot(
-        init.io,
-        allocator,
-        wasm_data,
-        wasm_args.items,
-        env_flags.items,
-        init.environ_map,
-        map_dirs.items,
+    std.debug.print(
+        "Error: '{s}' is a plain core wasm module and the `wamr` runtime is AOT-only (#644)\n" ++
+            "       without an embedded compiler (#680).\n" ++
+            "  Run `wamrc compile {s}` to produce a `.cwasm`, then `wamr run <output>.cwasm`, or\n" ++
+            "  run `wamrc run {s} [-- args...]` to compile and execute in one step.\n",
+        .{ path, path, path },
     );
-}
-
-/// Compile a plain core-wasm module to AOT in-process and execute it
-/// with WASI preview1 host functions resolved via the AOT host
-/// bridge (`src/runtime/aot/host_bridge.zig`). This is the only
-/// supported path for `\0asm` (core) inputs after #644 — the legacy
-/// interpreter `runWasm` was removed. The interpreter remains
-/// available as a library for tests / embedders.
-fn runCoreAot(
-    io: std.Io,
-    allocator: std.mem.Allocator,
-    wasm_data: []const u8,
-    wasm_args: []const []const u8,
-    env_flags: []const []const u8,
-    environ_map: *const std.process.Environ.Map,
-    map_dirs: []const MapDir,
-) u8 {
-    const aot_loader = wamr.aot_loader;
-    const aot_runtime = wamr.aot_runtime;
-
-    // 1. Build the WasiCtx (args, env, preopens). Same lifetime model
-    // as runComponent: borrows strings from caller-owned slices.
-    var ctx = wamr.WasiCtx.init(allocator, io) catch |err| {
-        std.debug.print("Error: failed to init WASI ctx: {s}\n", .{@errorName(err)});
-        return 1;
-    };
-    defer ctx.deinit();
-
-    // argv[0] is the wasm filename (matches the interpreter precedent).
-    // We can't pass `path` here because the caller-side variable lives
-    // higher up; pick "wasm" as a stable placeholder (wasi-libc only
-    // uses argv[0] for `program_invocation_name`, not for routing).
-    var argv_buf = allocator.alloc([]const u8, 1 + wasm_args.len) catch return 1;
-    defer allocator.free(argv_buf);
-    argv_buf[0] = "wasm";
-    for (wasm_args, 0..) |a, i| argv_buf[1 + i] = a;
-    ctx.setArgs(argv_buf);
-
-    var env_buf: std.ArrayListUnmanaged([]const u8) = .empty;
-    defer env_buf.deinit(allocator);
-    if (env_flags.len > 0) {
-        env_buf.ensureTotalCapacity(allocator, env_flags.len) catch return 1;
-        for (env_flags) |kv| env_buf.appendAssumeCapacity(kv);
-    } else {
-        var it = environ_map.array_hash_map.iterator();
-        while (it.next()) |kv| {
-            // wasi-libc expects "NAME=value" strings.
-            const joined = std.fmt.allocPrint(allocator, "{s}={s}", .{ kv.key_ptr.*, kv.value_ptr.* }) catch return 1;
-            env_buf.append(allocator, joined) catch {
-                allocator.free(joined);
-                return 1;
-            };
-        }
-    }
-    defer if (env_flags.len == 0) {
-        // Only free strings we allocated ourselves above.
-        for (env_buf.items) |s| allocator.free(s);
-    };
-    ctx.setEnv(env_buf.items);
-
-    for (map_dirs) |md| {
-        _ = ctx.openMappedDir(md.host_path, md.guest_name) catch |err| {
-            std.debug.print("Error: --map-dir '{s}::{s}': {s}\n", .{ md.host_path, md.guest_name, @errorName(err) });
-            return 1;
-        };
-    }
-
-    // 2. AOT-compile the core wasm in-process. `compileCoreWasm` mirrors
-    // `wamrc compile` exactly so the same artifact would be produced.
-    const cwasm = wamr.component_aot.compileCoreWasm(allocator, wasm_data, .{}) catch |err| {
-        std.debug.print("Error: failed to AOT-compile core wasm: {s}\n", .{@errorName(err)});
-        return 1;
-    };
-    defer allocator.free(cwasm);
-
-    const aot_module = aot_loader.load(cwasm, allocator) catch |err| {
-        std.debug.print("Error: failed to load freshly compiled AOT module: {s}\n", .{@errorName(err)});
-        return 1;
-    };
-    defer aot_loader.unload(&aot_module, allocator);
-
-    const inst = aot_runtime.instantiate(&aot_module, allocator) catch |err| {
-        std.debug.print("Error: failed to instantiate AOT module: {s}\n", .{@errorName(err)});
-        return 1;
-    };
-    defer aot_runtime.destroy(inst);
-
-    aot_runtime.mapCodeExecutable(inst) catch |err| {
-        std.debug.print("Error: failed to map AOT code as executable: {s}\n", .{@errorName(err)});
-        return 1;
-    };
-
-    // 3. Wire the WasiCtx so the AOT WASI adapters in
-    // `runtime/aot/host_bridge.zig` can resolve it via `vmctx.wasi_ctx`.
-    inst.wasi_ctx = @intFromPtr(ctx);
-
-    const func_idx = aot_runtime.findExportFunc(inst, "_start") orelse
-        aot_runtime.findExportFunc(inst, "main") orelse {
-        std.debug.print("Error: no _start or main export\n", .{});
-        return 1;
-    };
-
-    // `_start` / `main` take no params and return no values for the
-    // wasi-libc CRT shape; route through `callFuncScalar` with empty
-    // slices. Any guest call to `proc_exit` short-circuits via
-    // `std.process.exit` inside the host bridge.
-    var results_buf: [0]wamr.aot_runtime.ScalarResult = .{};
-    _ = aot_runtime.callFuncScalar(inst, func_idx, &.{}, &.{}, &.{}, &results_buf) catch |err| {
-        std.debug.print("Error: AOT execution failed: {s}\n", .{@errorName(err)});
-        return 1;
-    };
-
-    // If the guest never called proc_exit, exit_code is null → success.
-    if (ctx.exit_code) |code| return @intCast(code & 0xFF);
-    return 0;
+    return 2;
 }
 
 fn parseMapDir(spec: []const u8) !MapDir {
@@ -1185,17 +984,17 @@ fn writeStdout(io: std.Io, text: []const u8) void {
     stdout_file.writeStreamingAll(io, text) catch {};
 }
 
-/// Map an `HttpsTlsConfig.LoadError` to a short, user-facing
-/// diagnostic string. Used by `runRun` to surface cert / key load
-/// failures before bind in a uniform format.
+/// Map a `component_aot.LoadError` to a short, user-facing
+/// diagnostic string. Used by `runRun` to surface manifest load
+/// failures in a uniform format.
 fn loadManifestErrorMessage(err: wamr.component_aot.LoadError) []const u8 {
     return switch (err) {
-        error.ManifestNotFound => "manifest.json not found in the directory",
-        error.ManifestParseFailed => "manifest.json could not be parsed",
+        error.ManifestNotFound => "manifest sidecar not found at the given path",
+        error.ManifestParseFailed => "manifest sidecar could not be parsed",
         error.ManifestVersionMismatch => "manifest format version not understood by this build",
         error.ManifestBuildIdMismatch => "manifest was produced by a different wamr build (recompile with `wamrc compile-component`)",
-        error.ManifestComponentMismatch => "manifest's component hash does not match this component (stale bundle — recompile with `wamrc compile-component`)",
-        error.ManifestCoreMismatch => "manifest references a core module that does not appear in this component (stale bundle — recompile with `wamrc compile-component`)",
+        error.ManifestComponentMismatch => "manifest's component hash does not match this component (stale — recompile with `wamrc compile-component`)",
+        error.ManifestCoreMismatch => "manifest references a core module that does not appear in this component (stale — recompile with `wamrc compile-component`)",
         error.ComponentParseFailed => "manifest is valid but the component bytes failed to re-parse for nested-core resolution",
         error.CwasmReadFailed => "could not read a .cwasm artifact referenced from the manifest",
         error.CwasmHashMismatch => "a .cwasm artifact's contents differ from the manifest's recorded hash (tampered or partial write)",
@@ -1238,8 +1037,8 @@ const run_usage =
     \\  * `.cwasm`/`.aot` core modules (magic `\0aot`) run via the AOT
     \\    runtime directly.
     \\  * Component-model `.wasm` files run via AOT cores loaded from a
-    \\    `wamrc compile-component` bundle (see --precompiled-dir below).
-    \\    Components without a bundle fail with a clear error.
+    \\    `wamrc compile-component` manifest (see --precompiled-manifest below).
+    \\    Components without a manifest fail with a clear error.
     \\  * Plain core wasm modules are not supported — pre-compile to
     \\    `.cwasm`/`.aot` first.
     \\
@@ -1290,13 +1089,16 @@ const run_usage =
     \\                           file containing both certificate chain
     \\                           and private key. Mutually exclusive with
     \\                           --tls-cert / --tls-key.
-    \\  --precompiled-dir PATH   For components: load AOT-compiled cores from
-    \\                           a `wamrc compile-component` output directory
-    \\                           (containing manifest.json + module<N>.cwasm).
-    \\                           When omitted, `wamr run` auto-detects a
-    \\                           sibling `<input>.cwasm.d/manifest.json`. The
-    \\                           bundle is mandatory: components without one
-    \\                           fail with a clear error (issue #644).
+    \\  --precompiled-manifest PATH
+    \\                           For components: load AOT-compiled cores by
+    \\                           reading a `wamrc compile-component` manifest
+    \\                           sidecar (`<stem>.cwasm.json`). Per-core
+    \\                           `.cwasm` files resolve relative to the
+    \\                           manifest's directory. When omitted, `wamr
+    \\                           run` auto-detects a sibling
+    \\                           `<input>.cwasm.json`. The manifest is
+    \\                           mandatory: components without one fail
+    \\                           with a clear error (issues #644, #680).
     \\
 ;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -378,13 +378,25 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     };
     defer allocator.free(wasm_data);
 
-    // Detect file type by magic bytes: AOT (\0aot) vs Wasm (\0asm)
+    // Detect file type by magic bytes: AOT (\0aot) vs Wasm (\0asm).
+    // For an AOT image we still need a WASI host context (env, argv,
+    // preopens) — the same wiring `runCoreAot` used pre-#680 before the
+    // embedded compiler was removed. The `.cwasm` path now flows
+    // through this code via `wamrc compile` (or `wamrc run`).
     if (wasm_data.len >= 4 and std.mem.readInt(u32, wasm_data[0..4], .little) == wamr.types.aot_magic) {
         if (listen_address != null) {
-            std.debug.print("Error: --listen is not supported for AOT modules; rerun without --aot\n", .{});
+            std.debug.print("Error: --listen is not supported for AOT core modules (use a component)\n", .{});
             return 2;
         }
-        return runAot(wasm_data, allocator);
+        return runAot(
+            init.io,
+            allocator,
+            wasm_data,
+            wasm_args.items,
+            env_flags.items,
+            init.environ_map,
+            map_dirs.items,
+        );
     }
 
     // Distinguish core wasm from a component by the version word
@@ -924,30 +936,89 @@ fn runHttpComponent(
     return 0;
 }
 
-fn runAot(data: []const u8, allocator: std.mem.Allocator) u8 {
+fn runAot(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    data: []const u8,
+    wasm_args: []const []const u8,
+    env_flags: []const []const u8,
+    environ_map: *const std.process.Environ.Map,
+    map_dirs: []const MapDir,
+) u8 {
     if (comptime aot_supported) {
-        return runAotReal(data, allocator);
+        return runAotReal(io, allocator, data, wasm_args, env_flags, environ_map, map_dirs);
     } else {
         std.debug.print("Error: AOT execution not supported on this architecture\n", .{});
         return 1;
     }
 }
 
-fn runAotReal(data: []const u8, allocator: std.mem.Allocator) u8 {
+fn runAotReal(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    data: []const u8,
+    wasm_args: []const []const u8,
+    env_flags: []const []const u8,
+    environ_map: *const std.process.Environ.Map,
+    map_dirs: []const MapDir,
+) u8 {
     const aot_loader = wamr.aot_loader;
     const aot_runtime = wamr.aot_runtime;
 
+    // 1. Build the WasiCtx (args, env, preopens). Same lifetime model
+    // as runComponent: borrows strings from caller-owned slices. This
+    // mirrors the pre-#680 in-process `runCoreAot` setup so the AOT
+    // host-bridge WASI adapters can resolve `vmctx.wasi_ctx`.
+    var ctx = wamr.WasiCtx.init(allocator, io) catch |err| {
+        std.debug.print("Error: failed to init WASI ctx: {s}\n", .{@errorName(err)});
+        return 1;
+    };
+    defer ctx.deinit();
+
+    // argv[0] is a stable placeholder ("wasm"); wasi-libc only uses
+    // it for `program_invocation_name`, not for routing.
+    var argv_buf = allocator.alloc([]const u8, 1 + wasm_args.len) catch return 1;
+    defer allocator.free(argv_buf);
+    argv_buf[0] = "wasm";
+    for (wasm_args, 0..) |a, i| argv_buf[1 + i] = a;
+    ctx.setArgs(argv_buf);
+
+    var env_buf: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer env_buf.deinit(allocator);
+    if (env_flags.len > 0) {
+        env_buf.ensureTotalCapacity(allocator, env_flags.len) catch return 1;
+        for (env_flags) |kv| env_buf.appendAssumeCapacity(kv);
+    } else {
+        var it = environ_map.array_hash_map.iterator();
+        while (it.next()) |kv| {
+            const joined = std.fmt.allocPrint(allocator, "{s}={s}", .{ kv.key_ptr.*, kv.value_ptr.* }) catch return 1;
+            env_buf.append(allocator, joined) catch {
+                allocator.free(joined);
+                return 1;
+            };
+        }
+    }
+    defer if (env_flags.len == 0) {
+        for (env_buf.items) |s| allocator.free(s);
+    };
+    ctx.setEnv(env_buf.items);
+
+    for (map_dirs) |md| {
+        _ = ctx.openMappedDir(md.host_path, md.guest_name) catch |err| {
+            std.debug.print("Error: --map-dir '{s}::{s}': {s}\n", .{ md.host_path, md.guest_name, @errorName(err) });
+            return 1;
+        };
+    }
+
+    // 2. Load + instantiate the AOT image.
     const aot_module = aot_loader.load(data, allocator) catch |err| {
         std.debug.print("Error: failed to load AOT module: {}\n", .{err});
         return 1;
     };
     // Mirror the load/unload pairing used by every other `aot_loader.load`
     // call site in the repo (compiler/emit_aot.zig, tests/coldstart_test.zig,
-    // tests/aot_harness.zig). Without this, `runAotReal` leaks every owned
-    // slice on `AotModule` — func_offsets, local_func_type_indices,
-    // func_types, exports, memories, data_segments, tables, imports,
-    // global_inits, elem_segments — which DebugAllocator prints to stderr
-    // on exit, even though the AOT image executes successfully.
+    // tests/aot_harness.zig). Without this, owned slices on `AotModule`
+    // leak (DebugAllocator prints to stderr on exit).
     defer aot_loader.unload(&aot_module, allocator);
 
     const aot_inst = aot_runtime.instantiate(&aot_module, allocator) catch |err| {
@@ -956,25 +1027,32 @@ fn runAotReal(data: []const u8, allocator: std.mem.Allocator) u8 {
     };
     defer aot_runtime.destroy(aot_inst);
 
-    // Map native code as executable
     aot_runtime.mapCodeExecutable(aot_inst) catch |err| {
         std.debug.print("Error: failed to map code as executable: {}\n", .{err});
         return 1;
     };
 
-    // Find _start or main export
+    // 3. Wire the WasiCtx so the AOT WASI adapters in
+    // `runtime/aot/host_bridge.zig` can resolve it via `vmctx.wasi_ctx`.
+    aot_inst.wasi_ctx = @intFromPtr(ctx);
+
     const func_idx = aot_runtime.findExportFunc(aot_inst, "_start") orelse
         aot_runtime.findExportFunc(aot_inst, "main") orelse {
         std.debug.print("Error: no _start or main function exported in AOT module\n", .{});
         return 1;
     };
 
-    // Execute
-    const result = aot_runtime.callFunc(aot_inst, func_idx, i32) catch |err| {
+    // `_start` / `main` take no params and return no values for the
+    // wasi-libc CRT shape; route through `callFuncScalar` with empty
+    // slices. Any guest call to `proc_exit` short-circuits via
+    // `std.process.exit` inside the host bridge.
+    var results_buf: [0]wamr.aot_runtime.ScalarResult = .{};
+    _ = aot_runtime.callFuncScalar(aot_inst, func_idx, &.{}, &.{}, &.{}, &results_buf) catch |err| {
         std.debug.print("Error: AOT execution failed: {}\n", .{err});
         return 1;
     };
-    std.debug.print("{d}\n", .{result});
+
+    if (ctx.exit_code) |code| return @intCast(code & 0xFF);
     return 0;
 }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -129,6 +129,7 @@ pub const component_indexspace = @import("component/indexspace.zig");
 pub const component_instance = @import("component/instance.zig");
 pub const component_core_backend = @import("component/core_backend.zig");
 pub const component_aot = @import("component/aot.zig");
+pub const component_aot_compile = @import("component/aot_compile.zig");
 
 /// Component Model async ABI (tasks, futures, streams).
 pub const component_async = @import("component/async.zig");

--- a/src/tests/component_precompile_nested_test.zig
+++ b/src/tests/component_precompile_nested_test.zig
@@ -10,7 +10,7 @@
 //! instance section instantiates the sub-component.
 //!
 //! Validates that `precompileComponent` recurses into the
-//! sub-component (writing one `module<N>.cwasm` per leaf core) and
+//! sub-component (writing one `<stem>.<N>.cwasm` per leaf core) and
 //! that `loadManifest` resolves each entry to the live
 //! `core_modules[i].data` slice by `core_sha256`, stamping
 //! `core_wasm` so `Options.findPrecompiled` matches by slice
@@ -25,6 +25,7 @@ const instance = wamr.component_instance;
 const core_types = wamr.types;
 const aot_runtime_mod = wamr.aot_runtime;
 const component_aot = wamr.component_aot;
+const component_aot_compile = wamr.component_aot_compile;
 
 /// Same i32->i32 +42 module used by the phase-1 smoke test.
 const core_wasm = [_]u8{
@@ -119,16 +120,16 @@ test "#676: precompile recurses into nested sub-components" {
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const tmp_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
-    defer allocator.free(tmp_path);
+    const manifest_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}/nested.cwasm.json", .{tmp.sub_path});
+    defer allocator.free(manifest_path);
 
-    var precomp = try component_aot.precompileComponent(allocator, component_bytes, tmp_path, .{});
+    var precomp = try component_aot_compile.precompileComponent(allocator, component_bytes, manifest_path, .{});
     defer precomp.deinit();
     try std.testing.expectEqual(@as(usize, 1), precomp.manifest.modules.len);
     try std.testing.expect(precomp.manifest.modules[0].core_sha256 != null);
     try std.testing.expectEqual(@as(u32, 0), precomp.manifest.modules[0].idx);
 
-    var loaded = try component_aot.loadManifest(allocator, tmp_path, component_bytes);
+    var loaded = try component_aot.loadManifest(allocator, manifest_path, component_bytes);
     defer loaded.deinit();
 
     const pcs = loaded.precompiledCores();

--- a/src/tests/component_precompile_test.zig
+++ b/src/tests/component_precompile_test.zig
@@ -16,6 +16,7 @@ const instance = wamr.component_instance;
 const core_types = wamr.types;
 const aot_runtime_mod = wamr.aot_runtime;
 const component_aot = wamr.component_aot;
+const component_aot_compile = wamr.component_aot_compile;
 
 /// Same i32->i32 +42 module used by the phase-1 smoke test.
 const core_wasm = [_]u8{
@@ -81,19 +82,21 @@ test "#625 phase 2: precompile + loadManifest + instantiate round-trip" {
     defer allocator.free(component_bytes);
 
     // tmp dir that we own + clean up. Path is `.zig-cache/tmp/<sub_path>`
-    // per `std.testing.tmpDir`'s implementation.
+    // per `std.testing.tmpDir`'s implementation. The manifest sidecar
+    // lives at `<tmp>/component.cwasm.json` with cores at
+    // `<tmp>/component.<N>.cwasm`.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const tmp_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
-    defer allocator.free(tmp_path);
+    const manifest_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}/component.cwasm.json", .{tmp.sub_path});
+    defer allocator.free(manifest_path);
 
     // Precompile + write manifest.
-    var precomp = try component_aot.precompileComponent(allocator, component_bytes, tmp_path, .{});
+    var precomp = try component_aot_compile.precompileComponent(allocator, component_bytes, manifest_path, .{});
     defer precomp.deinit();
     try std.testing.expectEqual(@as(usize, 1), precomp.manifest.modules.len);
 
     // Load manifest from disk, verifying hashes + build id.
-    var loaded = try component_aot.loadManifest(allocator, tmp_path, component_bytes);
+    var loaded = try component_aot.loadManifest(allocator, manifest_path, component_bytes);
     defer loaded.deinit();
 
     const pcs = loaded.precompiledCores();
@@ -150,13 +153,13 @@ test "#625 phase 2: loadManifest rejects mismatched component bytes" {
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const tmp_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
-    defer allocator.free(tmp_path);
+    const manifest_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}/component.cwasm.json", .{tmp.sub_path});
+    defer allocator.free(manifest_path);
 
-    var precomp = try component_aot.precompileComponent(allocator, component_bytes, tmp_path, .{});
+    var precomp = try component_aot_compile.precompileComponent(allocator, component_bytes, manifest_path, .{});
     defer precomp.deinit();
 
     // Hash should reject any other bytes.
     const other_bytes = [_]u8{ 0xde, 0xad, 0xbe, 0xef };
-    try std.testing.expectError(error.ManifestComponentMismatch, component_aot.loadManifest(allocator, tmp_path, &other_bytes));
+    try std.testing.expectError(error.ManifestComponentMismatch, component_aot.loadManifest(allocator, manifest_path, &other_bytes));
 }

--- a/tests/wasi-testsuite-adapter/wamr-zig.py
+++ b/tests/wasi-testsuite-adapter/wamr-zig.py
@@ -10,6 +10,13 @@ break the runner.
 The wamr CLI uses a Wasmtime-shaped subcommand layout
 (`wamr run <file.wasm>`, `wamr version`), so the adapter inserts `run` /
 `version` after the binary path.
+
+Since #680, the `wamr` runtime is AOT-only and no longer embeds the
+compiler. This adapter therefore pre-compiles every `.wasm` fixture with
+`wamrc compile -o <sibling>.cwasm` (cached by mtime) and then hands the
+resulting `.cwasm` to `wamr run`. Set `WAMRC` to point at the freshly-built
+`wamrc` binary; the adapter falls back to a `wamrc` sibling of `WAMR` and
+then to `PATH`.
 """
 
 import os
@@ -22,6 +29,26 @@ from typing import Dict, List, Tuple
 
 
 WAMR = shlex.split(os.getenv("WAMR", "wamr"))
+
+
+def _resolve_wamrc() -> List[str]:
+    """Locate the `wamrc` binary. Preference order: $WAMRC, sibling of
+    $WAMR, then `wamrc` on $PATH. Mirrors `findWamrBinary` in
+    `src/compiler/main.zig` (just in reverse — there wamrc finds wamr).
+    """
+    env = os.getenv("WAMRC")
+    if env:
+        return shlex.split(env)
+    if WAMR:
+        sibling = Path(WAMR[0]).resolve().with_name(
+            "wamrc.exe" if os.name == "nt" else "wamrc"
+        )
+        if sibling.exists():
+            return [str(sibling)]
+    return ["wamrc"]
+
+
+WAMRC = _resolve_wamrc()
 
 
 def get_name() -> str:
@@ -80,6 +107,64 @@ def _isolate_preopens(dirs: List[Tuple[Path, str]]) -> List[Tuple[Path, str]]:
     return isolated
 
 
+def _is_component(path: Path) -> bool:
+    """Read the 8-byte wasm prefix and distinguish a component from a
+    core module. Both start with `\\0asm`; core's version word is
+    `0x0000_0001`, component's is `0x0001_000d`.
+    """
+    try:
+        with open(path, "rb") as f:
+            head = f.read(8)
+    except OSError:
+        return False
+    if len(head) < 8 or head[:4] != b"\x00asm":
+        return False
+    return head[4:8] == b"\x0d\x00\x01\x00"
+
+
+def _precompile(test_path: str) -> str:
+    """Compile `<test_path>` to a sibling AOT artifact, skipping
+    recompile if the artifact exists and is newer than the source.
+    Returns the path `wamr run` should be invoked with — the sibling
+    `.cwasm` for core wasm, or the source `.wasm` itself for a
+    component (since `wamr run` auto-probes the sibling
+    `<stem>.cwasm.json` manifest). Inputs that don't end in `.wasm`
+    pass through unchanged.
+
+    Passes `--no-verify-ir` to match the verifier setting the
+    in-process compiler used pre-#680 (`compileCoreWasm` defaults to
+    `.verify_mode = .off`). Verifier failures on production wasm
+    binaries are tracked separately (#662) and already gated through
+    `tests/wasi-testsuite-skip.json`; running the verifier here
+    surfaces those same bugs as adapter failures and breaks suites
+    that previously hit the silent codegen path.
+    """
+    p = Path(test_path)
+    if p.suffix != ".wasm":
+        return test_path
+    if _is_component(p):
+        manifest = p.with_suffix(".cwasm.json")
+        if not manifest.exists() or manifest.stat().st_mtime < p.stat().st_mtime:
+            # `wamrc compile-component` already disables the IR
+            # verifier internally (compileCoreWasm hard-codes
+            # verify_mode=.off), so no extra flag is needed here.
+            subprocess.run(
+                WAMRC + ["compile-component", "-o", str(manifest), str(p)],
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+        return test_path
+    cwasm = p.with_suffix(".cwasm")
+    if cwasm.exists() and cwasm.stat().st_mtime >= p.stat().st_mtime:
+        return str(cwasm)
+    subprocess.run(
+        WAMRC + ["compile", "--no-verify-ir", "-o", str(cwasm), str(p)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    return str(cwasm)
+
+
 def compute_argv(
     test_path: str,
     args_env_dirs: Tuple[List[str], Dict[str, str], List[Tuple[Path, str]]],
@@ -117,6 +202,10 @@ def compute_argv(
     if wasi_world == "wasi:http/service":
         argv += ["--listen"]
 
-    argv += [test_path]
+    # Pre-compile the wasm fixture to its sibling AOT artifact: for
+    # core wasm we get a `.cwasm`; for components we write a
+    # `<stem>.cwasm.json` manifest + per-core `.cwasm` files that
+    # `wamr run` auto-discovers via sibling probing. (#680)
+    argv += [_precompile(test_path)]
     argv += args
     return argv


### PR DESCRIPTION
Strip the AOT compiler from the \`wamr\` runtime binary to reclaim ~5.4 MB of disk, add a one-shot \`wamrc run\` so testing flows stay ergonomic, and flatten the component AOT layout so artifacts live next to the source \`.wasm\` (no \`.cwasm.d/\` bundle directory).

## Disk

- \`wamr\` 21.8 MB → **16.4 MB (-24.8 %)**.
- 0 compiler symbols remain in \`wamr\`; 1066 stay in \`wamrc\`.

## wamr (runtime CLI)

- Physically split \`src/component/aot.zig\`: runtime-only half (\`loadManifest\`, \`LoadedManifest\`, …) keeps the path; compile-only half moves to new \`src/component/aot_compile.zig\`, which \`src/main.zig\` never imports. Zig's per-module tree-shaker then actually drops the compiler.
- \`runCoreAot\` and component auto-precompile now emit hard errors pointing users at \`wamrc compile\` / \`wamrc run\`.
- New flag \`--precompiled-manifest <path>\` (auto-probes \`<input>.cwasm.json\` next to the source when absent).

## wamrc (compiler CLI)

- New \`wamrc run [-o <file>] [--force] [--target=…] <wasm> [-- args]\`: compiles only when format / build-id / mtime changed, then spawns \`wamr\` with stdio inherited and exit code propagated. \`wamr\` resolution order: \`WAMR_BIN\` env → sibling of \`wamrc\` → \`PATH\`.
- Core freshness sidecar: \`<file>.cwasm.id\` (JSON with target + build-id).
- Component freshness: manifest build-id + component hash + core set.
- \`wamrc compile-component [-o <manifest.json>] <wasm>\` writes the sidecar + cores next to the source by default.

## Flat component layout (no legacy back-compat)

\`foo.wasm\` → \`foo.cwasm.json\` (manifest sidecar) + \`foo.0.cwasm\`, \`foo.1.cwasm\`, … all in the same directory. Multiple components per directory don't collide because stems differ.

API migration:
- \`defaultPrecompiledDirFor\` → \`defaultManifestPathFor\`.
- \`loadManifest(dir, …)\` → \`loadManifest(manifest_path, …)\`.
- \`precompileComponent(out_dir, …)\` → \`precompileComponent(manifest_path, …)\`.

## Validation

- \`zig build test --summary all\` → **2938/2945 passed (7 skipped, 0 fail).**
- End-to-end smoke of \`wamrc run\` for both core wasm and component, including freshness cache-hit on second invocation.