### PR TITLE
Widen AOT cross-instance dispatcher cap 8 → 9 wasm params (#700)

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -5987,9 +5987,10 @@ pub export fn wamrAotDispatchComponentTrampoline(
     a6: u64,
     a7: u64,
     a8: u64,
+    a9: u64,
 ) callconv(.c) host_trampolines.DispatchResult {
     const ctx: *const ComponentTrampolineCtx = @ptrCast(@alignCast(ctx_opaque));
-    const result = dispatchAotComponentTrampoline(ctx, lowered_sig.*, .{ a0, a1, a2, a3, a4, a5, a6, a7, a8 }) catch |err| {
+    const result = dispatchAotComponentTrampoline(ctx, lowered_sig.*, .{ a0, a1, a2, a3, a4, a5, a6, a7, a8, a9 }) catch |err| {
         if (debugAotEnabled()) {
             std.debug.print(
                 "[aot-dispatch] canon.lower trampoline failed: {s}\n",
@@ -6005,11 +6006,11 @@ pub export fn wamrAotDispatchComponentTrampoline(
 /// stub shifts caller regs right by one to inject `slot` as the first
 /// C-ABI arg, so when the AOT codegen calls a host import as
 /// `host_fn(vmctx, arg0, arg1, …)`, this dispatcher receives
-/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a8=arg7)`. We discard `a0`
+/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a9=arg8)`. We discard `a0`
 /// (importer's vmctx) and re-issue `dispatchAotComponentTrampoline` over
-/// `a1..a8`, matching the lowered wasm-arg shape the host trampoline
-/// already expects. Widened from a0..a5 in #689 so WASIp2 filesystem
-/// methods (`link-at` = 7 wasm params, etc.) fit.
+/// `a1..a9`, matching the lowered wasm-arg shape the host trampoline
+/// already expects. Widened from a0..a5 in #689, then a0..a8 in #700 so
+/// `wasi_snapshot_preview1.path_open` (9 wasm params) fits.
 pub export fn wamrAotDispatchComponentTrampolineAot(
     ctx_opaque: *anyopaque,
     lowered_sig: *const host_trampolines.LoweredSig,
@@ -6022,10 +6023,11 @@ pub export fn wamrAotDispatchComponentTrampolineAot(
     a6: u64,
     a7: u64,
     a8: u64,
+    a9: u64,
 ) callconv(.c) host_trampolines.DispatchResult {
     _ = a0;
     const ctx: *const ComponentTrampolineCtx = @ptrCast(@alignCast(ctx_opaque));
-    const result = dispatchAotComponentTrampoline(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, a6, a7, a8, 0 }) catch |err| {
+    const result = dispatchAotComponentTrampoline(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, a6, a7, a8, a9, 0 }) catch |err| {
         if (debugAotEnabled()) {
             std.debug.print(
                 "[aot-dispatch] canon.lower(aot) trampoline failed: {s}\n",
@@ -6057,12 +6059,14 @@ pub const CrossInstanceThunkCtx = struct {
 /// shifts caller regs right by one to inject `slot` as the first C-ABI arg,
 /// so when the AOT codegen calls a host import as
 /// `host_fn(vmctx, arg0, arg1, …)`, the dispatcher receives
-/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a8=arg7)`. We ignore `a0`
+/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a9=arg8)`. We ignore `a0`
 /// (importer's vmctx — the sibling AotInstance builds its own vmctx
-/// internally in `callFuncScalar`) and use `a1..a8` as lowered wasm args.
-/// Calls outside the trampoline pool's 8-arg-in-regs envelope return a
+/// internally in `callFuncScalar`) and use `a1..a9` as lowered wasm args.
+/// Calls outside the trampoline pool's 9-arg-in-regs envelope return a
 /// failing status; richer signatures land in a follow-up. The 5 → 8 widening
-/// in #689 covers WASIp2 filesystem methods like `link-at` (7 wasm params).
+/// in #689 covered WASIp2 filesystem methods like `link-at` (7 wasm params);
+/// the 8 → 9 widening in #700 covers `wasi_snapshot_preview1.path_open`
+/// (9 wasm params), exposed by #699's WASI-guard reorder.
 pub export fn wamrAotDispatchCrossInstance(
     ctx_opaque: *anyopaque,
     lowered_sig: *const host_trampolines.LoweredSig,
@@ -6075,10 +6079,11 @@ pub export fn wamrAotDispatchCrossInstance(
     a6: u64,
     a7: u64,
     a8: u64,
+    a9: u64,
 ) callconv(.c) host_trampolines.DispatchResult {
     _ = a0; // importer's vmctx; the sibling AotInstance builds its own.
     const ctx: *const CrossInstanceThunkCtx = @ptrCast(@alignCast(ctx_opaque));
-    const result = dispatchAotCrossInstance(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, a6, a7, a8, 0 }) catch |err| {
+    const result = dispatchAotCrossInstance(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, a6, a7, a8, a9, 0 }) catch |err| {
         if (debugAotEnabled()) {
             std.debug.print(
                 "[aot-dispatch] cross-instance thunk '{s}' failed: {s}\n",
@@ -6093,20 +6098,20 @@ pub export fn wamrAotDispatchCrossInstance(
 fn dispatchAotCrossInstance(
     ctx: *const CrossInstanceThunkCtx,
     lowered_sig: host_trampolines.LoweredSig,
-    arg_regs: [9]u64,
+    arg_regs: [10]u64,
 ) !u64 {
-    // We support up to 8 args in registers (a1..a8 in the dispatcher's
+    // We support up to 9 args in registers (a1..a9 in the dispatcher's
     // frame, since a0 is the importer's vmctx). Spilled-arg / spilled-result
     // shapes route through the lift trampoline pathway, not this one.
     if (lowered_sig.has_retptr) return error.UnsupportedSignature;
-    if (lowered_sig.param_types.len > 8) return error.UnsupportedSignature;
+    if (lowered_sig.param_types.len > 9) return error.UnsupportedSignature;
     if (lowered_sig.result_types.len > 1) return error.UnsupportedSignature;
     if (lowered_sig.param_types.len != ctx.param_types.len) return error.UnsupportedSignature;
     if (lowered_sig.result_types.len != ctx.result_types.len) return error.UnsupportedSignature;
     for (lowered_sig.param_types, ctx.param_types) |a, b| if (a != b) return error.UnsupportedSignature;
     for (lowered_sig.result_types, ctx.result_types) |a, b| if (a != b) return error.UnsupportedSignature;
 
-    var args_buf: [8]core_types.Value = undefined;
+    var args_buf: [9]core_types.Value = undefined;
     for (ctx.param_types, 0..) |pt, i| {
         args_buf[i] = switch (pt) {
             .i32 => .{ .i32 = @bitCast(@as(u32, @truncate(arg_regs[i]))) },
@@ -6155,6 +6160,7 @@ pub export fn wamrAotDispatchTrapStub(
     a6: u64,
     a7: u64,
     a8: u64,
+    a9: u64,
 ) callconv(.c) host_trampolines.DispatchResult {
     _ = lowered_sig;
     _ = a0;
@@ -6166,6 +6172,7 @@ pub export fn wamrAotDispatchTrapStub(
     _ = a6;
     _ = a7;
     _ = a8;
+    _ = a9;
     if (debugAotEnabled()) {
         const label_ptr: *const [*:0]const u8 = @ptrCast(@alignCast(ctx_opaque));
         std.debug.print("[aot-dispatch] trap-stub fired for unbridged import '{s}' (#662 follow-up)\n", .{label_ptr.*});
@@ -6177,7 +6184,7 @@ pub export fn wamrAotDispatchTrapStub(
 fn dispatchAotComponentTrampoline(
     ctx: *const ComponentTrampolineCtx,
     lowered_sig: host_trampolines.LoweredSig,
-    regs: [9]u64,
+    regs: [10]u64,
 ) !u64 {
     if (ctx.lower_opts.is_async or ctx.is_async_func) return error.UnsupportedSignature;
     if (lowered_sig.param_types.len + @intFromBool(lowered_sig.has_retptr) > regs.len)
@@ -6259,7 +6266,7 @@ fn liftAotDispatcherArg(
     t: ctypes.ValType,
     lowered_param_types: []const core_types.ValType,
     reg_index: *usize,
-    regs: *const [9]u64,
+    regs: *const [10]u64,
     registry: TypeRegistry,
     allocator: Allocator,
 ) !InterfaceValue {

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -3197,11 +3197,12 @@ fn installCrossInstanceThunk(
 
     // Only register-fit signatures land in this fast path. Anything else
     // returns an error → the caller installs a trap stub instead. The cap
-    // of 8 covers every WASIp2 method emitted by the public adapters
-    // (`link-at` = 7 wasm params is the widest seen in real binaries);
-    // widened from 5 in #689 so the WASIp1→WASIp2 adapter's filesystem
-    // methods stop trap-stubbing.
-    if (ft.params.len > 8) return error.SignatureTooWide;
+    // of 9 covers `wasi_snapshot_preview1.path_open` (9 wasm params, the
+    // widest WASIp1 sig); widened from 8 in #700 — pre-fix #689 had
+    // widened from 5 to 8 to fit WASIp2 filesystem methods like `link-at`
+    // (7 wasm params), but `path_open` only started routing through this
+    // path with #699's WASI-guard reorder.
+    if (ft.params.len > 9) return error.SignatureTooWide;
     if (ft.results.len > 1) return error.MultipleResultsUnsupported;
     for (ft.params) |p| switch (p) {
         .i32, .i64, .f32, .f64 => {},

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -9,13 +9,15 @@ const platform = @import("../../platform/platform.zig");
 const core_types = @import("../common/types.zig");
 
 const page_size = std.heap.page_size_min;
-// Stubs forward up to 9 lowered C-ABI args (a0..a8) into `genericDispatcher`,
-// so the dispatcher kinds can carry up to 8 wasm-level params (after dropping
-// the importer's vmctx for the AOT-codegen variants). See #689 — the older
-// 6-arg shape couldn't lower WASIp2 filesystem methods like `link-at` (7
-// wasm params) and silently fell back to a trap stub.
-const x86_64_stub_bytes: usize = 61;
-const aarch64_stub_bytes: usize = 76;
+// Stubs forward up to 10 lowered C-ABI args (a0..a9) into `genericDispatcher`,
+// so the dispatcher kinds can carry up to 9 wasm-level params (after dropping
+// the importer's vmctx for the AOT-codegen variants). See #700 — widened from
+// 9 (a0..a8) so `wasi_snapshot_preview1.path_open` (9 wasm params) stops
+// trap-stubbing on the WASIp1→WASIp2 adapter path. Previously widened from
+// 6 → 9 in #689 to lower WASIp2 filesystem methods like `link-at` (7 wasm
+// params).
+const x86_64_stub_bytes: usize = 63;
+const aarch64_stub_bytes: usize = 84;
 
 pub const STUB_BYTES: usize = switch (builtin.cpu.arch) {
     .x86_64 => x86_64_stub_bytes,
@@ -49,6 +51,7 @@ extern fn wamrAotDispatchComponentTrampoline(
     a6: u64,
     a7: u64,
     a8: u64,
+    a9: u64,
 ) callconv(.c) DispatchResult;
 
 /// AOT-codegen-flavoured wrapper around `wamrAotDispatchComponentTrampoline`
@@ -68,6 +71,7 @@ extern fn wamrAotDispatchComponentTrampolineAot(
     a6: u64,
     a7: u64,
     a8: u64,
+    a9: u64,
 ) callconv(.c) DispatchResult;
 
 /// Cross-instance core-to-core fn-import dispatcher (#662). Implemented in
@@ -86,6 +90,7 @@ extern fn wamrAotDispatchCrossInstance(
     a6: u64,
     a7: u64,
     a8: u64,
+    a9: u64,
 ) callconv(.c) DispatchResult;
 
 /// Trap-on-call stub for non-WASI function imports that have no AOT-side
@@ -104,6 +109,7 @@ extern fn wamrAotDispatchTrapStub(
     a6: u64,
     a7: u64,
     a8: u64,
+    a9: u64,
 ) callconv(.c) DispatchResult;
 
 pub const DispatchKind = enum(u8) {
@@ -131,17 +137,17 @@ pub fn setActivePool(pool: ?*TrampolinePool) void {
     g_active_pool = pool;
 }
 
-pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64, a6: u64, a7: u64, a8: u64) callconv(.c) u64 {
+pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64, a6: u64, a7: u64, a8: u64, a9: u64) callconv(.c) u64 {
     const pool = g_active_pool orelse return 0;
     if (slot >= pool.next_slot) return 0;
 
     const entry = pool.slots[slot];
     const ctx = entry.ctx orelse return 0;
     const dispatched = switch (entry.dispatch_kind) {
-        .canon_lower => wamrAotDispatchComponentTrampoline(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8),
-        .canon_lower_aot => wamrAotDispatchComponentTrampolineAot(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8),
-        .cross_instance => wamrAotDispatchCrossInstance(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8),
-        .trap_stub => wamrAotDispatchTrapStub(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8),
+        .canon_lower => wamrAotDispatchComponentTrampoline(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
+        .canon_lower_aot => wamrAotDispatchComponentTrampolineAot(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
+        .cross_instance => wamrAotDispatchCrossInstance(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
+        .trap_stub => wamrAotDispatchTrapStub(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
     };
     if (dispatched.status != 0) return 0;
     return dispatched.value;
@@ -331,34 +337,31 @@ fn dispatcherAddr() usize {
 fn encodeX8664Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
     std.debug.assert(bytes.len >= STUB_BYTES);
 
-    // Caller passes up to 9 args (a0..a8): a0..a5 in regs (rdi, rsi, rdx,
-    // rcx, r8, r9), a6/a7/a8 on stack at [rsp+8/+16/+24]. We inject `slot`
-    // as the new first arg and forward a0..a8, so the dispatcher receives
-    // 10 args (slot + a0..a8): rdi=slot, rsi/rdx/rcx/r8/r9=a0..a4, and
-    // a5..a8 on stack at [rsp+8..+32] after `call rax` pushes the return
-    // address. We pre-push caller_a8/_a7/_a6 (read out of the caller's
+    // Caller passes up to 10 args (a0..a9): a0..a5 in regs (rdi, rsi, rdx,
+    // rcx, r8, r9), a6/a7/a8/a9 on stack at [rsp+8/+16/+24/+32]. We inject
+    // `slot` as the new first arg and forward a0..a9, so the dispatcher
+    // receives 11 args (slot + a0..a9): rdi=slot, rsi/rdx/rcx/r8/r9=a0..a4,
+    // and a5..a9 on stack at [rsp+8..+40] after `call rax` pushes the return
+    // address. We pre-push caller_a9/_a8/_a7/_a6 (read out of the caller's
     // outgoing stack-arg region) and r9 (caller_a5) to land them at the
     // right offsets.
     //
-    // SysV alignment (#691): at stub entry rsp%16==8 (caller's pre-call
-    // rsp was 16-aligned, `call` pushed 8). The 4 pushes below shift rsp
-    // by -32 (no net change mod 16), and `call rax` shifts by another -8
-    // → dispatcher would enter with rsp%16==0, violating SysV's
-    // `(rsp+8)%16==0` invariant. The first 16-aligned op in the
-    // dispatcher (e.g. SmpAllocator.alloc via vtable) then faults with
-    // a hardware #GP. Fix: `sub rsp, 8` before the 4 reads/pushes, then
-    // `add rsp, 40` in the epilogue. Read displacements also shift +8
-    // (0x18 → 0x20) because the caller_a6/a7/a8 stack-arg region now
-    // sits 8 bytes higher relative to the adjusted rsp.
+    // SysV alignment (#691, #700): at stub entry rsp%16==8 (caller's pre-call
+    // rsp was 16-aligned, `call` pushed 8). The 5 pushes below shift rsp
+    // by -40 → rsp%16==0 before `call rax`, which pushes another 8 → the
+    // dispatcher enters with rsp%16==8, satisfying SysV's
+    // `(rsp+8)%16==0` invariant. No extra align pad needed — the previous
+    // 4-push (a6..a8) layout in #689 did need a `sub rsp, 8` pad; widening
+    // to 5 pushes (a6..a9) in #700 naturally re-aligns.
     //
-    // Prologue-align (4 bytes): pad rsp for SysV.
-    const prologue_align = [_]u8{
-        0x48, 0x83, 0xEC, 0x08, // sub rsp, 8
-    };
-    // Prologue (20 bytes): read caller stack args into our frame, then
-    // push r9.
+    // Prologue (26 bytes): read caller stack args into our frame, then
+    // push r9. Reads always come from [rsp+0x20] because each push shifts
+    // the remaining caller args up by 8 (caller_a9 was at [rsp+32]; after
+    // pushing it, caller_a8 is at [rsp+32]; and so on).
     const prologue_stack = [_]u8{
-        0x48, 0x8B, 0x44, 0x24, 0x20, // mov rax, [rsp+32]  (caller_a8)
+        0x48, 0x8B, 0x44, 0x24, 0x20, // mov rax, [rsp+32]  (caller_a9)
+        0x50, // push rax
+        0x48, 0x8B, 0x44, 0x24, 0x20, // mov rax, [rsp+32]  (caller_a8, shifted)
         0x50, // push rax
         0x48, 0x8B, 0x44, 0x24, 0x20, // mov rax, [rsp+32]  (caller_a7, shifted)
         0x50, // push rax
@@ -377,8 +380,7 @@ fn encodeX8664Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
         0xBF, // mov edi, imm32 (slot)
     };
     const movabs = [_]u8{ 0x48, 0xB8 };
-    // Epilogue (7 bytes): call dispatcher, drop our 32-byte spill + 8-byte
-    // alignment pad, return.
+    // Epilogue (7 bytes): call dispatcher, drop our 40-byte spill, return.
     const epilogue = [_]u8{
         0xFF, 0xD0, // call rax
         0x48, 0x83, 0xC4, 0x28, // add rsp, 40
@@ -386,8 +388,6 @@ fn encodeX8664Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
     };
 
     var cursor: usize = 0;
-    @memcpy(bytes[cursor .. cursor + prologue_align.len], &prologue_align);
-    cursor += prologue_align.len;
     @memcpy(bytes[cursor .. cursor + prologue_stack.len], &prologue_stack);
     cursor += prologue_stack.len;
     @memcpy(bytes[cursor .. cursor + shift.len], &shift);
@@ -407,9 +407,10 @@ fn encodeX8664Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
 fn encodeAarch64Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
     std.debug.assert(bytes.len >= STUB_BYTES);
 
-    // AAPCS64: a0..a7 in x0..x7, a8 on stack at [sp+0]. We inject `slot`
-    // as x0 and forward a0..a8 to the dispatcher, so dispatcher sees
-    // (slot, a0..a8) = 10 args: x0=slot, x1..x7=a0..a6, [sp+0]=a7, [sp+8]=a8.
+    // AAPCS64: a0..a7 in x0..x7, a8 on stack at [sp+0], a9 at [sp+8]. We
+    // inject `slot` as x0 and forward a0..a9 to the dispatcher, so
+    // dispatcher sees (slot, a0..a9) = 11 args: x0=slot, x1..x7=a0..a6,
+    // [sp+0]=a7, [sp+8]=a8, [sp+16]=a9.
     //
     // Unlike the 6-arg version we can no longer tail-call: we own a stack
     // frame for the dispatcher's stack args + a saved LR. So we use
@@ -418,10 +419,16 @@ fn encodeAarch64Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
 
     // str x30, [sp, #-16]!  -- save LR, sp -= 16. Keeps sp 16-byte aligned.
     emitAarch64(bytes, &cursor, 0xF81F0FFE);
-    // ldr x9, [sp, #16]     -- x9 = caller_a8 (was at [sp+0] pre-push).
+    // ldr x9,  [sp, #16]    -- x9  = caller_a8 (was at [sp+0] pre-push).
     emitAarch64(bytes, &cursor, 0xF9400BE9);
-    // stp x7, x9, [sp, #-16]!  -- push caller_a7 + caller_a8.
-    // After this: [sp+0]=a7, [sp+8]=a8 (dispatcher's stack args).
+    // ldr x10, [sp, #24]    -- x10 = caller_a9 (was at [sp+8] pre-push).
+    emitAarch64(bytes, &cursor, 0xF9400FEA);
+    // str x10, [sp, #-16]!  -- push caller_a9; sp -= 16, [sp+0]=a9.
+    // (The upper 8 bytes are padding; the dispatcher won't read them.)
+    emitAarch64(bytes, &cursor, 0xF81F0FEA);
+    // stp x7, x9, [sp, #-16]!  -- push caller_a7 + caller_a8; sp -= 16.
+    // After this: [sp+0]=a7, [sp+8]=a8, [sp+16]=a9 (the dispatcher's stack
+    // args).
     emitAarch64(bytes, &cursor, 0xA9BF27E7);
 
     // Shift x0..x7 right by one register (x7=x6, x6=x5, ..., x1=x0).
@@ -449,8 +456,8 @@ fn encodeAarch64Stub(bytes: []u8, slot: u32, dispatcher: usize) void {
 
     // blr x16                 -- call dispatcher.
     emitAarch64(bytes, &cursor, 0xD63F0200);
-    // add sp, sp, #16         -- pop the two pushed stack args.
-    emitAarch64(bytes, &cursor, 0x910043FF);
+    // add sp, sp, #32         -- pop the two 16-byte pushes (a7+a8 + a9+pad).
+    emitAarch64(bytes, &cursor, 0x910083FF);
     // ldr x30, [sp], #16      -- restore LR with post-increment.
     emitAarch64(bytes, &cursor, 0xF84107FE);
     // ret                     -- branch to LR.
@@ -486,12 +493,12 @@ test "#648 phase 2: x86_64 trampoline encoder emits slot and dispatcher immediat
 
     encodeX8664Stub(&bytes, 0x11223344, 0x1122334455667788);
 
-    // Stub layout (#691): sub rsp, 8 (SysV align pad); pre-spill
-    // caller_a8/_a7/_a6 from [rsp+32], then push r9 (caller_a5); shift
-    // rdi..r9; mov edi, slot; movabs rax, dispatcher; call rax;
-    // add rsp, 40; ret.
+    // Stub layout (#700): pre-spill caller_a9/_a8/_a7/_a6 from [rsp+32],
+    // then push r9 (caller_a5); shift rdi..r9; mov edi, slot;
+    // movabs rax, dispatcher; call rax; add rsp, 40; ret. The 5 pushes
+    // self-align SysV (8 - 40 ≡ 0 mod 16) so no `sub rsp, 8` pad is needed.
     const expected = [_]u8{
-        0x48, 0x83, 0xEC, 0x08,
+        0x48, 0x8B, 0x44, 0x24, 0x20, 0x50,
         0x48, 0x8B, 0x44, 0x24, 0x20, 0x50,
         0x48, 0x8B, 0x44, 0x24, 0x20, 0x50,
         0x48, 0x8B, 0x44, 0x24, 0x20, 0x50,
@@ -522,12 +529,15 @@ test "#648 phase 2: aarch64 trampoline encoder emits slot and dispatcher immedia
 
     encodeAarch64Stub(&bytes, 0x1234, 0x1122334455667788);
 
-    // Stub layout (#689): save LR, read caller_a8, push x7+caller_a8;
-    // shift x0..x7; movz x0,slot; movz/movk x16,dispatcher; blr x16; pop
-    // pushed args; restore LR; ret.
+    // Stub layout (#700): save LR, read caller_a8/a9 into x9/x10, push
+    // caller_a9 (with pad), push x7+caller_a8; shift x0..x7;
+    // movz x0,slot; movz/movk x16,dispatcher; blr x16; pop the two 16-byte
+    // pushes (add sp, sp, #32); restore LR; ret.
     const expected = [_]u32{
         0xF81F0FFE, // str x30, [sp, #-16]!
-        0xF9400BE9, // ldr x9, [sp, #16]
+        0xF9400BE9, // ldr x9,  [sp, #16]
+        0xF9400FEA, // ldr x10, [sp, #24]
+        0xF81F0FEA, // str x10, [sp, #-16]!
         0xA9BF27E7, // stp x7, x9, [sp, #-16]!
         0xAA0603E7, // mov x7, x6
         0xAA0503E6, // mov x6, x5
@@ -542,7 +552,7 @@ test "#648 phase 2: aarch64 trampoline encoder emits slot and dispatcher immedia
         0xF2C66890, // movk x16, #0x3344, lsl 32
         0xF2E22450, // movk x16, #0x1122, lsl 48
         0xD63F0200, // blr x16
-        0x910043FF, // add sp, sp, #16
+        0x910083FF, // add sp, sp, #32
         0xF84107FE, // ldr x30, [sp], #16
         0xD65F03C0, // ret
     };

--- a/src/tests/aot_host_trampolines_test.zig
+++ b/src/tests/aot_host_trampolines_test.zig
@@ -112,7 +112,7 @@ test "#648 phase 1: trampoline pool allocates mmap-backed stub slots" {
     try std.testing.expectEqual(@as(u32, 4), pool.next_slot);
     try std.testing.expectEqual(@as(u32, 22), pool.slots[1].canon_lower_idx);
     try std.testing.expectEqual(@intFromPtr(&fake_component_2), @intFromPtr(pool.slots[2].component_inst));
-    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(3, 1, 2, 3, 4, 5, 6, 7, 8, 9));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 
     host_trampolines.setActivePool(null);
     pool.deinit(allocator);
@@ -224,7 +224,7 @@ test "#648 phase 3: genericDispatcher handles (i32) -> ()" {
     const lowered_results = [_]core_types.ValType{};
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
 
-    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 41, 0, 0, 0, 0, 0, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0));
     try std.testing.expect(state.called);
     try std.testing.expectEqual(@as(i32, 41), state.arg);
 }
@@ -258,7 +258,7 @@ test "#648 phase 3: genericDispatcher handles () -> i32" {
     const lowered_results = [_]core_types.ValType{.i32};
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
 
-    try std.testing.expectEqual(@as(u64, 77), host_trampolines.genericDispatcher(0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 77), host_trampolines.genericDispatcher(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 test "#648 phase 3: genericDispatcher handles (i32) -> i32" {
@@ -289,7 +289,7 @@ test "#648 phase 3: genericDispatcher handles (i32) -> i32" {
     const lowered_results = [_]core_types.ValType{.i32};
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &lowered_results });
 
-    try std.testing.expectEqual(@as(u64, 17), host_trampolines.genericDispatcher(0, 12, 0, 0, 0, 0, 0, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 17), host_trampolines.genericDispatcher(0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 test "#648 phase 3: genericDispatcher handles (i32 i32) -> () retptr" {
@@ -320,7 +320,7 @@ test "#648 phase 3: genericDispatcher handles (i32 i32) -> () retptr" {
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &.{}, .has_retptr = true });
 
     const retptr: u32 = 24;
-    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 9, retptr, 0, 0, 0, 0, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 9, retptr, 0, 0, 0, 0, 0, 0, 0, 0));
     const mem = inst.resolveTopLevelMemory(0).?.data;
     try expectStoredPtrLen(mem, retptr, 0x55, 7);
 }
@@ -355,7 +355,7 @@ test "#648 phase 3: genericDispatcher handles (i32 i32 i32 i32) -> ()" {
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &.{}, .has_retptr = true });
 
     const retptr: u32 = 40;
-    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 3, 0x40, 5, retptr, 0, 0, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 3, 0x40, 5, retptr, 0, 0, 0, 0, 0, 0));
     const mem = inst.resolveTopLevelMemory(0).?.data;
     try expectStoredPtrLen(mem, retptr, 0x80, 5);
 }
@@ -389,7 +389,7 @@ test "#648 phase 3: genericDispatcher handles (i32 i64 i32) -> ()" {
     _ = try pool.allocSlotWithCtx(@ptrCast(&ctx), .{ .param_types = &lowered_params, .result_types = &.{}, .has_retptr = true });
 
     const retptr: u32 = 56;
-    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 4, 0x1_0000_0002, retptr, 0, 0, 0, 0, 0, 0));
+    try std.testing.expectEqual(@as(u64, 0), host_trampolines.genericDispatcher(0, 4, 0x1_0000_0002, retptr, 0, 0, 0, 0, 0, 0, 0));
     const mem = inst.resolveTopLevelMemory(0).?.data;
     try expectStoredPtrLen(mem, retptr, 0x90, 2);
 }


### PR DESCRIPTION
Fixes #700.

After #699 routed component-wired WASIp1 imports through `buildCrossInstanceThunkAot`, `wasi_snapshot_preview1.path_open` (9 wasm params: 7 i32 + 2 i64) started hitting the `SignatureTooWide` cap at `src/component/instance.zig:3204` (then `> 8`), getting a trap-on-call stub installed. Any guest filesystem open then trapped, blocking the keyvault codegen-cli repro and any component that opens files via the WASIp1 adapter.

This is the same template as #689 (which widened 5 → 8 for WASIp2 `link-at`), now bumped 8 → 9 for WASIp1 `path_open`. The trampoline pool's register-forwarding pipeline grows by one slot.

## What changed

- `genericDispatcher` and the four extern dispatcher declarations (`wamrAotDispatch{ComponentTrampoline,ComponentTrampolineAot,CrossInstance,TrapStub}`) gain an `a9: u64` parameter.
- **x86_64 stub**: gains a 4th pre-spill (caller_a9 from `[rsp+32]`). 5 pushes happen to self-align SysV (`8 - 40 ≡ 0 mod 16`), so the `sub rsp, 8` align pad added in #691 is dropped. Net stub size **61 → 63 bytes**.
- **aarch64 stub**: gains `ldr x10, [sp, #24]` + `str x10, [sp, #-16]!` to push caller_a9 (with implicit 8-byte pad) and bumps the epilogue's `add sp, sp, #16` → `#32`. Net stub size **76 → 84 bytes**.
- `dispatchAotCrossInstance` widens `arg_regs: [9]u64` → `[10]u64`, `args_buf: [8]Value` → `[9]Value`, cap `> 8` → `> 9`.
- `dispatchAotComponentTrampoline` widens `regs: [9]u64` → `[10]u64` (and `liftAotDispatcherArg`'s matching pointer parameter).
- `buildCrossInstanceThunkAot`'s `SignatureTooWide` check bumps `> 8` → `> 9`.
- Encoder fixture tests refreshed for both arches.

## x86_64 alignment math

| step                 | rsp delta | rsp%16 |
| -------------------- | --------- | ------ |
| stub entry           | 0         | 8      |
| 5 pushes (5 × −8)    | −40       | 0      |
| `call rax` (push 8)  | −8        | 8      |
| dispatcher entry     |           | 8 ✓    |

SysV requires `rsp%16 == 8` at function entry — naturally satisfied by 5 pushes without the prior `sub rsp, 8` pad.

## Verification

- `zig build test --summary failures` → **2940/2947 passing (7 skipped)**, matches the #699 baseline.
- Keyvault codegen-cli repro: `path_open` no longer trap-stubbed (no `SignatureTooWide` warning post-fix). The previously trap-stubbed `[wasi-filesystem]` `response-outparam.set` also fits at the new cap and stopped trap-stubbing. The remaining warnings are all `[resource-drop]` `UnsupportedCrossInstanceSource` — tracked separately in #701.

Refs #698 #699 #689.