### PR TITLE
runtime: WAMR_WATCH_ADDR SIGUSR1-driven u32 watcher (#719)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -78,6 +78,13 @@ pub fn main(init: std.process.Init) !u8 {
             wamr.aot_runtime.g_trap_oob_dump_env = v;
         }
     }
+    if (init.environ_map.get("WAMR_WATCH_ADDR")) |v| {
+        if (v.len > 0) {
+            wamr.aot_runtime.initWatchAddrFromEnv(v) catch |err| {
+                std.debug.print("[watch-addr] init failed: {s}\n", .{@errorName(err)});
+            };
+        }
+    }
     if (args.len < 2) {
         std.debug.print("error: missing subcommand — try `wamr help`\n", .{});
         return 2;

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -55,6 +55,193 @@ var g_trap_occurred: bool = false;
 /// Forensic dump targets parsed from `WAMR_TRAP_OOB_DUMP`; populated by
 /// `main.zig` at startup. See `aotTrapOobDumpMem` (#719).
 pub var g_trap_oob_dump_env: ?[]const u8 = null;
+
+// ─── #719 watch-addr SIGUSR1-driven address watcher ─────────────────────
+//
+// When the env var `WAMR_WATCH_ADDR=<hex_off>:<lo>:<hi>[:<min_mem_mb>]`
+// is set, a background thread polls `*(u32*)(host_base + wasm_off)`
+// and signals the main thread via SIGUSR1 the first time the watched
+// value enters the half-open range `[lo, hi)`. The handler decodes
+// the interrupted RIP into `local_func[N] + rel_off` so we can pin
+// down the wasm function performing the rogue write.
+//
+// Intended for chasing the deep #719 trap where `tcgc-core` dlmalloc's
+// `treebins[0]` (wasm 0x247bb8) gets overwritten with a static-data
+// pointer (< 0x800000). Inert when the env var is unset.
+const WatchAddrConfig = struct {
+    wasm_off: u32,
+    lo: u32,
+    hi: u32,
+    min_mem_bytes: usize,
+};
+var g_watch_cfg: ?WatchAddrConfig = null;
+var g_watch_host_base: std.atomic.Value(usize) = .init(0);
+var g_watch_armed: std.atomic.Value(bool) = .init(false);
+var g_watch_caught: std.atomic.Value(u32) = .init(0);
+var g_watch_main_tid: i32 = 0;
+var g_watch_pid: i32 = 0;
+var g_watch_prev_action: std.os.linux.Sigaction = undefined;
+const WATCH_MAX_CATCHES: u32 = 16;
+const linux_watch = std.os.linux;
+const watch_supported = builtin.os.tag == .linux and builtin.cpu.arch == .x86_64;
+
+const WatchUcontextX86_64 = extern struct {
+    _flags: usize,
+    _link: ?*anyopaque,
+    _stack: linux_watch.stack_t,
+    mcontext: extern struct {
+        r8: u64,
+        r9: u64,
+        r10: u64,
+        r11: u64,
+        r12: u64,
+        r13: u64,
+        r14: u64,
+        r15: u64,
+        rdi: u64,
+        rsi: u64,
+        rbp: u64,
+        rbx: u64,
+        rdx: u64,
+        rax: u64,
+        rcx: u64,
+        rsp: u64,
+        rip: u64,
+    },
+};
+
+fn watchSigusr1(_: linux_watch.SIG, _: *const linux_watch.siginfo_t, ctx: ?*anyopaque) callconv(.c) void {
+    if (ctx == null) return;
+    if (!watch_supported) return;
+    const u: *const WatchUcontextX86_64 = @ptrCast(@alignCast(ctx.?));
+    const rip = u.mcontext.rip;
+    const cfg = g_watch_cfg orelse return;
+    const base = g_watch_host_base.load(.acquire);
+    var val: u32 = 0;
+    if (base != 0) {
+        const p: *const u32 = @ptrFromInt(base + cfg.wasm_off);
+        val = p.*;
+    }
+    const hits = g_watch_caught.load(.acquire);
+    const loc = decodeTrapReturnAddress(rip);
+    if (loc.name) |name| {
+        std.debug.print(
+            "[watch-caught #{d}] val=0x{x} rip=0x{x} code+0x{x} local_func[{d}] \"{s}\"+0x{x}\n",
+            .{ hits, val, rip, loc.code_off, loc.func_idx, name, loc.rel_off },
+        );
+    } else {
+        std.debug.print(
+            "[watch-caught #{d}] val=0x{x} rip=0x{x} code+0x{x} local_func[{d}]+0x{x}\n",
+            .{ hits, val, rip, loc.code_off, loc.func_idx, loc.rel_off },
+        );
+    }
+}
+
+fn watchSleepNs(ns: u64) void {
+    const sec: i64 = @intCast(ns / std.time.ns_per_s);
+    const nsec: i64 = @intCast(ns % std.time.ns_per_s);
+    const ts = std.posix.timespec{ .sec = sec, .nsec = nsec };
+    _ = std.posix.system.nanosleep(&ts, null);
+}
+
+fn watchPoller() void {
+    var prev: u32 = 0xFFFFFFFF;
+    var first_read = true;
+    while (g_watch_armed.load(.monotonic)) {
+        const base = g_watch_host_base.load(.acquire);
+        if (base == 0) {
+            std.Thread.yield() catch {};
+            watchSleepNs(1_000_000); // 1ms, wait for memory attach
+            continue;
+        }
+        const cfg = g_watch_cfg orelse return;
+        const p: *const u32 = @ptrFromInt(base + cfg.wasm_off);
+        const v = p.*;
+        if (first_read or v != prev) {
+            first_read = false;
+            prev = v;
+            if (v >= cfg.lo and v < cfg.hi) {
+                const cnt = g_watch_caught.fetchAdd(1, .acq_rel);
+                if (cnt < WATCH_MAX_CATCHES and watch_supported) {
+                    // Signal main thread to capture its RIP.
+                    _ = linux_watch.tgkill(g_watch_pid, g_watch_main_tid, linux_watch.SIG.USR1);
+                    // Sleep so handler runs before we keep polling.
+                    watchSleepNs(2_000_000); // 2ms
+                } else if (cnt == WATCH_MAX_CATCHES) {
+                    std.debug.print("[watch-addr] hit catch-cap; muting further signals\n", .{});
+                }
+            }
+        }
+        // tight poll — yield to let main thread run
+        std.atomic.spinLoopHint();
+    }
+}
+
+/// Parse `WAMR_WATCH_ADDR=<hex_off>:<lo>:<hi>[:<min_mem_mb>]` and start
+/// the watcher thread. Address fields accept `0x`-prefixed hex; the
+/// optional `<min_mem_mb>` arms only for memories at least that large
+/// (decimal). Inert if the platform isn't supported.
+pub fn initWatchAddrFromEnv(env_val: []const u8) !void {
+    if (!watch_supported) {
+        std.debug.print("[watch-addr] unsupported on this platform; ignoring\n", .{});
+        return;
+    }
+    var it = std.mem.splitScalar(u8, env_val, ':');
+    const off_s = it.next() orelse return error.BadFormat;
+    const lo_s = it.next() orelse return error.BadFormat;
+    const hi_s = it.next() orelse return error.BadFormat;
+    const mb_s = it.next();
+    const off = try parseWatchU32Hex(off_s);
+    const lo = try parseWatchU32Hex(lo_s);
+    const hi = try parseWatchU32Hex(hi_s);
+    const mb: usize = if (mb_s) |s| try parseWatchUsizeDec(s) else 0;
+
+    g_watch_cfg = .{
+        .wasm_off = off,
+        .lo = lo,
+        .hi = hi,
+        .min_mem_bytes = mb * 1024 * 1024,
+    };
+    g_watch_pid = @intCast(linux_watch.getpid());
+    g_watch_main_tid = @intCast(linux_watch.gettid());
+
+    const act: linux_watch.Sigaction = .{
+        .handler = .{ .sigaction = watchSigusr1 },
+        .mask = linux_watch.sigemptyset(),
+        .flags = linux_watch.SA.SIGINFO | linux_watch.SA.RESTART,
+    };
+    std.posix.sigaction(.USR1, &act, &g_watch_prev_action);
+
+    g_watch_armed.store(true, .release);
+    _ = try std.Thread.spawn(.{}, watchPoller, .{});
+
+    std.debug.print(
+        "[watch-addr] armed wasm_off=0x{x} bad_range=[0x{x}..0x{x}) min_mem={d}MB main_tid={d}\n",
+        .{ off, lo, hi, mb, g_watch_main_tid },
+    );
+}
+
+fn parseWatchU32Hex(s: []const u8) !u32 {
+    const trimmed = std.mem.trim(u8, s, " \t\r\n");
+    const hex = if (std.mem.startsWith(u8, trimmed, "0x") or std.mem.startsWith(u8, trimmed, "0X"))
+        trimmed[2..]
+    else
+        trimmed;
+    return std.fmt.parseInt(u32, hex, 16);
+}
+
+fn parseWatchUsizeDec(s: []const u8) !usize {
+    const trimmed = std.mem.trim(u8, s, " \t\r\n");
+    return std.fmt.parseInt(usize, trimmed, 10);
+}
+
+/// Called from `refreshVmCtxMemory` so the watcher always reads the
+/// freshest host base, including across `memory.grow` remappings.
+fn watchAddrNoteMemory(host_base: usize, wasm_size: usize) void {
+    const cfg = g_watch_cfg orelse return;
+    if (wasm_size < cfg.min_mem_bytes) return;
+    g_watch_host_base.store(host_base, .release);
+}
 /// Exception code of the last fault vehHandler redirected to trapLongjmp.
 /// Sampled by `callFuncScalar` after trap return to decide whether to
 /// re-arm the thread's stack guard page (see `resetStackGuardPage`).
@@ -1505,6 +1692,9 @@ fn refreshVmCtxMemory(vmctx: *VmCtx, mem: *types.MemoryInstance) void {
             .{ vmctx.memory_base, vmctx.memory_size, vmctx.memory_max_size },
         );
     }
