### PR TITLE
AOT trap diagnostics: function names + per-call decode globals (#694)

### DIFF
--- a/src/compiler/emit_aot.zig
+++ b/src/compiler/emit_aot.zig
@@ -107,6 +107,18 @@ pub const TagEntry = struct {
     type_idx: u32,
 };
 
+/// Function-name entry round-tripped from the wasm `name` custom section
+/// (subsection 1). `index` is the wasm function index space (imports
+/// first, then locals), matching the parser in
+/// `runtime/common/name_section.zig`. Used by the AOT trap helpers to
+/// resolve `local_func[N]` back to a readable symbol when an AOT-compiled
+/// guest traps. Names are slices into caller-owned buffers; the emitter
+/// copies them into the output.
+pub const FunctionNameEntry = struct {
+    index: u32,
+    name: []const u8,
+};
+
 /// Emit an AOT binary to an owned byte buffer.
 pub fn emit(
     allocator: std.mem.Allocator,
@@ -124,6 +136,7 @@ pub fn emit(
     local_func_type_indices: ?[]const u32,
     tags: ?[]const TagEntry,
     tables: ?[]const TableEntry,
+    function_names: ?[]const FunctionNameEntry,
 ) ![]u8 {
     var buf: std.ArrayList(u8) = .empty;
     errdefer buf.deinit(allocator);
@@ -357,6 +370,28 @@ pub fn emit(
         }
     }
 
+    // Section 7: function names (#694). Round-trips the wasm `name`
+    // custom section's function-names subsection so the AOT trap
+    // helpers can render `local_func[N]` as a symbolic identifier.
+    // Wire format (purely diagnostic — loader treats absence as no-op):
+    //   count: u32 LE
+    //   for each: index: u32 LE, name_len: u32 LE, name bytes
+    // `index` is the wasm function index space (imports first, then
+    // locals), matching `name_section.parseFunctionNames`.
+    if (function_names) |names| {
+        if (names.len > 0) {
+            var tmp: std.ArrayList(u8) = .empty;
+            defer tmp.deinit(allocator);
+            try appendU32Le(&tmp, allocator, @intCast(names.len));
+            for (names) |n| {
+                try appendU32Le(&tmp, allocator, n.index);
+                try appendU32Le(&tmp, allocator, @intCast(n.name.len));
+                try tmp.appendSlice(allocator, n.name);
+            }
+            try emitSection(allocator, &buf, 7, tmp.items);
+        }
+    }
+
     return buf.toOwnedSlice(allocator);
 }
 
@@ -392,7 +427,7 @@ fn buildTargetInfo(options: AotEmitOptions) [40]u8 {
 
 test "emit: minimal (no functions, no exports) has correct magic and version" {
     const allocator = std.testing.allocator;
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // At least header (8) + target_info section (8+40) + text section (8+0) + func section (8+4) + export section (8+4)
@@ -407,7 +442,7 @@ test "emit: one function offset produces valid function section" {
     const allocator = std.testing.allocator;
     const code = [_]u8{ 0xCC, 0xC3 }; // int3; ret
     const offsets = [_]u32{0};
-    const data = try emit(allocator, &code, &offsets, &.{}, .{}, null, null, null, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &code, &offsets, &.{}, .{}, null, null, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // Walk sections to find section type 3 (function)
@@ -438,7 +473,7 @@ test "emit: export section encodes name, kind, and index" {
         .kind = .function,
         .index = 7,
     }};
-    const data = try emit(allocator, &.{}, &.{}, &exports, .{}, null, null, null, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &exports, .{}, null, null, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // Walk sections to find section type 4 (export)
@@ -485,7 +520,7 @@ test "roundtrip: emit then load with AOT loader" {
     const data = try emit(allocator, &code, &offsets, &exports, .{
         .arch = arch_name,
         .e_machine = 0x3E,
-    }, null, null, null, null, null, null, null, null, null, null);
+    }, null, null, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     // Parse back with the AOT loader
@@ -527,7 +562,7 @@ test "emit: import section round-trip" {
         .{ .module_name = "env", .field_name = "tbl", .kind = .table, .table_elem_type = .funcref, .table_min = 8, .table_max = 8 },
         .{ .module_name = "wasi_snapshot_preview1", .field_name = "clock_time_get", .kind = .function, .func_type_idx = 1 },
     };
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, &import_entries, null, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, &import_entries, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     const module = try aot_loader.load(data, allocator);
@@ -555,7 +590,7 @@ test "emit: memory section round-trip" {
         .{ .min_pages = 2, .max_pages = null },
         .{ .min_pages = 1, .max_pages = 256 },
     };
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, &mem_entries, null, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, &mem_entries, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     const module = try aot_loader.load(data, allocator);
@@ -576,7 +611,7 @@ test "emit: locally-defined table section round-trip (#681)" {
         .{ .elem_type = .funcref, .min = 1, .max = null },
         .{ .elem_type = .funcref, .min = 2, .max = 10 },
     };
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, null, null, null, null, null, null, &tbl_entries);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, null, null, null, null, null, null, &tbl_entries, null);
     defer allocator.free(data);
 
     const module = try aot_loader.load(data, allocator);
@@ -600,7 +635,7 @@ test "emit: v128 global init payload round-trip" {
         .{ .val_type = 0x7F, .mutability = 0, .init_i64 = 0x1234 },
         .{ .val_type = 0x7B, .mutability = 1, .init_v128 = init_bits },
     };
-    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, &globals, null, null, null, null, null, null);
+    const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, null, &globals, null, null, null, null, null, null, null);
     defer allocator.free(data);
 
     const module = try aot_loader.load(data, allocator);
@@ -647,6 +682,7 @@ test "emit: type section and function type indices round-trip" {
         null,
         &ft_entries,
         &tidxs,
+        null,
         null,
         null,
     );
@@ -700,6 +736,7 @@ test "#672: tag imports and declared tags round-trip" {
         null,
         null,
         &tag_entries,
+        null,
         null,
     );
     defer allocator.free(data);

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -554,6 +554,24 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         try local_func_tidx_list.append(allocator, f.type_idx);
     }
 
