### PR TITLE
executor: detect & warn on cross-memory AOT cross-instance fast-thunk calls (#719)

### DIFF
--- a/src/component/core_backend.zig
+++ b/src/component/core_backend.zig
@@ -159,6 +159,21 @@ pub fn debugAotEnabled() bool {
     return aot_debug_enabled;
 }
 
+/// Process-global toggle that converts the cross-instance AOT fast-thunk's
+/// "caller memory != target memory" warning into a typed trap. Off by
+/// default; `main.zig` sets it during startup when `WAMR_TRAP_CROSS_MEMORY_THUNK`
+/// is set to a non-empty / non-`0` / non-`false` value. See the dispatcher
+/// in `executor.dispatchAotCrossInstance` and #719 Bug B for context.
+var trap_cross_memory_enabled: bool = false;
+
+pub fn setTrapCrossMemoryEnabled(on: bool) void {
+    trap_cross_memory_enabled = on;
+}
+
+pub fn trapCrossMemoryEnabled() bool {
+    return trap_cross_memory_enabled;
+}
+
 /// Caller-supplied instantiation options.
 pub const Options = struct {
     precompiled_cores: []const PrecompiledCore = &.{},

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -6497,15 +6497,29 @@ pub const CrossInstanceThunkCtx = struct {
     result_types: []const core_types.ValType,
     /// Human-readable label used in trap-shaped error messages.
     label: []const u8,
+    /// True once we've already complained about a caller / target memory
+    /// mismatch for this import. The fast thunk forwards raw core args
+    /// between sibling AOT instances with no canon.lower / canon.lift
+    /// marshaling, so any i32 that the caller intended as a *pointer into
+    /// its own linear memory* gets passed to the target unchanged and
+    /// silently dereferences whatever (unrelated) bytes happen to live at
+    /// the same numeric offset in the target's memory — corrupting
+    /// dlmalloc bookkeeping or worse. We can't distinguish "ptr i32" from
+    /// "scalar i32" at this layer, but if both source and target share the
+    /// same memory the forwarding is a no-op and safe, so the mismatch
+    /// itself is a strong red flag worth surfacing once per import.
+    /// (#719 Bug B follow-up.)
+    cross_memory_warned: bool = false,
 };
 
 /// Cross-instance core-to-core dispatcher (#662). The trampoline pool stub
 /// shifts caller regs right by one to inject `slot` as the first C-ABI arg,
 /// so when the AOT codegen calls a host import as
 /// `host_fn(vmctx, arg0, arg1, …)`, the dispatcher receives
-/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a9=arg8)`. We ignore `a0`
-/// (importer's vmctx — the sibling AotInstance builds its own vmctx
-/// internally in `callFuncScalar`) and use `a1..a9` as lowered wasm args.
+/// `(slot, a0=vmctx, a1=arg0, a2=arg1, …, a9=arg8)`. `a0` is the *importer's*
+/// vmctx — the sibling AotInstance builds its own vmctx internally in
+/// `callFuncScalar`, but we peek at the importer's `memory_base` for the
+/// cross-memory guard (#719 Bug B); `a1..a9` are the lowered wasm args.
 /// Calls outside the trampoline pool's 9-arg-in-regs envelope return a
 /// failing status; richer signatures land in a follow-up. The 5 → 8 widening
 /// in #689 covered WASIp2 filesystem methods like `link-at` (7 wasm params);
@@ -6525,9 +6539,8 @@ pub export fn wamrAotDispatchCrossInstance(
     a8: u64,
     a9: u64,
 ) callconv(.c) host_trampolines.DispatchResult {
-    _ = a0; // importer's vmctx; the sibling AotInstance builds its own.
-    const ctx: *const CrossInstanceThunkCtx = @ptrCast(@alignCast(ctx_opaque));
-    const result = dispatchAotCrossInstance(ctx, lowered_sig.*, .{ a1, a2, a3, a4, a5, a6, a7, a8, a9, 0 }) catch |err| {
+    const ctx: *CrossInstanceThunkCtx = @ptrCast(@alignCast(ctx_opaque));
+    const result = dispatchAotCrossInstance(ctx, lowered_sig.*, a0, .{ a1, a2, a3, a4, a5, a6, a7, a8, a9, 0 }) catch |err| {
         if (debugAotEnabled()) {
             std.debug.print(
                 "[aot-dispatch] cross-instance thunk '{s}' failed: {s}\n",
@@ -6540,8 +6553,9 @@ pub export fn wamrAotDispatchCrossInstance(
 }
 
 fn dispatchAotCrossInstance(
-    ctx: *const CrossInstanceThunkCtx,
+    ctx: *CrossInstanceThunkCtx,
     lowered_sig: host_trampolines.LoweredSig,
+    caller_vmctx: u64,
     arg_regs: [10]u64,
 ) !u64 {
     // We support up to 9 args in registers (a1..a9 in the dispatcher's
@@ -6554,6 +6568,33 @@ fn dispatchAotCrossInstance(
     if (lowered_sig.result_types.len != ctx.result_types.len) return error.UnsupportedSignature;
     for (lowered_sig.param_types, ctx.param_types) |a, b| if (a != b) return error.UnsupportedSignature;
     for (lowered_sig.result_types, ctx.result_types) |a, b| if (a != b) return error.UnsupportedSignature;
+
+    // Cross-memory guard (#719 Bug B follow-up). The fast thunk forwards
+    // raw core args between sibling AOT instances with no canon.lower /
+    // canon.lift marshaling. If the caller's i32s denote pointers into
+    // *its own* linear memory and the target has a different memory,
+    // they dereference garbage on the target side — typically corrupting
+    // the target's dlmalloc bookkeeping with a static-data address that
+    // happens to live at the same numeric offset. We can't distinguish
+    // "ptr i32" from "scalar i32" without component-level type info, but
+    // the memory mismatch *itself* is the strong signal worth surfacing.
+    // One-shot per ctx to keep the log readable.
+    if (!ctx.cross_memory_warned and caller_vmctx != 0 and hasPotentialPtr(ctx.param_types)) {
+        const vm: *const aot_runtime.VmCtx = @ptrFromInt(@as(usize, @intCast(caller_vmctx)));
+        const caller_mb = vm.memory_base;
+        if (ctx.target_ai.memories.len > 0) {
+            const target_mb = @intFromPtr(ctx.target_ai.memories[0].data.ptr);
+            if (caller_mb != 0 and caller_mb != target_mb) {
+                ctx.cross_memory_warned = true;
+                std.log.warn(
+                    "[aot cross-instance] '{s}': caller memory_base=0x{x} != target memory_base=0x{x}; sig has {d} i32 param(s) that may be pointers. " ++
+                        "If this import takes string/list args, the call will silently corrupt the target's heap; set WAMR_TRAP_CROSS_MEMORY_THUNK=1 to convert this into a trap.",
+                    .{ ctx.label, caller_mb, target_mb, countI32Params(ctx.param_types) },
+                );
+                if (trapCrossMemoryEnabled()) return error.CrossMemoryFastThunkUnsupported;
+            }
+        }
+    }
 
     var args_buf: [9]core_types.Value = undefined;
     for (ctx.param_types, 0..) |pt, i| {
@@ -6584,6 +6625,23 @@ fn dispatchAotCrossInstance(
         .f64 => @bitCast(results[0].f64),
         else => error.UnsupportedSignature,
     };
+}
+
+fn hasPotentialPtr(types: []const core_types.ValType) bool {
+    for (types) |t| if (t == .i32) return true;
+    return false;
+}
+
+fn countI32Params(types: []const core_types.ValType) usize {
+    var n: usize = 0;
+    for (types) |t| if (t == .i32) {
+        n += 1;
+    };
+    return n;
+}
+
+fn trapCrossMemoryEnabled() bool {
+    return core_backend.trapCrossMemoryEnabled();
 }
 
 /// Canon-builtin dispatcher for AOT-compiled core modules (#701, follow-up

--- a/src/main.zig
+++ b/src/main.zig
@@ -50,6 +50,20 @@ pub fn main(init: std.process.Init) !u8 {
         const on = !(v.len == 0 or std.mem.eql(u8, v, "0") or std.mem.eql(u8, v, "false"));
         wamr.component_core_backend.setDebugAotEnabled(on);
     }
+    // Process-global toggle for the AOT cross-instance fast-thunk
+    // cross-memory guard (#719 Bug B). The thunk forwards raw core args
+    // between sibling AOT instances with no canon.lower / canon.lift
+    // marshaling; when source and target memories differ, any i32 the
+    // caller intended as a pointer silently dereferences whatever bytes
+    // live at the same numeric offset in the target's memory. By default
+    // we only `std.log.warn` (once per import) on first detection so
+    // working configurations aren't broken; when this env var is set we
+    // also trap, which converts silent corruption into a clean error
+    // with the import label.
+    if (init.environ_map.get("WAMR_TRAP_CROSS_MEMORY_THUNK")) |v| {
+        const on = !(v.len == 0 or std.mem.eql(u8, v, "0") or std.mem.eql(u8, v, "false"));
+        wamr.component_core_backend.setTrapCrossMemoryEnabled(on);
+    }
     // Per-member adapter-call trace (#715). When `WAMR_TRACE_CLI_ADAPTER`
     // is set to a non-empty / non-`0` / non-`false` value, every call
     // into a `WasiCliAdapter` filesystem host import emits an


### PR DESCRIPTION
## Problem

The AOT cross-instance fast thunk (#662) forwards raw core args between sibling AOT instances with no canon.lower / canon.lift marshaling, on the assumption that source and target share the same linear memory. When they don't, any i32 the caller intended as a pointer into *its own* memory is dereferenced on the target side at the same numeric offset — silently corrupting whatever bytes live there.

This is one plausible mechanism behind the #719 'AOT trap deep in tcgc-core dlmalloc' (treebins[0] ends up pointing at a static-data address; phase-C bisect showed forcing only tcgc-core to interp avoids the trap).

## What this PR does

We don't know if a given i32 is a pointer at this layer, so we can't fully fix the issue here. But the memory-mismatch *itself* is a strong signal worth surfacing:

- For each `CrossInstanceThunkCtx` we now peek at the importer's vmctx (`a0`, previously discarded) on first dispatch and compare its `memory_base` against `target_ai.memories[0].data.ptr`.
- When they differ and the sig has at least one i32 param, we emit a one-shot `std.log.warn` with the import label, both memory bases, and the i32 count.
- A new process-global `trap_cross_memory_enabled` toggle (off by default, set via the `WAMR_TRAP_CROSS_MEMORY_THUNK` env var in `main.zig` next to the existing `WAMR_AOT_DEBUG` knob) converts the warning into an `error.CrossMemoryFastThunkUnsupported` trap, so developers debugging cross-component AOT issues can pinpoint the first offending import without waiting for the downstream corruption to surface.

## Behavior change

None by default. The guard runs at most once per import and only logs a warning. Existing scenarios that share memory (the common case: WASIp1 adapter cores reusing the host module's memory) skip the warning entirely.

## Why not a full fix

A real fix requires either:
- Routing cross-memory calls through `installCanonLowerBackedCrossInstanceThunk` (the slow path) **and** adding byte-copying to `dispatchAotComponentTrampoline` (which today still pushes (ptr, len) tuples as-is across memories).
- Or, augmenting `CrossInstanceThunkCtx` with component-level type info and materializing string/list args via memcpy + the target's cabi_realloc between memories — mirroring the interp-side `forwardingHostFnCall` fix (PR #721).

Both are larger changes that deserve their own PR (and a proper cross-memory fixture to pin them). This PR converts silent corruption into a loud warning that points at the offending import, unblocking that follow-up.

## Test

Full Zig suite green (2954/2961 passed, 7 skipped — identical to baseline).

Stacks on #719's #723 (open with auto-merge); independent of it for review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>