### PR TITLE
adapter: always realloc directory-entry name (defensive #715 analogue)

### DIFF
--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -10904,10 +10904,17 @@ pub const WasiCliAdapter = struct {
                 else => .unknown,
             };
 
-            const name_ptr: u32 = if (entry.name.len == 0) 0 else (ci.hostAllocAndWrite(entry.name) orelse {
+            // Always go through `hostAllocAndWrite`, even when the entry
+            // name is empty, so the returned string ptr matches the
+            // `TwoAllocs` pin the wit-component preview1 adapter installs
+            // around `read-directory-entry` (it asserts
+            // `name.as_ptr() == temporary_data`). `std.fs.Dir.Iterator`
+            // never yields a zero-length name today, but mirror the #715
+            // `fd_read` fix here for symmetry/defence in depth.
+            const name_ptr: u32 = ci.hostAllocAndWrite(entry.name) orelse {
                 results[0] = try fsResultErr(allocator, .insufficient_memory);
                 return;
-            });
+            };
 
             const fields = try allocator.alloc(InterfaceValue, 2);
             fields[0] = .{ .variant_val = .{


### PR DESCRIPTION
## What

`fsDescriptorReadDirectoryEntryStreamReadDirectoryEntry` (`src/component/wasi_cli_adapter.zig:10907`) short-circuited `entry.name.len == 0` to `name_ptr = 0`. That's the exact bug shape that #715 / #716 just fixed for `fsDescriptorRead`. Drop the zero-check and always go through `hostAllocAndWrite` so the returned name pointer matches the `cabi_realloc` slot the wit-component preview1 adapter pinned.

## Why

The wit-component preview1 adapter (v44, line ~1571) lifts the entry name through a `TwoAllocs` setup and asserts:

```rust
assert_eq!(name.as_ptr(), self.state.temporary_data);
```

A zero-length name would have made the lift produce `as_ptr() == 0` and tripped the assertion just like the keyvault `fd_readdir` repro in #715 did for `fd_read`. `std.fs.Dir.Iterator` never yields a zero-length name today (no filesystem permits empty basenames), so this is latent — but defensive symmetry with the #715 fix matters: every host method whose result is lifted under a canon-lower `OneAlloc` / `TwoAllocs` pin must go through `hostAllocAndWrite` (which now honours `current_lower_call_ctx`) even on empty payloads.

## Audit

In a follow-up audit after #716 merged I checked every `len == 0 ? 0 : hostAllocAndWrite` site and every naked `.{ .ptr = 0, .len = 0 }` list return in `wasi_cli_adapter.zig`:

- `getRandomBytes` / `getInsecureRandomBytes` / `fsDescriptorReadlinkAt` — already always-allocate.
- `getEnvironment` / `getArguments` empty lists return `{ptr:0,len:0}`, but the preview1 adapter's `*_sizes_get` short-circuits to length 0 before `*_get` would ever lift the list.
- HTTP fields entries, HTTP outparams, keyvalue `get-all`, UDP `receive-datagram`, datagram batches, `wasi:io/poll` ready-index list, config-store `get-all` — all out of the preview1 adapter's scope; their wit-bindgen-emitted lifts don't ptr-assert.

`read-directory-entry` is the only remaining defensive site.

## Test

```sh
cd /work/wamr-717b
unset ZIG_LOCAL_CACHE_DIR
export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
zig build test --summary all
```

All test steps pass (final summary shows every `run test` line as `N pass (N total)`). No new tests added — the existing `fd_readdir` regression added in #716 still covers the AOT path, and the empty-name case is unreachable from the OS.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>