### PR TITLE
instance: resolve cross-component instance import member func types via instance-local type space (#719)

### DIFF
--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -1281,7 +1281,22 @@ pub const ComponentInstance = struct {
                             }
                             const flat = resolved orelse continue;
 
-                            const member_func_td = resolveTypeDef(child.component, member_func_type) orelse
+                            // `member_func_type` is the type index inside the
+                            // instance body's local type space — NOT the
+                            // child component's outer type indexspace.
+                            // The previous code called
+                            // `resolveTypeDef(child.component, …)`, which
+                            // only worked when the local index happened to
+                            // alias an outer func type. Components emitted
+                            // by jco — including the keyvault repro's
+                            // `azure:codegen/tcgc` instance import — declare
+                            // their func types inline inside the instance
+                            // body, and surfaced as `error.SubComponentLinkFailed`
+                            // because the outer-space lookup returned a
+                            // non-func TypeDef (in this case the next
+                            // outer-space instance type at the same index).
+                            // (#719 cross-component composition path.)
+                            const member_func_td = resolveInstanceTypeLocal(decls, member_func_type) orelse
                                 return error.SubComponentLinkFailed;
                             const member_ft = switch (member_func_td) {
                                 .func => |f| f,


### PR DESCRIPTION
Surfaced while continuing the #719 keyvault repro forensics. After PR #728 merged, rerunning the repro produced a new earlier-stage failure mode — `error.LinkFailed` from `linkImports` — instead of the original deep tcgc.compile dlmalloc OOB trap. This change unblocks that link step so the underlying #719 deep trap can be re-attacked.

## What was wrong

When a parent component composes a sub-component and passes an `(instance ...)` `with` argument, the sub-component's import descriptor enumerates the expected member funcs through type indices that are **local to the imported instance type's body** (per the canonical component-model type-index rules — `.type`, `.alias`, and `.@"export"`-with-type each contribute one slot to that body's local type indexspace).

The runtime member-resolution loop in `resolveSubComponentArg` instead looked up that local index against the **child component's outer type indexspace** via `resolveTypeDef(child.component, member_func_type)`.

That happens to work for components whose instance bodies alias their member func types from outer types (which is the case for every WASI instance import the project has exercised so far). But for components emitted by jco — including the keyvault repro's `azure:codegen/tcgc` instance import where the `compile` member declares its func type inline inside the body — the outer-space lookup returns a non-func TypeDef (in this case the adjacent outer-space instance type at the same index 1), and the link aborts with `error.SubComponentLinkFailed`. That error reaches the top of `runComponentBytes` mapped through `linkImports → error.LinkFailed`, which the CLI prints as the misleading

```
Error: component imports something other than wasi:cli/stdout + wasi:io/streams (only those are wired in this build).
```

## Fix

Use the existing `resolveInstanceTypeLocal` helper (already used for the same purpose in `resolveCompFuncType`'s `.aliased` arm) — it walks the instance body's decls in order and resolves the Nth type-producing declarator to its concrete `TypeDef`, matching the canonical-ABI local-index rules.

The fix is one line; the rest of the diff is an explanatory comment for posterity.

## Validation

```
unset ZIG_LOCAL_CACHE_DIR
export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
zig build test --summary all
```
`Build Summary: 68/68 steps succeeded; 2963/2970 tests passed (7 skipped)` — same as the baseline on `main`. No regressions.

End-to-end keyvault repro now reaches `calling tcgc.compile...` and reproduces the existing #719 deep trap at `local_func[4788]+0x1e12` (out of bounds memory access, the dlmalloc bookkeeping corruption being tracked separately), confirming the link step is no longer blocking the repro.

## Scope

This PR fixes only the **type-resolution** bug. The fix passes `member_ft` to `buildForwardingHostFnCtx` with the child component's outer `TypeRegistry`, which means typed cross-memory marshaling (PR #728) for instance-import members whose params/results reference *compound named types via local indices* would still mis-resolve. That codepath isn't exercised by the keyvault repro (tcgc/compile is `(string, string) → result<string, string>` — all primitive/structural). The richer `buildInstanceTypeExtension` + `rewriteValTypeAbsolute` plumbing already used by the trampoline path (see `instance.zig:2310-2362`) would be the right follow-up if a real component hits that limit.