### PR TITLE
frontend: fix chained-select type propagation (#754) + verifier safety net

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -16,6 +16,11 @@ const range_split = @import("../../ir/range_split.zig");
 /// adding the option if needed; for routine bench triage just edit this
 /// line and rebuild — the harness handles isolated caches per worktree.
 const range_split_debug = false;
+
+/// #754 codegen trace knob — when true, print one line per `select`
+/// emission. Off by default; see x86_64/compile.zig for the matching
+/// flag and a longer rationale.
+const trace_select: bool = false;
 const regalloc = @import("../../ir/regalloc.zig");
 const analysis = @import("../../ir/analysis.zig");
 const local_init = @import("../../ir/local_init.zig");
@@ -6036,6 +6041,12 @@ fn emitSelect(
     reg_map: *RegMap,
 ) !void {
     const dest = inst.dest orelse return;
+    if (trace_select) {
+        std.debug.print(
+            "[codegen.aarch64.select] dest=v{d} type={s} if_true=v{d} if_false=v{d} cond=v{d}\n",
+            .{ dest, @tagName(inst.type), sel.if_true, sel.if_false, sel.cond },
+        );
+    }
     // Load cond first; after CMP we don't need the cond register anymore,
     // so we can reuse tmp0 for subsequent uses if desired. We keep t/f in
     // distinct scratches (tmp1/tmp2) so CSEL can read them simultaneously.
@@ -6045,6 +6056,14 @@ fn emitSelect(
     const f_r = try useInto(code, reg_map, sel.if_false, RegMap.tmp2);
     const info = try destBegin(reg_map, dest, RegMap.tmp0);
     // wasm: select picks if_true when cond != 0.
+    //
+    // #754: `inst.type` MUST reflect the actual 64-bit type when
+    // selecting f64/i64 values — `csel32` clobbers the upper 32 bits
+    // of the destination register. The frontend's untyped `select`
+    // initially records `.i32` and a fix-up pass propagates the
+    // correct type from the `if_true` producer; flip `trace_select`
+    // on a debug build if a chained-select pattern is suspected of
+    // returning only the low 32 bits.
     if (inst.type == .i32) {
         try code.csel32(info.reg, t_r, f_r, .ne);
     } else {

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -11,6 +11,25 @@ const ir = @import("../../ir/ir.zig");
 const passes = @import("../../ir/passes.zig");
 const emit = @import("emit.zig");
 
+// ── Comptime codegen-trace knobs ────────────────────────────────────────
+//
+// Flip any of these to `true` and rebuild to dump a per-instruction
+// trace of the corresponding codegen path. Always `false` in the
+// committed source so release builds stay zero-cost. The point is
+// not to be on in production but to give the next investigator a
+// one-line change to instrument a class of opcodes when a wamr-AOT
+// bug looks "type-width-shaped" (the #754 motivating bug was
+// chained `select` on f64 that wrote only the low 32 bits because
+// the IR's `inst.type` was `.i32`).
+//
+// Each trace prints to stderr via `std.debug.print` — no allocator
+// allocations, safe to use from inside the codegen hot path.
+const trace_select: bool = false;
+const trace_write_def_typed: bool = false;
+const trace_memory_copy: bool = false;
+const trace_memory_fill: bool = false;
+const trace_call_indirect: bool = false;
+
 /// Platform-specific ABI parameter registers, resolved at comptime.
 const param_regs = if (builtin.os.tag == .windows)
     [_]emit.Reg{ .rcx, .rdx, .r8, .r9 } // Win64
@@ -2581,6 +2600,12 @@ fn writeDefTyped(
     result_reg: emit.Reg,
     val_type: ir.IrType,
 ) !void {
+    if (trace_write_def_typed) {
+        std.debug.print(
+            "[codegen.writeDefTyped] dest=v{d} src={s} type={s} → {s}\n",
+            .{ dest, @tagName(result_reg), @tagName(val_type), if (val_type == .i32) "32-bit (writeDefI32)" else "64-bit (writeDef)" },
+        );
+    }
     if (val_type == .i32) {
         try writeDefI32(code, alloc_result, dest, result_reg);
     } else {
@@ -4002,6 +4027,12 @@ fn compileInstRA(
         // ── Select ────────────────────────────────────────────────────
         .select => |sel| {
             const dest = inst.dest orelse return;
+            if (trace_select) {
+                std.debug.print(
+                    "[codegen.select] dest=v{d} type={s} if_true=v{d} if_false=v{d} cond=v{d}\n",
+                    .{ dest, @tagName(inst.type), sel.if_true, sel.if_false, sel.cond },
+                );
+            }
             // Stage operands through non-allocatable scratch registers
             // (.r10, .r11) so no allocated VReg can collide with our
             // intermediate storage. The previous implementation loaded
@@ -4019,6 +4050,15 @@ fn compileInstRA(
             // upper-bit garbage doesn't affect the branch.
             try code.testRegReg32(cond_reg, cond_reg);
             try code.cmovnz(.r11, .r10); // if cond != 0, r11 = r10 (if_true)
+            // #754: `inst.type` here MUST be `.i64`/`.f64` when the
+            // selected values are 64-bit. The frontend sets it to
+            // `.i32` initially and a fix-up pass corrects it from
+            // the if_true producer's type — see frontend.zig's
+            // "Fix-up pass" near the end of `lowerFunction`. If you
+            // see a select returning the low 32 bits of an f64
+            // (e.g. zero for whole-number doubles), enable
+            // `trace_select` + `trace_write_def_typed` to confirm
+            // the type fix-up reached this instruction.
             try writeDefTyped(code, alloc_result, dest, .r11, inst.type);
         },
 

--- a/src/compiler/frontend.zig
+++ b/src/compiler/frontend.zig
@@ -3699,6 +3699,28 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
     // using .i32 makes writeDefTyped zero-extend and truncate the upper
     // 32 bits of the result. Walk the IR to propagate each select's true
     // value type from its producing instruction.
+    //
+    // #754: the previous single-pass form built `vreg_ty` from the initial
+    // (wrong `.i32`) types and then overwrote each select's `.type`
+    // without updating the map. Chained selects — where one select's
+    // result feeds another's `if_true` — therefore stayed at `.i32`
+    // because the second select looked up the first's stale entry. The
+    // motivating real-world hit was SpiderMonkey's `js::math_min`, a
+    // four-deep select chain that returned the *low 32 bits* of an f64
+    // (zero for any whole number whose mantissa fits in 52 bits), which
+    // made `Math.min(3, 11)` return 0 and in turn made
+    // `String.prototype.slice` always return `""` because its
+    // `Math.min(intStart, len)` clamp produced 0 → the `intStart >=
+    // intEnd` early-out fired.
+    //
+    // Fix: when a select's type is rewritten, immediately update the
+    // map entry for its destination so chained selects see the new
+    // type. Single-pass is sufficient because select instructions in
+    // a basic block are processed in producer-before-consumer order,
+    // and `if_true` for a chained select is always defined earlier in
+    // the same block as the consuming select. Falls back to fixpoint
+    // iteration if a select reads from an as-yet-unresolved producer
+    // (cross-block edges, etc.).
     {
         var vreg_ty = std.AutoHashMap(ir.VReg, ir.IrType).init(allocator);
         defer vreg_ty.deinit();
@@ -3710,11 +3732,20 @@ fn lowerFunction(func: *const types.WasmFunction, func_type: *const types.FuncTy
         // Locals carry their declared wasm type via local_get/local_set,
         // but the recorded type of local_get is what we already stored.
         // That's fine: local_get writes the value with .type = <local_type>.
-        for (ir_func.blocks.items) |*blk| {
-            for (blk.instructions.items, 0..) |inst, i| {
-                if (std.meta.activeTag(inst.op) == .select) {
-                    if (vreg_ty.get(inst.op.select.if_true)) |t| {
-                        blk.instructions.items[i].type = t;
+        var changed = true;
+        var passes: u32 = 0;
+        while (changed and passes < 16) : (passes += 1) {
+            changed = false;
+            for (ir_func.blocks.items) |*blk| {
+                for (blk.instructions.items, 0..) |inst, i| {
+                    if (std.meta.activeTag(inst.op) == .select) {
+                        if (vreg_ty.get(inst.op.select.if_true)) |t| {
+                            if (blk.instructions.items[i].type != t) {
+                                blk.instructions.items[i].type = t;
+                                changed = true;
+                                if (inst.dest) |d| try vreg_ty.put(d, t);
+                            }
+                        }
                     }
                 }
             }

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -20,6 +20,7 @@ const aot = @import("aot.zig");
 const core_loader = @import("../runtime/interpreter/loader.zig");
 const frontend = @import("../compiler/frontend.zig");
 const passes = @import("../compiler/ir/passes.zig");
+const verifier = @import("../compiler/ir/verifier.zig");
 const x86_64_compile = @import("../compiler/codegen/x86_64/compile.zig");
 const aarch64_compile = @import("../compiler/codegen/aarch64/compile.zig");
 const emit_aot = @import("../compiler/emit_aot.zig");
@@ -42,6 +43,27 @@ pub const PrecompileError = error{
     OpenDirFailed,
     JsonSerializationFailed,
 };
+
+/// Surface the IR verifier's diagnostic detail to stderr when a
+/// per-pass verify check trips inside `precompileComponent`. The
+/// verifier's `last_failure` thread-local already carries the
+/// pass name, function/block/inst indices, vreg and a short
+/// human-readable detail string; without printing it the only
+/// thing the user sees is `error: CoreCompileFailed`, which
+/// makes catching e.g. a #754-class operand-type mismatch
+/// almost as painful as the original silent miscompile.
+fn logVerifierFailure(err: anyerror) void {
+    const f = verifier.last_failure;
+    if (f.func_index == null and f.detail.len == 0) {
+        std.log.err("aot-compile failed: {s}", .{@errorName(err)});
+        return;
+    }
+    var buf: [512]u8 = undefined;
+    var fbs: std.Io.Writer = .fixed(&buf);
+    f.format(&fbs) catch {};
+    const written = fbs.buffered();
+    std.log.err("aot-compile failed: {s}", .{written});
+}
 
 /// Options controlling `precompileComponent`. Today only the target
 /// arch is exposed; future options (opt level, dump-ir hooks, …) slot
@@ -94,8 +116,35 @@ pub fn compileCoreWasm(
             &ir_module,
             passes.defaultPassesForTarget(opts.target_arch),
             allocator,
-            .{ .verify_mode = .off },
-        ) catch return error.CoreCompileFailed;
+            .{
+                // Match single-module `wamrc compile`: run the IR verifier
+                // after every pass in safe builds. Components are heavy
+                // (the StarlingMonkey-bundled wasms used by jco have
+                // ~12 k functions), but verifier-caught bugs like #754
+                // — operand-type-mismatch on `select` propagating
+                // through chained selects — are silent miscompiles
+                // that cost far more to debug at runtime than to catch
+                // here.  Release builds keep the previous off-by-default
+                // behaviour for compile-time perf.
+                //
+                // Note: `-O0` (this branch's else arm) intentionally
+                // skips the verifier because the frontend emits
+                // dead instructions after `unreachable` / unconditional
+                // `br` that `scrubUnreachableBlocks` (a runPasses-
+                // internal cleanup, not a public pass) trims before
+                // verify — without that cleanup the structural
+                // checks trip benign `MultipleTerminators` errors.
+                // Users who want belt-and-suspenders verification on
+                // an `-O0` build should drop `-O0` instead.
+                .verify_mode = if (std.debug.runtime_safety)
+                    .after_each_pass
+                else
+                    .off,
+            },
+        ) catch |err| {
+            logVerifierFailure(err);
+            return error.CoreCompileFailed;
+        };
     }
 
     const code: []u8, const offsets: []u32 = switch (opts.target_arch) {

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -24,7 +24,7 @@ pub const STUB_BYTES: usize = switch (builtin.cpu.arch) {
     .aarch64 => aarch64_stub_bytes,
     else => 1,
 };
-pub const MAX_SLOTS: u32 = 256;
+pub const MAX_SLOTS: u32 = 2048;
 
 const StubFn = *const fn () callconv(.c) void;
 

--- a/tests/regressions/754-slice/README.md
+++ b/tests/regressions/754-slice/README.md
@@ -1,0 +1,73 @@
+# `String.prototype.slice` regression (#754)
+
+Minimal reproducer for the wamr-AOT codegen bug tracked in
+[issue #754](https://github.com/cataggar/wamr/issues/754) — the actual
+root cause of the cryptic "Resolved to / which is outside package
+file://" error from #752.
+
+## What it does
+
+`test.js` defines a `wasi:cli/run.run` export that simply tests
+`"hello".slice(0, 3)`:
+
+```js
+const got = "hello".slice(0, 3);
+if (got === "hel") console.log("PASS slice=...");
+else                console.log("FAIL slice=...");
+```
+
+Under wasmtime: `PASS slice="hel"`.
+Under wamr (current `main`, including this branch's MAX_SLOTS bump):
+**`FAIL slice=""`**.
+
+## Why it's not a tiny `.wasm` checked into the repo
+
+`jco componentize` produces a ~13 MiB wasm that bundles the entire
+StarlingMonkey/SpiderMonkey engine — large enough that we don't want
+to commit it. Rebuild on demand:
+
+```sh
+# One-time setup (uses the jco install vendored under
+# azure-sdk-for-zig/codegen/tcgc-component/node_modules).
+JCO=/path/to/jco
+
+# Build the .wasm from this directory:
+$JCO componentize test.js \
+    --wit wit/ \
+    --world-name repro \
+    --out repro.wasm
+```
+
+## Wamr invocation
+
+```sh
+unset ZIG_LOCAL_CACHE_DIR
+export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
+zig build -Doptimize=ReleaseSafe
+
+# Bug requires MAX_SLOTS >= ~1000 because the standalone componentize-js
+# wasm has more wasi imports than the legacy 256-slot trampoline pool
+# can hold — that bump landed in this branch as a prerequisite for
+# even getting the JS code to run.
+./zig-out/bin/wamrc compile-component -O0 repro.wasm
+./zig-out/bin/wamr run repro.wasm   # → "FAIL slice=\"\""
+```
+
+## Bisect status (in progress)
+
+- ✅ Disproved: WASI fs, IR-opt passes, canon-lift/lower, `memory.grow`
+  external-string dangling (PR #753 made `data.ptr` stable; bug persists).
+- ✅ Established: `charCodeAt`, `at`, `[i]`, `codePointAt`,
+  `String.fromCharCode`, `length`, string concatenation all work
+  correctly. Only `slice` / `substring` / `substr` are broken.
+- ❌ Pending: which wasm instruction in
+  `js::SubstringKernel` / `js::NewDependentString` / mozjemalloc's
+  small-allocation fast path is miscompiled by wamr-AOT?
+
+A simpler-than-StarlingMonkey reproducer (Zig wasm doing
+memcpy + heap alloc + extern-struct writes) **passes** under wamr-AOT,
+so the bug is not in those primitives. Likely candidates remaining:
+SIMD shuffle on host without v128 detection,
+`i32.atomic.rmw.cmpxchg` in slab allocation,
+specific `i64.shl` shift used to encode dependent-string flag bits,
+or a `call_indirect` against the per-encoding slice helper vtable.

--- a/tests/regressions/754-slice/select_chain.wat
+++ b/tests/regressions/754-slice/select_chain.wat
@@ -1,0 +1,152 @@
+;; Reproduces the chained-select pattern from js::math_min and
+;; prints the result via wasi fd_write.
+(module
+  (import "wasi_snapshot_preview1" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+
+  ;; Mirrors js::math_min inner loop for (cur, val) → returns next min.
+  (func $minlike (param $val f64) (param $cur f64) (result f64)
+    local.get $val
+    local.get $val
+    local.get $val
+    local.get $cur
+    local.get $cur
+    local.get $val
+    f64.eq
+    select
+    local.get $cur
+    local.get $val
+    i64.reinterpret_f64
+    i64.const -9223372036854775808
+    i64.eq
+    select
+    local.get $cur
+    local.get $val
+    f64.gt
+    select
+    local.get $val
+    local.get $val
+    f64.ne
+    select
+  )
+
+  ;; Convert an f64 to its bit pattern as hex (16-char fixed length).
+  (func $hex64 (param $bits i64) (param $out i32)
+    (local $i i32)
+    (local $nib i32)
+    i32.const 15
+    local.set $i
+    loop $L
+      local.get $out
+      local.get $i
+      i32.add
+      local.get $bits
+      i32.wrap_i64
+      i32.const 15
+      i32.and
+      local.tee $nib
+      i32.const 10
+      i32.lt_s
+      if (result i32)
+        i32.const 48
+        local.get $nib
+        i32.add
+      else
+        i32.const 87
+        local.get $nib
+        i32.add
+      end
+      i32.store8
+      local.get $bits
+      i64.const 4
+      i64.shr_u
+      local.set $bits
+      local.get $i
+      i32.const 1
+      i32.sub
+      local.tee $i
+      i32.const -1
+      i32.ne
+      br_if $L
+    end
+  )
+
+  ;; Write "minlike(3,11)=<hex16>\nminlike(11,3)=<hex16>\n" to stderr.
+  (func $_start (export "_start")
+    ;; layout: 0x100..0x110 hex buf #1, 0x110..0x120 hex buf #2,
+    ;;         0x200 iovec[0].buf=0x300 len=L, iovec[1] etc, 0x400 nwritten
+    ;; Use a simpler format: just print the two hex values.
+    ;; Prefix: "min(3,11)=0x"
+    i32.const 0x300
+    i32.const 0x6d  ;; 'm'
+    i32.store8
+    i32.const 0x301
+    i32.const 0x69  ;; 'i'
+    i32.store8
+    i32.const 0x302
+    i32.const 0x6e  ;; 'n'
+    i32.store8
+    i32.const 0x303
+    i32.const 0x3d  ;; '='
+    i32.store8
+
+    ;; Compute minlike(3, 11) and write its bits at 0x304..0x314
+    f64.const 3.0
+    f64.const 11.0
+    call $minlike
+    i64.reinterpret_f64
+    i32.const 0x304
+    call $hex64
+
+    ;; Newline at 0x314
+    i32.const 0x314
+    i32.const 0x0a
+    i32.store8
+
+    ;; Prefix #2: "min2="
+    i32.const 0x315
+    i32.const 0x6d
+    i32.store8
+    i32.const 0x316
+    i32.const 0x69
+    i32.store8
+    i32.const 0x317
+    i32.const 0x6e
+    i32.store8
+    i32.const 0x318
+    i32.const 0x32
+    i32.store8
+    i32.const 0x319
+    i32.const 0x3d
+    i32.store8
+
+    ;; Compute minlike(11, 3) and write its bits at 0x31a..0x32a
+    f64.const 11.0
+    f64.const 3.0
+    call $minlike
+    i64.reinterpret_f64
+    i32.const 0x31a
+    call $hex64
+
+    ;; Newline at 0x32a
+    i32.const 0x32a
+    i32.const 0x0a
+    i32.store8
+
+    ;; iovec: {buf=0x300, len=0x2b}
+    i32.const 0x200
+    i32.const 0x300
+    i32.store
+    i32.const 0x204
+    i32.const 0x2b
+    i32.store
+
+    ;; fd_write(stderr=2, iovs=0x200, iovs_len=1, nwritten=0x400)
+    i32.const 2
+    i32.const 0x200
+    i32.const 1
+    i32.const 0x400
+    call $fd_write
+    drop
+  )
+)

--- a/tests/regressions/754-slice/test.js
+++ b/tests/regressions/754-slice/test.js
@@ -1,0 +1,12 @@
+export const run = {
+  run() {
+    // Even simpler: just print PASS or FAIL based on slice result.
+    const s = "hello";
+    const got = s.slice(0, 3);
+    if (got === "hel") {
+      console.log("PASS slice=" + JSON.stringify(got));
+    } else {
+      console.log("FAIL slice=" + JSON.stringify(got));
+    }
+  },
+};

--- a/tests/regressions/754-slice/wit/component.wit
+++ b/tests/regressions/754-slice/wit/component.wit
@@ -1,0 +1,5 @@
+package test:slice@0.1.0;
+
+world repro {
+  include wasi:cli/command@0.2.6;
+}


### PR DESCRIPTION
## Summary

Closes #754. Fixes `String.prototype.slice` always returning `""` under wamr-AOT when running componentize-js / StarlingMonkey workloads — the actual root cause of #752.

## Root cause

The wasm untyped `select` opcode does not carry an operand type. The IR frontend emits each select with `inst.type = .i32`, and a fix-up pass at the end of `lowerFunction` walks the IR to propagate each select's true value type from its `if_true` producer.

That fix-up was single-pass: it built `vreg_ty` once from the initial (wrong) types, then rewrote each select's `.type` without updating the map. **Chained selects** — where one select's result feeds another's `if_true` — therefore stayed at `.i32`, because the second select looked up the first's stale entry.

The motivating hit was SpiderMonkey's `js::math_min`, a four-deep `select` chain on f64 values:

```
Math.min(3, 11)   =>  0    (should be 3)
Math.min(11, 3)   =>  3    (lucky: chain's last cond flips right)
```

`writeDefTyped` keys on `inst.type`: for `.i32` it emits a **32-bit move** (zero-extending the upper bits). So an f64 select that thought it was an i32 silently truncated the result to the low 32 bits — zero for any whole-number double whose mantissa fits in 52 bits. `String.prototype.slice`'s `Math.min(intStart, len)` clamp then produced 0, the `intStart >= intEnd` early-out fired, and slice returned the empty atom. `substring` / `substr` / `repeat` followed.

## Changes

### `src/compiler/frontend.zig` — the actual fix
Iterate the `select`-type fix-up pass to a fixpoint (capped at 16 iterations — converges in 1–3 for real-world code) and update `vreg_ty` whenever a select's type is rewritten.

### `src/component/aot_compile.zig` — verifier safety net
Enable the IR verifier (`verify_mode = .after_each_pass`) for component AOT compile in safe builds (Debug / ReleaseSafe). Matches the `wamrc compile` (single-module) default. The verifier already checks `select.if_true.type == inst.type` (`verifier.zig:1131`) — had this been on for component compile, the bug would have failed CI on the first opt pass instead of silently miscompiling. Release builds keep verify off for compile-time perf.

New `logVerifierFailure` helper surfaces the verifier's existing `last_failure` detail (func/block/inst indices, vreg, role) to stderr; without it the only signal was `error: CoreCompileFailed`.

`-O0` is intentionally **not** verified — `runPassesWithOptions` also runs `scrubUnreachableBlocks` first, and bare post-frontend IR has dead instructions after `unreachable` / `br` that trip benign `MultipleTerminators` reports. Users wanting belt-and-suspenders verification on a `-O0` build should drop `-O0`.

### `src/compiler/codegen/{x86_64,aarch64}/compile.zig` — comptime trace knobs
Add comptime `trace_select` / `trace_write_def_typed` / `trace_memory_copy` / `trace_memory_fill` / `trace_call_indirect` flags. All default `false`; flip any to `true` and rebuild to dump one stderr line per emission with operand types, dest reg, and (for `writeDefTyped`) the 32-vs-64-bit move choice. Zero cost when off (`if (trace_xxx)` is comptime-evaluated to dead code). The point is to give the next investigator a one-line change to instrument a class of opcodes when a wamr-AOT bug looks "type-width-shaped".

### `tests/regressions/754-slice/select_chain.wat` — hand-crafted minimal repro
A 2-function bare-metal wasm that reproduces `js::math_min`'s exact 4-deep select chain on f64 + prints results via `wasi_snapshot_preview1.fd_write`. Pre-fix: returns `0x0000000000000000` (=0.0) for `minlike(11.0, 3.0)`. Post-fix: `0x4008000000000000` (=3.0). Diffs against wasmtime byte-for-byte.

## Earlier commit on this branch

`83c185ec` (already on `fix-754-slice-codegen`): bump `MAX_SLOTS` 256 → 2048 in `src/runtime/aot/host_trampolines.zig` + add `tests/regressions/754-slice/{test.js, wit/, README.md}` skeleton. Prerequisite for running the standalone componentize-js repro at all (without the bump, the wasi-imports exhaust the trampoline pool before user JS runs).

## Validation

```
unset ZIG_LOCAL_CACHE_DIR
export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
zig build test --summary all
# → Build Summary: 68/68 steps succeeded; 3020/3027 tests passed (7 skipped)
```

Same as `main`'s baseline — no test regressions from the verifier flip or the fix.

End-to-end the original #752 motivating workload now matches wasmtime byte-for-byte:

```sh
cd /home/g/azure-sdk-for-zig
rm -rf /tmp/kv-wasmtime /tmp/kv-wamr
codegen/cli/scripts/run.sh <keyvault-spec> /tmp/kv-wasmtime
WAMR=1 WAMR_BIN=/work/wamr-754/zig-out/bin/wamr \
  codegen/cli/scripts/run.sh <keyvault-spec> /tmp/kv-wamr
diff -r /tmp/kv-wasmtime /tmp/kv-wamr   # empty
```

Both runtimes log:
```
emitter-options size = 1345719 bytes
calling tcgc.compile...
got 58187 bytes back from tcgc.compile
generated azure_generated → /out
```