+    // Parse the wasm `name` custom section directly from the source
+    // bytes. The interpreter loader skips custom sections, so this is
+    // a separate pass over the same buffer. A malformed name section is
+    // non-fatal (diagnostic-only): fall back to no names and let the
+    // trap helpers print `local_func[N]` without a symbol. Allocates
+    // into the same arena as the other emit-side scratch buffers.
+    const fn_name_entries: ?[]emit_aot.FunctionNameEntry = blk: {
+        const parsed = wamr.name_section.parseFunctionNames(wasm_data, allocator) catch break :blk null;
+        defer allocator.free(parsed);
+        if (parsed.len == 0) break :blk null;
+        const entries = allocator.alloc(emit_aot.FunctionNameEntry, parsed.len) catch break :blk null;
+        for (parsed, 0..) |p, idx| {
+            entries[idx] = .{ .index = p.index, .name = p.name };
+        }
+        break :blk entries;
+    };
+    defer if (fn_name_entries) |e| allocator.free(e);
+
     const aot_binary = try emit_aot.emit(
         allocator,
         compiled.code,
@@ -570,6 +588,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         if (local_func_tidx_list.items.len > 0) local_func_tidx_list.items else null,
         if (tag_entries.items.len > 0) tag_entries.items else null,
         if (table_entries.items.len > 0) table_entries.items else null,
+        fn_name_entries,
     );
     defer allocator.free(aot_binary);
 

--- a/src/component/aot.zig
+++ b/src/component/aot.zig
@@ -31,6 +31,7 @@ const std = @import("std");
 const ctypes = @import("types.zig");
 const component_loader = @import("loader.zig");
 const core_backend = @import("core_backend.zig");
