### PR TITLE
fix #701: bridge canon-builtin resource.{drop,new,rep} through AOT cross-instance dispatcher

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -6142,6 +6142,101 @@ fn dispatchAotCrossInstance(
     };
 }
 
+/// Canon-builtin dispatcher for AOT-compiled core modules (#701, follow-up
+/// to #687). Mirrors `wamrAotDispatchCrossInstance`'s vmctx-as-first-arg
+/// convention: `a0` is the importer's vmctx (ignored — canon-builtins
+/// operate on the component instance carried in the ctx), and `a1` is the
+/// wasm-level handle / rep value. Today this handles the three
+/// `resource.{drop,new,rep}` kinds that #701 explicitly targets; other
+/// canon-builtin kinds (`context.*`, `task.*`, async ABI) trap-stub
+/// pending a follow-up.
+pub export fn wamrAotDispatchCanonBuiltin(
+    ctx_opaque: *anyopaque,
+    lowered_sig: *const host_trampolines.LoweredSig,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
+    a9: u64,
+) callconv(.c) host_trampolines.DispatchResult {
+    _ = a0; // importer's vmctx; canon-builtins resolve state via ctx.comp_inst.
+    _ = a2;
+    _ = a3;
+    _ = a4;
+    _ = a5;
+    _ = a6;
+    _ = a7;
+    _ = a8;
+    _ = a9;
+    const ctx: *const CanonBuiltinTrampolineCtx = @ptrCast(@alignCast(ctx_opaque));
+    const result = dispatchAotCanonBuiltin(ctx, lowered_sig.*, @as(u32, @truncate(a1))) catch |err| {
+        if (debugAotEnabled()) {
+            std.debug.print(
+                "[aot-dispatch] canon-builtin '{s}' failed: {s}\n",
+                .{ @tagName(ctx.canon), @errorName(err) },
+            );
+        }
+        return .{ .status = 1, .value = 0 };
+    };
+    return .{ .status = 0, .value = result };
+}
+
+fn dispatchAotCanonBuiltin(
+    ctx: *const CanonBuiltinTrampolineCtx,
+    lowered_sig: host_trampolines.LoweredSig,
+    arg0: u32,
+) !u64 {
+    // All in-scope canon-builtins ({resource}.drop/new/rep) lower to a single
+    // i32 input and 0 or 1 i32 outputs. Any other shape is a wiring bug.
+    if (lowered_sig.has_retptr) return error.UnsupportedSignature;
+    if (lowered_sig.param_types.len != 1) return error.UnsupportedSignature;
+    if (lowered_sig.param_types[0] != .i32) return error.UnsupportedSignature;
+    if (lowered_sig.result_types.len > 1) return error.UnsupportedSignature;
+    if (lowered_sig.result_types.len == 1 and lowered_sig.result_types[0] != .i32)
+        return error.UnsupportedSignature;
+
+    const comp_inst = ctx.comp_inst;
+    const allocator = comp_inst.allocator;
+
+    switch (ctx.canon) {
+        .resource_new => |resource_idx| {
+            if (lowered_sig.result_types.len != 1) return error.UnsupportedSignature;
+            const rt = comp_inst.getOrCreateResourceTable(resource_idx) catch
+                return error.OutOfMemory;
+            const handle = try canonResourceNew(rt, arg0, allocator);
+            return @as(u64, @intCast(handle));
+        },
+        .resource_drop => |resource_idx| {
+            if (lowered_sig.result_types.len != 0) return error.UnsupportedSignature;
+            const rt = comp_inst.getOrCreateResourceTable(resource_idx) catch
+                return error.OutOfMemory;
+            _ = canonResourceDrop(rt, arg0, allocator);
+            // Mirror the interp arm in `dispatchCanonBuiltinWithCtx`: notify
+            // the host adapter so it can release kernel-side state attached
+            // to the dropped handle. WAMR's host fns return reps as wire
+            // handles directly (no automatic `canon resource.new` wrap), so
+            // the per-type table is typically empty here. (#575)
+            if (comp_inst.on_resource_drop) |hook| {
+                hook(comp_inst.on_resource_drop_ctx, comp_inst, resource_idx, arg0);
+            }
+            return 0;
+        },
+        .resource_rep => |resource_idx| {
+            if (lowered_sig.result_types.len != 1) return error.UnsupportedSignature;
+            const rt = comp_inst.getOrCreateResourceTable(resource_idx) catch
+                return error.OutOfMemory;
+            const rep_val = canonResourceRep(rt, arg0) orelse 0;
+            return @as(u64, @intCast(rep_val));
+        },
+        else => return error.UnsupportedSignature,
+    }
+}
+
 /// Trap-on-call stub dispatcher (#662 follow-up). The trampoline pool
 /// installs this dispatcher for non-WASI fn imports the AOT bridge has
 /// no wiring for yet (canon.lower / canon-builtin). Instantiation
