### PR TITLE
fix #694: AOT call_indirect for funcidx ≥ 256 in mapCodeExecutable

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -544,6 +544,22 @@ pub fn build(b: *std.Build) void {
     const run_differential_tests = b.addRunArtifact(differential_tests);
     test_step.dependOn(&run_differential_tests.step);
 
+    // #694: regression test for active elem segments referencing
+    // funcidx ≥ 256 (was capped by a fixed 256-entry buffer in
+    // `mapCodeExecutable`, silently dropping both the native pointer
+    // and the sig_id update for any high-funcidx slot).
+    const aot_high_funcidx_module = b.createModule(.{
+        .root_source_file = b.path("src/tests/aot_high_funcidx_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    aot_high_funcidx_module.addImport("wamr", lib_module);
+    const aot_high_funcidx_tests = b.addTest(.{
+        .root_module = aot_high_funcidx_module,
+    });
+    const run_aot_high_funcidx_tests = b.addRunArtifact(aot_high_funcidx_tests);
+    test_step.dependOn(&run_aot_high_funcidx_tests.step);
+
     // #625 phase 1: AOT-backed component-core smoke test. Lives in its
     // own test step for the same reason `differential.zig` does:
     // `aot_harness.zig` cannot be pulled into the `wamr` lib module

--- a/scripts/bench_coremark.py
+++ b/scripts/bench_coremark.py
@@ -31,15 +31,17 @@ ITER_PATTERN = re.compile(r"Iterations/Sec\s*:\s*([0-9]+(?:\.[0-9]+)?)")
 # Signature of the known x86_64 native AOT-run flake from issue #406:
 # `wamr run` traps with `out of bounds memory access (..., local_func[N]+0x0, ...)`
 # at the very first byte of a local function (or with a synthetic `[-1]`
-# function index). The trap is non-deterministic on shared GitHub-hosted
-# x86_64 runners — it has been observed firing on baseline `main` after a
-# clean run of the same binary, proving it's not introduced by any single
-# change. Real coremark regressions would trap deeper inside a function
-# (non-zero offset), so a `+0x0` offset is the discriminator. Retry this
-# failure mode up to `_TRAP_RETRY_MAX` times before treating it as a real
-# regression.
+# function index). PR #696 added an optional `"<name>"` annotation between
+# the bracketed funcidx and the offset (e.g. `local_func[0] "__wasm_call_ctors"+0x0`),
+# so the pattern accepts an optional quoted name. The trap is non-deterministic
+# on shared GitHub-hosted x86_64 runners — it has been observed firing on
+# baseline `main` after a clean run of the same binary, proving it's not
+# introduced by any single change. Real coremark regressions would trap
+# deeper inside a function (non-zero offset), so a `+0x0` offset is the
+# discriminator. Retry this failure mode up to `_TRAP_RETRY_MAX` times
+# before treating it as a real regression.
 _TRAP_FLAKE_PATTERN = re.compile(
-    r"wasm trap: out of bounds memory access.*local_func\[-?\d+\]\+0x0",
+    r'wasm trap: out of bounds memory access.*local_func\[-?\d+\](?:\s+"[^"]*")?\+0x0',
     re.IGNORECASE,
 )
 _TRAP_RETRY_MAX = 3

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -1567,10 +1567,22 @@ pub fn mapCodeExecutable(inst: *AotInstance) RuntimeError!void {
     // Build function pointer table for call_indirect
     const import_count = module.import_function_count;
 
-    // Build module func idx → native address mapping (temporary)
+    // Build module func idx → native address mapping (temporary).
+    //
+    // #694: must be sized to `total_funcs`, NOT a fixed 256-entry stack
+    // buffer. With a fixed cap, any module whose import_count +
+    // func_count exceeds the cap silently dropped both the funcptr
+    // and the type_backing update for high-funcidx active elem
+    // segments, causing call_indirect through those slots to fail the
+    // sig-id type check and trap on `unreachable`.
     const total_funcs = import_count + module.func_count;
-    var func_addrs: [256]usize = std.mem.zeroes([256]usize);
-    const n_addrs = @min(total_funcs, func_addrs.len);
+    const func_addrs: []usize = if (total_funcs > 0)
+        inst.allocator.alloc(usize, total_funcs) catch return error.OutOfMemory
+    else
+        &.{};
+    defer if (func_addrs.len > 0) inst.allocator.free(func_addrs);
+    @memset(func_addrs, 0);
+    const n_addrs = func_addrs.len;
     // Import functions → host function pointers
     for (0..@min(import_count, @min(inst.host_functions.len, n_addrs))) |i| {
         func_addrs[i] = if (inst.host_functions[i]) |ptr| @intFromPtr(ptr) else 0;

--- a/src/tests/aot_high_funcidx_test.zig
+++ b/src/tests/aot_high_funcidx_test.zig
@@ -1,0 +1,171 @@
+//! #694 — AOT call_indirect to a function whose funcidx exceeds the
+//! historical 256-entry `func_addrs` cap in `mapCodeExecutable`.
+//!
+//! Before the fix, `mapCodeExecutable` used a stack-allocated fixed
+//! `[256]usize func_addrs` buffer. Active element segments referencing
+//! a funcidx ≥ 256 silently dropped both the native pointer AND the
+//! sig_id update on `TableInstance.type_backing`. The next
+//! `call_indirect` against that slot saw `type_backing[slot] == 0`
+//! while `sig_table[type_idx] != 0`, failed the sig-id type check, and
+//! trapped via `trap_unreachable_fn`. This bit `codegen-cli` because
+//! its `heap.ArenaAllocator.alloc` body dispatches through the Zig
+//! stdlib `Allocator.VTable.alloc` funcref — type 2 — pointing at a
+//! local funcidx well past 256 in the 2080-function module 0.
+//!
+//! This test programmatically builds a small module with 259 local
+//! functions and verifies that a `call_indirect` through a funcidx
+//! ≥ 256 dispatched via an active elem segment returns the expected
+//! value. Pre-fix this test trapped on `unreachable`; post-fix it
+//! returns 42.
+
+const std = @import("std");
+const wamr = @import("wamr");
+const aot_harness = @import("aot_harness.zig");
+
+const core_types = wamr.types;
+const aot_loader_mod = wamr.aot_loader;
+const aot_runtime_mod = wamr.aot_runtime;
+
+const FILLER_COUNT: u32 = 256;
+const TARGET_LOCAL_IDX: u32 = FILLER_COUNT; // local funcidx 256 — first one past the old 256-entry cap
+const ENTRY_LOCAL_IDX: u32 = FILLER_COUNT + 1; // local funcidx 257 — entry point doing `call_indirect`
+
+fn writeULEB128(buf: *std.ArrayList(u8), gpa: std.mem.Allocator, value: u64) !void {
+    var v = value;
+    while (true) {
+        var byte: u8 = @intCast(v & 0x7f);
+        v >>= 7;
+        if (v != 0) byte |= 0x80;
+        try buf.append(gpa, byte);
+        if (v == 0) break;
+    }
+}
+
+fn writeSLEB128(buf: *std.ArrayList(u8), gpa: std.mem.Allocator, value: i64) !void {
+    var v = value;
+    while (true) {
+        const byte_unsigned: u8 = @as(u8, @intCast(@as(u64, @bitCast(v)) & 0x7f));
+        const sign_bit_set = (byte_unsigned & 0x40) != 0;
+        v >>= 7;
+        const done = (v == 0 and !sign_bit_set) or (v == -1 and sign_bit_set);
+        try buf.append(gpa, if (done) byte_unsigned else byte_unsigned | 0x80);
+        if (done) break;
+    }
+}
+
+fn writeSection(buf: *std.ArrayList(u8), gpa: std.mem.Allocator, id: u8, payload: []const u8) !void {
+    try buf.append(gpa, id);
+    try writeULEB128(buf, gpa, payload.len);
+    try buf.appendSlice(gpa, payload);
+}
+
+/// Build a wasm module:
+///   * 1 type:  type 0 = () -> i32
+///   * 259 local functions, all of type 0
+///       0..255  filler bodies (`i32.const 0`)
+///       256     target body   (`i32.const 42`)  — funcidx ≥ 256
+///       257     entry body    (`i32.const 0 ; call_indirect 0 (type 0)`)
+///   * 1 funcref table of size 1
+///   * 1 active elem segment placing func 256 at table[0]
+///   * export the entry as "run"
+fn buildWasm(gpa: std.mem.Allocator) ![]u8 {
+    var bytes: std.ArrayList(u8) = .empty;
+    try bytes.appendSlice(gpa, &.{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 });
+
+    // Type section: 1 type, () -> i32
+    var sec: std.ArrayList(u8) = .empty;
+    defer sec.deinit(gpa);
+    try writeULEB128(&sec, gpa, 1);
+    try sec.appendSlice(gpa, &.{ 0x60, 0x00, 0x01, 0x7f });
+    try writeSection(&bytes, gpa, 0x01, sec.items);
+    sec.clearRetainingCapacity();
+
+    // Function section: 258 funcs, all type 0
+    const n_funcs: u32 = ENTRY_LOCAL_IDX + 1;
+    try writeULEB128(&sec, gpa, n_funcs);
+    var i: u32 = 0;
+    while (i < n_funcs) : (i += 1) try writeULEB128(&sec, gpa, 0);
+    try writeSection(&bytes, gpa, 0x03, sec.items);
+    sec.clearRetainingCapacity();
+
+    // Table section: 1 table, funcref, min=1, max=1
+    try writeULEB128(&sec, gpa, 1);
+    try sec.appendSlice(gpa, &.{ 0x70, 0x01, 0x01, 0x01 });
+    try writeSection(&bytes, gpa, 0x04, sec.items);
+    sec.clearRetainingCapacity();
+
+    // Export section: 1 export, "run" → entry func
+    try writeULEB128(&sec, gpa, 1);
+    try writeULEB128(&sec, gpa, 3);
+    try sec.appendSlice(gpa, "run");
+    try sec.append(gpa, 0x00);
+    try writeULEB128(&sec, gpa, ENTRY_LOCAL_IDX);
+    try writeSection(&bytes, gpa, 0x07, sec.items);
+    sec.clearRetainingCapacity();
+
+    // Element section: 1 active segment, table 0, offset i32.const 0,
+    // funcref elemkind, 1 entry = target funcidx.
+    try writeULEB128(&sec, gpa, 1);
+    try sec.append(gpa, 0x00);
+    try sec.append(gpa, 0x41);
+    try writeSLEB128(&sec, gpa, 0);
+    try sec.append(gpa, 0x0b);
+    try writeULEB128(&sec, gpa, 1);
+    try writeULEB128(&sec, gpa, TARGET_LOCAL_IDX);
+    try writeSection(&bytes, gpa, 0x09, sec.items);
+    sec.clearRetainingCapacity();
+
+    // Code section: filler[0..256] + target + entry.
+    try writeULEB128(&sec, gpa, n_funcs);
+    var idx: u32 = 0;
+    while (idx < FILLER_COUNT) : (idx += 1) {
+        // body: 0 locals; i32.const 0; end. Body bytes = 0x00 0x41 0x00 0x0b = 4 bytes.
+        try writeULEB128(&sec, gpa, 4);
+        try sec.appendSlice(gpa, &.{ 0x00, 0x41, 0x00, 0x0b });
+    }
+    // Target: i32.const 42
+    try writeULEB128(&sec, gpa, 4);
+    try sec.appendSlice(gpa, &.{ 0x00, 0x41, 42, 0x0b });
+    // Entry: i32.const 0; call_indirect 0 (type 0); end
+    // body bytes: 0x00 (locals), 0x41 0x00 (i32.const 0), 0x11 0x00 0x00 (call_indirect type=0 table=0), 0x0b
+    try writeULEB128(&sec, gpa, 7);
+    try sec.appendSlice(gpa, &.{ 0x00, 0x41, 0x00, 0x11, 0x00, 0x00, 0x0b });
+    try writeSection(&bytes, gpa, 0x0a, sec.items);
+    sec.clearRetainingCapacity();
+
+    return bytes.toOwnedSlice(gpa);
+}
+
+test "#694 call_indirect to funcidx beyond historical 256-entry cap" {
+    if (comptime !aot_harness.can_exec_aot) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const wasm_bytes = try buildWasm(allocator);
+    defer allocator.free(wasm_bytes);
+
+    const cwasm_bytes = try aot_harness.compileWasmToAot(allocator, wasm_bytes);
+    defer allocator.free(cwasm_bytes);
+
+    var module = try aot_loader_mod.load(cwasm_bytes, allocator);
+    defer aot_loader_mod.unload(&module, allocator);
+
+    const inst = try aot_runtime_mod.instantiate(&module, allocator);
+    defer aot_runtime_mod.destroy(inst);
+    try aot_runtime_mod.mapCodeExecutable(inst);
+
+    const fn_idx = aot_runtime_mod.findExportFunc(inst, "run") orelse return error.TestFailed;
+    const no_params = [_]core_types.ValType{};
+    const result_types = [_]core_types.ValType{.i32};
+    const no_args = [_]core_types.Value{};
+    var results_buf: [1]aot_runtime_mod.ScalarResult = .{.{ .i32 = 0 }};
+    const results = try aot_runtime_mod.callFuncScalar(
+        inst,
+        fn_idx,
+        &no_params,
+        &result_types,
+        &no_args,
+        &results_buf,
+    );
+    try std.testing.expectEqual(@as(usize, 1), results.len);
+    try std.testing.expectEqual(@as(i32, 42), results[0].i32);
+}


### PR DESCRIPTION
Closes #694.

## Symptom

Under `WAMR=1`, codegen-cli (Zig 0.16 wasm32-wasi) traps before reaching any WASIp1 syscall:

```
wasm trap: unreachable (code+0x1a71e, local_func[58] "heap.ArenaAllocator.alloc"+0x563c)
```

(This message format requires #696, which preserves function names through AOT.)

## Root cause

`mapCodeExecutable` in `src/runtime/aot/runtime.zig` built the funcidx → native address scratch table in a fixed 256-entry stack buffer:

```zig
var func_addrs: [256]usize = std.mem.zeroes([256]usize);
const n_addrs = @min(total_funcs, func_addrs.len);
```

For any module with `import_count + func_count > 256`, the active element-segment loop further down silently dropped both the native pointer and the `type_backing` sig-id update for any segment entry whose funcidx ≥ 256:

```zig
} else if (func_idx < n_addrs) {
    native_table[dst] = func_addrs[func_idx];
    if (dst < tbl.type_backing.len and func_idx < inst.func_sig_ids.len) {
        tbl.type_backing[dst] = inst.func_sig_ids[func_idx];
    }
}
```

The next `call_indirect` against such a table slot then saw `type_backing[dst] == 0` while `sig_table[type_idx] != 0` and trapped via `emitCallIndirectSigCheck`'s `call rax → trap_unreachable_fn`.

Codegen-cli hit this because module 0 of the composed component contains **2080 local functions**, and the Zig stdlib `std.heap.ArenaAllocator.alloc` dispatches into the allocator vtable via an active elem-installed funcref well past funcidx 256.

(For context: the original issue hypothesis pointed at the atomic-rmw lowering in `compile.zig:1144-1196`. Disassembling the trap site (39-byte `call rax` sig-check sequence, no atomic instructions in the window) ruled that out and led to the real bug in `runtime.zig`.)

## Fix

Size `func_addrs` to `total_funcs` and free with `defer`. `n_addrs` now naturally equals `func_addrs.len`, so the elem-segment loop, `inst.funcptrs` memcpy, and `ptr_to_sig` builder all keep working unmodified.

## Regression test

`src/tests/aot_high_funcidx_test.zig` programmatically builds a 258-function wasm with an active elem segment placing func 256 at table[0], plus an entry func that does `i32.const 0 ; call_indirect 0 (type 0)`. Asserts the call returns 42. Pre-fix this test crashes with the same `unreachable` trap; post-fix it passes.

## Validation

* `zig build test --summary all` → 2940/2947 pass, 7 skipped, 0 failures (including the new test).
* Repro that originally triggered #694 (codegen-cli with a `tsp` spec dir) no longer traps in `ArenaAllocator.alloc`. The component now reaches its own argv parsing.