### PR TITLE
wamrc compile-component: add -O0 to skip IR optimization passes (#743)

### DIFF
--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -653,6 +653,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
     }
     var input_path: ?[]const u8 = null;
     var output_manifest: ?[]const u8 = null;
+    var optimize: bool = true;
     var target_arch: TargetArch = switch (builtin.cpu.arch) {
         .aarch64 => .aarch64,
         else => .x86_64,
@@ -668,6 +669,8 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
                 std.process.exit(1);
             }
             output_manifest = sub_args[i];
+        } else if (std.mem.eql(u8, a, "-O0")) {
+            optimize = false;
         } else if (std.mem.startsWith(u8, a, "--target=")) {
             const v = a["--target=".len..];
             if (std.mem.eql(u8, v, "x86_64") or std.mem.eql(u8, v, "x86-64")) {
@@ -717,6 +720,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
 
     var result = wamr.component_aot_compile.precompileComponent(allocator, component_data, manifest_path, .{
         .target_arch = target_arch,
+        .optimize = optimize,
     }) catch |err| {
         std.debug.print("error: precompile failed: {s}\n", .{@errorName(err)});
         std.process.exit(1);
@@ -1194,6 +1198,7 @@ const compile_component_usage =
     \\Options:
     \\  -o <manifest.json>            Manifest path (default: <input>.cwasm.json)
     \\  --target=<x86_64|aarch64>     Target architecture (default: host)
+    \\  -O0                           Disable IR optimizations (every core)
     \\
 ;
 

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -51,6 +51,11 @@ pub const PrecompileOptions = struct {
         .aarch64 => .aarch64,
         else => .x86_64,
     },
+    /// When false, skip IR optimization passes (mirrors `wamrc compile -O0`).
+    /// Useful for #743-style AOT-codegen bisection: if a bug disappears at
+    /// `-O0` we know it's in the optimization pipeline; if it persists the
+    /// bug is in the frontend / SSA / codegen.
+    optimize: bool = true,
 };
 
 /// AOT-compile a single core wasm module. Returns freshly-allocated
@@ -84,12 +89,14 @@ pub fn compileCoreWasm(
     var ir_module = frontend.lowerModule(&module, allocator) catch return error.CoreCompileFailed;
     defer ir_module.deinit();
 
-    _ = passes.runPassesWithOptions(
-        &ir_module,
-        passes.defaultPassesForTarget(opts.target_arch),
-        allocator,
-        .{ .verify_mode = .off },
-    ) catch return error.CoreCompileFailed;
+    if (opts.optimize) {
+        _ = passes.runPassesWithOptions(
+            &ir_module,
+            passes.defaultPassesForTarget(opts.target_arch),
+            allocator,
+            .{ .verify_mode = .off },
+        ) catch return error.CoreCompileFailed;
+    }
 
     const code: []u8, const offsets: []u32 = switch (opts.target_arch) {
         .aarch64 => blk: {


### PR DESCRIPTION
## Why

Bisecting AOT codegen bugs on multi-MB component bundles (the actively-investigated #743 tcgc.compile OOB) needs a switch to compile a component with all IR optimization passes disabled. The single-core \`wamrc compile -O0\` flag has done that for raw wasm since the project started; \`compile-component\` did not have an equivalent and refused the flag with \"unknown argument\".

## What

- Add \`optimize: bool = true\` to \`PrecompileOptions\` (\`src/component/aot_compile.zig\`).
- Wrap the \`passes.runPassesWithOptions(...)\` call in \`compileCoreWasm\` under \`if (opts.optimize)\`. When false, IR is handed directly to codegen without GVN / CSE / FRL / DCE / DSE / hoist / bounds-elision / etc.
- Add \`-O0\` to the \`compile-component\` CLI argument parser (\`src/compiler/main.zig\`); propagate to \`PrecompileOptions\`.
- Update \`compile_component_usage\` text.

Default remains \`.optimize = true\`, so this is inert for existing callers and tooling.

## Test plan

\`\`\`sh
unset ZIG_LOCAL_CACHE_DIR
export ZIG_GLOBAL_CACHE_DIR=\"\$PWD/.zig-global-cache\"
zig build test --summary all   # all 1100+ tests pass
zig build install
zig-out/bin/wamrc compile-component help | grep -- -O0   # flag is documented
\`\`\`

## Caveat

\`runPassesWithOptions\` also drives inlining + \`promoteLocalsToSSA\` + \`lowerPhisToLocals\`. \`-O0\` currently skips ALL of that. Codegen handles non-SSA IR fine (the existing single-core \`compile -O0\` already takes this path). If the bisect concludes that the bug is in inlining specifically we can split that knob out later; right now the goal is the single coarse on/off switch.

## Related

- #743 — deeper tcgc.compile OOB forensics.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>