@@ -7312,4 +7407,166 @@ test "encode/decodeResourceWire round-trip (#520 wave 2)" {
         const slot: u32 = @intCast(i);
         try testing.expectEqual(slot, decodeResourceWire(encodeResourceWire(slot)));
     }
+}
+
+// ── #701: AOT canon-builtin dispatcher ──────────────────────────────────────
+
+test "wamrAotDispatchCanonBuiltin: resource.new/rep/drop round-trip + on_resource_drop hook (#701)" {
+    // End-to-end test of the AOT-side canon-builtin dispatcher added in
+    // #701. Drives a `*ComponentInstance` through `wamrAotDispatchCanonBuiltin`
+    // for each of the three in-scope canon kinds and verifies the resource
+    // table mutates correctly + the `on_resource_drop` hook fires.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, allocator);
+    defer inst.deinit();
+
+    // Wire a drop-hook so we can assert it fires with the right
+    // (resource_idx, handle) pair when `.resource_drop` dispatches.
+    const HookState = struct {
+        var fires: u32 = 0;
+        var last_resource_idx: u32 = 0xFFFF_FFFF;
+        var last_handle: u32 = 0xFFFF_FFFF;
+        fn reset() void {
+            fires = 0;
+            last_resource_idx = 0xFFFF_FFFF;
+            last_handle = 0xFFFF_FFFF;
+        }
+        fn cb(_: ?*anyopaque, _: *ComponentInstance, ridx: u32, h: u32) void {
+            fires += 1;
+            last_resource_idx = ridx;
+            last_handle = h;
+        }
+    };
+    HookState.reset();
+    inst.on_resource_drop = &HookState.cb;
+    inst.on_resource_drop_ctx = null;
+
+    const resource_idx: u32 = 7;
+    const new_ctx = CanonBuiltinTrampolineCtx{
+        .comp_inst = inst,
+        .canon = .{ .resource_new = resource_idx },
+    };
+    const drop_ctx = CanonBuiltinTrampolineCtx{
+        .comp_inst = inst,
+        .canon = .{ .resource_drop = resource_idx },
+    };
+    const rep_ctx = CanonBuiltinTrampolineCtx{
+        .comp_inst = inst,
+        .canon = .{ .resource_rep = resource_idx },
+    };
+
+    const i32_one = [_]core_types.ValType{.i32};
+    const sig_one_to_one = host_trampolines.LoweredSig{
+        .param_types = &i32_one,
+        .result_types = &i32_one,
+    };
+    const sig_one_to_void = host_trampolines.LoweredSig{
+        .param_types = &i32_one,
+        .result_types = &.{},
+    };
+
+    // resource.new(rep=123) → handle.  Convention: a0 is importer's
+    // vmctx (ignored), a1 is the wasm arg.
+    const new_res = wamrAotDispatchCanonBuiltin(
+        @ptrCast(@constCast(&new_ctx)),
+        &sig_one_to_one,
+        0xDEAD, 123, 0, 0, 0, 0, 0, 0, 0, 0,
+    );
+    try testing.expectEqual(@as(u32, 0), new_res.status);
+    const handle: u32 = @intCast(new_res.value);
+    // ResourceTable.new returns the slot index, starting at 0 for a fresh
+    // table — don't assume handle != 0; round-trip via rep / drop instead.
+
+    // resource.rep(handle) → 123. Resource table is keyed by the
+    // canon's `resource_idx` immediate, so use the same idx as new.
+    const rep_res = wamrAotDispatchCanonBuiltin(
+        @ptrCast(@constCast(&rep_ctx)),
+        &sig_one_to_one,
+        0, handle, 0, 0, 0, 0, 0, 0, 0, 0,
+    );
+    try testing.expectEqual(@as(u32, 0), rep_res.status);
+    try testing.expectEqual(@as(u64, 123), rep_res.value);
+
+    // resource.drop(handle). Status=0, value=0 (drop returns no
+    // i32 result on the wasm side). Hook must fire exactly once
+    // with (resource_idx, handle).
+    const drop_res = wamrAotDispatchCanonBuiltin(
+        @ptrCast(@constCast(&drop_ctx)),
+        &sig_one_to_void,
+        0, handle, 0, 0, 0, 0, 0, 0, 0, 0,
+    );
+    try testing.expectEqual(@as(u32, 0), drop_res.status);
+    try testing.expectEqual(@as(u64, 0), drop_res.value);
+    try testing.expectEqual(@as(u32, 1), HookState.fires);
+    try testing.expectEqual(resource_idx, HookState.last_resource_idx);
+    try testing.expectEqual(handle, HookState.last_handle);
+
+    // After drop, resource.rep on the freed handle returns 0 (canonResourceRep
+    // returns null → dispatcher coerces to 0).
+    const rep_after = wamrAotDispatchCanonBuiltin(
+        @ptrCast(@constCast(&rep_ctx)),
+        &sig_one_to_one,
+        0, handle, 0, 0, 0, 0, 0, 0, 0, 0,
+    );
+    try testing.expectEqual(@as(u32, 0), rep_after.status);
+    try testing.expectEqual(@as(u64, 0), rep_after.value);
+}
+
+test "wamrAotDispatchCanonBuiltin: rejects malformed lowered_sig (#701)" {
+    // Any sig that isn't `(i32) → ()` (drop) or `(i32) → i32`
+    // (new/rep) must return a failing DispatchResult so the wiring
+    // bug surfaces as a clean trap instead of a misread arg.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var comp = ctypes.Component{
+        .core_modules = &.{},     .core_instances = &.{}, .core_types = &.{},
+        .components = &.{},       .instances = &.{},      .aliases = &.{},
+        .types = &.{},            .canons = &.{},         .imports = &.{},
+        .exports = &.{},
+    };
+    const inst = try instance_mod.instantiate(&comp, allocator);
+    defer inst.deinit();
+
+    const drop_ctx = CanonBuiltinTrampolineCtx{
+        .comp_inst = inst,
+        .canon = .{ .resource_drop = 0 },
+    };
+
+    // Wrong shape: drop with a result; reject.
+    const i32_one = [_]core_types.ValType{.i32};
+    const bad_sig = host_trampolines.LoweredSig{
+        .param_types = &i32_one,
+        .result_types = &i32_one,
+    };
+    const res = wamrAotDispatchCanonBuiltin(
+        @ptrCast(@constCast(&drop_ctx)),
+        &bad_sig,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    );
+    try testing.expectEqual(@as(u32, 1), res.status);
+
+    // Unsupported canon kind (e.g. context.get) → reject.
+    const ctx_get = CanonBuiltinTrampolineCtx{
+        .comp_inst = inst,
+        .canon = .{ .context_get = .{ .val_type = .i32, .slot = 0 } },
+    };
+    const ok_sig = host_trampolines.LoweredSig{
+        .param_types = &i32_one,
+        .result_types = &i32_one,
+    };
+    const res2 = wamrAotDispatchCanonBuiltin(
+        @ptrCast(@constCast(&ctx_get)),
+        &ok_sig,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    );
+    try testing.expectEqual(@as(u32, 1), res2.status);
 }

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -3137,11 +3137,33 @@ fn resolveAotImportedFunctionOverrides(
                             break :blk null;
                         };
                     },
