### PR TITLE
canon-lower(aot): widen dispatcher for compound params/results (#707)

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -342,7 +342,7 @@ pub fn callComponentFuncByLocal(
         for (args, param_types) |arg, pt| {
             const al = typeAlign(registry, pt);
             offset = abi.alignUp(offset, al);
-            storeInterfaceValue(mem, offset, arg, pt, registry);
+            storeInterfaceValue(mem, offset, arg, pt, registry) catch return error.LowerError;
             offset += typeSize(registry, pt);
         }
 
@@ -582,7 +582,7 @@ pub fn callComponentFuncByLocalAsyncLifted(
         for (args, param_types) |arg, pt| {
             const al = typeAlign(registry, pt);
             offset = abi.alignUp(offset, al);
-            storeInterfaceValue(mem, offset, arg, pt, registry);
+            storeInterfaceValue(mem, offset, arg, pt, registry) catch return error.LowerError;
             offset += typeSize(registry, pt);
         }
         env.pushI32(@bitCast(ptr)) catch return error.StackOverflow;
@@ -1394,10 +1394,12 @@ fn storeInterfaceValue(
     val: InterfaceValue,
     t: ctypes.ValType,
     registry: TypeRegistry,
-) void {
+) abi.StoreError!void {
     abi.storeVal(mem, ptr, t, val) catch {
-        // Compound type — use registry-aware store
-        abi.storeValReg(mem, ptr, t, val, registry) catch {};
+        // Only error storeVal can return is CompoundNeedsRegistry —
+        // re-attempt via the registry-aware path so the error
+        // propagates instead of silently writing nothing. Issue #707.
+        try abi.storeValReg(mem, ptr, t, val, registry);
     };
 }
 
@@ -5963,7 +5965,8 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
         for (results, ctx.result_types) |r, t| {
             const al = typeAlign(registry, t);
             offset = abi.alignUp(offset, al);
-            storeInterfaceValue(mem.data, offset, r, t, registry);
+            storeInterfaceValue(mem.data, offset, r, t, registry) catch |err|
+                return trampolineTrap(env, ctx, err, .lower_results);
             offset += typeSize(registry, t);
         }
     } else {
@@ -5997,7 +6000,7 @@ pub export fn wamrAotDispatchComponentTrampoline(
                 .{@errorName(err)},
             );
         }
-        return .{ .status = 1, .value = 0 };
+        return .{ .status = 1, .value = 0, .err_name = @errorName(err).ptr };
     };
     return .{ .status = 0, .value = result };
 }
@@ -6034,7 +6037,7 @@ pub export fn wamrAotDispatchComponentTrampolineAot(
                 .{@errorName(err)},
             );
         }
-        return .{ .status = 1, .value = 0 };
+        return .{ .status = 1, .value = 0, .err_name = @errorName(err).ptr };
     };
     return .{ .status = 0, .value = result };
 }
@@ -6181,7 +6184,7 @@ pub export fn wamrAotDispatchCanonBuiltin(
                 .{ @tagName(ctx.canon), @errorName(err) },
             );
         }
-        return .{ .status = 1, .value = 0 };
+        return .{ .status = 1, .value = 0, .err_name = @errorName(err).ptr };
     };
     return .{ .status = 0, .value = result };
 }
