### PR TITLE
executor: fix AOT canon.lift spilled-result convention (callee-allocates) (#719)

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -518,36 +518,36 @@ pub fn callComponentFuncByLocal(
         frame.pushSlot(.{ .i32 = @bitCast(ptr) }) catch return error.StackOverflow;
     }
 
-    // 4b. Spilled-result mode on AOT: caller-allocates retptr and
-    // passes it as the trailing core arg. The core function returns
-    // void in this mode. (Canon ABI v1 spec; matches the convention
-    // wit-bindgen emits on AOT-compiled guests.)
+    // 4b. Spilled-result mode: per canon-ABI v1 spec for canon.lift,
+    // when `flat_count(results) > MAX_FLAT_RESULTS` the lifted core
+    // function uses CALLEE-allocates — it allocates the result buffer
+    // (via its own realloc) and returns the pointer as a single i32
+    // result. The caller does NOT pass a retptr. This matches what
+    // wit-bindgen / rust-wit-bindgen emit on both interp and AOT.
     //
-    // The interp path uses callee-allocates: the core returns the
-    // retptr it allocated itself, popped after executeCore below.
-    var aot_retptr: ?u32 = null;
-    if (is_aot and flat_result_count > MAX_FLAT_RESULTS and result_types.len > 0) {
-        const realloc_idx = resolved_realloc_idx orelse return error.ReallocNotAvailable;
-        const ret_size = computeTupleSize(registry, result_types);
-        const ret_align = computeTupleAlign(registry, result_types);
-        const rp = try callRealloc(&frame, realloc_idx, 0, 0, ret_align, ret_size);
-        // Re-fetch memory after realloc.
-        memory = frame.memory(default_mem_idx);
-        frame.pushSlot(.{ .i32 = @bitCast(rp) }) catch return error.StackOverflow;
-        aot_retptr = rp;
-    }
+    // Earlier this path had a backend split (AOT caller-allocates,
+    // interp callee-allocates), which broke real components: tcgc.compile
+    // is emitted as `(param i32 i32 i32 i32) (result i32)` and the
+    // AOT-pushed extra retptr arg was simply ignored, so the result
+    // pointer was never read — see #719.
 
     // 5. Compute core result types for executeCore. Advisory for
     // interp (signature comes from the module); load-bearing for AOT
     // since callFuncScalar needs an accurate signature. Only compute
     // it for AOT — for interp we pass an empty slice and let
     // `executeFunction` read the core sig from the module.
+    //
+    // Spilled-result lift returns the retptr as a single i32 (callee-
+    // allocates); other cases return the (single) flat result.
     var core_rt_buf: [1]core_types.ValType = undefined;
     const core_result_types: []const core_types.ValType = if (!is_aot)
         &.{}
-    else if (flat_result_count > MAX_FLAT_RESULTS or result_types.len == 0)
+    else if (result_types.len == 0)
         &.{}
-    else blk: {
+    else if (flat_result_count > MAX_FLAT_RESULTS) blk: {
+        core_rt_buf[0] = .i32;
+        break :blk core_rt_buf[0..1];
+    } else blk: {
         core_rt_buf[0] = coreFlatSlotType(result_types[0], registry) catch
             return error.AotPathUnsupported;
         break :blk core_rt_buf[0..1];
@@ -593,15 +593,11 @@ pub fn callComponentFuncByLocal(
             out_results[i] = popInterfaceValue(&frame, rt, registry, allocator) catch return error.LiftError;
         }
     } else {
-        // Spilled-result path — read tuple from linear memory.
-        // Backend split: AOT pre-allocated the retptr (caller-
-        // allocates); interp expects the callee to return it.
-        if (aot_retptr) |rp| {
-            result_ptr_for_post_return = rp;
-        } else {
-            const popped = frame.popSlot(.i32) catch return error.StackUnderflow;
-            result_ptr_for_post_return = @bitCast(popped.i32);
-        }
+        // Spilled-result path — callee allocated the buffer and
+        // returned its pointer as a single i32 (canon-ABI v1 lift
+        // convention). Pop it and read the tuple from linear memory.
+        const popped = frame.popSlot(.i32) catch return error.StackUnderflow;
+        result_ptr_for_post_return = @bitCast(popped.i32);
         // Re-fetch memory after executeCore — the core function may
         // have grown linear memory, invalidating the captured slice.
         memory = frame.memory(default_mem_idx);
@@ -636,9 +632,11 @@ pub fn callComponentFuncByLocal(
 /// Map a single-flat-slot interface result type to its core wasm
 /// value type. Only valid when the interface type flattens to exactly
 /// one core slot (i.e. `flat_result_count <= MAX_FLAT_RESULTS=1`).
-/// Multi-slot results spill to memory and the core function returns
-/// void instead — see the `aot_retptr` / `flat_result_count >
-/// MAX_FLAT_RESULTS` branch in `callComponentFuncByLocal`.
+/// Multi-slot results spill to memory: the lifted core function
+/// callee-allocates the buffer (via realloc) and returns its pointer
+/// as a single i32 (canon-ABI v1 spilled-result convention) — see
+/// the `flat_result_count > MAX_FLAT_RESULTS` branch in
+/// `callComponentFuncByLocal`.
 fn coreFlatSlotType(t: ctypes.ValType, registry: TypeRegistry) !core_types.ValType {
     return switch (t) {
         .bool, .s8, .u8, .s16, .u16, .s32, .u32, .char => .i32,

--- a/src/tests/component_aot_canonlift_test.zig
+++ b/src/tests/component_aot_canonlift_test.zig
@@ -296,25 +296,28 @@ test "#650 phase A: AOT lifts result<(),()> via scalar fast path" {
 //   * `realloc(orig, sz, align, new_sz)` — fixed-bump allocator
 //      that always returns 16, so the lifted return tuple lands
 //      at offset 16 in linear memory.
-//   * `wp(retptr)` — writes 0x000000AA at retptr+0 and 0x000000BB
-//      at retptr+4, returns no flat results.
+//   * `wp()` — writes 0x000000AA at offset 16 and 0x000000BB at
+//      offset 20, returns the retptr (16) as a single i32 result.
 //
 // canon.lift retypes `wp` as `func() -> tuple<u32, u32>`. The lifted
 // type flattens to 2 i32 slots, exceeding `MAX_FLAT_RESULTS=1`, so
-// canon ABI emits the core function as `(retptr) -> ()` and the
-// AOT path must (a) call realloc to obtain retptr, (b) push retptr
-// as the trailing i32 arg, and (c) read both u32 fields back from
-// linear memory via `loadInterfaceValue`.
+// canon ABI v1 spilled-result convention applies: the core function
+// is emitted as `() -> i32` (CALLEE-allocates retptr) — the callee
+// allocates the buffer via its own realloc and returns the pointer.
+// The lift trampoline pops the i32 retptr and reads both u32 fields
+// back from linear memory via `loadInterfaceValue`.
 //
 // Pre-phase-B.1 this lift hit `error.AotPathUnsupported` on
 // `result_types.len > MAX_FLAT_RESULTS` (which conflated interface
-// arity with flat slot count anyway).
+// arity with flat slot count anyway). Pre-#719 the AOT path used
+// caller-allocates (passing retptr as a trailing arg, expecting void
+// return) which mismatched what wit-bindgen actually emits.
 const retptr_core_wasm = [_]u8{
     0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
-    // type section: 2 types
+    // type section: 2 types (size = 9 + 4 = 13)
     0x01, 0x0d, 0x02,
     0x60, 0x04, 0x7f, 0x7f, 0x7f, 0x7f, 0x01, 0x7f, // realloc: (i32,i32,i32,i32) -> i32
-    0x60, 0x01, 0x7f, 0x00, // wp: (i32) -> ()
+    0x60, 0x00, 0x01, 0x7f, // wp: () -> i32
     // func section: 2 funcs
     0x03, 0x03, 0x02, 0x00, 0x01,
     // memory section: 1 page
@@ -324,14 +327,19 @@ const retptr_core_wasm = [_]u8{
     0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
     0x07, 'r', 'e', 'a', 'l', 'l', 'o', 'c', 0x00, 0x00,
     0x02, 'w', 'p', 0x00, 0x01,
-    // code section: 2 funcs (payload=25 = count(1) + body0(5) + body1(19))
-    0x0a, 0x19, 0x02,
+    // code section: 2 funcs (payload = count(1) + body0(5) + body1(21) = 27)
+    0x0a, 0x1b, 0x02,
     0x04, 0x00, 0x41, 0x10, 0x0b, // realloc: i32.const 16; end
-    // wp body (size=18): 00 20 00 41 AA 01 36 02 00 20 00 41 BB 01 36 02 04 0b
-    0x12,
+    // wp body (size=20): locals(0) +
+    //   i32.const 16; i32.const 0xAA; i32.store offset=0
+    //   i32.const 16; i32.const 0xBB; i32.store offset=4
+    //   i32.const 16          ;; return retptr
+    //   end
+    0x14,
     0x00,
-    0x20, 0x00, 0x41, 0xaa, 0x01, 0x36, 0x02, 0x00,
-    0x20, 0x00, 0x41, 0xbb, 0x01, 0x36, 0x02, 0x04,
+    0x41, 0x10, 0x41, 0xaa, 0x01, 0x36, 0x02, 0x00,
+    0x41, 0x10, 0x41, 0xbb, 0x01, 0x36, 0x02, 0x04,
+    0x41, 0x10,
     0x0b,
 };
 
@@ -563,19 +571,21 @@ test "#650 commit 2: AOT lowers tuple<u32,u32> as multi-slot compound param" {
 // Two-stage lowering on the AOT path:
 //   1. list<u8> flattens to 2 i32 slots (ptr, len) — fits flat, no spill.
 //   2. string flattens to 2 i32 slots — > MAX_FLAT_RESULTS=1 → spilled.
-//      AOT uses caller-allocates: host calls `realloc(0,0,4,8)` to
-//      reserve 8 bytes for the (str_ptr, str_len) tuple, then passes
-//      retptr as the trailing core arg. Core returns void.
+//      AOT uses callee-allocates (canon-ABI v1 lift convention,
+//      matching wit-bindgen): core is emitted as
+//      `(list_ptr, list_len) -> retptr`. Core allocates the
+//      (str_ptr, str_len) buffer via its own realloc and returns
+//      the pointer as a single i32 result.
 //
 // Core wasm:
-//   func[0] realloc:  (i32 i32 i32 i32) -> i32           ;; returns 16
-//   func[1] cast:     (list_ptr list_len retptr) -> ()   ;; stores list_ptr/len at retptr+{0,4}
+//   func[0] realloc:  (i32 i32 i32 i32) -> i32      ;; returns 16
+//   func[1] cast:     (list_ptr list_len) -> i32    ;; stores list_ptr/len at 16+{0,4}, returns 16
 const list_to_string_core_wasm = [_]u8{
     0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
-    // type section: 2 types
+    // type section: 2 types (size = 9 + 6 = 15)
     0x01, 0x0f, 0x02,
-    0x60, 0x04, 0x7f, 0x7f, 0x7f, 0x7f, 0x01, 0x7f, // realloc: (i32,i32,i32,i32) -> i32 (8 bytes)
-    0x60, 0x03, 0x7f, 0x7f, 0x7f, 0x00, // cast: (i32,i32,i32) -> () (6 bytes)
+    0x60, 0x04, 0x7f, 0x7f, 0x7f, 0x7f, 0x01, 0x7f, // realloc: (i32,i32,i32,i32) -> i32 (9 bytes)
+    0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, // cast: (i32,i32) -> i32 (6 bytes)
     // func section: 2 funcs (types 0 and 1)
     0x03, 0x03, 0x02, 0x00, 0x01,
     // memory section: 1 page
@@ -588,15 +598,19 @@ const list_to_string_core_wasm = [_]u8{
     0x04, 'c', 'a', 's', 't', 0x00, 0x01,
     // code section: 2 funcs
     // body0 (realloc): 0x00 0x41 0x10 0x0b = 4 bytes (preceded by size 0x04)
-    // body1 (cast): locals(0) + 2× (local.get x; local.get y; i32.store memarg) + end
-    //   = 0x00 + (0x20 0x02 0x20 0x00 0x36 0x02 0x00) + (0x20 0x02 0x20 0x01 0x36 0x02 0x04) + 0x0b
-    //   = 1 + 7 + 7 + 1 = 16 bytes (preceded by size 0x10)
-    // section payload = count(1) + len-prefix(1)+body0(4) + len-prefix(1)+body1(16) = 23
-    0x0a, 0x17, 0x02,
+    // body1 (cast, callee-allocates): locals(0) +
+    //   i32.const 16; local.get 0; i32.store offset=0
+    //   i32.const 16; local.get 1; i32.store offset=4
+    //   i32.const 16              ;; return retptr
+    //   end
+    //   = 1 + (2+2+3) + (2+2+3) + 2 + 1 = 18 bytes (preceded by size 0x12)
+    // section payload = count(1) + len-prefix(1)+body0(4) + len-prefix(1)+body1(18) = 25
+    0x0a, 0x19, 0x02,
     0x04, 0x00, 0x41, 0x10, 0x0b,
-    0x10, 0x00,
-    0x20, 0x02, 0x20, 0x00, 0x36, 0x02, 0x00,
-    0x20, 0x02, 0x20, 0x01, 0x36, 0x02, 0x04,
+    0x12, 0x00,
+    0x41, 0x10, 0x20, 0x00, 0x36, 0x02, 0x00,
+    0x41, 0x10, 0x20, 0x01, 0x36, 0x02, 0x04,
+    0x41, 0x10,
     0x0b,
 };
 


### PR DESCRIPTION
For `canon.lift` with `flat_count(results) > MAX_FLAT_RESULTS=1`, the canonical-ABI v1 convention is **callee-allocates**: the lifted core function takes `(args...) -> i32` where the i32 result is the retptr the callee allocated via its own realloc. This is what wit-bindgen emits — verified against tcgc.compile: `(i32 i32 i32 i32) -> i32`.

The interp path has always used callee-allocates. The AOT path, since #671, used **caller-allocates**: it pre-allocated a retptr via host realloc and pushed it as a trailing core arg, expecting a void return.

## Impact

Any AOT-compiled component returning a spilled result silently failed. The pushed retptr was ignored by the core function (which expected to return its own pointer), and the host then read result bytes from a buffer the callee never wrote to. This is the `InvalidDiscriminant` trap path observed in #719's tcgc-core repro once the lift signature is multi-slot.

## Fix

In `callComponentFuncByLocal`:
- Drop the AOT pre-allocate-retptr block.
- `core_result_types` returns `[.i32]` for spilled-result on AOT.
- Spilled-result lift always pops i32 retptr (was branched on `aot_retptr` capture).
- Updated `coreFlatSlotType` doc-comment.

Tests `#650 phase B.1` and `#650 commit 2` pinned the OLD caller-allocates convention via hand-crafted wasm with `(...) -> ()` core sigs. Updated their wasm bodies to `(...) -> i32` (return retptr=16), matching the production lift convention and the interp path.

## Note on canon.lower

The lower direction (`dispatchAotComponentTrampoline`) genuinely uses caller-allocates with retptr-last — that path is unchanged and correct.

## Test

- Full `zig build test --summary failures` — 2954/2961 passed (7 skipped, 0 failed).
- Re-exercises the deeper #719 repro: the canon-lift `InvalidDiscriminant` failure is gone; surfaces a separate cross-instance AOT-thunk arg-copy bug (will be addressed in a follow-up).

Refs #719