+const name_section_mod = @import("../runtime/common/name_section.zig");
 const core_types = @import("../runtime/common/types.zig");
 const config = @import("../config.zig");
 

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -23,6 +23,7 @@ const passes = @import("../compiler/ir/passes.zig");
 const x86_64_compile = @import("../compiler/codegen/x86_64/compile.zig");
 const aarch64_compile = @import("../compiler/codegen/aarch64/compile.zig");
 const emit_aot = @import("../compiler/emit_aot.zig");
+const name_section_mod = @import("../runtime/common/name_section.zig");
 const core_types = @import("../runtime/common/types.zig");
 const interp_instance = @import("../runtime/interpreter/instance.zig");
 const config = @import("../config.zig");
@@ -306,6 +307,22 @@ pub fn compileCoreWasm(
         .aarch64 => @memcpy(arch_name[0..7], "aarch64"),
     }
 
+    // Parse the wasm `name` custom section directly from the source
+    // bytes for trap-decode diagnostics (#694). The interpreter loader
+    // skips custom sections, so this is a separate pass over the same
+    // buffer. A malformed or absent name section is non-fatal:
+    // fall back to no names and let the trap helpers print
+    // `local_func[N]` without a symbol.
+    const fn_name_entries: ?[]emit_aot.FunctionNameEntry = blk: {
+        const parsed = name_section_mod.parseFunctionNames(wasm_bytes, ea) catch break :blk null;
+        if (parsed.len == 0) break :blk null;
+        const entries = ea.alloc(emit_aot.FunctionNameEntry, parsed.len) catch break :blk null;
+        for (parsed, 0..) |p, idx| {
+            entries[idx] = .{ .index = p.index, .name = p.name };
+        }
+        break :blk entries;
+    };
+
     return emit_aot.emit(
         allocator,
         code,
@@ -329,6 +346,7 @@ pub fn compileCoreWasm(
         if (local_func_tidx_list.items.len > 0) local_func_tidx_list.items else null,
         if (tag_entries.items.len > 0) tag_entries.items else null,
         if (table_entries.items.len > 0) table_entries.items else null,
+        fn_name_entries,
     ) catch return error.CoreCompileFailed;
 }
 