+    // Keep the WAMR_WATCH_ADDR poller pointed at the current mapping;
+    // memory.grow can move us via mremap so this must run every refresh.
+    watchAddrNoteMemory(vmctx.memory_base, vmctx.memory_size);
 }
 
 fn refreshVmCtxForInstance(inst: *AotInstance, globals_buf: ?[]u8) void {


### PR DESCRIPTION
Stacks on #730. Adds a forensic background-thread watcher that polls a single u32 guest-memory location and signals the main thread via SIGUSR1 the first time the value enters a configured "bad" range. The handler decodes the interrupted RIP into `local_func[N] + rel_off` via the existing `aotProbeDecodePc` helper.

## Usage
```
WAMR_WATCH_ADDR=<hex_off>:<lo>:<hi>[:<min_mem_mb>]
```

Inert when env unset.

## Findings on #719
- Caught `treebins[0] = 0x2e1a28` (a static-data pointer) inside dlmalloc functions including `local_func[4788]`.
- 4788 is the same function that later traps walking the corrupted freelist.

## Caveat
SIGUSR1 has async delivery latency (~10s of µs = thousands of x86 insns), so the captured RIP is approximate — useful for **function identification**, not exact instruction pinpointing. For exact instruction capture, follow-up work needs `perf_event_open` + `HW_BREAKPOINT_W` (hardware watchpoint).

## Test
`zig build test --summary all` → 68/68 steps, 2963/2970 (7 skipped).