### PR TITLE
fix #705: run AOT core-module start functions on instantiation

### DIFF
--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -270,6 +270,18 @@ pub const ComponentInstance = struct {
     /// bound by `linkImports` first. Drained by `linkImports` in core-instance
     /// order; see `runDeferredCoreStarts` (issue #308).
     pending_core_starts: std.ArrayListUnmanaged(*core_types.ModuleInstance) = .empty,
+    /// Pending AOT-instantiated core-module start functions whose execution
+    /// was deferred during `instantiate` so cross-instance imports (resolved
+    /// against sibling cores) are wired before the start runs. Drained by
+    /// `linkImports` after `pending_core_starts`. Mirrors #308 for the AOT
+    /// path. Without this, AOT modules with start sections — e.g. the
+    /// wasi-libc adapter's `path_unlink_file` (`State::new` cabi_realloc) —
+    /// never initialize `__stack_pointer` / `allocation_state`, and any
+    /// subsequent guest call into the adapter traps on State magic mismatch.
+    pending_aot_starts: std.ArrayListUnmanaged(struct {
+        inst: *aot_runtime.AotInstance,
+        start_idx: u32,
+    }) = .empty,
     /// Whether the start function has been executed.
     started: bool = false,
     /// Caller-supplied instantiation options (e.g. precompiled-core
@@ -1228,6 +1240,7 @@ pub const ComponentInstance = struct {
         const ExecEnv = @import("../runtime/common/exec_env.zig").ExecEnv;
         const interp = @import("../runtime/interpreter/interp.zig");
         defer self.pending_core_starts.clearRetainingCapacity();
+        defer self.pending_aot_starts.clearRetainingCapacity();
 
         for (self.pending_core_starts.items) |mi| {
             const start_idx = mi.module.start_function orelse continue;
@@ -1240,6 +1253,16 @@ pub const ComponentInstance = struct {
                         .{ ht.core_func_idx, ht.import_module_name, ht.import_field_name, @tagName(ht.stage), ht.err_name },
                     );
                 }
+                return inst_mod.InstantiationError.StartFunctionFailed;
+            };
+        }
+
+        for (self.pending_aot_starts.items) |entry| {
+            aot_runtime.callFunc(entry.inst, entry.start_idx, void) catch |err| {
+                std.debug.print(
+                    "[component init trap] aot start_func={d} error={s}\n",
+                    .{ entry.start_idx, @errorName(err) },
+                );
                 return inst_mod.InstantiationError.StartFunctionFailed;
             };
         }
@@ -1356,6 +1379,7 @@ pub const ComponentInstance = struct {
             self.allocator.destroy(pool);
         }
         self.pending_core_starts.deinit(self.allocator);
+        self.pending_aot_starts.deinit(self.allocator);
         if (self.core_instances.len > 0) {
             const inst_mod = @import("../runtime/interpreter/instance.zig");
             for (self.core_instances) |entry| {
@@ -1738,6 +1762,19 @@ pub fn instantiateWithOptions(
                                 break :aot_blk;
                             };
                             cis[ci_idx] = .{ .aot_inst = aot_inst_ptr };
+                            // Defer the AOT core module's `(start ...)` until
+                            // `runDeferredCoreStarts`, after all sibling cores
+                            // are wired and trampolines are bound (#308 AOT
+                            // analogue).
+                            if (aot_module_ptr.start_function) |start_idx| {
+                                inst.pending_aot_starts.append(allocator, .{
+                                    .inst = aot_inst_ptr,
+                                    .start_idx = start_idx,
+                                }) catch {
+                                    if (aot_only) return error.AotImportUnresolvable;
+                                    break :aot_blk;
+                                };
+                            }
                             // AOT cross-instance overrides were resolved
                             // above before instantiation; unresolved imports
                             // either fall back to interp or use a trap stub.


### PR DESCRIPTION
Fixes #705.

## Root cause

The AOT core-instantiation branch in `instantiateWithOptions` only stored the new `AotInstance` and `continue`d, never enqueuing the module's `(start ...)` for execution. Only the interpreter fallback path called `pending_core_starts.append(mi)` for the post-`linkImports` drain in `runDeferredCoreStarts`. Any AOT-only module with a wasm start section therefore had its start function **silently skipped**.

The keyvault repro from #705 surfaced as an OOB inside the WASIp1 adapter's `Filetype::from`. The real failure was that the adapter's `State::new` start function — which calls `__main_module__.cabi_realloc` to allocate 64 KiB, then sets `__stack_pointer` and `allocation_state = 2` — never ran. The first guest call into the adapter (`args_sizes_get`, `environ_sizes_get`, …) found `State`'s magic mismatch at offset 0, took the `unreachable!` panic-helper branch, and trapped on the next load through an uninitialized stack pointer. The OOB landed at `+0x84` inside whatever wit-bindgen had inlined into the calling function, which is why the trap message named `Filetype::from` even though the actual call site was earlier in the chain.

## Fix

Mirror `pending_core_starts` with a parallel
`pending_aot_starts: ArrayListUnmanaged(struct{ inst, start_idx })` queue. Enqueue in the AOT branch (using `aot_module_ptr.start_function` that the loader already parses), drain in `runDeferredCoreStarts` via `aot_runtime.callFunc(entry.inst, entry.start_idx, void)` after the existing interp drain, and deinit in the destructor. Draining after `linkImports` (same ordering as the interp path, #308) ensures the start function's cross-instance import calls — here `__main_module__.cabi_realloc` — find their wired trampolines.

## Verification

- `zig build test --summary all` → **2940/2940 pass** (7 skipped)
- Keyvault repro from the issue: `Filetype::from`/`args_sizes_get` OOB no longer reproduces; execution now reaches `_start`, `get-environment`, `get-directories`, and stdout writes via `wasi:io/streams`. A later SIGSEGV during streams cleanup (`[resource-drop]output-stream` trap-on-call stubs) is unrelated to #705 and is a #687-class follow-up.