### PR TITLE
component: rebase instance-type-body func types into TypeRegistry extension for forwarding (#743)

### DIFF
--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -224,10 +224,28 @@ pub const ForwardingHostFnCtx = struct {
     param_types: []const ctypes.ValType = &.{},
     result_types: []const ctypes.ValType = &.{},
     registry: TypeRegistry = .{ .types = &.{} },
+    /// Per-trampoline extended TypeRegistry slot table. Used when the
+    /// FuncType being forwarded was lifted out of an instance-type body
+    /// whose nested `.record`/`.result`/etc. references use indices
+    /// LOCAL to that body's decl space. Empty for top-level imports.
+    /// Allocated by `buildInstanceTypeExtension`; freed in `deinit`
+    /// with a deep walk of `extended_types`.
+    extended_types: []const ctypes.TypeDef = &.{},
+    extended_indexspace: []const ?u32 = &.{},
 
     pub fn deinit(self: *ForwardingHostFnCtx, allocator: Allocator) void {
         if (self.param_types.len > 0) allocator.free(self.param_types);
         if (self.result_types.len > 0) allocator.free(self.result_types);
+        if (self.extended_types.len > 0) {
+            for (self.extended_types) |td| switch (td) {
+                .record => |rec| allocator.free(rec.fields),
+                .tuple => |tup| allocator.free(tup.fields),
+                .variant => |v| allocator.free(v.cases),
+                else => {},
+            };
+            allocator.free(self.extended_types);
+        }
+        if (self.extended_indexspace.len > 0) allocator.free(self.extended_indexspace);
     }
 };
 
@@ -261,6 +279,38 @@ pub fn buildForwardingHostFnCtx(
 pub fn destroyForwardingHostFnCtx(ctx: *ForwardingHostFnCtx, allocator: Allocator) void {
     ctx.deinit(allocator);
     allocator.destroy(ctx);
+}
+
+/// Like `buildForwardingHostFnCtx`, but takes pre-rewritten ValType
+/// slices for `param_types` / `result_types` plus an instance-type
+/// extension. Used when the FuncType being forwarded was lifted from
+/// an instance-type body whose local type indexspace must be merged
+/// into the registry via `TypeRegistry.fromExtended` so canon-ABI
+/// resolution sees through `.result` / `.record` / etc. references.
+///
+/// Ownership: the ctx takes ownership of all four passed slices and
+/// frees them via `deinit`.
+pub fn buildForwardingHostFnCtxWithExtension(
+    allocator: Allocator,
+    owner: *const ComponentInstance,
+    local: ComponentInstance.ExportedFunc.Local,
+    param_types: []const ctypes.ValType,
+    result_types: []const ctypes.ValType,
+    registry: TypeRegistry,
+    extended_types: []const ctypes.TypeDef,
+    extended_indexspace: []const ?u32,
+) !*ForwardingHostFnCtx {
+    const ctx = try allocator.create(ForwardingHostFnCtx);
+    ctx.* = .{
+        .owner = owner,
+        .local = local,
+        .param_types = param_types,
+        .result_types = result_types,
+        .registry = registry,
+        .extended_types = extended_types,
+        .extended_indexspace = extended_indexspace,
+    };
+    return ctx;
 }
 
 /// `HostFunc.call` adapter for forwarding contexts. Ignores the

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -1302,13 +1302,75 @@ pub const ComponentInstance = struct {
                                 .func => |f| f,
                                 else => return error.SubComponentLinkFailed,
                             };
-                            const member_reg = @import("canonical_abi.zig").TypeRegistry.init(child.component);
-                            const ctx = try executor_mod.buildForwardingHostFnCtx(
+
+                            // The FuncType lives inside the instance-type body,
+                            // so its param/result `.record`/`.result`/`.list`/etc.
+                            // type-index references are LOCAL to that body's decl
+                            // space — NOT the child's outer component
+                            // type-indexspace. If we hand `child.component`'s
+                            // registry to the forwarding ctx as-is, the cross-
+                            // memory rewriter's `valTypeHasPtrLen` walks the
+                            // outer indexspace at the local index and gets back
+                            // garbage (e.g. the keyvault repro's tcgc.compile
+                            // result type — `result<string,string>` — resolved
+                            // through the OUTER registry to an `.instance`
+                            // TypeDef and `needs_rewrite` came back `false`).
+                            // That caused the lifted string ptr — which points
+                            // into TCGC's 31 MiB memory — to never get
+                            // translated into the caller's (codegen-cli's)
+                            // 22 MiB memory; canon-lift validation then tripped
+                            // and the AOT dispatcher returned a sentinel that
+                            // the guest tried to JSON.parse as a `len`, leading
+                            // to the `unreachable` crash. (#743 / sibling of
+                            // #719 / #729 — same instance-type-local index bug.)
+                            //
+                            // Build a per-trampoline extension that materializes
+                            // the instance body's local type space at an absolute
+                            // offset, rewrite each ValType to the absolute index,
+                            // and hand the ctx a `fromExtended` registry that
+                            // can resolve both spaces.
+                            const ext_base: u32 = if (child.component.type_indexspace.len > 0)
+                                @intCast(child.component.type_indexspace.len)
+                            else
+                                @intCast(child.component.types.len);
+                            const ext = buildInstanceTypeExtension(child.allocator, decls, ext_base, child.component) catch
+                                return error.OutOfMemory;
+                            errdefer ext.deinit(child.allocator, true);
+
+                            const member_params = try child.allocator.alloc(ctypes.ValType, member_ft.params.len);
+                            errdefer child.allocator.free(member_params);
+                            for (member_ft.params, 0..) |p, i| {
+                                member_params[i] = rewriteValTypeAbsolute(ext_base, p.type);
+                            }
+                            const member_results: []ctypes.ValType = switch (member_ft.results) {
+                                .none => try child.allocator.alloc(ctypes.ValType, 0),
+                                .unnamed => |t| blk: {
+                                    const r = try child.allocator.alloc(ctypes.ValType, 1);
+                                    r[0] = rewriteValTypeAbsolute(ext_base, t);
+                                    break :blk r;
+                                },
+                                .named => |named| blk: {
+                                    const r = try child.allocator.alloc(ctypes.ValType, named.len);
+                                    for (named, 0..) |n, i| r[i] = rewriteValTypeAbsolute(ext_base, n.type);
+                                    break :blk r;
+                                },
+                            };
+                            errdefer child.allocator.free(member_results);
+
+                            const member_reg = @import("canonical_abi.zig").TypeRegistry.fromExtended(
+                                child.component,
+                                ext.extension_types,
+                                ext.extension_indexspace,
+                            );
+                            const ctx = try executor_mod.buildForwardingHostFnCtxWithExtension(
                                 child.allocator,
                                 flat.owner,
                                 flat.local,
-                                member_ft,
+                                member_params,
+                                member_results,
                                 member_reg,
+                                ext.extension_types,
+                                ext.extension_indexspace,
                             );
                             errdefer executor_mod.destroyForwardingHostFnCtx(ctx, child.allocator);
                             try child.forwarding_ctxs.append(child.allocator, ctx);


### PR DESCRIPTION
## Summary

Instance-import members (e.g. the keyvault repro's `azure:codegen/tcgc` import) had their FuncType lifted from inside an **instance-type body** whose nested `.record` / `.result` / `.list` / `.tuple` type-index references use indices LOCAL to that body's decl space — NOT the child component's outer type-indexspace.

The forwarding ctx, though, was built against `TypeRegistry.init(child.component)`. When the cross-memory rewriter asked `valTypeHasPtrLen` whether a result type contained any string/list payloads, the registry resolved the local index against the outer type-indexspace and got back garbage (in the repro, `result<string,string>` collided with an unrelated `.instance` TypeDef at the same numeric index).

`needs_rewrite` came back `false`, the lifted string ptr — which pointed into TCGC's 31 MiB linear memory — was never translated into the caller's (codegen-cli's) 22 MiB memory, canon-lift validation tripped, and the AOT dispatcher returned a `0xdeaddeaddeaddead` sentinel that the guest tried to JSON.parse as a list length, unreachable-ing with a GP fault.

## Fix

Build a per-trampoline `InstanceTypeExtension` materialising the instance body's local type space at an absolute offset, rewrite each param/result `ValType` through `rewriteValTypeAbsolute(ext_base, …)`, and hand the forwarding ctx a `TypeRegistry.fromExtended` registry that can resolve both spaces.

Mirrors the canon-lower trampoline path in `instantiateCoreInstance` (the same shape that was added for #534 / #571 / #719 — same instance-type-local index bug).

`ForwardingHostFnCtx` is extended with optional `extended_types` / `extended_indexspace` fields and a deep `deinit` that frees them. A new `buildForwardingHostFnCtxWithExtension` constructor accepts pre-rewritten params/results plus the extension; the existing `buildForwardingHostFnCtx` is unchanged.

## Validation

- All 1989 unit tests pass.
- Keyvault repro (codegen-cli with TCGC sub-component): before, crashed with `unreachable` after canon-lift sentinel; after, the guest correctly receives TCGC's real error message: `"Could not resolve import \"@typespec/compiler\""`. That error is itself a separate semantic issue (TCGC module-resolution mismatch with wasmtime — to be tracked in a follow-up); the fix here is that the framework no longer drops the cross-memory string.

Fixes the framework half of #743.