### PR TITLE
fix #698: route component-wired WASIp1 imports to adapter, not host_bridge

### DIFF
--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -3045,18 +3045,31 @@ fn resolveAotImportedFunctionOverrides(
         if (imp.kind != .function) continue;
         defer func_idx += 1;
 
-        // WASI / spectest stay null so the runtime can pick them up from
-        // `host_bridge` (matches the existing behaviour pre-#662).
-        if (aot_host_bridge.isWasiModule(imp.module_name)) continue;
-        if (aot_host_bridge.isSpectestModule(imp.module_name)) continue;
-
-        // Look up the `with` arg that names this import's wasm module.
+        // Look up the `with` arg that names this import's wasm module
+        // FIRST — before any WASI / spectest short-circuit. For
+        // component-embedded WASIp1 cores, `wasm-tools component new
+        // --adapt …` rewrites the WASIp1 imports to point at a sibling
+        // **adapter** core, but keeps `imp.module_name ==
+        // "wasi_snapshot_preview1"`. If we let the WASI guard fire
+        // first, the adapter wiring is discarded and the runtime falls
+        // back to `host_bridge.aot*` with no `WasiCtx` on the inner
+        // core's vmctx — guest sees empty argv/env (#698).
         const source_inst_idx: u32 = arg_blk: {
             for (args) |arg| {
                 if (std.mem.eql(u8, arg.name, imp.module_name)) break :arg_blk arg.instance_idx;
             }
             break :arg_blk std.math.maxInt(u32);
         };
+
+        // No `with` arg → standalone-style WASIp1 / spectest import.
+        // Leave the override `null` so the AOT runtime fills it from
+        // `host_bridge` at resolve time (matches pre-#662 behaviour;
+        // `aot_inst.wasi_ctx` gets wired by `main.runRun` for the
+        // standalone `wamr run hello.wasm` path).
+        if (source_inst_idx == std.math.maxInt(u32)) {
+            if (aot_host_bridge.isWasiModule(imp.module_name)) continue;
+            if (aot_host_bridge.isSpectestModule(imp.module_name)) continue;
+        }
 
         var thunk: ?*const anyopaque = null;
         if (source_inst_idx != std.math.maxInt(u32) and source_inst_idx < ci_idx) {


### PR DESCRIPTION
Fixes #698.

`resolveAotImportedFunctionOverrides` short-circuited every import whose `module_name` matched a WASIp1 / spectest module **before** checking the component's `with` args. For component-embedded WASIp1 cores wired by `wasm-tools component new --adapt …`, the sibling adapter's module-import name is also `"wasi_snapshot_preview1"`, so the adapter wiring was silently discarded. The AOT runtime then filled those slots from `host_bridge.aot*`; `getCtx(vmctx)` is null on component-inner cores, so the stateless fallbacks returned zero args / zero env. Symptom: codegen-cli exited `missing positional: <spec-dir>` even though `runComponent` correctly seeded `adapter.setArguments` with argv.

## Fix
Move the `source_inst_idx` `with`-arg lookup **above** the WASI / spectest guard. Only short-circuit to `host_bridge` when no `with` arg matches (= standalone-style WASIp1 via `wamr run hello.wasm`, where `main.runRun` wires `aot_inst.wasi_ctx`). Component-wired imports fall through to the existing canon-lower / cross-instance pipeline so the adapter's `canon.lower` reaches `wasi_cli_adapter`, which actually holds the argv.

Matches the ordering suggested in the issue body.

## Verification
- `zig build test --summary failures`: **2940/2947 pass** (7 skipped — same as baseline; no regressions).
- Standalone WASIp1 path unchanged: when no `with` arg matches the WASI module name, `source_inst_idx == maxInt` and the existing `host_bridge` fallback fires (same code path as today).
- End-to-end keyvault repro from the issue now reaches user code with argv populated — no more `missing positional: <spec-dir>`.

## Out-of-scope follow-ups surfaced

End-to-end keyvault codegen still needs two pre-existing infra widenings, both **already flagged in the issue body as "unrelated"**:

1. **Cross-instance dispatcher `SignatureTooWide` cap.** `src/component/instance.zig:3204` caps cross-instance thunks at 8 wasm params (widened from 5 in #689). `wasi_snapshot_preview1.path_open` has 9 params (7 i32 + 2 i64). Post-fix, path_open now correctly routes via cross-instance and hits the cap → trap stub. Needs widening to ≥9 (asm stub + dispatcher signature). Pre-fix this never surfaced because the WASI guard discarded the routing before the cap check.
2. **`[resource-drop]` `UnsupportedCrossInstanceSource`.** ~14 trap stubs installed for `[resource-drop]` cross-instance builtins (e.g. `wasi:io/streams.[resource-drop]input-stream`). Existing comment at `instance.zig:3091-3094` flags this as a follow-up to #687.

Both will be filed as separate issues if not already tracked.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>