@@ -6323,8 +6326,17 @@ fn dispatchAotComponentTrampoline(
     else
         try allocator.alloc(InterfaceValue, ctx.result_types.len);
     const results: []InterfaceValue = results_heap orelse results_stack_buf[0..ctx.result_types.len];
+    // `host_func.call` only initialises the prefix of `results` it
+    // successfully fills before returning an error; the remainder is
+    // backed by `undefined` stack/heap memory. We track how many
+    // entries are valid and only `deinit` that prefix. Without this
+    // a failing host (e.g. `getEnvironment` -> `error.IoError` when
+    // `cabi_realloc` is unavailable) used to dereference an
+    // `undefined` tag in `InterfaceValue.deinit`'s switch and panic
+    // with "switch on corrupt value".
+    var results_filled: usize = 0;
     defer {
-        for (results) |r| r.deinit(allocator);
+        for (results[0..results_filled]) |r| r.deinit(allocator);
         if (results_heap) |h| allocator.free(h);
     }
 
@@ -6334,15 +6346,19 @@ fn dispatchAotComponentTrampoline(
         const call = ctx.host_func.call orelse return error.HostFuncNotBound;
         try call(ctx.host_func.context, ctx.comp_inst, args, results, allocator);
     }
+    results_filled = results.len;
 
     if (lowered_sig.has_retptr) {
-        const mem_idx = ctx.lower_opts.memory_idx orelse return error.MemoryNotAvailable;
+        // Default to memory 0 when canon-lower has no explicit `.memory` opt,
+        // mirroring the canon-lift path (see line ~321). The component's
+        // single core memory is what the AOT caller's retptr points into.
+        const mem_idx = ctx.lower_opts.memory_idx orelse 0;
         const mem = ctx.comp_inst.resolveTopLevelMemory(mem_idx) orelse return error.MemoryNotAvailable;
         var offset: u32 = result_dest_ptr;
         for (results, ctx.result_types) |r, t| {
             const al = typeAlign(registry, t);
             offset = abi.alignUp(offset, al);
-            storeInterfaceValue(mem.data, offset, r, t, registry);
+            try storeInterfaceValue(mem.data, offset, r, t, registry);
             offset += typeSize(registry, t);
         }
         return 0;
@@ -6365,36 +6381,54 @@ fn liftAotDispatcherArg(
     registry: TypeRegistry,
     allocator: Allocator,
 ) !InterfaceValue {
-    switch (t) {
-        .bool, .s8, .u8, .s16, .u16, .s32, .u32, .char, .own, .borrow, .future, .stream, .error_context, .enum_ => {
-            if (reg_index.* >= lowered_param_types.len or lowered_param_types[reg_index.*] != .i32)
-                return error.UnsupportedSignature;
-            const slots = [_]u32{@truncate(regs[reg_index.*])};
-            reg_index.* += 1;
-            return abi.liftFlatReg(slots[0..], t, registry, allocator);
-        },
-        .s64, .u64 => {
-            if (reg_index.* >= lowered_param_types.len or lowered_param_types[reg_index.*] != .i64)
-                return error.UnsupportedSignature;
-            const raw = regs[reg_index.*];
-            const slots = [_]u32{ @truncate(raw), @truncate(raw >> 32) };
-            reg_index.* += 1;
-            return abi.liftFlatReg(slots[0..], t, registry, allocator);
-        },
-        .string, .list => {
-            if (reg_index.* + 1 >= lowered_param_types.len or
-                lowered_param_types[reg_index.*] != .i32 or
-                lowered_param_types[reg_index.* + 1] != .i32)
-                return error.UnsupportedSignature;
-            const slots = [_]u32{
-                @truncate(regs[reg_index.*]),
-                @truncate(regs[reg_index.* + 1]),
-            };
-            reg_index.* += 2;
-            return abi.liftFlatReg(slots[0..], t, registry, allocator);
-        },
-        else => return error.UnsupportedSignature,
+    // Generic slot-driven lift: derive the wasm flat-slot count from the
+    // canonical ABI's `flattenCount`, then walk that many lowered core
+    // slots converting each into the u32-cell encoding expected by
+    // `abi.liftFlatReg` (i32/f32 -> 1 cell; i64/f64 -> 2 cells lo|hi).
+    // This covers every primitive the narrow per-type switch used to
+    // enumerate (bool/sN/uN/char/own/borrow/future/stream/error_context/
+    // enum_/s64/u64/string/list) plus the compound shapes the canonical
+    // ABI flattens into multiple slots (type_idx, record, tuple, variant,
+    // option, result, flags). Without the compound coverage every
+    // canon.lower import carrying a compound param lands in the old
+    // `else` arm and rejects with `UnsupportedSignature` — silently
+    // collapsed to `return 0` by `genericDispatcher`
+    // (`host_trampolines.zig:175`). Issue #707.
+    const slot_count = abi.flattenCount(registry, t);
+    if (slot_count == 0) return error.UnsupportedSignature;
+    if (reg_index.* + slot_count > lowered_param_types.len) return error.UnsupportedSignature;
+
+    var cell_buf: [MAX_FLAT_PARAMS * 2]u32 = undefined;
+    var cells_used: usize = 0;
+    var k: usize = 0;
+    while (k < slot_count) : (k += 1) {
+        const lpt = lowered_param_types[reg_index.* + k];
+        const raw = regs[reg_index.* + k];
+        switch (lpt) {
+            .i32, .f32 => {
+                if (cells_used >= cell_buf.len) return error.UnsupportedSignature;
+                cell_buf[cells_used] = @truncate(raw);
+                cells_used += 1;
+            },
+            .i64, .f64 => {
+                if (cells_used + 2 > cell_buf.len) return error.UnsupportedSignature;
+                cell_buf[cells_used] = @truncate(raw);
+                cell_buf[cells_used + 1] = @truncate(raw >> 32);
+                cells_used += 2;
+            },
+            else => return error.UnsupportedSignature,
+        }
     }
+    reg_index.* += slot_count;
+    // Use the local `liftFlatReg` (above in this file) rather than
+    // `abi.liftFlatReg`: the local copy has full compound coverage —
+    // `.record`, `.tuple`, `.flags`, plus all `.type_idx` reifications
+    // (including `.list`). The `canonical_abi.liftFlatReg` copy falls
+    // back to `liftFlat` for `.record/.tuple/.flags` and returns
+    // `CompoundNeedsRegistry` — which would silently zero-return to
+    // the guest through `genericDispatcher`. Issue #707.
+    const r = liftFlatReg(cell_buf[0..cells_used], t, registry, allocator) catch return error.UnsupportedSignature;
+    return r.val;
 }
 
 fn lowerAotDispatcherResult(
@@ -6402,7 +6436,7 @@ fn lowerAotDispatcherResult(
     t: ctypes.ValType,
     lowered_ty: core_types.ValType,
     registry: TypeRegistry,
-) !u64 {
+) error{UnsupportedSignature}!u64 {
     if (lowered_ty == .f32 or lowered_ty == .f64) return error.UnsupportedSignature;
     // Single-flat-slot interface results only — multi-slot shapes
     // (string/list/multi-slot compounds) spill via the retptr path.
@@ -6424,6 +6458,31 @@ fn lowerAotDispatcherResult(
         .result => @as(u64, if (val.result_val.is_ok) 0 else 1),
         .variant => @as(u64, val.variant_val.discriminant),
         .option => @as(u64, if (val.option_val.is_some) 1 else 0),
+        // Resolve a typedef-encoded result through the registry and recurse.
+        // The shape is unwrapped exactly as `coreFlatSlotType` does for
+        // `.type_idx`, so it lands on one of the inline arms above (which
+        // are already guarded by the `flattenCount == 1` check inside
+        // `coreFlatSlotType`). Without this arm any canon.lower import
+        // returning a typedef-bound compound (e.g. an exported
+        // `result<unit, error-code>` alias) rejects with
+        // `UnsupportedSignature` and silently zero-returns to the guest
+        // via `genericDispatcher` (`host_trampolines.zig:175`). Issue #707.
+        .type_idx => |idx| blk: {
+            const td = registry.get(idx) orelse return error.UnsupportedSignature;
+            const reified: ctypes.ValType = switch (td) {
+                .val => |inner| inner,
+                .resource => .{ .own = idx },
+                .result => .{ .result = idx },
+                .variant => .{ .variant = idx },
+                .option => .{ .option = idx },
+                .flags => .{ .flags = idx },
+                .enum_ => .{ .enum_ = idx },
+                .tuple => .{ .tuple = idx },
+                .record => .{ .record = idx },
+                else => return error.UnsupportedSignature,
+            };
+            break :blk try lowerAotDispatcherResult(val, reified, lowered_ty, registry);
+        },
         else => error.UnsupportedSignature,
     };
 }

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -574,15 +574,31 @@ pub const ComponentInstance = struct {
     ///      core module (where the local memory idx matches N).
     pub fn resolveTopLevelMemory(self: *const ComponentInstance, idx: u32) ?*core_types.MemoryInstance {
         const ref = indexspace.resolveCoreMemory(self.component, idx) orelse {
-            const mi = self.firstModuleInst() orelse return null;
-            return mi.getMemory(idx);
+            if (self.firstModuleInst()) |mi| return mi.getMemory(idx);
+            // All-AOT components have no interp `module_inst` on any core
+            // instance; fall through to the backend-agnostic probe so
+            // canon-lower(aot) retptr stores and `canonicalMemory()`
+            // succeed against the AOT core's memory. Issue #707.
+            return self.firstBackendMemory();
         };
         const ie = self.component.aliases[ref.aliased].instance_export;
         if (ie.instance_idx >= self.core_instances.len) return null;
-        const src_mi = self.core_instances[ie.instance_idx].module_inst orelse return null;
-        const exp = src_mi.module.findExport(ie.name, .memory) orelse return null;
-        if (exp.index >= src_mi.memories.len) return null;
-        return src_mi.memories[exp.index];
+        const src_entry = self.core_instances[ie.instance_idx];
+        if (src_entry.module_inst) |src_mi| {
+            const exp = src_mi.module.findExport(ie.name, .memory) orelse return null;
+            if (exp.index >= src_mi.memories.len) return null;
+            return src_mi.memories[exp.index];
+        }
+        // AOT source — go via backend-agnostic memory probe. The AOT
+        // runtime synthesises a single canonical memory; we look up
+        // by name through `findExportMemory`, falling back to memory
+        // 0 when the AOT export table doesn't carry memory entries
+        // by name. Issue #707.
+        if (src_entry.aot_inst) |ai| {
+            if (aot_runtime.findExportMemory(ai, ie.name)) |mi| return mi;
+            if (src_entry.backend()) |be| return be.memory(0);
+        }
+        return null;
     }
 
     /// Resolve a top-level core func indexspace index to a callable
@@ -665,6 +681,23 @@ pub const ComponentInstance = struct {
         return null;
     }
 
+    /// AOT analogue of `reallocOwner`. Walks `core_instances` looking
+    /// for an `aot_inst` that exports `cabi_realloc`. Required because
+    /// fully-precompiled components have no interp `module_inst` on any
+    /// `core_instances` entry, and `hostAllocGuest`'s interp fallback
+    /// otherwise returns null — surfacing as `error.IoError` from
+    /// `getEnvironment` / `read-via-stream` / any other adapter that
+    /// must materialise a host-built `list` / `string` into guest
+    /// memory before lowering. Pairs with the canon-lower-aot
+    /// dispatcher widening in this PR (issue #707).
+    fn reallocOwnerAot(self: *const ComponentInstance) ?*aot_runtime.AotInstance {
+        for (self.core_instances) |entry| {
+            const ai = entry.aot_inst orelse continue;
+            if (aot_runtime.findExportFunc(ai, "cabi_realloc") != null) return ai;
+        }
+        return null;
+    }
+
     /// Allocate `size` bytes inside the canonical guest linear memory
     /// (or the test_mem shim, if installed) aligned to `align_`. Returns
     /// the guest-side pointer, or null on failure.
@@ -674,6 +707,23 @@ pub const ComponentInstance = struct {
     /// canonical ABI sees a `(ptr, len)` PtrLen.
     pub fn hostAllocGuest(self: *ComponentInstance, size: u32, align_: u32) ?u32 {
         if (self.test_mem) |tm| return tm.alloc(size, align_);
+        const a: u32 = if (align_ == 0) 1 else align_;
+        // Prefer the AOT path when a precompiled core owns `cabi_realloc`:
+        // it dispatches straight into native code via `aot_runtime.callFuncScalar`,
+        // matching the dispatch path the rest of the all-AOT component
+        // already uses. The interp path below only runs when no AOT
+        // core exports `cabi_realloc`. (#707 surfaced this — every
+        // canon-lower import returning a `list`/`string`/multi-slot
+        // compound goes through `hostAllocGuest`, and all-AOT
+        // components previously failed here with `error.IoError`.)
+        if (self.reallocOwnerAot()) |ai| {
+            const realloc_idx = aot_runtime.findExportFunc(ai, "cabi_realloc") orelse return null;
+            const executor = @import("executor.zig");
+            const aot_call_frame = @import("call_frame.zig");
+            var frame: executor.CallFrame = .{ .aot = aot_call_frame.AotFrame.init(ai, self.allocator) };
+            defer frame.deinit();
+            return executor.callRealloc(&frame, realloc_idx, 0, 0, a, size) catch null;
+        }
         const realloc_owner = self.reallocOwner() orelse return null;
         const realloc_local = realloc_owner.getExportFunc("cabi_realloc") orelse return null;
         const ExecEnv = @import("../runtime/common/exec_env.zig").ExecEnv;
@@ -689,7 +739,6 @@ pub const ComponentInstance = struct {
             self.realloc_env_owner = if (self.realloc_env != null) realloc_owner else null;
         }
         const env = self.realloc_env orelse return null;
-        const a: u32 = if (align_ == 0) 1 else align_;
         var frame: executor.CallFrame = .{ .interp = executor.InterpFrame.init(env) };
         defer frame.deinit();
         return executor.callRealloc(&frame, realloc_local, 0, 0, a, size) catch null;
@@ -3463,19 +3512,54 @@ fn installCanonLowerBackedCrossInstanceThunk(
     // take the AOT importer's view of the import's signature — that's
     // what the AOT codegen's call site emits, and it must match what
     // `dispatchAotComponentTrampoline` lifts off the register file.
+    //
+    // `has_retptr` must be derived from the component-level result
+    // flatten count, not hardcoded: per the canonical ABI, results
+    // whose joined flatten count exceeds `MAX_FLAT_RESULTS` (1 for
+    // canon.lower) are returned via a caller-allocated buffer whose
+    // pointer is appended as the last i32 param of the wasm core
+    // signature. The AOT codegen emits exactly that shape, so the
+    // last `ft.params` slot is the retptr — `lowered_params` must
+    // omit it and `has_retptr` must be `true`. Without this fix every
+    // canon.lower import returning a compound (`result<…>`, `list<…>`,
+    // `option<…>`, multi-field record/tuple) lands in
+    // `dispatchAotComponentTrampoline`'s
+    // `reg_index != lp.len + has_retptr` check and rejects with
+    // `UnsupportedSignature` — silently degraded by `genericDispatcher`
+    // (`host_trampolines.zig:175`) to a `return 0`. Issue #707.
     if (imp.func_type_idx >= module.func_types.len) return error.InvalidFuncType;
     const ft = module.func_types[imp.func_type_idx];
+
+    const canonical_abi = @import("canonical_abi.zig");
+    const registry = if (ctx_ptr.extended_types.len > 0)
+        canonical_abi.TypeRegistry.fromExtended(ctx_ptr.comp_inst.component, ctx_ptr.extended_types, ctx_ptr.extended_indexspace)
+    else
+        canonical_abi.TypeRegistry.init(ctx_ptr.comp_inst.component);
+    var flat_result_count: u32 = 0;
+    for (ctx_ptr.result_types) |rt| flat_result_count += canonical_abi.flattenCount(registry, rt);
+    const has_retptr = ctx_ptr.result_types.len > 0 and flat_result_count > canonical_abi.MAX_FLAT_RESULTS;
+
     const arena = inst.module_arena.allocator();
-    const lowered_params = try arena.alloc(core_types.ValType, ft.params.len);
-    for (ft.params, 0..) |p, i| lowered_params[i] = p;
+    const lowered_param_len: usize = if (has_retptr) blk: {
+        if (ft.params.len == 0) return error.InvalidFuncType;
+        break :blk ft.params.len - 1;
+    } else ft.params.len;
+    const lowered_params = try arena.alloc(core_types.ValType, lowered_param_len);
+    for (ft.params[0..lowered_param_len], 0..) |p, i| lowered_params[i] = p;
     const lowered_results = try arena.alloc(core_types.ValType, ft.results.len);
     for (ft.results, 0..) |r, i| lowered_results[i] = r;
 
     const stub = try pool.allocCanonLowerAotSlot(@ptrCast(ctx_ptr), .{
         .param_types = lowered_params,
         .result_types = lowered_results,
-        .has_retptr = false,
+        .has_retptr = has_retptr,
     });
+    if (core_backend.debugAotEnabled()) {
+        std.debug.print(
+            "[install canon-lower(aot)] slot={d} module='{s}' field='{s}' cfi={d} flat_results={d} has_retptr={} mem_opt={?} realloc_opt={?}\n",
+            .{ pool.next_slot - 1, imp.module_name, imp.field_name, ctx_ptr.component_func_idx, flat_result_count, has_retptr, ctx_ptr.lower_opts.memory_idx, ctx_ptr.lower_opts.realloc_idx },
+        );
+    }
     return @ptrCast(stub);
 }
 

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -37,6 +37,12 @@ pub const LoweredSig = struct {
 pub const DispatchResult = extern struct {
     status: u32,
     value: u64,
+    /// On `status != 0`, optional pointer to a `@errorName()` C string set
+    /// by the wrapper before returning. `genericDispatcher` surfaces it in
+    /// the one-shot per-slot warning so the underlying lift/lower failure
+    /// is visible in release builds without needing `WAMR_AOT_DEBUG=1`.
+    /// Issue #707.
+    err_name: ?[*:0]const u8 = null,
 };
 
 extern fn wamrAotDispatchComponentTrampoline(
@@ -159,6 +165,17 @@ pub fn setActivePool(pool: ?*TrampolinePool) void {
     g_active_pool = pool;
 }
 
+// One-shot per-slot "silent zero" warning. The trampoline pool collapses
+// any non-zero dispatcher status into `return 0` to the guest so we don't
+// corrupt the caller's wasm return-slot stack (we have no way to raise a
+// trap from this calling convention). That mask is what historically hid
+// every `UnsupportedSignature` regression — see issues #687, #689, #691,
+// #707 — because the guest sees the dispatch as a successful zero-return
+// rather than a trap. To surface the failure without spamming stderr on
+// hot paths, warn at most once per `(slot)` site via a 256-bit set
+// (one bit per `MAX_SLOTS` entry). Released-build visible.
+var g_dispatch_warn_once: std.bit_set.IntegerBitSet(MAX_SLOTS) = .initEmpty();
+
 pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64, a6: u64, a7: u64, a8: u64, a9: u64) callconv(.c) u64 {
     const pool = g_active_pool orelse return 0;
     if (slot >= pool.next_slot) return 0;
@@ -172,7 +189,24 @@ pub fn genericDispatcher(slot: u32, a0: u64, a1: u64, a2: u64, a3: u64, a4: u64,
         .canon_builtin_aot => wamrAotDispatchCanonBuiltin(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
         .trap_stub => wamrAotDispatchTrapStub(ctx, &entry.lowered_sig, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9),
     };
-    if (dispatched.status != 0) return 0;
+    if (dispatched.status != 0) {
+        // Surface the silent-zero collapse once per slot. The `trap_stub`
+        // kind is an explicit, expected trap path — it has already
+        // printed its own diagnostic and the slot pre-emptively means
+        // "this import is known-unbound", so no extra warning helps.
+        if (entry.dispatch_kind != .trap_stub and slot < MAX_SLOTS and !g_dispatch_warn_once.isSet(slot)) {
+            g_dispatch_warn_once.set(slot);
+            const err_str: []const u8 = if (dispatched.err_name) |p|
+                std.mem.span(p)
+            else
+                "(unknown — wrapper did not populate err_name)";
+            std.log.warn(
+                "[aot dispatch] slot={d} kind={s} status={d} err={s}: returning 0 to guest (likely UnsupportedSignature in canon-lower/aot lift/lower path); set WAMR_AOT_DEBUG=1 for the underlying error.",
+                .{ slot, @tagName(entry.dispatch_kind), dispatched.status, err_str },
+            );
+        }
+        return 0;
+    }
     return dispatched.value;
 }
 

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -1507,6 +1507,17 @@ pub fn findExportFunc(inst: *const AotInstance, name: []const u8) ?u32 {
     return null;
 }
 
+/// Look up an exported memory by name, returning the underlying
+/// `*MemoryInstance` from the AOT instance's `memories` array.
+/// Used by `ComponentInstance.resolveTopLevelMemory` to follow an
+/// `alias core export "name"` decl through an AOT sibling core
+/// instance for canon-lower(aot) retptr stores. Issue #707.
+pub fn findExportMemory(inst: *const AotInstance, name: []const u8) ?*types.MemoryInstance {
+    const exp = inst.module.findExport(name, .memory) orelse return null;
+    if (exp.index >= inst.memories.len) return null;
+    return inst.memories[exp.index];
+}
+
 /// Get the native code pointer for a function by module-level index.
 /// Import functions (func_idx < import_function_count) have no native code
 /// and return null.  Local functions are looked up in func_offsets after


### PR DESCRIPTION
Fixes #707.

The AOT canon-lower dispatcher's lift/lower helpers narrowly enumerated primitive `ValType` arms, rejecting any compound (`record`, `tuple`, `variant`, `option`, `result`, `flags`, `type_idx`) with `error.UnsupportedSignature`. `genericDispatcher` (`host_trampolines.zig:175`) then collapsed the non-zero status into `return 0` to the guest — so every WASIp2 host import returning a compound value silently handed back zeros, surfacing as empty output from the keyvault codegen-cli AOT repro.

## Changes

**Phase 1 — `liftAotDispatcherArg`** (`src/component/executor.zig`)
- Rewrite as a slot-driven loop using `flattenCount` and the executor-local `liftFlatReg` (which has full compound coverage including `type_idx` reifications). Each lowered core slot is converted into the u32-cell encoding (i32/f32 → 1 cell, i64/f64 → 2 cells lo|hi).

**Phase 2 — `lowerAotDispatcherResult`** (`src/component/executor.zig`)
- Add a `.type_idx` arm that recurses after registry reification, so typedef-encoded single-slot results land on the inline scalar arms.

**Phase 3 — surface silent-zero collapse** (`src/runtime/aot/host_trampolines.zig`)
- `DispatchResult.err_name`: new optional field populated by wrappers from `@errorName(err)`.
- `genericDispatcher`: one-shot per-slot `std.log.warn` (released-build visible) including `err=<name>`. Next regression in this class is now immediately visible.

**Cross-cutting fixes uncovered by the dispatcher widening**
- `installCanonLowerBackedCrossInstanceThunk` (`src/component/instance.zig`): derive `has_retptr` from the component-level result flatten count (vs hardcoded `false`); trim trailing retptr param from `lowered_params`. Compound returns now correctly route through retptr spill.
- `hostAllocGuest` (`src/component/instance.zig`): add AOT path via `reallocOwnerAot` + `callRealloc` so canon-lower returns that materialise a list/string into guest memory succeed on fully-precompiled components.
- `resolveTopLevelMemory` (`src/component/instance.zig`): fall back to `firstBackendMemory()` when there are no alias-core-export decls and no interp `module_inst`; follow alias-core-export through AOT siblings via new `findExportMemory` helper.
- `findExportMemory` (`src/runtime/aot/runtime.zig`): look up an exported memory by name on an `AotInstance`.
- `storeInterfaceValue` (`src/component/executor.zig`): propagate errors instead of silently swallowing `CompoundNeedsRegistry`; updated call sites.
- `dispatchAotComponentTrampoline` (`src/component/executor.zig`): track `results_filled` so the deinit defer only walks initialised entries; default `memory_idx` to 0 in the retptr path, mirroring the canon-lift convention.

## Verification

- `zig build test --summary failures` — green
- Keyvault codegen-cli AOT repro no longer silently exits 0 with empty output. It now executes through the WASIp2 boundary into real guest computation, exposing a separate guest-side OOB to be filed independently.