### PR TITLE
executor: comptime-typesafe funcidx newtypes + tighten trap-PC decode

### DIFF
--- a/src/component/call_frame.zig
+++ b/src/component/call_frame.zig
@@ -48,6 +48,22 @@ const interp = @import("../runtime/interpreter/interp.zig");
 const aot_runtime = @import("../runtime/aot/runtime.zig");
 const Allocator = std.mem.Allocator;
 
+/// A core-funcidx in the owning module instance's local function index
+/// space — directly callable via `CallFrame.realloc` /
+/// `CallFrame.executeCore`. Distinct from `executor.CoreFuncIdxComponent`
+/// so the compiler rejects passing a component-level idx straight
+/// through to a frame call (the #719 bug class). Zero runtime cost.
+pub const CoreFuncIdxLocal = enum(u32) {
+    _,
+    pub inline fn from(raw: u32) CoreFuncIdxLocal {
+        return @enumFromInt(raw);
+    }
+    pub inline fn value(self: CoreFuncIdxLocal) u32 {
+        return @intFromEnum(self);
+    }
+};
+
+
 pub const FrameError = error{
     StackOverflow,
     StackUnderflow,
@@ -104,7 +120,7 @@ pub const InterpFrame = struct {
 
     pub fn realloc(
         self: *InterpFrame,
-        realloc_idx: u32,
+        realloc_idx: CoreFuncIdxLocal,
         old_ptr: u32,
         old_size: u32,
         alignment: u32,
@@ -114,7 +130,7 @@ pub const InterpFrame = struct {
         self.env.pushI32(@bitCast(old_size)) catch return error.StackOverflow;
         self.env.pushI32(@bitCast(alignment)) catch return error.StackOverflow;
         self.env.pushI32(@bitCast(new_size)) catch return error.StackOverflow;
-        interp.executeFunction(self.env, realloc_idx) catch return error.ReallocFailed;
+        interp.executeFunction(self.env, realloc_idx.value()) catch return error.ReallocFailed;
         const result = self.env.popI32() catch return error.StackUnderflow;
         return @bitCast(result);
     }
@@ -127,13 +143,13 @@ pub const InterpFrame = struct {
     /// they are kept in the API to keep the two impls symmetric.
     pub fn executeCore(
         self: *InterpFrame,
-        func_idx: u32,
+        func_idx: CoreFuncIdxLocal,
         param_types: []const core_types.ValType,
         result_types: []const core_types.ValType,
     ) FrameError!void {
         _ = param_types;
         _ = result_types;
-        interp.executeFunction(self.env, func_idx) catch return error.TrapInCoreFunction;
+        interp.executeFunction(self.env, func_idx.value()) catch return error.TrapInCoreFunction;
     }
 };
 
@@ -226,7 +242,7 @@ pub const AotFrame = struct {
 
     pub fn realloc(
         self: *AotFrame,
-        realloc_idx: u32,
+        realloc_idx: CoreFuncIdxLocal,
         old_ptr: u32,
         old_size: u32,
         alignment: u32,
@@ -243,7 +259,7 @@ pub const AotFrame = struct {
         var rbuf: [1]aot_runtime.ScalarResult = .{.{ .i32 = 0 }};
         const rres = aot_runtime.callFuncScalar(
             self.ai,
-            realloc_idx,
+            realloc_idx.value(),
             &param_types,
             &result_types,
             &args,
@@ -257,7 +273,7 @@ pub const AotFrame = struct {
 
     pub fn executeCore(
         self: *AotFrame,
-        func_idx: u32,
+        func_idx: CoreFuncIdxLocal,
         param_types: []const core_types.ValType,
         result_types: []const core_types.ValType,
     ) FrameError!void {
@@ -281,7 +297,7 @@ pub const AotFrame = struct {
 
         const got = aot_runtime.callFuncScalar(
             self.ai,
-            func_idx,
+            func_idx.value(),
             self.arg_types.items,
             result_types,
             self.args.items,
@@ -352,7 +368,7 @@ pub const CallFrame = union(enum) {
 
     pub fn realloc(
         self: *CallFrame,
-        realloc_idx: u32,
+        realloc_idx: CoreFuncIdxLocal,
         old_ptr: u32,
         old_size: u32,
         alignment: u32,
@@ -366,7 +382,7 @@ pub const CallFrame = union(enum) {
 
     pub fn executeCore(
         self: *CallFrame,
-        func_idx: u32,
+        func_idx: CoreFuncIdxLocal,
         param_types: []const core_types.ValType,
         result_types: []const core_types.ValType,
     ) FrameError!void {

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -37,6 +37,34 @@ pub const AotFrame = call_frame_mod.AotFrame;
 pub const MAX_FLAT_PARAMS: u32 = 16;
 pub const MAX_FLAT_RESULTS: u32 = 1;
 
+// ── Core function index newtypes ────────────────────────────────────────────
+
+/// A core-funcidx that lives in the **component**'s function index space
+/// (as carried in `canon lift` / `canon lower` opts). Must be translated
+/// through `ComponentInstance.resolveTopLevelCoreFuncAny` before it can
+/// be invoked on a `CallFrame`. Distinct from `CoreFuncIdxLocal` so the
+/// compiler rejects the (#719) bug class where a component-level idx
+/// was passed straight through to a frame call. Zero runtime cost.
+pub const CoreFuncIdxComponent = enum(u32) {
+    _,
+    pub inline fn from(raw: u32) CoreFuncIdxComponent {
+        return @enumFromInt(raw);
+    }
+    pub inline fn value(self: CoreFuncIdxComponent) u32 {
+        return @intFromEnum(self);
+    }
+};
+
+/// A core-funcidx in the **owning module instance**'s local function
+/// index space — directly callable via `CallFrame.realloc` /
+/// `CallFrame.executeCore`. Produced by translating a
+/// `CoreFuncIdxComponent` through `resolveTopLevelCoreFuncAny`, or
+/// minted by lookups like `aot_runtime.findExportFunc` /
+/// `ModuleInstance.getExportFunc`. Re-exported from `call_frame.zig`
+/// where the frame methods consume it.
+pub const CoreFuncIdxLocal = call_frame_mod.CoreFuncIdxLocal;
+
+
 /// Component-model `MAX_FLAT_PARAMS_ASYNC` per the spec's
 /// canonical-ABI rules for `canon.lower (async)`: when a lifted async
 /// func has more than 4 flat-params, the caller spills the entire
@@ -106,8 +134,12 @@ pub const ExecutionError = error{
 /// Parsed canonical options for a lifted function.
 pub const LiftOptions = struct {
     memory_idx: ?u32 = null,
-    realloc_idx: ?u32 = null,
-    post_return_idx: ?u32 = null,
+    /// Component-level core-funcidx. Translate via
+    /// `ComponentInstance.resolveTopLevelCoreFuncAny` before calling.
+    realloc_idx: ?CoreFuncIdxComponent = null,
+    /// Component-level core-funcidx. Translate via
+    /// `ComponentInstance.resolveTopLevelCoreFuncAny` before calling.
+    post_return_idx: ?CoreFuncIdxComponent = null,
     string_encoding: ctypes.StringEncoding = .utf8,
     /// Whether this lift uses the async ABI (Binary.md `canonopt 0x06`).
     /// Async lifts return a packed status immediately; results are
@@ -116,18 +148,18 @@ pub const LiftOptions = struct {
     /// Optional resumption callback core funcidx (Binary.md `canonopt 0x07`).
     /// Only meaningful when `is_async`; the single-threaded poll-cycle
     /// dispatcher invokes it once after each yield. (#478 sub-PR 2.)
-    callback_idx: ?u32 = null,
+    callback_idx: ?CoreFuncIdxComponent = null,
 
     pub fn fromOpts(opts: []const ctypes.CanonOpt) LiftOptions {
         var lo = LiftOptions{};
         for (opts) |opt| {
             switch (opt) {
                 .memory => |idx| lo.memory_idx = idx,
-                .realloc => |idx| lo.realloc_idx = idx,
-                .post_return => |idx| lo.post_return_idx = idx,
+                .realloc => |idx| lo.realloc_idx = CoreFuncIdxComponent.from(idx),
+                .post_return => |idx| lo.post_return_idx = CoreFuncIdxComponent.from(idx),
                 .string_encoding => |enc| lo.string_encoding = enc,
                 .async_lift => lo.is_async = true,
-                .callback => |idx| lo.callback_idx = idx,
+                .callback => |idx| lo.callback_idx = CoreFuncIdxComponent.from(idx),
             }
         }
         return lo;
@@ -139,7 +171,7 @@ pub const LiftOptions = struct {
 /// Call the core module's realloc function: (old_ptr, old_size, align, new_size) -> ptr.
 pub fn callRealloc(
     frame: *CallFrame,
-    realloc_idx: u32,
+    realloc_idx: CoreFuncIdxLocal,
     old_ptr: u32,
     old_size: u32,
     align_val: u32,
@@ -308,6 +340,45 @@ pub fn flattenForwardedChain(
     }
 }
 
+// ── Component → module-local funcidx translation ────────────────────────────
+
+/// Translate a component-level core-funcidx into a `CoreFuncIdxLocal`
+/// inside `core_entry`'s owning module instance. Returns `null` when
+/// `comp_idx` is `null`. The fallback is the pre-#719 behaviour for
+/// hand-authored test fixtures that do not register an `aliases[]`
+/// entry — we interpret the component-level index as module-local.
+/// Real wit-component output always carries the alias and hits the
+/// translation path. Returns `error.ReallocNotAvailable` when the
+/// alias resolves to a *different* core instance than the one
+/// currently executing the lift, which Canon ABI v1 forbids
+/// (`(realloc $f)` must live on the same core module as the lift's
+/// memory).
+fn translateComponentFuncIdx(
+    owner_inst: *const ComponentInstance,
+    core_entry: ComponentInstance.CoreInstanceEntry,
+    comp_idx: ?CoreFuncIdxComponent,
+) ExecutionError!?CoreFuncIdxLocal {
+    const cidx = comp_idx orelse return null;
+    const target = owner_inst.resolveTopLevelCoreFuncAny(cidx.value()) orelse
+        return CoreFuncIdxLocal.from(cidx.value());
+    switch (target) {
+        .aot => |t| {
+            if (core_entry.aot_inst) |ai| {
+                if (ai != t.ai) return error.ReallocNotAvailable;
+                return t.local_idx;
+            }
+            return error.ReallocNotAvailable;
+        },
+        .interp => |t| {
+            if (core_entry.module_inst) |mi| {
+                if (mi != t.mi) return error.ReallocNotAvailable;
+                return t.local_idx;
+            }
+            return error.ReallocNotAvailable;
+        },
+    }
+}
+
 /// Invoke a component-level lifted export, given the owning instance and
 /// its already-resolved owner-relative indices. This is the common path
 /// shared between name-keyed dispatch (`callComponentFunc`) and the
@@ -363,44 +434,31 @@ pub fn callComponentFuncByLocal(
     // Parse canonical options
     const lift_opts = LiftOptions.fromOpts(exported.opts);
 
-    // Translate the component-level `realloc` core-funcidx (as carried
-    // in `canon lift` opts) into a function index local to the lifted
-    // core function's own AOT module / interp module instance. Without
-    // this translation, `AotFrame.realloc` / `InterpFrame.realloc`
-    // would dispatch against the WRONG wasm function — sometimes
-    // landing inside an unrelated once-init guard whose body starts
-    // with `unreachable` (#719: tcgc.compile trapping at
+    // Translate the component-level `realloc` and `post_return`
+    // core-funcidx (as carried in `canon lift` opts) into function
+    // indices local to the lifted core function's own AOT module /
+    // interp module instance. Without this translation,
+    // `AotFrame.realloc` / `InterpFrame.realloc` (or `executeCore` for
+    // post_return) would dispatch against the WRONG wasm function —
+    // sometimes landing inside an unrelated once-init guard whose body
+    // starts with `unreachable` (#719: tcgc.compile trapping at
     // `local_func[26]+0x23f` because component-level realloc_idx 81
-    // was passed straight through as a module-local funcidx).
+    // was passed straight through as a module-local funcidx). The
+    // `CoreFuncIdxComponent` / `CoreFuncIdxLocal` newtype enums make
+    // this conversion explicit and compiler-enforced.
     //
-    // Per Canon ABI v1, `(realloc $f)` must live on the same core
-    // module as the lift's memory; we treat a cross-instance resolve
-    // as a malformed component. Hand-authored test fixtures that do
-    // not register an `aliases[]` entry for their realloc export
-    // fall back to interpreting `realloc_idx` as module-local (the
-    // pre-#719 behaviour) — real wit-component output always carries
-    // a corresponding alias and hits the translation path.
-    const resolved_realloc_idx: ?u32 = blk: {
-        const ridx = lift_opts.realloc_idx orelse break :blk null;
-        const target = owner_inst.resolveTopLevelCoreFuncAny(ridx) orelse
-            break :blk ridx;
-        switch (target) {
-            .aot => |t| {
-                if (core_entry.aot_inst) |ai| {
-                    if (ai != t.ai) return error.ReallocNotAvailable;
-                    break :blk t.local_idx;
-                }
-                return error.ReallocNotAvailable;
-            },
-            .interp => |t| {
-                if (core_entry.module_inst) |mi| {
-                    if (mi != t.mi) return error.ReallocNotAvailable;
-                    break :blk t.local_idx;
-                }
-                return error.ReallocNotAvailable;
-            },
-        }
-    };
+    // Per Canon ABI v1, `(realloc $f)` and `(post-return $f)` must
+    // live on the same core module as the lift's memory; we treat a
+    // cross-instance resolve as a malformed component. Hand-authored
+    // test fixtures that do not register an `aliases[]` entry for
+    // their realloc/post_return export fall back to interpreting the
+    // index as module-local (the pre-#719 behaviour) — real
+    // wit-component output always carries a corresponding alias and
+    // hits the translation path.
+    const resolved_realloc_idx: ?CoreFuncIdxLocal =
+        try translateComponentFuncIdx(owner_inst, core_entry, lift_opts.realloc_idx);
+    const resolved_post_return_idx: ?CoreFuncIdxLocal =
+        try translateComponentFuncIdx(owner_inst, core_entry, lift_opts.post_return_idx);
 
     // Get the type registry — must come from the owner so component-
     // level type indices resolve in the owner's type-indexspace.
@@ -496,7 +554,7 @@ pub fn callComponentFuncByLocal(
     };
 
     // 5b. Call the core function
-    frame.executeCore(exported.core_func_idx, &.{}, core_result_types) catch {
+    frame.executeCore(CoreFuncIdxLocal.from(exported.core_func_idx), &.{}, core_result_types) catch {
         switch (frame) {
             .interp => |f| if (f.env.host_trap) |ht| {
                 // Suppress the diagnostic when this trap is actually a
@@ -559,7 +617,7 @@ pub fn callComponentFuncByLocal(
     }
 
     // 7. Post-return callback
-    if (lift_opts.post_return_idx) |pr_idx| {
+    if (resolved_post_return_idx) |pr_idx| {
         // Per spec: post_return receives the flat result value(s).
         // For inline results (≤ MAX_FLAT_RESULTS): re-push the flat values.
         // For spilled results: re-push the result pointer as i32.
@@ -688,9 +746,9 @@ pub fn callComponentFuncByLocalAsyncLifted(
         // Falls back to `ridx_comp` when no alias entry resolves, matching
         // the pre-#719 hand-authored fixture convention.
         const ridx_comp = lift_opts.realloc_idx orelse return error.ReallocNotAvailable;
-        const realloc_idx = blk2: {
-            const target = owner_inst.resolveTopLevelCoreFuncAny(ridx_comp) orelse
-                break :blk2 ridx_comp;
+        const realloc_idx: CoreFuncIdxLocal = blk2: {
+            const target = owner_inst.resolveTopLevelCoreFuncAny(ridx_comp.value()) orelse
+                break :blk2 CoreFuncIdxLocal.from(ridx_comp.value());
             switch (target) {
                 .interp => |t| {
                     if (t.mi != module_inst) return error.ReallocNotAvailable;
@@ -2930,19 +2988,19 @@ test "LiftOptions: parse from CanonOpt array" {
     };
     const lo = LiftOptions.fromOpts(&opts);
     try std.testing.expectEqual(@as(?u32, 0), lo.memory_idx);
-    try std.testing.expectEqual(@as(?u32, 1), lo.realloc_idx);
-    try std.testing.expectEqual(@as(?u32, 2), lo.post_return_idx);
+    try std.testing.expectEqual(@as(?CoreFuncIdxComponent, CoreFuncIdxComponent.from(1)), lo.realloc_idx);
+    try std.testing.expectEqual(@as(?CoreFuncIdxComponent, CoreFuncIdxComponent.from(2)), lo.post_return_idx);
     try std.testing.expectEqual(ctypes.StringEncoding.utf16, lo.string_encoding);
 }
 
 test "LiftOptions: defaults" {
     const lo = LiftOptions.fromOpts(&.{});
     try std.testing.expectEqual(@as(?u32, null), lo.memory_idx);
-    try std.testing.expectEqual(@as(?u32, null), lo.realloc_idx);
-    try std.testing.expectEqual(@as(?u32, null), lo.post_return_idx);
+    try std.testing.expectEqual(@as(?CoreFuncIdxComponent, null), lo.realloc_idx);
+    try std.testing.expectEqual(@as(?CoreFuncIdxComponent, null), lo.post_return_idx);
     try std.testing.expectEqual(ctypes.StringEncoding.utf8, lo.string_encoding);
     try std.testing.expectEqual(false, lo.is_async);
-    try std.testing.expectEqual(@as(?u32, null), lo.callback_idx);
+    try std.testing.expectEqual(@as(?CoreFuncIdxComponent, null), lo.callback_idx);
 }
 
 test "LiftOptions: async + callback (#478 sub-PR 2)" {
@@ -2954,7 +3012,7 @@ test "LiftOptions: async + callback (#478 sub-PR 2)" {
     const lo = LiftOptions.fromOpts(&opts);
     try std.testing.expectEqual(@as(?u32, 0), lo.memory_idx);
     try std.testing.expectEqual(true, lo.is_async);
-    try std.testing.expectEqual(@as(?u32, 7), lo.callback_idx);
+    try std.testing.expectEqual(@as(?CoreFuncIdxComponent, CoreFuncIdxComponent.from(7)), lo.callback_idx);
 }
 
 test "LowerOptions: async opt flips is_async (#551 canon-lower-of-async-func)" {
@@ -5965,7 +6023,9 @@ const HostFunc = instance_mod.HostFunc;
 /// resolve once at instantiation time instead of on every call.
 pub const LowerOptions = struct {
     memory_idx: ?u32 = null,
-    realloc_idx: ?u32 = null,
+    /// Component-level core-funcidx. Translate via
+    /// `ComponentInstance.resolveTopLevelCoreFuncAny` before calling.
+    realloc_idx: ?CoreFuncIdxComponent = null,
     string_encoding: ctypes.StringEncoding = .utf8,
     /// `canon.lower (async) (func)` — Binary.md `canonopt 0x06` shared with
     /// the lift side. When set, the canon-lower trampoline returns a packed
@@ -5982,7 +6042,7 @@ pub const LowerOptions = struct {
         for (opts) |opt| {
             switch (opt) {
                 .memory => |idx| lo.memory_idx = idx,
-                .realloc => |idx| lo.realloc_idx = idx,
+                .realloc => |idx| lo.realloc_idx = CoreFuncIdxComponent.from(idx),
                 .post_return => {},
                 .string_encoding => |enc| lo.string_encoding = enc,
                 // `async` flips into the async-lower path (#551). The
@@ -6014,7 +6074,7 @@ fn resolveLowerCallCtx(
         cctx.memory = comp_inst.resolveTopLevelMemory(midx);
     }
     if (lower_opts.realloc_idx) |ridx| {
-        cctx.realloc = comp_inst.resolveTopLevelCoreFuncAny(ridx);
+        cctx.realloc = comp_inst.resolveTopLevelCoreFuncAny(ridx.value());
     }
     return cctx;
 }

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -13,6 +13,8 @@ const core_backend = @import("core_backend.zig");
 const aot_loader = @import("../runtime/aot/loader.zig");
 const aot_runtime = @import("../runtime/aot/runtime.zig");
 const host_trampolines = @import("../runtime/aot/host_trampolines.zig");
+const call_frame_mod = @import("call_frame.zig");
+const CoreFuncIdxLocal = call_frame_mod.CoreFuncIdxLocal;
 
 const aot_host_bridge = @import("../runtime/aot/host_bridge.zig");
 
@@ -467,11 +469,11 @@ pub const ComponentInstance = struct {
     pub const ReallocTarget = union(enum) {
         interp: struct {
             mi: *core_types.ModuleInstance,
-            local_idx: u32,
+            local_idx: CoreFuncIdxLocal,
         },
         aot: struct {
             ai: *aot_runtime.AotInstance,
-            local_idx: u32,
+            local_idx: CoreFuncIdxLocal,
         },
     };
 
@@ -701,11 +703,11 @@ pub const ComponentInstance = struct {
                 const entry = self.core_instances[ie.instance_idx];
                 if (entry.module_inst) |mi| {
                     const local = mi.getExportFunc(ie.name) orelse return null;
-                    return .{ .interp = .{ .mi = mi, .local_idx = local } };
+                    return .{ .interp = .{ .mi = mi, .local_idx = CoreFuncIdxLocal.from(local) } };
                 }
                 if (entry.aot_inst) |ai| {
                     const local = aot_runtime.findExportFunc(ai, ie.name) orelse return null;
-                    return .{ .aot = .{ .ai = ai, .local_idx = local } };
+                    return .{ .aot = .{ .ai = ai, .local_idx = CoreFuncIdxLocal.from(local) } };
                 }
                 return null;
             },
@@ -813,7 +815,6 @@ pub const ComponentInstance = struct {
         if (self.current_lower_call_ctx) |cctx| {
             if (cctx.realloc) |target| {
                 const executor = @import("executor.zig");
-                const call_frame_mod = @import("call_frame.zig");
                 switch (target) {
                     .aot => |t| {
                         var frame: executor.CallFrame = .{
@@ -851,7 +852,7 @@ pub const ComponentInstance = struct {
             const aot_call_frame = @import("call_frame.zig");
             var frame: executor.CallFrame = .{ .aot = aot_call_frame.AotFrame.init(ai, self.allocator) };
             defer frame.deinit();
-            return executor.callRealloc(&frame, realloc_idx, 0, 0, a, size) catch null;
+            return executor.callRealloc(&frame, CoreFuncIdxLocal.from(realloc_idx), 0, 0, a, size) catch null;
         }
         const realloc_owner = self.reallocOwner() orelse return null;
         const realloc_local = realloc_owner.getExportFunc("cabi_realloc") orelse return null;
@@ -870,7 +871,7 @@ pub const ComponentInstance = struct {
         const env = self.realloc_env orelse return null;
         var frame: executor.CallFrame = .{ .interp = executor.InterpFrame.init(env) };
         defer frame.deinit();
-        return executor.callRealloc(&frame, realloc_local, 0, 0, a, size) catch null;
+        return executor.callRealloc(&frame, CoreFuncIdxLocal.from(realloc_local), 0, 0, a, size) catch null;
     }
 
     /// Return a writable slice into the canonical guest memory (or the
@@ -3704,9 +3705,10 @@ fn installCanonLowerBackedCrossInstanceThunk(
         .has_retptr = has_retptr,
     });
     if (core_backend.debugAotEnabled()) {
+        const realloc_dbg: ?u32 = if (ctx_ptr.lower_opts.realloc_idx) |r| r.value() else null;
         std.debug.print(
             "[install canon-lower(aot)] slot={d} module='{s}' field='{s}' cfi={d} flat_results={d} has_retptr={} mem_opt={?} realloc_opt={?}\n",
-            .{ pool.next_slot - 1, imp.module_name, imp.field_name, ctx_ptr.component_func_idx, flat_result_count, has_retptr, ctx_ptr.lower_opts.memory_idx, ctx_ptr.lower_opts.realloc_idx },
+            .{ pool.next_slot - 1, imp.module_name, imp.field_name, ctx_ptr.component_func_idx, flat_result_count, has_retptr, ctx_ptr.lower_opts.memory_idx, realloc_dbg },
         );
     }
     return @ptrCast(stub);

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -512,33 +512,22 @@ fn lookupLocalFuncName(local_idx: isize) ?[]const u8 {
 }
 
 pub fn aotTrapOOB(vmctx: *VmCtx) callconv(.c) noreturn {
-    const ret_addr: usize = @returnAddress();
-    const code_off_s: isize = @as(isize, @bitCast(ret_addr)) - @as(isize, @bitCast(g_code_base));
-    const code_off: usize = if (code_off_s >= 0) @intCast(code_off_s) else 0;
-    var func_idx: isize = -1;
-    var func_start: usize = 0;
-    for (g_func_offsets, 0..) |off, idx| {
-        if (off <= code_off) {
-            func_idx = @intCast(idx);
-            func_start = off;
-        } else break;
-    }
-    const rel_off: usize = if (code_off >= func_start) code_off - func_start else 0;
+    const loc = decodeTrapReturnAddress(@returnAddress());
     if (@atomicLoad(bool, &g_trap_catching, .seq_cst)) {
         // Caller has armed trap-as-error; unwind instead of exiting.
         trapLongjmp();
     }
     // Flush any buffered stdout from the guest before we tear down the
     // process so user-visible output isn't lost. Best-effort.
-    if (lookupLocalFuncName(func_idx)) |name| {
+    if (loc.name) |name| {
         std.debug.print(
             "wasm trap: out of bounds memory access (code+0x{x}, local_func[{d}] \"{s}\"+0x{x}, mem_size=0x{x})\n",
-            .{ code_off, func_idx, name, rel_off, vmctx.memory_size },
+            .{ loc.code_off, loc.func_idx, name, loc.rel_off, vmctx.memory_size },
         );
     } else {
         std.debug.print(
             "wasm trap: out of bounds memory access (code+0x{x}, local_func[{d}]+0x{x}, mem_size=0x{x})\n",
-            .{ code_off, func_idx, rel_off, vmctx.memory_size },
+            .{ loc.code_off, loc.func_idx, loc.rel_off, vmctx.memory_size },
         );
     }
     std.process.exit(2);
@@ -558,6 +547,13 @@ const TrapPcLocation = struct {
 fn decodeTrapReturnAddress(ret_addr: usize) TrapPcLocation {
     const code_off_s: isize = @as(isize, @bitCast(ret_addr)) - @as(isize, @bitCast(g_code_base));
     const code_off: usize = if (code_off_s >= 0) @intCast(code_off_s) else 0;
+    // PC falls outside the currently-installed code region (e.g. a trap
+    // raised from a different AOT instance whose decode frame was just
+    // restored, or a PC corruption). Refuse to scan g_func_offsets so we
+    // don't report a stale last-index match.
+    if (g_code_size == 0 or code_off >= g_code_size) {
+        return .{ .code_off = code_off, .func_idx = -1, .rel_off = 0, .name = null };
+    }
     var func_idx: isize = -1;
     var func_start: usize = 0;
     for (g_func_offsets, 0..) |off, idx| {


### PR DESCRIPTION
Follow-up to #721 (issue #719). Make the recent class of cross-scope
core-function-index bugs unrepresentable at compile time, plus drive-by
trap-PC decode hygiene.

## A — funcidx newtypes

Two non-exhaustive enum newtypes replace the bare \`u32\` that has been
flowing across scope boundaries:

* \`CoreFuncIdxComponent\` (component-scope) carried by \`LiftOptions\` /
  \`LowerOptions\` from \`CanonOpt\` parsing.
* \`CoreFuncIdxLocal\` (module-instance scope) consumed by frame methods.

\`translateComponentFuncIdx\` is now the **sole bridge** between scopes
and routes through \`resolveTopLevelCoreFuncAny\` (mirroring the #721
fix). Zero runtime cost: non-exhaustive enums lower to plain u32.

### Latent post_return bug fixed (same class as #719)

While threading the newtypes, the compiler immediately rejected this
existing line:

\`\`\`zig
frame.executeCore(lift_opts.post_return_idx.?, ...);
//                ^^^^^^^^^^^ component-scope passed where local-scope expected
\`\`\`

Both \`realloc\` and \`post_return\` now route through the same helper.

## C — trap-PC decode hygiene

* \`decodeTrapReturnAddress\`: add \`g_code_size\` bounds check. Previously
  walked \`g_func_offsets\` even when the trap PC was outside the
  installed code region and returned a stale last-index — a bad PC
  display that cost ~a day of chasing on #719. Now returns
  \`func_idx=-1\` cleanly.
* \`aotTrapOOB\`: refactor to share the same decoder.

## Validation

\`zig build install\` clean. \`zig build test\`:
\`2954/2961 passed (7 skipped)\` — matches main baseline.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>