### PR TITLE
fix #715: route canon-lower realloc/memory + zero-byte read realloc

### DIFF
--- a/src/component/canonical_abi.zig
+++ b/src/component/canonical_abi.zig
@@ -129,6 +129,31 @@ pub fn decodeResourceWireAbi(wire: u32) u32 {
     return wire -% 1;
 }
 
+/// Read the discriminant from an interface value that represents an
+/// enum/payload-less variant. Host adapters and codegen both build
+/// such values, and they conventionally use either of two equivalent
+/// tags interchangeably:
+///
+///   * `.enum_val = N`                         (the canonical enum form)
+///   * `.variant_val = .{ .discriminant = N, .payload = null }`
+///     (the variant form, used when the constructor doesn't know
+///     whether the registered WIT type is `enum` or a payload-less
+///     `variant`).
+///
+/// Zig's `union(enum)` has no guaranteed in-memory layout, so the two
+/// fields do **not** alias — reading `val.enum_val` when the active
+/// tag is `.variant_val` returns garbage (0 in practice for our
+/// `InterfaceValue` layout). Every `.enum_` store/load branch must
+/// therefore go through this helper instead of `val.enum_val`. (#715)
+fn enumDiscriminantOf(val: InterfaceValue) StoreError!u32 {
+    return switch (val) {
+        .enum_val => |e| e,
+        .variant_val => |v| v.discriminant,
+        else => error.InvalidDiscriminant,
+    };
+}
+
+
 /// Runtime representation of a component interface value.
 /// Primitives are stored inline; compound types use allocator-owned slices.
 pub const InterfaceValue = union(enum) {
@@ -841,6 +866,7 @@ pub fn storeVal(memory: []u8, ptr: u32, t: ctypes.ValType, val: InterfaceValue) 
 pub const StoreError = error{
     CompoundNeedsRegistry,
     InvalidTypeIndex,
+    InvalidDiscriminant,
 } || CanonPtrLenError;
 
 /// Store any value to linear memory, resolving compound types via registry.
@@ -852,10 +878,11 @@ pub fn storeValReg(memory: []u8, ptr: u32, t: ctypes.ValType, val: InterfaceValu
             const idx = t.enum_;
             const td = reg.get(idx) orelse return error.InvalidTypeIndex;
             const disc_sz = discriminantSize(td.enum_.names.len);
+            const disc = try enumDiscriminantOf(val);
             switch (disc_sz) {
-                1 => storeU8(memory, ptr, @intCast(val.enum_val)),
-                2 => storeU16(memory, ptr, @intCast(val.enum_val)),
-                else => storeU32(memory, ptr, val.enum_val),
+                1 => storeU8(memory, ptr, @intCast(disc)),
+                2 => storeU16(memory, ptr, @intCast(disc)),
+                else => storeU32(memory, ptr, disc),
             }
         },
         .flags => {
@@ -1037,10 +1064,11 @@ fn storeValFromDef(memory: []u8, ptr: u32, td: ctypes.TypeDef, val: InterfaceVal
         },
         .enum_ => |en| {
             const disc_sz = discriminantSize(en.names.len);
+            const disc = try enumDiscriminantOf(val);
             switch (disc_sz) {
-                1 => storeU8(memory, ptr, @intCast(val.enum_val)),
-                2 => storeU16(memory, ptr, @intCast(val.enum_val)),
-                else => storeU32(memory, ptr, val.enum_val),
+                1 => storeU8(memory, ptr, @intCast(disc)),
+                2 => storeU16(memory, ptr, @intCast(disc)),
+                else => storeU32(memory, ptr, disc),
             }
         },
         .option => |opt| {

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -941,7 +941,11 @@ fn lowerFlatReg(
         .enum_ => |idx| {
             const td = registry.get(idx) orelse return error.InvalidTypeIndex;
             if (td != .enum_) return error.InvalidTypeIndex;
-            out[0] = val.enum_val;
+            out[0] = switch (val) {
+                .enum_val => |e| e,
+                .variant_val => |v| v.discriminant,
+                else => return error.InvalidValue,
+            };
             return 1;
         },
         .flags => |idx| {
@@ -5873,6 +5877,27 @@ pub const LowerOptions = struct {
     }
 };
 
+/// Resolve a canon-lower's `(memory $m)` / `(realloc $f)` opts into a
+/// directly-usable `CanonLowerCallCtx`. Called by the trampoline once
+/// per host import dispatch and stashed on `comp_inst` so
+/// `hostAllocAndWrite` honors the lowerer's pinned memory + realloc
+/// (e.g. wit-component preview1 adapter's `cabi_import_realloc`
+/// routing to per-call `temporary_data`). (#715.)
+fn resolveLowerCallCtx(
+    comp_inst: *ComponentInstance,
+    lower_opts: LowerOptions,
+) ?ComponentInstance.CanonLowerCallCtx {
+    if (lower_opts.memory_idx == null and lower_opts.realloc_idx == null) return null;
+    var cctx: ComponentInstance.CanonLowerCallCtx = .{};
+    if (lower_opts.memory_idx) |midx| {
+        cctx.memory = comp_inst.resolveTopLevelMemory(midx);
+    }
+    if (lower_opts.realloc_idx) |ridx| {
+        cctx.realloc = comp_inst.resolveTopLevelCoreFuncAny(ridx);
+    }
+    return cctx;
+}
+
 /// Per-import-slot context for the canon-lower trampoline. Owned by the
 /// `ComponentInstance` that installs the trampoline onto a core
 /// ModuleInstance's `host_func_entries`.
@@ -6112,6 +6137,9 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
     const call = ctx.host_func.call orelse {
         return trampolineTrap(env, ctx, error.HostFuncNotBound, .host_call);
     };
+    const saved_lower_ctx = ctx.comp_inst.current_lower_call_ctx;
+    ctx.comp_inst.current_lower_call_ctx = resolveLowerCallCtx(ctx.comp_inst, ctx.lower_opts);
+    defer ctx.comp_inst.current_lower_call_ctx = saved_lower_ctx;
     call(ctx.host_func.context, ctx.comp_inst, args, results, allocator) catch |err| {
         return trampolineTrap(env, ctx, err, .host_call);
     };
@@ -6636,6 +6664,9 @@ fn dispatchAotComponentTrampoline(
         try callComponentFuncByLocal(ctx.comp_inst, target, args, results, allocator);
     } else {
         const call = ctx.host_func.call orelse return error.HostFuncNotBound;
+        const saved_lower_ctx = ctx.comp_inst.current_lower_call_ctx;
+        ctx.comp_inst.current_lower_call_ctx = resolveLowerCallCtx(ctx.comp_inst, ctx.lower_opts);
+        defer ctx.comp_inst.current_lower_call_ctx = saved_lower_ctx;
         try call(ctx.host_func.context, ctx.comp_inst, args, results, allocator);
     }
     results_filled = results.len;
@@ -6756,11 +6787,19 @@ fn lowerAotDispatcherResult(
         .u32, .char => @as(u64, val.u32),
         .s64 => @as(u64, @bitCast(val.s64)),
         .u64 => val.u64,
-        .enum_ => @as(u64, val.enum_val),
+        .enum_ => @as(u64, switch (val) {
+            .enum_val => |e| e,
+            .variant_val => |v| v.discriminant,
+            else => return error.UnsupportedSignature,
+        }),
         .own, .borrow => @as(u64, encodeResourceWire(val.handle)),
         .future, .stream, .error_context => @as(u64, val.handle),
         .result => @as(u64, if (val.result_val.is_ok) 0 else 1),
-        .variant => @as(u64, val.variant_val.discriminant),
+        .variant => @as(u64, switch (val) {
+            .variant_val => |v| v.discriminant,
+            .enum_val => |e| e,
+            else => return error.UnsupportedSignature,
+        }),
         .option => @as(u64, if (val.option_val.is_some) 1 else 0),
         // Resolve a typedef-encoded result through the registry and recurse.
         // The shape is unwrapped exactly as `coreFlatSlotType` does for

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -433,6 +433,48 @@ pub const ComponentInstance = struct {
     realloc_env: ?*@import("../runtime/common/exec_env.zig").ExecEnv = null,
     realloc_env_owner: ?*core_types.ModuleInstance = null,
 
+    /// Canon-lower opts of the in-flight host import call, set by
+    /// `componentTrampoline` / `dispatchAotComponentTrampoline` before
+    /// dispatching into the host method and cleared after. Lets
+    /// `hostAllocAndWrite` honor the lowerer's chosen `(realloc $f)` +
+    /// `(memory $m)` instead of falling back to the canonical
+    /// `cabi_realloc` search.
+    ///
+    /// Critical for wit-component's `wasi_snapshot_preview1` adapter:
+    /// the adapter imports WASIp2 via `canon.lower (realloc
+    /// $cabi_import_realloc)`, where `cabi_import_realloc` routes
+    /// through a per-call `import_alloc` cell that pins string
+    /// allocations to the adapter's own `temporary_data` buffer.
+    /// `fd_readdir` (in the adapter) asserts the returned `name` ptr
+    /// equals `temporary_data` — calling the main module's
+    /// `cabi_realloc` instead returns a ptr in the wrong memory and
+    /// trips that assertion. (#715.)
+    current_lower_call_ctx: ?CanonLowerCallCtx = null,
+
+    /// Resolved canon-lower opts for an in-flight host import call.
+    /// `memory` and `realloc` are pre-resolved from the canon-lower
+    /// opts' top-level indices so `hostAllocAndWrite` does not redo
+    /// the indexspace lookups per byte. Either field may be null when
+    /// the canon-lower decl omitted the corresponding opt.
+    pub const CanonLowerCallCtx = struct {
+        memory: ?*core_types.MemoryInstance = null,
+        realloc: ?ReallocTarget = null,
+    };
+
+    /// A directly-callable realloc, resolved from a top-level core-func
+    /// index in canon-lower opts. Backend-tagged because realloc can
+    /// live on either a fully-AOT-precompiled core or an interp core.
+    pub const ReallocTarget = union(enum) {
+        interp: struct {
+            mi: *core_types.ModuleInstance,
+            local_idx: u32,
+        },
+        aot: struct {
+            ai: *aot_runtime.AotInstance,
+            local_idx: u32,
+        },
+    };
+
     /// Allocate a fresh async-handle (#478 sub-PR 3). Used by every
     /// `.new`-flavoured canon-builtin to mint a unique key into the
     /// per-instance future / stream / error-context / waitable-set
@@ -632,6 +674,44 @@ pub const ComponentInstance = struct {
         }
     }
 
+    /// AOT-aware sibling of `resolveTopLevelCoreFunc`. Returns either an
+    /// AOT or interp `ReallocTarget` for the named export of the
+    /// aliased core instance. Used by the canon-lower trampoline to
+    /// pre-resolve `(realloc $f)` before stashing the call ctx on
+    /// `current_lower_call_ctx`. (#715.)
+    pub fn resolveTopLevelCoreFuncAny(
+        self: *const ComponentInstance,
+        idx: u32,
+    ) ?ReallocTarget {
+        const ref = indexspace.resolveCoreFunc(self.component, idx) orelse return null;
+        switch (ref) {
+            .lowered,
+            .resource_drop,
+            .resource_new,
+            .resource_rep,
+            .task_yield,
+            .context_get,
+            .context_set,
+            .task_return,
+            .async_canon,
+            => return null,
+            .aliased => |alias_idx| {
+                const ie = self.component.aliases[alias_idx].instance_export;
+                if (ie.instance_idx >= self.core_instances.len) return null;
+                const entry = self.core_instances[ie.instance_idx];
+                if (entry.module_inst) |mi| {
+                    const local = mi.getExportFunc(ie.name) orelse return null;
+                    return .{ .interp = .{ .mi = mi, .local_idx = local } };
+                }
+                if (entry.aot_inst) |ai| {
+                    const local = aot_runtime.findExportFunc(ai, ie.name) orelse return null;
+                    return .{ .aot = .{ .ai = ai, .local_idx = local } };
+                }
+                return null;
+            },
+        }
+    }
+
     /// Read `len` bytes starting at guest linear-memory offset `ptr` from the
     /// canonical memory of this component. Used by host adapter callbacks
     /// invoked from `componentTrampoline` to materialize `list<u8>` /
@@ -647,6 +727,19 @@ pub const ComponentInstance = struct {
             const end = @as(usize, ptr) + @as(usize, len);
             if (end > tm.buffer.len) return null;
             return tm.buffer[ptr..end];
+        }
+        // Mirror `writableGuestBytes`: when the in-flight canon-lower
+        // pinned a specific `(memory $m)`, read from THAT memory so
+        // string/list args lifted from the lowerer (e.g. the
+        // wit-component preview1 adapter's per-page memory) resolve
+        // correctly. Falls back to the canonical memory otherwise.
+        // (#715.)
+        if (self.current_lower_call_ctx) |cctx| {
+            if (cctx.memory) |mem| {
+                const end = @as(usize, ptr) + @as(usize, len);
+                if (end > mem.data.len) return null;
+                return mem.data[ptr..end];
+            }
         }
         const mem = self.canonicalMemory() orelse return null;
         const end = @as(usize, ptr) + @as(usize, len);
@@ -708,6 +801,42 @@ pub const ComponentInstance = struct {
     pub fn hostAllocGuest(self: *ComponentInstance, size: u32, align_: u32) ?u32 {
         if (self.test_mem) |tm| return tm.alloc(size, align_);
         const a: u32 = if (align_ == 0) 1 else align_;
+        // Honor the in-flight canon-lower's `(realloc $f)` when set.
+        // This is required for wit-component's preview1 adapter, which
+        // imports WASIp2 via `canon.lower (realloc $cabi_import_realloc)`;
+        // `cabi_import_realloc` routes through a per-call `import_alloc`
+        // cell that pins return-string allocations to the adapter's
+        // internal `temporary_data` buffer. Falling back to the main
+        // module's `cabi_realloc` here returns a ptr in the wrong
+        // memory and trips an assertion inside the adapter's
+        // `fd_readdir` handler. (#715.)
+        if (self.current_lower_call_ctx) |cctx| {
+            if (cctx.realloc) |target| {
+                const executor = @import("executor.zig");
+                const call_frame_mod = @import("call_frame.zig");
+                switch (target) {
+                    .aot => |t| {
+                        var frame: executor.CallFrame = .{
+                            .aot = call_frame_mod.AotFrame.init(t.ai, self.allocator),
+                        };
+                        defer frame.deinit();
+                        return executor.callRealloc(&frame, t.local_idx, 0, 0, a, size) catch null;
+                    },
+                    .interp => |t| {
+                        const ExecEnv = @import("../runtime/common/exec_env.zig").ExecEnv;
+                        if (self.realloc_env_owner != t.mi) {
+                            if (self.realloc_env) |old| old.destroy();
+                            self.realloc_env = ExecEnv.create(t.mi, 1024, self.allocator) catch null;
+                            self.realloc_env_owner = if (self.realloc_env != null) t.mi else null;
+                        }
+                        const env = self.realloc_env orelse return null;
+                        var frame: executor.CallFrame = .{ .interp = executor.InterpFrame.init(env) };
+                        defer frame.deinit();
+                        return executor.callRealloc(&frame, t.local_idx, 0, 0, a, size) catch null;
+                    },
+                }
+            }
+        }
         // Prefer the AOT path when a precompiled core owns `cabi_realloc`:
         // it dispatches straight into native code via `aot_runtime.callFuncScalar`,
         // matching the dispatch path the rest of the all-AOT component
@@ -752,6 +881,18 @@ pub const ComponentInstance = struct {
             const end = @as(usize, ptr) + @as(usize, len);
             if (end > tm.buffer.len) return null;
             return tm.buffer[ptr..end];
+        }
+        // When the in-flight canon-lower pinned a specific `(memory $m)`,
+        // write into THAT memory — the `hostAllocGuest` ptr above came
+        // from the lowerer's realloc, which allocates inside the same
+        // memory. Mismatching here would write into the wrong module's
+        // memory and silently corrupt unrelated guest state. (#715.)
+        if (self.current_lower_call_ctx) |cctx| {
+            if (cctx.memory) |mem| {
+                const end = @as(usize, ptr) + @as(usize, len);
+                if (end > mem.data.len) return null;
+                return mem.data[ptr..end];
+            }
         }
         const mem = self.canonicalMemory() orelse return null;
         const end = @as(usize, ptr) + @as(usize, len);

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -3895,6 +3895,119 @@ pub const ConfigEntry = struct {
     value: []const u8,
 };
 
+/// One-shot trace helpers used by `WasiCliAdapter.tracedAdapterCall`.
+/// File-scoped because they don't touch adapter state — the wrapper
+/// only forwards what `args` / `results` / the error happen to be.
+/// All lines go through `std.log.warn` so they survive in release
+/// builds without needing `WAMR_AOT_DEBUG=1`. (#715)
+fn logAdapterEntry(
+    comptime iface_short: []const u8,
+    comptime member: []const u8,
+    args: []const InterfaceValue,
+) void {
+    if (args.len == 0) {
+        std.debug.print("[adapter→] {s}/{s} args=()\n", .{ iface_short, member });
+    } else {
+        std.debug.print("[adapter→] {s}/{s} args.len={d} arg0={s}\n", .{
+            iface_short,
+            member,
+            args.len,
+            describeInterfaceValue(args[0]),
+        });
+    }
+}
+
+fn logAdapterExitOk(
+    comptime iface_short: []const u8,
+    comptime member: []const u8,
+    results: []const InterfaceValue,
+) void {
+    if (results.len == 0) {
+        std.debug.print("[adapter←] {s}/{s} ok results=()\n", .{ iface_short, member });
+    } else {
+        std.debug.print("[adapter←] {s}/{s} ok result0={s}\n", .{
+            iface_short,
+            member,
+            describeInterfaceValue(results[0]),
+        });
+    }
+}
+
+fn logAdapterExitErr(
+    comptime iface_short: []const u8,
+    comptime member: []const u8,
+    err: anyerror,
+) void {
+    std.debug.print("[adapter←] {s}/{s} err={s}\n", .{
+        iface_short,
+        member,
+        @errorName(err),
+    });
+}
+
+/// Render a short, log-line-safe summary of an `InterfaceValue`:
+/// primitive tag + scalar value when applicable; for `result_val`
+/// includes is_ok and the inner variant discriminant if any (this is
+/// the shape that matters for #715 — `result<descriptor-type,
+/// error-code>` ok-arm discriminant tells us whether the adapter
+/// thinks the descriptor is a directory).
+///
+/// Returns a static or short-lived buffer slice via a fixed-size
+/// thread-local — fine for log lines, not safe to retain.
+fn describeInterfaceValue(v: InterfaceValue) []const u8 {
+    const S = struct {
+        threadlocal var buf: [128]u8 = undefined;
+    };
+    return std.fmt.bufPrint(&S.buf, "{f}", .{InterfaceValueBrief{ .v = v }}) catch
+        @tagName(v);
+}
+
+const InterfaceValueBrief = struct {
+    v: InterfaceValue,
+
+    pub fn format(self: InterfaceValueBrief, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        switch (self.v) {
+            .bool => |b| try writer.print("bool({})", .{b}),
+            .u8 => |x| try writer.print("u8({d})", .{x}),
+            .s8 => |x| try writer.print("s8({d})", .{x}),
+            .u16 => |x| try writer.print("u16({d})", .{x}),
+            .s16 => |x| try writer.print("s16({d})", .{x}),
+            .u32 => |x| try writer.print("u32({d})", .{x}),
+            .s32 => |x| try writer.print("s32({d})", .{x}),
+            .u64 => |x| try writer.print("u64({d})", .{x}),
+            .s64 => |x| try writer.print("s64({d})", .{x}),
+            .f32 => |x| try writer.print("f32(0x{x:0>8})", .{x}),
+            .f64 => |x| try writer.print("f64(0x{x:0>16})", .{x}),
+            .char => |x| try writer.print("char(U+{x})", .{x}),
+            .handle => |h| try writer.print("handle({d})", .{h}),
+            .string => |sl| try writer.print("string(ptr=0x{x},len={d})", .{ sl.ptr, sl.len }),
+            .list => |sl| try writer.print("list(ptr=0x{x},len={d})", .{ sl.ptr, sl.len }),
+            .enum_val => |d| try writer.print("enum({d})", .{d}),
+            .variant_val => |vv| try writer.print("variant(disc={d})", .{vv.discriminant}),
+            .option_val => |ov| try writer.print("option({s})", .{if (ov.is_some) "some" else "none"}),
+            .result_val => |rv| {
+                if (rv.payload) |p| {
+                    switch (p.*) {
+                        .variant_val => |vv| try writer.print(
+                            "result({s},disc={d})",
+                            .{ if (rv.is_ok) "ok" else "err", vv.discriminant },
+                        ),
+                        else => try writer.print(
+                            "result({s},payload={s})",
+                            .{ if (rv.is_ok) "ok" else "err", @tagName(p.*) },
+                        ),
+                    }
+                } else {
+                    try writer.print("result({s},no-payload)", .{if (rv.is_ok) "ok" else "err"});
+                }
+            },
+            .record_val => |fields| try writer.print("record(len={d})", .{fields.len}),
+            .tuple_val => |fields| try writer.print("tuple(len={d})", .{fields.len}),
+            .flags_val => |words| try writer.print("flags(words={d})", .{words.len}),
+        }
+    }
+};
+
 pub const WasiCliAdapter = struct {
     allocator: Allocator,
     stdout: streams.OutputStream,
@@ -4280,6 +4393,24 @@ pub const WasiCliAdapter = struct {
     /// the pair on first call and cache it for the lifetime of the
     /// adapter. (#520)
     insecure_seed_cache: ?[2]u64 = null,
+
+    /// When true, every host-import callback registered through
+    /// `populateWasiFilesystem*` emits one `std.log.warn` line on entry
+    /// and one on exit (with the interface + member name, a short
+    /// summary of `args[0]`, and the success/error outcome). Off by
+    /// default; flipped on by `WAMR_TRACE_CLI_ADAPTER=1` (wired in
+    /// `main.zig`). The thunks compiled around each member are
+    /// zero-cost when this is false (one load + branch per call).
+    ///
+    /// This sub-layer trace complements the `[aot dispatch]` warn-once
+    /// machinery added in #714 — the dispatch layer surfaces failures
+    /// in the canon-lower / cross-instance / canon-builtin paths,
+    /// while this surfaces *which* adapter member the guest is
+    /// actually calling. #715 is the motivating bug: AOT
+    /// `fd_readdir` panics with `ENOTDIR` after `descriptor.get-type`
+    /// returns `directory` cleanly, and the dispatch layer is silent,
+    /// so the divergence has to be in the adapter sub-layer.
+    trace_calls: bool = false,
 
     /// Initialize with a buffer-backed stdout sink. Use `getStdoutBytes`
     /// after the component runs to inspect captured output. This is the
@@ -4745,6 +4876,68 @@ pub const WasiCliAdapter = struct {
     /// and `warning` aliases).
     pub fn setLogLevel(self: *WasiCliAdapter, level: WasiLogLevel) void {
         self.log_level = level;
+    }
+
+    /// Toggle the per-member adapter-call trace described on
+    /// `trace_calls`. Intended to be flipped on once at process
+    /// startup from the `WAMR_TRACE_CLI_ADAPTER` env var (see
+    /// `main.zig`); tests can set it directly. (#715)
+    pub fn setTraceCalls(self: *WasiCliAdapter, on: bool) void {
+        self.trace_calls = on;
+    }
+
+    /// Function-pointer shape every adapter member callback shares
+    /// (matches the inline type used by the existing `M` structs in
+    /// each `populate*` function). Hoisting it as a named alias keeps
+    /// `tracedAdapterCall` readable. (#715)
+    pub const AdapterCallFn = *const fn (
+        ?*anyopaque,
+        *ComponentInstance,
+        []const InterfaceValue,
+        []InterfaceValue,
+        Allocator,
+    ) anyerror!void;
+
+    /// Wrap an adapter callback in a comptime-generated trace thunk
+    /// (#715). The returned function pointer has the same signature as
+    /// `impl` and:
+    ///   * when `self.trace_calls == false` (the default), does one
+    ///     extra load + branch per call before tail-calling `impl`;
+    ///   * when `self.trace_calls == true`, also emits one
+    ///     `std.log.warn` line on entry and one on exit, carrying
+    ///     `iface_short`, `member`, a short `args[0]` summary, and
+    ///     the success/error outcome.
+    ///
+    /// `iface_short` is a stable shorthand (e.g. `"filesystem/types"`)
+    /// — keep it short, it's repeated on every line.
+    pub fn tracedAdapterCall(
+        comptime iface_short: []const u8,
+        comptime member: []const u8,
+        comptime impl: AdapterCallFn,
+    ) AdapterCallFn {
+        const Thunk = struct {
+            fn wrapped(
+                ctx_opaque: ?*anyopaque,
+                ci: *ComponentInstance,
+                args: []const InterfaceValue,
+                results: []InterfaceValue,
+                allocator: Allocator,
+            ) anyerror!void {
+                const self_opt: ?*WasiCliAdapter = if (ctx_opaque) |c|
+                    @ptrCast(@alignCast(c))
+                else
+                    null;
+                const tracing = if (self_opt) |s| s.trace_calls else false;
+                if (tracing) logAdapterEntry(iface_short, member, args);
+                if (impl(ctx_opaque, ci, args, results, allocator)) |_| {
+                    if (tracing) logAdapterExitOk(iface_short, member, results);
+                } else |err| {
+                    if (tracing) logAdapterExitErr(iface_short, member, err);
+                    return err;
+                }
+            }
+        };
+        return Thunk.wrapped;
     }
 
     /// Captured stdout bytes (valid for buffer-backed sinks).
@@ -8601,7 +8794,10 @@ pub const WasiCliAdapter = struct {
         interface_name: []const u8,
     ) !void {
         try self.fs_preopens_iface.members.put(self.allocator, "get-directories", .{
-            .func = .{ .context = self, .call = &fsGetDirectories },
+            .func = .{
+                .context = self,
+                .call = tracedAdapterCall("filesystem/preopens", "get-directories", &fsGetDirectories),
+            },
         });
         try providers.put(self.allocator, interface_name, .{
             .host_instance = &self.fs_preopens_iface,
@@ -8650,9 +8846,12 @@ pub const WasiCliAdapter = struct {
             .{ .name = "filesystem-error-code", .call = &fsFilesystemErrorCode },
             .{ .name = "[resource-drop]descriptor", .call = &fsDescriptorDrop },
         };
-        for (members) |m| {
+        inline for (members) |m| {
             try self.fs_types_iface.members.put(self.allocator, m.name, .{
-                .func = .{ .context = self, .call = m.call },
+                .func = .{
+                    .context = self,
+                    .call = tracedAdapterCall("filesystem/types", m.name, m.call),
+                },
             });
         }
         try providers.put(self.allocator, interface_name, .{
@@ -8671,7 +8870,10 @@ pub const WasiCliAdapter = struct {
         interface_name: []const u8,
     ) !void {
         try self.fs_preopens_p3_iface.members.put(self.allocator, "get-directories", .{
-            .func = .{ .context = self, .call = &fsGetDirectories },
+            .func = .{
+                .context = self,
+                .call = tracedAdapterCall("filesystem/preopens@p3", "get-directories", &fsGetDirectories),
+            },
         });
         try providers.put(self.allocator, interface_name, .{
             .host_instance = &self.fs_preopens_p3_iface,
@@ -8729,9 +8931,12 @@ pub const WasiCliAdapter = struct {
             // Tier D: verbatim carry-over.
             .{ .name = "[resource-drop]descriptor", .call = &fsDescriptorDrop },
         };
-        for (members) |m| {
+        inline for (members) |m| {
             try self.fs_types_p3_iface.members.put(self.allocator, m.name, .{
-                .func = .{ .context = self, .call = m.call },
+                .func = .{
+                    .context = self,
+                    .call = tracedAdapterCall("filesystem/types@p3", m.name, m.call),
+                },
             });
         }
         try providers.put(self.allocator, interface_name, .{
@@ -9606,7 +9811,15 @@ pub const WasiCliAdapter = struct {
             return;
         };
 
-        const guest_ptr: u32 = if (n == 0) 0 else (ci.hostAllocAndWrite(buf[0..n]) orelse return error.IoError);
+        // Always invoke `cabi_realloc` (via `hostAllocAndWrite`), even for
+        // a zero-length read. The wit-component preview1 adapter's
+        // `fd_read`/`fd_pread` pin a `OneAlloc(BumpAlloc::new(ptr, len))`
+        // for the duration of the call and then assert
+        // `data.as_ptr() == ptr` on the lifted list. If we short-circuit
+        // and return `{ptr: 0, len: 0}`, the assertion fires and the
+        // guest panics. `BumpAlloc::alloc(0)` returns the pinned ptr,
+        // which is exactly what the adapter's lift expects. (#715.)
+        const guest_ptr: u32 = ci.hostAllocAndWrite(buf[0..n]) orelse return error.IoError;
 
         const eof = (cap == 0) or (n < cap);
         const tuple_fields = try allocator.alloc(InterfaceValue, 2);
@@ -27119,6 +27332,61 @@ test "filesystem #475: read without read flag returns access" {
     );
 }
 
+// #715: positional `descriptor.read` past EOF must still invoke
+// `cabi_realloc` (via `hostAllocAndWrite`) so the wit-component
+// preview1 adapter's `OneAlloc(BumpAlloc::new(ptr, len))` returns
+// the pinned ptr to the list lift. If we short-circuit `n == 0` →
+// `guest_ptr = 0`, the adapter trips `assert_eq!(data.as_ptr(),
+// ptr)` inside `fd_read`/`fd_pread` and the guest panics with
+// `NOTDIR` (mistranslated, but the assertion path is the cause).
+test "#715: positional read past EOF returns non-zero allocated guest ptr" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const io = std.Io.Threaded.global_single_threaded.io();
+    try tmp.dir.writeFile(io, .{ .sub_path = "f", .data = "abc" });
+    const file = try tmp.dir.openFile(io, "f", .{ .mode = .read_only });
+    const handle = try adapter.pushFsDescriptor(.{ .file = .{
+        .file = file,
+        .flags = .{ .read = true },
+    } });
+
+    var ci: ComponentInstance = undefined;
+    try ci.enableTestMem(testing.allocator, 4096);
+    defer ci.disableTestMem();
+    // Pre-advance the bump so a subsequent 0-byte alloc returns a
+    // distinct, post-priming offset only if it actually went through
+    // `hostAllocAndWrite` → `cabi_realloc`. (First allocation always
+    // returns offset 0 in `TestGuestMem`, hence the prime.)
+    _ = ci.hostAllocAndWrite("priming-bytes") orelse return error.TestOom;
+    const bump_after_prime = ci.test_mem.?.bump;
+    try testing.expect(bump_after_prime > 0);
+
+    // Offset past end of file → reads zero bytes, eof=true.
+    var args = [_]InterfaceValue{
+        .{ .handle = handle },
+        .{ .u64 = 64 },
+        .{ .u64 = 100 },
+    };
+    var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+    try WasiCliAdapter.fsDescriptorRead(&adapter, &ci, &args, &results, testing.allocator);
+    defer results[0].deinit(testing.allocator);
+
+    try testing.expect(results[0].result_val.is_ok);
+    const tup = results[0].result_val.payload.?.*.tuple_val;
+    const list_pl = tup[0].list;
+    try testing.expectEqual(@as(u32, 0), list_pl.len);
+    try testing.expect(tup[1].bool); // eof
+    // The fix: even with len=0, the list ptr must come from
+    // `cabi_realloc`. The pre-fix code returned 0; the fix returns
+    // the current bump offset (≥ `bump_after_prime`).
+    try testing.expectEqual(bump_after_prime, list_pl.ptr);
+}
+
 test "filesystem #475: positional write extends file" {
     const testing = std.testing;
     var adapter = WasiCliAdapter.init(testing.allocator);
@@ -42022,4 +42290,137 @@ test "wasi:sockets/network.network-error-code: returns option::none for opaque i
 
     try testing.expect(results[0] == .option_val);
     try testing.expect(!results[0].option_val.is_some);
+}
+
+// =========================================================================
+// #715: WAMR_TRACE_CLI_ADAPTER trace-thunk smoke tests.
+//
+// These verify the comptime wrapper installed around every fs adapter
+// member by `populateWasiFilesystem*`:
+//   * defaults to off and forwards transparently,
+//   * propagates the underlying impl's return value (ok or error),
+//   * does not crash when flipped on (we cannot assert on `std.log.warn`
+//     output in the default test runner, but exercising the on-path
+//     gives the comptime-formatter helpers any-actual-call coverage).
+// =========================================================================
+
+test "#715: trace_calls defaults off; setTraceCalls flips it" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+    try testing.expect(!adapter.trace_calls);
+    adapter.setTraceCalls(true);
+    try testing.expect(adapter.trace_calls);
+    adapter.setTraceCalls(false);
+    try testing.expect(!adapter.trace_calls);
+}
+
+test "#715: traced fs/preopens get-directories forwards ok with trace off" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+    try adapter.populateWasiFilesystemPreopens(&providers, "wasi:filesystem/preopens");
+
+    const binding = providers.get("wasi:filesystem/preopens").?;
+    const member = binding.host_instance.members.get("get-directories").?;
+
+    var ci: ComponentInstance = undefined;
+    var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+    try member.func.call.?(member.func.context, &ci, &.{}, &results, testing.allocator);
+    try testing.expect(results[0] == .list);
+    try testing.expectEqual(@as(u32, 0), results[0].list.len);
+}
+
+test "#715: traced fs/preopens get-directories forwards ok with trace on" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+    adapter.setTraceCalls(true);
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+    try adapter.populateWasiFilesystemPreopens(&providers, "wasi:filesystem/preopens");
+
+    const binding = providers.get("wasi:filesystem/preopens").?;
+    const member = binding.host_instance.members.get("get-directories").?;
+
+    var ci: ComponentInstance = undefined;
+    var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+    try member.func.call.?(member.func.context, &ci, &.{}, &results, testing.allocator);
+    try testing.expect(results[0] == .list);
+    try testing.expectEqual(@as(u32, 0), results[0].list.len);
+}
+
+test "#715: traced fs/types descriptor.get-type propagates impl errors with trace on" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+    adapter.setTraceCalls(true);
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+    try adapter.populateWasiFilesystemTypes(&providers, "wasi:filesystem/types");
+
+    const binding = providers.get("wasi:filesystem/types").?;
+    const member = binding.host_instance.members.get("[method]descriptor.get-type").?;
+
+    var ci: ComponentInstance = undefined;
+    var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+    // empty args → underlying fsDescriptorGetType returns error.InvalidArgs.
+    // The thunk must surface the error unchanged.
+    try testing.expectError(
+        error.InvalidArgs,
+        member.func.call.?(member.func.context, &ci, &.{}, &results, testing.allocator),
+    );
+}
+
+test "#715: traced fs/types descriptor.get-type ok-path returns directory for preopen" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+    adapter.setTraceCalls(true);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const handle = try adapter.addPreopen("/data", tmp.dir);
+    defer adapter.fs_descriptor_table.items[handle] = null;
+
+    var providers: std.StringHashMapUnmanaged(ImportBinding) = .empty;
+    defer providers.deinit(testing.allocator);
+    try adapter.populateWasiFilesystemTypes(&providers, "wasi:filesystem/types");
+
+    const binding = providers.get("wasi:filesystem/types").?;
+    const member = binding.host_instance.members.get("[method]descriptor.get-type").?;
+
+    var ci: ComponentInstance = undefined;
+    var args = [_]InterfaceValue{.{ .handle = handle }};
+    var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+    try member.func.call.?(member.func.context, &ci, &args, &results, testing.allocator);
+    defer results[0].deinit(testing.allocator);
+
+    try testing.expect(results[0] == .result_val);
+    try testing.expect(results[0].result_val.is_ok);
+    const payload = results[0].result_val.payload.?;
+    try testing.expect(payload.* == .variant_val);
+    // 3 = `DescType.directory` in WIT order.
+    try testing.expectEqual(@as(u32, 3), payload.*.variant_val.discriminant);
+}
+
+test "#715: describeInterfaceValue formats common shapes" {
+    const testing = std.testing;
+    // result(ok, variant(disc=3)) — exactly the shape get-type returns for
+    // a preopen. This is the shape #715 turns on.
+    const ok_inner: InterfaceValue = .{ .variant_val = .{ .discriminant = 3, .payload = null } };
+    const ok_res: InterfaceValue = .{ .result_val = .{ .is_ok = true, .payload = &ok_inner } };
+    const s = describeInterfaceValue(ok_res);
+    try testing.expect(std.mem.indexOf(u8, s, "result(ok") != null);
+    try testing.expect(std.mem.indexOf(u8, s, "disc=3") != null);
+
+    // handle(7)
+    const h: InterfaceValue = .{ .handle = 7 };
+    const s2 = describeInterfaceValue(h);
+    try testing.expect(std.mem.indexOf(u8, s2, "handle(7)") != null);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -17,6 +17,12 @@ pub const MapDir = struct {
 
 const Subcommand = enum { run, version, help };
 
+/// Set by `WAMR_TRACE_CLI_ADAPTER=1` at startup (#715). Each
+/// `WasiCliAdapter` constructed during `runRun` / `runComponent`
+/// receives this flag via `setTraceCalls`. Process-global mirrors
+/// the `WAMR_AOT_DEBUG` toggle next door.
+var wasi_cli_adapter_trace_enabled: bool = false;
+
 fn parseSubcommand(s: []const u8) ?Subcommand {
     if (std.mem.eql(u8, s, "run")) return .run;
     if (std.mem.eql(u8, s, "version")) return .version;
@@ -44,7 +50,15 @@ pub fn main(init: std.process.Init) !u8 {
         const on = !(v.len == 0 or std.mem.eql(u8, v, "0") or std.mem.eql(u8, v, "false"));
         wamr.component_core_backend.setDebugAotEnabled(on);
     }
-
+    // Per-member adapter-call trace (#715). When `WAMR_TRACE_CLI_ADAPTER`
+    // is set to a non-empty / non-`0` / non-`false` value, every call
+    // into a `WasiCliAdapter` filesystem host import emits an
+    // `[adapter→]`/`[adapter←]` warn line. The adapter constructed in
+    // `runRun` (or `runComponent`) reads this flag through `setTraceCalls`.
+    if (init.environ_map.get("WAMR_TRACE_CLI_ADAPTER")) |v| {
+        const on = !(v.len == 0 or std.mem.eql(u8, v, "0") or std.mem.eql(u8, v, "false"));
+        wasi_cli_adapter_trace_enabled = on;
+    }
     if (args.len < 2) {
         std.debug.print("error: missing subcommand — try `wamr help`\n", .{});
         return 2;
@@ -731,6 +745,7 @@ fn runComponent(
     // inspect captured stdout, use `WasiCliAdapter.init` instead.
     var adapter = adapter_mod.WasiCliAdapter.initWithHostStdio(allocator);
     defer adapter.deinit();
+    adapter.setTraceCalls(wasi_cli_adapter_trace_enabled);
 
     // argv[0] = basename of the wasm path, rest = user args. Matches
     // the wasmtime convention (and wasi-testsuite fixtures' assumption,
@@ -882,6 +897,7 @@ fn runHttpComponent(
     const adapter_mod = wamr.wasi_cli_adapter;
     var adapter = adapter_mod.WasiCliAdapter.init(allocator);
     defer adapter.deinit();
+    adapter.setTraceCalls(wasi_cli_adapter_trace_enabled);
 
     var argv_buf = allocator.alloc([]const u8, 1 + wasm_args.len) catch
         return 1;


### PR DESCRIPTION
Closes the reported root cause of #715: the keyvault repro panicking inside
`std.Io.Threaded` → `wasi.fd_readdir` with `NOTDIR` on the first
`/spec` preopen.

## Root cause

wit-component's `wasi_snapshot_preview1` adapter imports WASIp2 via
`canon.lower (memory \$f) (realloc \$cabi_import_realloc)`. Both opts
matter for every host-implemented WASIp2 import:

* `cabi_import_realloc` routes through a per-call `import_alloc` cell
  that pins string allocations to the adapter's internal
  `temporary_data` buffer (for directory iteration) or to a
  `OneAlloc(BumpAlloc::new(ptr, len))` (for `fd_read`/`fd_pread`).
* The `(memory \$f)` opt tells the canonical lift which memory to
  write the list/string bytes into.

Pre-#715 our `hostAllocAndWrite` walked back to the main core
module's `cabi_realloc` and the canonical memory. The adapter's lift
then saw `data.as_ptr() != import_alloc.ptr` and tripped its own
`assert_eq!`'s — which the Zig guest's WASIp1 layer mistranslates as
`NOTDIR` on the directory-iteration path.

## Fix

* **`ComponentInstance.current_lower_call_ctx`** — per-call cache
  populated by `componentTrampoline` / `dispatchAotComponentTrampoline`
  and consulted by `hostAllocGuest`, `writableGuestBytes`, and
  `readGuestBytes`. Pre-resolves `(memory \$m)` to a `*MemoryInstance`
  and `(realloc \$f)` to an AOT or interp `ReallocTarget`.

* **`resolveTopLevelCoreFuncAny`** — AOT-aware sibling of
  `resolveTopLevelCoreFunc`. `cabi_import_realloc` may live on either
  a precompiled core or an interp core.

* **`fsDescriptorRead`** — always invoke `hostAllocAndWrite`, even
  for a zero-byte read past EOF. The adapter's
  `OneAlloc(BumpAlloc::new(ptr, len))` returns the pinned ptr on a
  zero-size alloc, which is what the canonical lift asserts against.
  Short-circuiting `n == 0` → `guest_ptr = 0` made the lift trip
  `assert_eq!(data.as_ptr(), ptr)` inside `fd_read`/`fd_pread`.

* **`enumDiscriminantOf`** — dual `.enum_val`/`.variant_val`
  acceptance across `canonical_abi.zig` and `executor.zig` enum/
  variant lower/store paths. Host adapter construction uses whichever
  tag the caller has handy; treating only `.enum_val` as legitimate
  silently dropped the discriminant to 0 when the value originated as
  `.variant_val{ .discriminant = N, .payload = null }`.

* **`WAMR_TRACE_CLI_ADAPTER`** env var + `tracedAdapterCall` thunks
  on the `populateWasiFilesystem*` member tables. Per-member entry/
  exit trace, off by default, gives the same observability lens used
  to localise this bug without re-patching the adapter — sibling to
  the `[aot-dispatch]` machinery from #714, one layer down.

## Verification

* `zig build test --summary failures` passes (full suite).
* Added regression test `#715: positional read past EOF returns
  non-zero allocated guest ptr` covering the zero-byte realloc path.
* Keyvault repro (issue's primary acceptance test) advances past the
  reported `NOTDIR` panic, through all 10 preopens, all
  `read-directory-entry` calls, opens, stats, and into actual file
  reads:

  ```
  collecting spec files from /spec
  collecting stdlib files from /node_modules/@typespec/compiler
  collecting stdlib files from /node_modules/@typespec/http
  ... (8 more)
  emitter-options size = 1345719 bytes
  calling tcgc.compile...
  ```

  A separate trap inside `tcgc.compile` (`wasm trap: unreachable
  (code+0x950, local_func[26]+0x23f)`) remains and will be filed as a
  follow-up issue — it is downstream of the `fd_readdir` fix and was
  not reachable previously.