-                    // Resource-drop / new / rep and other canon-builtin
-                    // contributors still fall through to the trap stub.
-                    // Bridging them requires a separate canon-builtin
-                    // dispatch kind in the trampoline pool; tracked as a
-                    // follow-up to #687.
+                    // Canon-builtin contributors: `resource.{drop,new,rep}`
+                    // are bridged through `CanonBuiltinTrampolineCtx` +
+                    // `wamrAotDispatchCanonBuiltin`. Other canon-builtin
+                    // kinds (`context.*`, `task.*`, async ABI) still fall
+                    // through to the trap stub pending follow-up to #701.
+                    .resource_drop, .resource_new, .resource_rep => {
+                        const canon_idx_b: u32 = switch (canon_ref) {
+                            .resource_drop => |i| i,
+                            .resource_new => |i| i,
+                            .resource_rep => |i| i,
+                            else => unreachable,
+                        };
+                        thunk = installCanonBuiltinBackedCrossInstanceThunk(
+                            allocator,
+                            inst,
+                            component,
+                            canon_idx_b,
+                            imp,
+                            module,
+                        ) catch |err| blk: {
+                            std.log.warn(
+                                "[aot reject] core module {d}: canon-builtin thunk for '{s}.{s}' failed ({s}); falling back to cross-instance / trap-stub",
+                                .{ module_idx, imp.module_name, imp.field_name, @errorName(err) },
+                            );
+                            break :blk null;
+                        };
+                    },
                     else => {},
                 }
             }