--- a/src/runtime/aot/loader.zig
+++ b/src/runtime/aot/loader.zig
@@ -153,6 +153,12 @@ pub const AotModule = struct {
     global_inits: []const AotGlobalInit = &.{},
     elem_segments: []const AotElemSegment = &.{},
     start_function: ?u32 = null,
+    /// Round-tripped wasm function-name custom section (subsection 1).
+    /// Optional, purely diagnostic — empty when the source wasm had no
+    /// names. The AOT trap helpers use this to render `local_func[N]`
+    /// with the wasm-side symbol. Indices follow the wasm convention
+    /// (imports first, then locals). Owned by the loader allocator.
+    function_names: []const types.NameSection.FunctionName = &.{},
 
     /// Find an export by name and kind.
     pub fn findExport(self: *const AotModule, name: []const u8, kind: types.ExternalKind) ?types.ExportDesc {
@@ -298,6 +304,9 @@ pub fn load(data: []const u8, allocator: std.mem.Allocator) LoadError!AotModule 
             .table => {
                 try parseTableSection(&reader, section_size, &module, allocator);
             },
+            .name => {
+                try parseNameSection(&reader, section_size, &module, allocator);
+            },
             else => {
                 // Skip unknown/unhandled sections
                 reader.pos += section_size;
@@ -378,6 +387,12 @@ pub fn unload(module: *const AotModule, allocator: std.mem.Allocator) void {
     }
     if (module.elem_segments.len > 0) {
         allocator.free(module.elem_segments);
+    }
+    for (module.function_names) |fn_name| {
+        if (fn_name.name.len > 0) allocator.free(fn_name.name);
+    }
+    if (module.function_names.len > 0) {
+        allocator.free(module.function_names);
     }
 }
 
@@ -471,6 +486,40 @@ fn parseTagSection(reader: *BinaryReader, section_size: u32, module: *AotModule,
         tag_types[i] = try reader.readU32Le();
     }
     module.tag_types = tag_types;
+}
+
+/// Parse the AOT function-names section (#694). Wire format mirrors the
+/// emitter in `compiler/emit_aot.zig`:
+///   count: u32 LE
+///   for each: index: u32 LE, name_len: u32 LE, name bytes
+/// Indices are in the wasm function index space (imports first, then
+/// locals). Each name is allocator-duped so it outlives the source AOT
+/// buffer. Purely diagnostic — used by the AOT trap helpers to render
+/// `local_func[N]` symbolically.
+fn parseNameSection(reader: *BinaryReader, section_size: u32, module: *AotModule, allocator: std.mem.Allocator) LoadError!void {
+    if (section_size < 4) return error.InvalidSection;
+    const count = try reader.readU32Le();
+    if (count == 0) return;
+
+    const entries = allocator.alloc(types.NameSection.FunctionName, count) catch return error.OutOfMemory;
+    var initialized: usize = 0;
+    errdefer {
+        for (0..initialized) |i| {
+            if (entries[i].name.len > 0) allocator.free(entries[i].name);
+        }
+        allocator.free(entries);
+    }
+    for (0..count) |i| {
+        const idx = try reader.readU32Le();
+        const name_len = try reader.readU32Le();
+        if (reader.remaining() < name_len) return error.UnexpectedEnd;
+        const name_bytes = try reader.readBytes(name_len);
+        const owned = allocator.alloc(u8, name_len) catch return error.OutOfMemory;
+        @memcpy(owned, name_bytes);
+        entries[i] = .{ .index = idx, .name = owned };
+        initialized = i + 1;
+    }
+    module.function_names = entries;
 }
 
 fn parseExportSection(reader: *BinaryReader, section_size: u32, module: *AotModule, allocator: std.mem.Allocator) LoadError!void {

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -19,6 +19,16 @@ var g_code_base: usize = 0;
 var g_code_size: usize = 0;
 var g_mem_base: usize = 0;
 var g_mem_size: usize = 0;
+/// Wasm `name` custom-section entries for the AOT core whose code is
+/// currently mapped through `g_code_base`. Used by `aotTrapUnreachable`
+/// / `aotTrapOOB` / `aotTrap*` to render `local_func[N]` symbolically
+/// when a guest traps. Set alongside `g_func_offsets` and cleared on
+/// `callFunc` / `callFuncScalar` exit (see `pushTrapDecodeFrame`).
+var g_func_names: []const types.NameSection.FunctionName = &.{};
+/// Number of imported functions in the currently-active core. Needed
+/// to convert a local-func index back to the wasm function index space
+/// (imports first, then locals) for `g_func_names` lookup.
+var g_imported_function_count: u32 = 0;
 
 // ── Trap-as-error plumbing (Windows x86_64 only) ─────────────────────
 //
@@ -436,6 +446,71 @@ pub const PtrSigEntry = extern struct {
 var g_func_offsets: []const u32 = &.{};
 var g_veh_installed: bool = false;
 
+/// Snapshot of the per-`callFunc`/`callFuncScalar` trap-decode globals so
+/// that nested cross-instance calls (#694) can restore the caller's
+/// view after they return. Without this, the inner call's overwrite of
+/// `g_code_base` / `g_func_offsets` / `g_func_names` /
+/// `g_imported_function_count` / `g_mem_base` / `g_mem_size` leaks past
+/// the return and mis-decodes any later trap in the outer AOT body.
+const TrapDecodeFrame = struct {
+    code_base: usize,
+    code_size: usize,
+    func_offsets: []const u32,
+    func_names: []const types.NameSection.FunctionName,
+    imported_function_count: u32,
+    mem_base: usize,
+    mem_size: usize,
+};
+
+fn captureTrapDecodeFrame() TrapDecodeFrame {
+    return .{
+        .code_base = g_code_base,
+        .code_size = g_code_size,
+        .func_offsets = g_func_offsets,
+        .func_names = g_func_names,
+        .imported_function_count = g_imported_function_count,
+        .mem_base = g_mem_base,
+        .mem_size = g_mem_size,
+    };
+}
+
+fn restoreTrapDecodeFrame(frame: TrapDecodeFrame) void {
+    g_code_base = frame.code_base;
+    g_code_size = frame.code_size;
+    g_func_offsets = frame.func_offsets;
+    g_func_names = frame.func_names;
+    g_imported_function_count = frame.imported_function_count;
+    g_mem_base = frame.mem_base;
+    g_mem_size = frame.mem_size;
+}
+
+/// Install the calling AOT instance's diagnostic identity. Caller is
+/// expected to pair this with a `defer restoreTrapDecodeFrame(...)`.
+fn installTrapDecodeFrameFor(inst: *const AotInstance) void {
+    if (inst.code_base) |cb| {
+        g_code_base = @intFromPtr(cb);
+        g_code_size = inst.code_size;
+        g_func_offsets = inst.module.func_offsets;
+    }
+    g_func_names = inst.module.function_names;
+    g_imported_function_count = inst.module.import_function_count;
+}
+
+/// Resolve `local_func[N]` back to the wasm-side symbol when the AOT
+/// artifact preserves a `name` custom section. `local_idx` is the
+/// `func_offsets` index reported by the trap helper's PC decode; the
+/// wasm function index space prefixes imports, so we shift by
+/// `g_imported_function_count` before looking up.
+fn lookupLocalFuncName(local_idx: isize) ?[]const u8 {
+    if (local_idx < 0) return null;
+    if (g_func_names.len == 0) return null;
+    const wasm_idx: u32 = @intCast(@as(usize, @intCast(local_idx)) + g_imported_function_count);
+    for (g_func_names) |entry| {
+        if (entry.index == wasm_idx) return entry.name;
+    }
+    return null;
+}
+
 pub fn aotTrapOOB(vmctx: *VmCtx) callconv(.c) noreturn {
     const ret_addr: usize = @returnAddress();
     const code_off_s: isize = @as(isize, @bitCast(ret_addr)) - @as(isize, @bitCast(g_code_base));
@@ -455,11 +530,63 @@ pub fn aotTrapOOB(vmctx: *VmCtx) callconv(.c) noreturn {
     }
     // Flush any buffered stdout from the guest before we tear down the
     // process so user-visible output isn't lost. Best-effort.
-    std.debug.print(
-        "wasm trap: out of bounds memory access (code+0x{x}, local_func[{d}]+0x{x}, mem_size=0x{x})\n",
-        .{ code_off, func_idx, rel_off, vmctx.memory_size },
-    );
+    if (lookupLocalFuncName(func_idx)) |name| {
+        std.debug.print(
+            "wasm trap: out of bounds memory access (code+0x{x}, local_func[{d}] \"{s}\"+0x{x}, mem_size=0x{x})\n",
+            .{ code_off, func_idx, name, rel_off, vmctx.memory_size },
+        );
+    } else {
+        std.debug.print(
+            "wasm trap: out of bounds memory access (code+0x{x}, local_func[{d}]+0x{x}, mem_size=0x{x})\n",
+            .{ code_off, func_idx, rel_off, vmctx.memory_size },
+        );
+    }
     std.process.exit(2);
+}
+
+/// Resolve the trapping wasm function from `@returnAddress()` for the
+/// non-OOB trap helpers (`aotTrapUnreachable`, `aotTrapInt*`,
+/// `aotTrapInvalidConversion`). Returns `(local_idx, rel_off, name_opt)`
+/// where `local_idx == -1` when no `func_offsets` entry contains the PC.
+const TrapPcLocation = struct {
+    code_off: usize,
+    func_idx: isize,
+    rel_off: usize,
+    name: ?[]const u8,
+};
+
+fn decodeTrapReturnAddress(ret_addr: usize) TrapPcLocation {
+    const code_off_s: isize = @as(isize, @bitCast(ret_addr)) - @as(isize, @bitCast(g_code_base));
+    const code_off: usize = if (code_off_s >= 0) @intCast(code_off_s) else 0;
+    var func_idx: isize = -1;
+    var func_start: usize = 0;
+    for (g_func_offsets, 0..) |off, idx| {
+        if (off <= code_off) {
+            func_idx = @intCast(idx);
+            func_start = off;
+        } else break;
+    }
+    const rel_off: usize = if (code_off >= func_start) code_off - func_start else 0;
+    return .{
+        .code_off = code_off,
+        .func_idx = func_idx,
+        .rel_off = rel_off,
+        .name = lookupLocalFuncName(func_idx),
+    };
+}
+
+fn printTrapWithPc(kind: []const u8, loc: TrapPcLocation) void {
+    if (loc.name) |name| {
+        std.debug.print(
+            "wasm trap: {s} (code+0x{x}, local_func[{d}] \"{s}\"+0x{x})\n",
+            .{ kind, loc.code_off, loc.func_idx, name, loc.rel_off },
+        );
+    } else {
+        std.debug.print(
+            "wasm trap: {s} (code+0x{x}, local_func[{d}]+0x{x})\n",
+            .{ kind, loc.code_off, loc.func_idx, loc.rel_off },
+        );
+    }
 }
 
 /// Host helper invoked from AOT-compiled code for `unreachable`,
@@ -469,29 +596,33 @@ pub fn aotTrapOOB(vmctx: *VmCtx) callconv(.c) noreturn {
 /// returns `error.WasmTrap`. Otherwise prints a diagnostic and exits.
 pub fn aotTrapUnreachable(vmctx: *VmCtx) callconv(.c) noreturn {
     _ = vmctx;
+    const loc = decodeTrapReturnAddress(@returnAddress());
     if (@atomicLoad(bool, &g_trap_catching, .seq_cst)) trapLongjmp();
-    std.debug.print("wasm trap: unreachable\n", .{});
+    printTrapWithPc("unreachable", loc);
     std.process.exit(2);
 }
 
 pub fn aotTrapIntDivZero(vmctx: *VmCtx) callconv(.c) noreturn {
     _ = vmctx;
+    const loc = decodeTrapReturnAddress(@returnAddress());
     if (@atomicLoad(bool, &g_trap_catching, .seq_cst)) trapLongjmp();
-    std.debug.print("wasm trap: integer divide by zero\n", .{});
+    printTrapWithPc("integer divide by zero", loc);
     std.process.exit(2);
 }
 
 pub fn aotTrapIntOverflow(vmctx: *VmCtx) callconv(.c) noreturn {
     _ = vmctx;
+    const loc = decodeTrapReturnAddress(@returnAddress());
     if (@atomicLoad(bool, &g_trap_catching, .seq_cst)) trapLongjmp();
-    std.debug.print("wasm trap: integer overflow\n", .{});
+    printTrapWithPc("integer overflow", loc);
     std.process.exit(2);
 }
 
 pub fn aotTrapInvalidConversion(vmctx: *VmCtx) callconv(.c) noreturn {
     _ = vmctx;
+    const loc = decodeTrapReturnAddress(@returnAddress());
     if (@atomicLoad(bool, &g_trap_catching, .seq_cst)) trapLongjmp();
-    std.debug.print("wasm trap: invalid conversion to integer\n", .{});
+    printTrapWithPc("invalid conversion to integer", loc);
     std.process.exit(2);
 }
 
@@ -1656,11 +1787,14 @@ pub fn callFunc(inst: *AotInstance, func_idx: u32, comptime Result: type) Runtim
     // uses `g_code_base` / `g_func_offsets` to map the trap PC back
     // to a wasm function index. The Windows-only block below adds
     // the VEH path on top (which also needs g_mem_*).
-    if (inst.code_base) |cb| {
-        g_code_base = @intFromPtr(cb);
-        g_code_size = inst.code_size;
-        g_func_offsets = inst.module.func_offsets;
-    }
+    //
+    // Snapshot the previous decode frame so a nested cross-instance
+    // call (#694) can restore it on return; without this, a trap that
+    // fires in the outer body after the inner returns mis-decodes the
+    // PC against the *callee's* func_offsets table.
+    const previous_trap_frame = captureTrapDecodeFrame();
+    defer restoreTrapDecodeFrame(previous_trap_frame);
+    installTrapDecodeFrameFor(inst);
     if (comptime windows_trap_supported) {
         g_mem_base = vmctx.memory_base;
         g_mem_size = vmctx.memory_size;
@@ -1978,11 +2112,13 @@ pub fn callFuncScalar(
         raw[args.len] = @intFromPtr(&hrp_buf);
     }
 
-    if (inst.code_base) |cb| {
-        g_code_base = @intFromPtr(cb);
-        g_code_size = inst.code_size;
-        g_func_offsets = inst.module.func_offsets;
-    }
+    // Snapshot the previous decode frame so a nested cross-instance
+    // call (#694) can restore it on return; without this, a trap that
+    // fires in the outer body after the inner returns mis-decodes the
+    // PC against the *callee's* func_offsets table.
+    const previous_trap_frame = captureTrapDecodeFrame();
+    defer restoreTrapDecodeFrame(previous_trap_frame);
+    installTrapDecodeFrameFor(inst);
     if (comptime windows_trap_supported) {
         g_mem_base = vmctx.memory_base;
         g_mem_size = vmctx.memory_size;

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -1314,6 +1314,7 @@ fn compileToAot(
         if (tidxs.len > 0) tidxs else null,
         if (tag_entries.items.len > 0) tag_entries.items else null,
         if (table_entries.items.len > 0) table_entries.items else null,
+        null,
     );
 }
 


### PR DESCRIPTION
Phase 1 of #694. Diagnostic-only change — does not fix the codegen bug at `local_func[58]+0x563c`, but makes the next bisection step tractable by printing the function symbolically and fixing a real PC mis-attribution bug after cross-instance returns.

## What you see now

Before:
```
wasm trap: unreachable (code+0x1a71e, local_func[58]+0x563c)
```

After (verified against the codegen-cli.composed.wasm repro from #694):
```
wasm trap: unreachable (code+0x1a71e, local_func[58] "heap.ArenaAllocator.alloc"+0x563c)
```

## What changed

1. **Name section round-trip** — `emit_aot.emit()` gains an optional trailing `function_names` parameter; new AOT section type 7 (mirroring the wasm `name` custom-section id) encodes `count, { idx, name_len, name }*`. Backward-compatible: older readers fall through the unknown-section arm. AOT version stays at 7. `compiler/main.zig` and `component/aot.zig` both parse the source wasm's `name` custom section via the existing `common.name_section.parseFunctionNames` and pipe it through. Failure is non-fatal.
2. **Per-call diagnostic-globals snapshot/restore** — `g_code_base`, `g_code_size`, `g_func_offsets`, `g_mem_base`, `g_mem_size`, `g_func_names`, `g_imported_function_count` were last-writer-wins module-level globals overwritten unconditionally on every `callFunc` / `callFuncScalar` entry. A nested cross-instance call would corrupt the outer frame's trap-decode context. Both call sites now capture into a `TrapDecodeFrame` and `defer`-restore on all exit paths (including `error.WasmTrap`).
3. **Trap helpers decode and print PC** — `aotTrapOOB` / `aotTrapUnreachable` / `aotTrapIntDivZero` / `aotTrapIntOverflow` / `aotTrapInvalidConversion` capture `@returnAddress()`, decode it via `decodeTrapReturnAddress`, and resolve `wasm_idx = local_idx + imported_function_count` against `g_func_names` for symbolic output.

## Tests

- `zig build test --summary failures`: 988/988 green.
- Repro reproduced and confirmed function name in trap output.

## What's still pending (separate PRs)

- Phase 2: hello-world bisection + a `--aot-fallback-interp` flag so future cross-instance regressions are recoverable in production.
- Phase 3: actual codegen fix at `local_func[58] heap.ArenaAllocator.alloc+0x563c`.