@@ -3450,6 +3472,85 @@ fn installCanonLowerBackedCrossInstanceThunk(
     for (ft.results, 0..) |r, i| lowered_results[i] = r;
 
     const stub = try pool.allocCanonLowerAotSlot(@ptrCast(ctx_ptr), .{
+        .param_types = lowered_params,
+        .result_types = lowered_results,
+        .has_retptr = false,
+    });
+    return @ptrCast(stub);
+}
+
+/// Bridge an AOT core module's import that resolves through a sibling
+/// inline-export to a canon-builtin (`resource.{drop,new,rep}`) contributor.
+/// Mirrors `installCanonLowerBackedCrossInstanceThunk` but uses the
+/// existing `CanonBuiltinTrampolineCtx` (shared with the interp wiring at
+/// `linkImports`) and the canon-builtin trampoline-pool slot. Other
+/// canon-builtin kinds (`context.*`, `task.*`, async ABI) return
+/// `error.UnsupportedCanonKind` so the caller falls through to the trap
+/// stub; bridging them is a follow-up to #701.
+fn installCanonBuiltinBackedCrossInstanceThunk(
+    allocator: std.mem.Allocator,
+    inst: *ComponentInstance,
+    component: *const ctypes.Component,
+    canon_idx: u32,
+    imp: aot_loader.AotImportDesc,
+    module: *const aot_loader.AotModule,
+) !*const anyopaque {
+    if (canon_idx >= component.canons.len) return error.InvalidCanonIdx;
+    const canon = component.canons[canon_idx];
+    switch (canon) {
+        .resource_drop, .resource_new, .resource_rep => {},
+        else => return error.UnsupportedCanonKind,
+    }
+
+    // Defensive shape check: every in-scope canon-builtin is `(i32) → ()`
+    // (drop) or `(i32) → i32` (new/rep). Reject anything else early so
+    // the trampoline-pool slot can rely on the lowered-sig invariants.
+    if (imp.func_type_idx >= module.func_types.len) return error.InvalidFuncType;
+    const ft = module.func_types[imp.func_type_idx];
+    if (ft.params.len != 1 or ft.params[0] != .i32) return error.UnsupportedSignature;
+    switch (canon) {
+        .resource_drop => if (ft.results.len != 0) return error.UnsupportedSignature,
+        .resource_new, .resource_rep => {
+            if (ft.results.len != 1 or ft.results[0] != .i32) return error.UnsupportedSignature;
+        },
+        else => unreachable,
+    }
+
+    // Probe the pool first so failures on platforms without RWX trampoline
+    // pages bail before we publish a new ctx — the caller installs a trap
+    // stub instead.
+    const pool = try ensureAotTrampolinePool(inst);
+
+    // Reuse / build the per-canon-def-id ctx. Same memoisation map the
+    // interp `linkImports` sweep at instance.zig:1939 uses, so a single
+    // canon-def shared by interp and AOT imports points at one ctx.
+    const ctx_ptr = ctx_blk: {
+        if (inst.canon_builtin_ctx_by_canon_idx.get(canon_idx)) |existing| {
+            break :ctx_blk existing;
+        }
+        const new_ctx = try allocator.create(executor_mod.CanonBuiltinTrampolineCtx);
+        errdefer allocator.destroy(new_ctx);
+        new_ctx.* = .{
+            .comp_inst = inst,
+            .canon = canon,
+        };
+        try inst.canon_builtin_ctxs.append(allocator, new_ctx);
+        errdefer _ = inst.canon_builtin_ctxs.pop();
+        // Failing to record the memoisation entry is non-fatal — the
+        // canon_builtin_ctxs list still owns the allocation, so it gets
+        // freed on `deinit`. Subsequent duplicate slots will allocate
+        // their own ctx (graceful degradation under OOM).
+        inst.canon_builtin_ctx_by_canon_idx.put(allocator, canon_idx, new_ctx) catch {};
+        break :ctx_blk new_ctx;
+    };
+
+    const arena = inst.module_arena.allocator();
+    const lowered_params = try arena.alloc(core_types.ValType, ft.params.len);
+    for (ft.params, 0..) |p, i| lowered_params[i] = p;
+    const lowered_results = try arena.alloc(core_types.ValType, ft.results.len);
+    for (ft.results, 0..) |r, i| lowered_results[i] = r;
+
+    const stub = try pool.allocCanonBuiltinAotSlot(@ptrCast(ctx_ptr), .{
         .param_types = lowered_params,
         .result_types = lowered_results,
         .has_retptr = false,

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -93,6 +93,27 @@ extern fn wamrAotDispatchCrossInstance(
     a9: u64,
 ) callconv(.c) DispatchResult;
 
+/// Canon-builtin dispatcher for AOT-compiled core modules whose imports
+/// resolve through a sibling inline-export to a `canon.resource.{drop,new,rep}`
+/// (or other canon-builtin) contributor. Same vmctx-as-first-arg convention
+/// as the other `*Aot` dispatchers — `a0` is the importer's vmctx (ignored),
+/// `a1` is the wasm-level handle / rep. Implemented in
+/// `src/component/executor.zig`. (#701, follow-up to #687.)
+extern fn wamrAotDispatchCanonBuiltin(
+    ctx_opaque: *anyopaque,
+    lowered_sig: *const LoweredSig,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
+    a9: u64,
+) callconv(.c) DispatchResult;
+
 /// Trap-on-call stub for non-WASI function imports that have no AOT-side
 /// wiring yet (e.g. adapter-core canon.lower imports left over after #662
 /// Phase C). Returns a failing `DispatchResult` so the caller traps with
@@ -116,6 +137,7 @@ pub const DispatchKind = enum(u8) {
     canon_lower,
     canon_lower_aot,
     cross_instance,
+    canon_builtin_aot,
     trap_stub,
 };
 
@@ -147,6 +169,7 @@ pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64,
         .canon_lower => wamrAotDispatchComponentTrampoline(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
         .canon_lower_aot => wamrAotDispatchComponentTrampolineAot(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
         .cross_instance => wamrAotDispatchCrossInstance(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
+        .canon_builtin_aot => wamrAotDispatchCanonBuiltin(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
         .trap_stub => wamrAotDispatchTrapStub(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
     };
     if (dispatched.status != 0) return 0;
@@ -268,6 +291,30 @@ pub const TrampolinePool = struct {
             .ctx = ctx,
             .lowered_sig = lowered_sig,
             .dispatch_kind = .cross_instance,
+        };
+        self.next_slot += 1;
+        writeStub(self.stubBytes(slot), slot);
+        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
+        g_active_pool = self;
+
+        return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
+    }
+
+    /// Allocate a slot for a canon-builtin (`resource.{drop,new,rep}`, etc.)
+    /// imported by an AOT-compiled core module. Routes through
+    /// `wamrAotDispatchCanonBuiltin`, which switches on the `CanonBuiltinTrampolineCtx`
+    /// to invoke the right pure helper against the component's resource
+    /// table. (#701, follow-up to #687.)
+    pub fn allocCanonBuiltinAotSlot(self: *TrampolinePool, ctx: *anyopaque, lowered_sig: LoweredSig) !StubFn {
+        const slot = self.next_slot;
+        if (slot >= MAX_SLOTS) return error.OutOfTrampolineSlots;
+
+        self.slots[slot] = .{
+            .component_inst = ctx,
+            .canon_lower_idx = 0,
+            .ctx = ctx,
+            .lowered_sig = lowered_sig,
+            .dispatch_kind = .canon_builtin_aot,
         };
         self.next_slot += 1;
         writeStub(self.stubBytes(slot), slot);


### PR DESCRIPTION
Fixes #701.

## Problem

After #687 (cross-instance pipeline), #698/#699 (route component-wired WASIp1 to adapter), and #700 (widen cap to 9), the keyvault codegen-cli repro still emitted ~14 `[aot reject] UnsupportedCrossInstanceSource` warnings of the shape:

```
warning: [aot reject] core module N: cross-instance thunk for
  'wasi:io/poll@0.2.6.[resource-drop]pollable' failed
  (UnsupportedCrossInstanceSource); installing trap-on-call stub
```

When an AOT core imports a sibling core's inline export backed by a `canon.lower` contributor, #699 routes it via `installCanonLowerBackedCrossInstanceThunk`. But when the contributor is a canon-**builtin** (`resource.drop` / `resource.new` / `resource.rep`), the fan-out switch fell through to `installTrapStub`, so any guest call to `resource.drop` on a WASIp2 handle trapped under AOT.

## Approach

Add a fourth `DispatchKind.canon_builtin_aot` to the trampoline pool, mirroring how #687 added `canon_lower` and #699 added `canon_lower_aot`. Reuses the existing `CanonBuiltinTrampolineCtx` (already populated for the interp path via `inst.canon_builtin_ctx_by_canon_idx`) and the existing pure helpers `canonResource{New,Drop,Rep}` — no `ExecEnv` needed.

| canon          | wasm sig         | dispatcher does                                                       |
| -------------- | ---------------- | --------------------------------------------------------------------- |
| `resource.drop`| `(i32) -> ()`    | `canonResourceDrop(rt, handle); on_resource_drop?(...)`               |
| `resource.new` | `(i32) -> i32`   | return `canonResourceNew(rt, rep)`                                    |
| `resource.rep` | `(i32) -> i32`   | return `canonResourceRep(rt, handle) orelse 0`                        |

## Changes

- `src/runtime/aot/host_trampolines.zig`: extern decl `wamrAotDispatchCanonBuiltin`, new `.canon_builtin_aot` `DispatchKind`, generic-dispatcher arm, `TrampolinePool.allocCanonBuiltinAotSlot`.
- `src/component/executor.zig`: `pub export fn wamrAotDispatchCanonBuiltin` + `dispatchAotCanonBuiltin` helper. Handles `resource.new` / `resource.drop` (with `on_resource_drop` hook) / `resource.rep`; validates lowered_sig is `(i32)->i32` or `(i32)->()`; rejects other canons.
- `src/component/instance.zig`: replace the `else => {}` arm in `resolveAotImportedFunctionOverrides` fan-out with explicit `.resource_drop/.resource_new/.resource_rep` branches calling new `installCanonBuiltinBackedCrossInstanceThunk` (memoises ctx via `inst.canon_builtin_ctx_by_canon_idx`, validates sig shape, allocates pool slot).

## Tests

- 2 new regression tests in `executor.zig`: round-trip `new`/`rep`/`drop` + `on_resource_drop` hook firing, and malformed-sig / unsupported-canon rejection.
- Full suite: **2942 pass / 7 skip / 0 fail** (was 2940/2947; +2 from new tests, same baseline).

## E2E note

The keyvault `wamrc compile-component` pipeline currently hangs on core 4 of the composed wasm — this is **pre-existing on main** (filed as #703), unrelated to this PR (which only adds runtime-side dispatcher code never reached by wamrc). The runtime change in this PR is validated by unit tests; end-to-end keyvault validation is blocked on #703.

## Refs

Refs #687, #698, #699, #700, #701. Follow-up: #703.
