### PR TITLE
wamrc: per-function pass-skip bisection knobs (#761 Phase 1)

### DIFF
--- a/docs/wamrc-bisect.md
+++ b/docs/wamrc-bisect.md
@@ -1,0 +1,138 @@
+# wamrc AOT codegen bisection knobs
+
+Three env vars let you narrow a suspected IR-optimisation miscompile down
+to a single (pass, function) pair without recompiling the rest of the
+module with a partial pipeline. Introduced for #743 keyvault bisection
+(issue #761).
+
+The knobs apply to every `wamrc` invocation — single-module `compile` and
+component `compile-component` — and are honoured by every
+`runPassesWithOptions` caller.
+
+## Syntax
+
+```text
+WAMR_AOT_SKIP_PASS=<spec>           # at most one skip spec
+WAMR_AOT_SKIP_PASSES=<spec>[;<spec>...]  # multiple, ';'-separated
+WAMR_AOT_PASSES_LIMIT=<limit_spec>  # cap pipeline length
+```
+
+```text
+spec        := <pass_idx_or_range> [ ':fn=' <fn_list> ]
+limit_spec  := <usize>             [ ':fn=' <fn_list> ]
+pass_idx_or_range := <usize> [ '-' <usize> ]   # inclusive range
+fn_list     := <fn_item> { ',' <fn_item> }
+fn_item     := <usize> [ '-' <usize> ]         # inclusive range
+```
+
+Pass indices refer to positions in the per-function pipeline returned by
+`passes.defaultPassesForTarget(target_arch)` — i.e. the pipeline that
+`runPassesWithOptions` iterates per function. The infrastructure passes
+(`inlineSmallFunctions`, `promoteLocalsToSSA`, `lowerPhisToLocals`,
+`scrubUnreachableBlocks`) live outside that slice and are never affected
+by these knobs.
+
+Function indices are 0-based module-level function indices (same numbering
+as `--dump-ir-after`'s `func_index` and the AOT runtime's
+`local_func[N]` traps).
+
+## Examples
+
+```sh
+# Skip pass 15 in every function (module-global; useful first cut).
+WAMR_AOT_SKIP_PASS=15 wamrc compile-component …
+
+# Skip pass 15 only in function 11040. Every other function runs the
+# full pipeline, so the rest of the module remains correct.
+WAMR_AOT_SKIP_PASS=15:fn=11040 wamrc compile-component …
+
+# Skip a pass range across two specific functions (e.g. paired bisects
+# on caller + callee).
+WAMR_AOT_SKIP_PASS=15-19:fn=11040,11041 wamrc compile-component …
+
+# Two independent skips — pass 15 everywhere AND pass 17 only in fn 11040.
+WAMR_AOT_SKIP_PASSES="15;17:fn=11040" wamrc compile-component …
+
+# Cap the per-function pipeline at 30 passes for function 11040 only.
+WAMR_AOT_PASSES_LIMIT=30:fn=11040 wamrc compile-component …
+```
+
+## Diagnostics
+
+On startup wamrc logs one line per active knob:
+
+```text
+warning: [#761 bisect] SKIP pass 15 for 1 func(s)
+warning: [#761 bisect] LIMIT pipeline to first 30 passes for 1 func(s)
+```
+
+Parse errors degrade gracefully — the offending knob is ignored with a
+single warning, and the rest of the pipeline runs unmodified:
+
+```text
+warning: [#761 bisect] WAMR_AOT_SKIP_PASS=abc: InvalidNumber — ignoring
+```
+
+## Verifier suppression
+
+Per-function: any function whose pipeline is narrowed by the knobs runs
+with the IR verifier off, because partial pipelines often leave IR in a
+state that later cleanups would normalise and trip benign structural
+checks. Unaffected functions still verify normally — most of the
+module retains soundness coverage during a bisect.
+
+## Interaction with module-level inlining
+
+`runPassesWithOptions` normally runs **two** outer rounds of
+`inlineSmallFunctions` interleaved with per-function passes. When any
+bisect knob is active the second round is **suppressed** — otherwise
+the second `inlineSmallFunctions` would observe IR that has already
+been partially-bisected for the target function and could leak those
+effects into callers/callees that were supposed to be unaffected.
+
+Practical consequence: the first round of `inlineSmallFunctions` still
+runs (over vanilla post-frontend IR) before any per-function filtering,
+so unaffected functions retain the *first*-round inlining behaviour
+they would have had without the bisect; affected functions lose any
+*second*-round inlining. For a single-pass-skip bisect that's what
+users want — every function still gets first-round inlining identical
+to a non-bisected baseline.
+
+## Mapping pass indices to pass names
+
+Pass indices are positional in `passes.defaultPassesForTarget(target)`.
+To look up a name from an index, grep
+`src/compiler/ir/passes.zig` for `default_passes` (target-independent)
+or `x86_64_default_passes` (x86_64 overlay) and count from zero. The
+`--dump-ir-after=<pass_name>` flag emits the canonical name in each
+dump filename, which is the easiest way to confirm the mapping before
+running a bisect cycle.
+
+## Limitations / out of scope (Phase 1)
+
+* The knobs do not change pass ordering or repeat counts — only
+  inclusion. To experiment with reordering, edit
+  `defaultPassesForTarget` and rebuild.
+* Selective-recompile (cwasm cache by function) is Phase 2 of #761 — a
+  bisect cycle today still recompiles every function in the module.
+  With the per-function skip, the cycle's runtime change is restricted
+  to one function but every function is still re-codegened.
+* The infrastructure passes (`inlineSmallFunctions`,
+  `promoteLocalsToSSA`, `lowerPhisToLocals`,
+  `scrubUnreachableBlocks`) are not addressable by index — they run
+  unconditionally on every function (subject to the
+  outer-inlining-round suppression above). `WAMR_AOT_PASSES_LIMIT=0`
+  removes every indexed pass but does NOT remove these.
+* `fn=<lo>-<hi>` ranges are expanded into an explicit `[]u32` and
+  scanned linearly per (function, pass) check, so very wide ranges
+  (e.g. `fn=0-10000` on a 12 k-function module) are O(N) per check.
+  The parser rejects ranges wider than 1 000 000 entries as a typo
+  guard. For "all functions" omit `fn=` entirely.
+
+## Related
+
+* `#743` — the active bug this was built to unblock.
+* `#757` — `wamrc verify` differential testing (complementary: oracle).
+* `#755` — per-function codegen trace knobs (`trace_select`,
+  `trace_write_def_typed`); the optimiser-side counterpart of those
+  knobs is what this file documents.

--- a/src/compiler/aot_bisect.zig
+++ b/src/compiler/aot_bisect.zig
@@ -1,0 +1,393 @@
+//! AOT codegen bisection knobs (#761 / #743).
+//!
+//! `wamrc` exposes three env vars to let bisects narrow a suspected
+//! IR-optimisation miscompile down to a single (pass, function) pair
+//! without recompiling the rest of the module with a partial pipeline:
+//!
+//! ```
+//! WAMR_AOT_SKIP_PASS=15                    # skip pass 15 in every func
+//! WAMR_AOT_SKIP_PASS=15:fn=11040           # skip pass 15 only in fn 11040
+//! WAMR_AOT_SKIP_PASS=15-19:fn=11040        # skip a pass range
+//! WAMR_AOT_SKIP_PASSES=15;17:fn=11040      # multiple specs, ';'-joined
+//! WAMR_AOT_PASSES_LIMIT=30                 # cap pipeline at 30 passes
+//! WAMR_AOT_PASSES_LIMIT=30:fn=11040,11041  # cap only listed funcs
+//! ```
+//!
+//! Grammar (single env var):
+//!   spec        := skip_spec | limit_spec
+//!   skip_spec   := <pass_idx_or_range> [ ':fn=' <fn_list> ]
+//!   limit_spec  := <usize>             [ ':fn=' <fn_list> ]
+//!   pass_idx_or_range := <usize> [ '-' <usize> ]
+//!   fn_list     := <fn_item> { ',' <fn_item> }
+//!   fn_item     := <usize> [ '-' <usize> ]
+//!
+//! Multiple `Skip` entries may be supplied via `WAMR_AOT_SKIP_PASSES`
+//! by joining specs with `;`. The single-spec form
+//! (`WAMR_AOT_SKIP_PASS`) is an alias accepting at most one spec.
+//!
+//! All parsing is pure (`parseSkipSpec` / `parseLimitSpec` /
+//! `parseFnList`) and unit-tested without env-var I/O. `parseFromEnv`
+//! is a thin wrapper that pulls the three keys and stamps the result
+//! into the process-global `global` for `runPassesWithOptions` to
+//! consult via `passes.RunOptions.bisect`.
+
+const std = @import("std");
+const passes = @import("ir/passes.zig");
+
+pub const Spec = passes.PassBisectSpec;
+pub const Skip = passes.PassBisectSpec.Skip;
+pub const Limit = passes.PassBisectSpec.Limit;
+
+pub const ParseError = error{
+    EmptyInput,
+    InvalidNumber,
+    InvalidRange,
+    UnknownTrailing,
+    OutOfMemory,
+};
+
+/// Process-global bisect spec. Populated by `parseFromEnv` at wamrc
+/// startup; consumed by both single-module (`runCompile`) and
+/// component (`compileCoreWasm`) AOT paths. Default `.{}` means "no
+/// filtering, full pipeline".
+///
+/// Lifetime: the env parser leaks the backing slices into the GPA
+/// passed to `parseFromEnv` for the process lifetime — `wamrc` is a
+/// short-lived CLI tool and these are tens of bytes.
+pub var global: Spec = .{};
+
+/// Pull the three env vars out of `env` and stamp `global` with the
+/// resulting spec. Logs `[#761 bisect] …` warnings for each active
+/// knob and `[#761 bisect] WARN: …` on parse errors (env-var typos
+/// silently degrading to "full pipeline" is the failure mode users
+/// have repeatedly hit with the global form on the 743b branch).
+///
+/// Allocations live in `gpa` and are never freed.
+pub fn parseFromEnv(env: *const std.process.Environ.Map, gpa: std.mem.Allocator) void {
+    // Warn if both forms are set — we silently prefer the strictly-
+    // more-expressive `_PASSES`, but a contradiction is worth
+    // surfacing so users aren't confused by which spec is active.
+    if (env.get("WAMR_AOT_SKIP_PASS") != null and env.get("WAMR_AOT_SKIP_PASSES") != null) {
+        std.log.warn("[#761 bisect] both WAMR_AOT_SKIP_PASS and WAMR_AOT_SKIP_PASSES set — using WAMR_AOT_SKIP_PASSES", .{});
+    }
+
+    // Parse SKIP first. `appendSkipsFromMulti` is *atomic*: any parse
+    // error leaves `skips` empty so a single typo in
+    // `WAMR_AOT_SKIP_PASSES="3;bad"` does NOT silently apply the
+    // pass-3 skip while warning that the env var was ignored.
+    var skips: std.ArrayList(Skip) = .empty;
+    if (env.get("WAMR_AOT_SKIP_PASSES")) |v| {
+        appendSkipsFromMulti(&skips, v, gpa) catch |e| {
+            std.log.warn("[#761 bisect] WAMR_AOT_SKIP_PASSES={s}: {s} — ignoring entire spec", .{ v, @errorName(e) });
+        };
+    } else if (env.get("WAMR_AOT_SKIP_PASS")) |v| {
+        if (parseSkipSpec(v, gpa)) |s| {
+            skips.append(gpa, s) catch {};
+        } else |e| {
+            std.log.warn("[#761 bisect] WAMR_AOT_SKIP_PASS={s}: {s} — ignoring", .{ v, @errorName(e) });
+        }
+    }
+    if (skips.items.len > 0) {
+        global.skip = skips.toOwnedSlice(gpa) catch &.{};
+        for (global.skip) |s| {
+            logSkip(s);
+        }
+    }
+
+    if (env.get("WAMR_AOT_PASSES_LIMIT")) |v| {
+        if (parseLimitSpec(v, gpa)) |lim| {
+            global.limit = lim;
+            logLimit(lim);
+        } else |e| {
+            std.log.warn("[#761 bisect] WAMR_AOT_PASSES_LIMIT={s}: {s} — ignoring", .{ v, @errorName(e) });
+        }
+    }
+}
+
+/// Parse a `;`-joined sequence of skip specs into `out`. Atomic: on
+/// any per-spec parse error the staging buffer is discarded and `out`
+/// is left untouched, so callers don't see partially-applied filters.
+fn appendSkipsFromMulti(out: *std.ArrayList(Skip), text: []const u8, gpa: std.mem.Allocator) ParseError!void {
+    var staging: std.ArrayList(Skip) = .empty;
+    errdefer {
+        for (staging.items) |s| if (s.func_filter) |f| gpa.free(f);
+        staging.deinit(gpa);
+    }
+    var it = std.mem.splitScalar(u8, text, ';');
+    while (it.next()) |raw| {
+        const t = std.mem.trim(u8, raw, " \t");
+        if (t.len == 0) continue;
+        const s = try parseSkipSpec(t, gpa);
+        try staging.append(gpa, s);
+    }
+    if (staging.items.len == 0) return error.EmptyInput;
+    // Commit to the caller's list.
+    try out.appendSlice(gpa, staging.items);
+    staging.deinit(gpa);
+}
+
+/// Parse a single skip spec, e.g. `"15"`, `"15-19"`, `"15:fn=11040"`,
+/// `"15-19:fn=11040,11050-11060"`.
+pub fn parseSkipSpec(text: []const u8, gpa: std.mem.Allocator) ParseError!Skip {
+    const trimmed = std.mem.trim(u8, text, " \t");
+    if (trimmed.len == 0) return error.EmptyInput;
+    const head, const rest = splitOnce(trimmed, ':');
+    const lo, const hi = try parsePassRange(head);
+    var fn_filter: ?[]const u32 = null;
+    if (rest) |r| {
+        const fn_text = stripFnPrefix(r) orelse return error.UnknownTrailing;
+        fn_filter = try parseFnList(fn_text, gpa);
+    }
+    return .{ .pass_idx_lo = lo, .pass_idx_hi = hi, .func_filter = fn_filter };
+}
+
+/// Parse a single limit spec, e.g. `"30"`, `"30:fn=11040"`.
+pub fn parseLimitSpec(text: []const u8, gpa: std.mem.Allocator) ParseError!Limit {
+    const trimmed = std.mem.trim(u8, text, " \t");
+    if (trimmed.len == 0) return error.EmptyInput;
+    const head, const rest = splitOnce(trimmed, ':');
+    const n = parseU32(head) catch return error.InvalidNumber;
+    var fn_filter: ?[]const u32 = null;
+    if (rest) |r| {
+        const fn_text = stripFnPrefix(r) orelse return error.UnknownTrailing;
+        fn_filter = try parseFnList(fn_text, gpa);
+    }
+    return .{ .n = n, .func_filter = fn_filter };
+}
+
+/// Parse a comma-separated function list with optional inclusive
+/// ranges, e.g. `"11040"`, `"11040,11050-11055,11100"`. Returns a
+/// sorted, de-duplicated slice owned by `gpa`.
+pub fn parseFnList(text: []const u8, gpa: std.mem.Allocator) ParseError![]const u32 {
+    var out: std.ArrayList(u32) = .empty;
+    errdefer out.deinit(gpa);
+    var it = std.mem.splitScalar(u8, text, ',');
+    while (it.next()) |raw| {
+        const t = std.mem.trim(u8, raw, " \t");
+        if (t.len == 0) continue;
+        const lo, const hi = try parseFnRange(t);
+        // Defensive cap: a typo like `fn=0-4000000000` would otherwise
+        // allocate ~16 GB. The keyvault component has ~12 k functions;
+        // 1 M is a generous ceiling that still rejects the typo case.
+        if (hi - lo > 1_000_000) return error.InvalidRange;
+        var v = lo;
+        while (true) : (v += 1) {
+            try out.append(gpa, v);
+            if (v == hi) break;
+        }
+    }
+    if (out.items.len == 0) return error.EmptyInput;
+    return try out.toOwnedSlice(gpa);
+}
+
+fn parsePassRange(text: []const u8) ParseError!struct { u32, u32 } {
+    const lo, const hi = try parseRangeBody(text);
+    return .{ lo, hi };
+}
+
+fn parseFnRange(text: []const u8) ParseError!struct { u32, u32 } {
+    return parseRangeBody(text);
+}
+
+fn parseRangeBody(text: []const u8) ParseError!struct { u32, u32 } {
+    if (std.mem.indexOfScalar(u8, text, '-')) |i| {
+        if (i == 0 or i == text.len - 1) return error.InvalidRange;
+        const lo = parseU32(text[0..i]) catch return error.InvalidNumber;
+        const hi = parseU32(text[i + 1 ..]) catch return error.InvalidNumber;
+        if (hi < lo) return error.InvalidRange;
+        return .{ lo, hi };
+    }
+    const v = parseU32(text) catch return error.InvalidNumber;
+    return .{ v, v };
+}
+
+fn parseU32(text: []const u8) !u32 {
+    const trimmed = std.mem.trim(u8, text, " \t");
+    return std.fmt.parseInt(u32, trimmed, 10);
+}
+
+fn stripFnPrefix(text: []const u8) ?[]const u8 {
+    const t = std.mem.trim(u8, text, " \t");
+    const prefix = "fn=";
+    if (!std.mem.startsWith(u8, t, prefix)) return null;
+    return t[prefix.len..];
+}
+
+fn splitOnce(text: []const u8, sep: u8) struct { []const u8, ?[]const u8 } {
+    if (std.mem.indexOfScalar(u8, text, sep)) |i| {
+        return .{ text[0..i], text[i + 1 ..] };
+    }
+    return .{ text, null };
+}
+
+fn logSkip(s: Skip) void {
+    if (s.func_filter) |list| {
+        if (s.pass_idx_lo == s.pass_idx_hi) {
+            std.log.warn("[#761 bisect] SKIP pass {d} for {d} func(s)", .{ s.pass_idx_lo, list.len });
+        } else {
+            std.log.warn("[#761 bisect] SKIP passes {d}-{d} for {d} func(s)", .{ s.pass_idx_lo, s.pass_idx_hi, list.len });
+        }
+    } else {
+        if (s.pass_idx_lo == s.pass_idx_hi) {
+            std.log.warn("[#761 bisect] SKIP pass {d} (all funcs)", .{s.pass_idx_lo});
+        } else {
+            std.log.warn("[#761 bisect] SKIP passes {d}-{d} (all funcs)", .{ s.pass_idx_lo, s.pass_idx_hi });
+        }
+    }
+}
+
+fn logLimit(lim: Limit) void {
+    if (lim.func_filter) |list| {
+        std.log.warn("[#761 bisect] LIMIT pipeline to first {d} passes for {d} func(s)", .{ lim.n, list.len });
+    } else {
+        std.log.warn("[#761 bisect] LIMIT pipeline to first {d} passes (all funcs)", .{lim.n});
+    }
+}
+
+// ---------------------------------------------------------------------
+// Tests — pure, no env-var or filesystem I/O.
+// ---------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "parseSkipSpec: bare pass index" {
+    const s = try parseSkipSpec("15", testing.allocator);
+    try testing.expectEqual(@as(u32, 15), s.pass_idx_lo);
+    try testing.expectEqual(@as(u32, 15), s.pass_idx_hi);
+    try testing.expectEqual(@as(?[]const u32, null), s.func_filter);
+}
+
+test "parseSkipSpec: pass range" {
+    const s = try parseSkipSpec("15-19", testing.allocator);
+    try testing.expectEqual(@as(u32, 15), s.pass_idx_lo);
+    try testing.expectEqual(@as(u32, 19), s.pass_idx_hi);
+    try testing.expectEqual(@as(?[]const u32, null), s.func_filter);
+}
+
+test "parseSkipSpec: single pass + fn filter" {
+    const s = try parseSkipSpec("15:fn=11040", testing.allocator);
+    defer testing.allocator.free(s.func_filter.?);
+    try testing.expectEqual(@as(u32, 15), s.pass_idx_lo);
+    try testing.expectEqual(@as(u32, 15), s.pass_idx_hi);
+    try testing.expectEqualSlices(u32, &.{11040}, s.func_filter.?);
+}
+
+test "parseSkipSpec: range + multi-fn filter with sub-range" {
+    const s = try parseSkipSpec("15-19:fn=11040,11050-11052", testing.allocator);
+    defer testing.allocator.free(s.func_filter.?);
+    try testing.expectEqual(@as(u32, 15), s.pass_idx_lo);
+    try testing.expectEqual(@as(u32, 19), s.pass_idx_hi);
+    try testing.expectEqualSlices(u32, &.{ 11040, 11050, 11051, 11052 }, s.func_filter.?);
+}
+
+test "parseSkipSpec: rejects malformed range" {
+    try testing.expectError(error.InvalidRange, parseSkipSpec("15-", testing.allocator));
+    try testing.expectError(error.InvalidRange, parseSkipSpec("19-15", testing.allocator));
+    try testing.expectError(error.InvalidNumber, parseSkipSpec("abc", testing.allocator));
+    try testing.expectError(error.UnknownTrailing, parseSkipSpec("15:foo=1", testing.allocator));
+    try testing.expectError(error.EmptyInput, parseSkipSpec("", testing.allocator));
+}
+
+test "parseSkipSpec: rejects oversize fn range (typo guard)" {
+    try testing.expectError(error.InvalidRange, parseSkipSpec("15:fn=0-4000000000", testing.allocator));
+}
+
+test "parseLimitSpec: bare + with fn filter" {
+    {
+        const lim = try parseLimitSpec("30", testing.allocator);
+        try testing.expectEqual(@as(u32, 30), lim.n);
+        try testing.expectEqual(@as(?[]const u32, null), lim.func_filter);
+    }
+    {
+        const lim = try parseLimitSpec("30:fn=11040,11041", testing.allocator);
+        defer testing.allocator.free(lim.func_filter.?);
+        try testing.expectEqual(@as(u32, 30), lim.n);
+        try testing.expectEqualSlices(u32, &.{ 11040, 11041 }, lim.func_filter.?);
+    }
+}
+
+test "Spec.shouldSkip + effectiveLimit + affectsFunction" {
+    const funcs = [_]u32{11040};
+    const spec: Spec = .{
+        .skip = &.{
+            .{ .pass_idx_lo = 15, .pass_idx_hi = 15, .func_filter = &funcs },
+            .{ .pass_idx_lo = 17, .pass_idx_hi = 19, .func_filter = null },
+        },
+        .limit = .{ .n = 30, .func_filter = &funcs },
+    };
+    // pass 15 skipped only for func 11040
+    try testing.expect(spec.shouldSkip(11040, 15));
+    try testing.expect(!spec.shouldSkip(11041, 15));
+    // pass 17 / 18 / 19 skipped for everyone
+    try testing.expect(spec.shouldSkip(0, 17));
+    try testing.expect(spec.shouldSkip(99999, 19));
+    try testing.expect(!spec.shouldSkip(0, 20));
+    // limit applies only to func 11040
+    try testing.expectEqual(@as(?u32, 30), spec.effectiveLimit(11040));
+    try testing.expectEqual(@as(?u32, null), spec.effectiveLimit(11041));
+    // affectsFunction: any of skip/limit
+    try testing.expect(spec.affectsFunction(11040));
+    try testing.expect(spec.affectsFunction(0)); // hit by pass-17 all-funcs skip
+    try testing.expect(spec.affectsFunction(99999)); // same
+}
+
+test "Spec.isEmpty default" {
+    const spec: Spec = .{};
+    try testing.expect(spec.isEmpty());
+    try testing.expect(!spec.affectsFunction(0));
+    try testing.expect(!spec.shouldSkip(0, 0));
+    try testing.expectEqual(@as(?u32, null), spec.effectiveLimit(0));
+}
+
+test "appendSkipsFromMulti: ';' joined" {
+    var skips: std.ArrayList(Skip) = .empty;
+    defer {
+        for (skips.items) |s| if (s.func_filter) |f| testing.allocator.free(f);
+        skips.deinit(testing.allocator);
+    }
+    try appendSkipsFromMulti(&skips, "15;17:fn=11040", testing.allocator);
+    try testing.expectEqual(@as(usize, 2), skips.items.len);
+    try testing.expectEqual(@as(u32, 15), skips.items[0].pass_idx_lo);
+    try testing.expectEqual(@as(u32, 17), skips.items[1].pass_idx_lo);
+    try testing.expectEqualSlices(u32, &.{11040}, skips.items[1].func_filter.?);
+}
+
+test "appendSkipsFromMulti: atomic on per-spec parse error" {
+    // Regression: previously `appendSkipsFromMulti` mutated `out` as
+    // it parsed, so `3;abc` would commit a skip for pass 3 while
+    // logging that the env var was ignored. Atomic semantics now
+    // discard everything on first error.
+    var skips: std.ArrayList(Skip) = .empty;
+    defer {
+        for (skips.items) |s| if (s.func_filter) |f| testing.allocator.free(f);
+        skips.deinit(testing.allocator);
+    }
+    try testing.expectError(error.InvalidNumber, appendSkipsFromMulti(&skips, "3;abc", testing.allocator));
+    try testing.expectEqual(@as(usize, 0), skips.items.len);
+}
+
+test "appendSkipsFromMulti: tolerates trailing or doubled ';'" {
+    var skips: std.ArrayList(Skip) = .empty;
+    defer {
+        for (skips.items) |s| if (s.func_filter) |f| testing.allocator.free(f);
+        skips.deinit(testing.allocator);
+    }
+    try appendSkipsFromMulti(&skips, "3;;7;", testing.allocator);
+    try testing.expectEqual(@as(usize, 2), skips.items.len);
+    try testing.expectEqual(@as(u32, 3), skips.items[0].pass_idx_lo);
+    try testing.expectEqual(@as(u32, 7), skips.items[1].pass_idx_lo);
+}
+
+test "parseSkipSpec: rejects ';' embedded in single-spec form" {
+    // `WAMR_AOT_SKIP_PASS` accepts at most one spec; use _PASSES for
+    // multi. We make sure `parseSkipSpec` (not the multi wrapper)
+    // rejects.
+    try testing.expectError(error.InvalidNumber, parseSkipSpec("3;7", testing.allocator));
+}
+
+test "parseLimitSpec: zero pipeline length is legal (skip all passes for fn)" {
+    const lim = try parseLimitSpec("0:fn=11040", testing.allocator);
+    defer testing.allocator.free(lim.func_filter.?);
+    try testing.expectEqual(@as(u32, 0), lim.n);
+    try testing.expectEqualSlices(u32, &.{11040}, lim.func_filter.?);
+}

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -2679,6 +2679,91 @@ pub const RunOptions = struct {
     /// release builds pay nothing. Callers in debug / fuzz contexts
     /// should set this to `.after_each_pass`.
     verify_mode: verifier.VerifyMode = .off,
+    /// Optional per-function pass-pipeline filter used to bisect AOT
+    /// codegen miscompiles (#743 / #761). Default `.{}` means "no
+    /// filtering" — the full pipeline runs for every function.
+    bisect: PassBisectSpec = .{},
+};
+
+/// Filter that selectively skips IR optimisation passes or caps the
+/// pipeline length for specific functions. Used by `wamrc` bisection
+/// knobs (`WAMR_AOT_SKIP_PASS` / `WAMR_AOT_PASSES_LIMIT`) to narrow a
+/// suspected codegen miscompile to a single pass + function pair
+/// without recompiling the rest of the module with a partial pipeline.
+///
+/// `pass_idx` here refers to the index into the per-function pipeline
+/// slice handed to `runPassesWithOptions` (typically the slice
+/// returned by `defaultPassesForTarget`). The infrastructure passes
+/// (`inlineSmallFunctions`, `promoteLocalsToSSA`, `lowerPhisToLocals`,
+/// `scrubUnreachableBlocks`) live outside that slice and are never
+/// affected by this filter.
+///
+/// Lifetime: `Skip.func_filter` / `Limit.func_filter` are borrowed
+/// slices. Callers (typically `aot_bisect.global`) keep them live for
+/// the process lifetime.
+pub const PassBisectSpec = struct {
+    /// Skip pass-indices in the inclusive range `[pass_idx_lo,
+    /// pass_idx_hi]` for the listed functions (or all functions when
+    /// `func_filter == null`). Multiple entries may overlap; a pass is
+    /// skipped if *any* entry matches.
+    pub const Skip = struct {
+        pass_idx_lo: u32,
+        pass_idx_hi: u32,
+        func_filter: ?[]const u32 = null,
+    };
+    /// Cap the per-function pipeline to the first `n` passes for the
+    /// listed functions (or all functions when `func_filter == null`).
+    /// Only one `Limit` is supported — the env parser overwrites on
+    /// repeat.
+    pub const Limit = struct {
+        n: u32,
+        func_filter: ?[]const u32 = null,
+    };
+
+    skip: []const Skip = &.{},
+    limit: ?Limit = null,
+
+    /// True when no filtering is configured — fast path for callers
+    /// that want to skip per-pass overhead checks.
+    pub fn isEmpty(self: PassBisectSpec) bool {
+        return self.skip.len == 0 and self.limit == null;
+    }
+
+    /// True when pass index `pass_idx` should be skipped for function
+    /// `func_idx` per any `Skip` entry.
+    pub fn shouldSkip(self: PassBisectSpec, func_idx: u32, pass_idx: u32) bool {
+        for (self.skip) |s| {
+            if (pass_idx < s.pass_idx_lo or pass_idx > s.pass_idx_hi) continue;
+            if (funcMatches(s.func_filter, func_idx)) return true;
+        }
+        return false;
+    }
+
+    /// The pipeline-length cap for `func_idx`, or `null` when no
+    /// `Limit` applies (run the full slice).
+    pub fn effectiveLimit(self: PassBisectSpec, func_idx: u32) ?u32 {
+        const lim = self.limit orelse return null;
+        if (!funcMatches(lim.func_filter, func_idx)) return null;
+        return lim.n;
+    }
+
+    /// True when this spec narrows behaviour for `func_idx` at all.
+    /// Used to decide per-function verifier suppression: partial
+    /// pipelines on a function can leave its IR in a state later
+    /// cleanups would normalise, tripping benign structural checks.
+    pub fn affectsFunction(self: PassBisectSpec, func_idx: u32) bool {
+        if (self.effectiveLimit(func_idx) != null) return true;
+        for (self.skip) |s| {
+            if (funcMatches(s.func_filter, func_idx)) return true;
+        }
+        return false;
+    }
+
+    fn funcMatches(filter: ?[]const u32, func_idx: u32) bool {
+        const list = filter orelse return true;
+        for (list) |f| if (f == func_idx) return true;
+        return false;
+    }
 };
 
 const PassNameEntry = struct { fn_ptr: PassFn, name: []const u8 };
@@ -6628,7 +6713,17 @@ pub fn runPassesWithOptions(
     // Cap the outer iterations at 2 — sufficient for the
     // constant-argument-specialisation cases that motivate this loop,
     // without exploding compile time.
-    const outer_max: u32 = 2;
+    //
+    // #761: when a per-function bisect spec is active, force a single
+    // outer iteration. The second iteration re-runs module-level
+    // `inlineSmallFunctions` on IR that the first per-function pass
+    // round has already filtered, which would leak the partial
+    // pipeline's effects into otherwise-unaffected callers/callees and
+    // defeat the per-function isolation promise. One outer round still
+    // runs full inlining first (over vanilla post-frontend IR), so
+    // unaffected functions retain the same inlining behaviour as
+    // without the bisect.
+    const outer_max: u32 = if (opts.bisect.isEmpty()) 2 else 1;
     var outer_iter: u32 = 0;
     while (outer_iter < outer_max) : (outer_iter += 1) {
         // Module-level: inline small leaf callees. Iterate to fixpoint so
@@ -6643,7 +6738,11 @@ pub fn runPassesWithOptions(
 
             if (opts.verify_mode != .off) {
                 for (module.functions.items, 0..) |*f, fi| {
-                    try Verify.check(opts.verify_mode, "inlineSmallFunctions", f, @intCast(fi), allocator);
+                    const fi32: u32 = @intCast(fi);
+                    // #761: suppress verifier on bisect-affected funcs.
+                    const vm: verifier.VerifyMode =
+                        if (opts.bisect.affectsFunction(fi32)) .off else opts.verify_mode;
+                    try Verify.check(vm, "inlineSmallFunctions", f, fi32, allocator);
                 }
             }
 
@@ -6674,6 +6773,18 @@ pub fn runPassesWithOptions(
 
         for (module.functions.items, 0..) |*func, func_idx_usize| {
             const func_idx: u32 = @intCast(func_idx_usize);
+            // #761: per-function verifier suppression — skipping a
+            // pass (or capping the pipeline) on a function can leave
+            // IR in a state that later cleanups would normalise,
+            // tripping benign structural checks. Unaffected functions
+            // still verify normally so most of the module retains
+            // soundness coverage during a bisect. Computed once
+            // per-function and reused for every Verify.check site
+            // below (promoteLocalsToSSA, lowerPhisToLocals, the per-
+            // pass fixpoint, scrubUnreachableBlocks).
+            const effective_verify_mode: verifier.VerifyMode =
+                if (opts.bisect.affectsFunction(func_idx)) .off else opts.verify_mode;
+
             // SSA promotion: only meaningful on the first outer round. On
             // later rounds the function is already past mem2reg and any new
             // local_set/get inserted by inlining is handled by
@@ -6681,7 +6792,7 @@ pub fn runPassesWithOptions(
             if (outer_iter == 0) {
                 if (try promoteLocalsToSSA(func, allocator)) {
                     total_changes += 1;
-                    try Verify.check(opts.verify_mode, "promoteLocalsToSSA", func, func_idx, allocator);
+                    try Verify.check(effective_verify_mode, "promoteLocalsToSSA", func, func_idx, allocator);
                     if (opts.dump_hook) |hook| {
                         try hook.callback(hook.ctx, .{
                             .pass_name = "promoteLocalsToSSA",
@@ -6694,7 +6805,7 @@ pub fn runPassesWithOptions(
                     }
                     if (try lowerPhisToLocals(func, allocator)) {
                         total_changes += 1;
-                        try Verify.check(opts.verify_mode, "lowerPhisToLocals", func, func_idx, allocator);
+                        try Verify.check(effective_verify_mode, "lowerPhisToLocals", func, func_idx, allocator);
                         if (opts.dump_hook) |hook| {
                             try hook.callback(hook.ctx, .{
                                 .pass_name = "lowerPhisToLocals",
@@ -6713,17 +6824,27 @@ pub fn runPassesWithOptions(
             // re-expose opportunities for each other (e.g. constantFold →
             // CSE → DCE → more constantFold). Cap iterations as a safety
             // net.
+            // Apply #761 bisect filter: per-function pipeline-length
+            // cap (`limit`) and per-pass skip mask. When the spec is
+            // empty `effective_passes_len == passes.len` and the
+            // shouldSkip check inside the loop short-circuits.
+            const effective_passes_len: usize = blk: {
+                const cap = opts.bisect.effectiveLimit(func_idx) orelse break :blk passes.len;
+                break :blk @min(@as(usize, cap), passes.len);
+            };
             var iter: u32 = 0;
             while (iter < 8) : (iter += 1) {
                 var any_changed = false;
-                for (passes) |pass| {
+                for (passes[0..effective_passes_len], 0..) |pass, pass_idx_usize| {
+                    const pass_idx: u32 = @intCast(pass_idx_usize);
+                    if (opts.bisect.shouldSkip(func_idx, pass_idx)) continue;
                     const changed = try pass(func, allocator);
                     if (changed) {
                         any_changed = true;
                         total_changes += 1;
                     }
                     if (changed) {
-                        try Verify.check(opts.verify_mode, passName(pass), func, func_idx, allocator);
+                        try Verify.check(effective_verify_mode, passName(pass), func, func_idx, allocator);
                     }
                     if (opts.dump_hook) |hook| {
                         try hook.callback(hook.ctx, .{
@@ -6749,7 +6870,7 @@ pub fn runPassesWithOptions(
             // (issue #620).
             if (try scrubUnreachableBlocks(func, allocator)) {
                 total_changes += 1;
-                try Verify.check(opts.verify_mode, "scrubUnreachableBlocks", func, func_idx, allocator);
+                try Verify.check(effective_verify_mode, "scrubUnreachableBlocks", func, func_idx, allocator);
             }
         }
     }
@@ -7099,6 +7220,125 @@ test "constantFold: iconst + iconst + add → iconst" {
 
     // The add should now be iconst_32(7)
     try std.testing.expectEqual(ir.Inst.Op{ .iconst_32 = 7 }, block.instructions.items[2].op);
+}
+
+// ── #761 bisect-filter integration tests ────────────────────────────────────
+//
+// These exercise `runPassesWithOptions`'s consumption of the
+// `PassBisectSpec` filter. The pure-Spec unit tests live in
+// `src/compiler/aot_bisect.zig`; here we assert that the per-function
+// loop actually honours `shouldSkip` and `effectiveLimit`.
+
+fn bisectTestBuildAddModule(allocator: std.mem.Allocator) !ir.IrModule {
+    // Two functions, each just `iconst 3; iconst 4; v2 = add v0 v1; ret v2`.
+    // `constantFold` should rewrite the `add` to `iconst_32 7` when it
+    // runs; the filter test asserts whether that happened per function.
+    var module = ir.IrModule.init(allocator);
+    errdefer module.deinit();
+
+    inline for (0..2) |_| {
+        var func = ir.IrFunction.init(allocator, 0, 1, 0);
+        errdefer func.deinit();
+        const block_id = try func.newBlock();
+        var block = &func.blocks.items[block_id];
+        const v0 = func.newVReg();
+        const v1 = func.newVReg();
+        const v2 = func.newVReg();
+        try block.append(.{ .op = .{ .iconst_32 = 3 }, .dest = v0 });
+        try block.append(.{ .op = .{ .iconst_32 = 4 }, .dest = v1 });
+        try block.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v2 });
+        try block.append(.{ .op = .{ .ret = v2 } });
+        _ = try module.addFunction(func);
+    }
+    return module;
+}
+
+fn bisectTestAddOpAt(module: *const ir.IrModule, func_idx: usize) ir.Inst.Op {
+    return module.functions.items[func_idx].blocks.items[0].instructions.items[2].op;
+}
+
+test "PassBisectSpec: skip filter honours per-function func_filter" {
+    const allocator = std.testing.allocator;
+    var module = try bisectTestBuildAddModule(allocator);
+    defer module.deinit();
+
+    const fn0_only = [_]u32{0};
+    const single_pass: []const PassFn = &.{&constantFold};
+    const spec: PassBisectSpec = .{
+        .skip = &.{.{ .pass_idx_lo = 0, .pass_idx_hi = 0, .func_filter = &fn0_only }},
+    };
+    _ = try runPassesWithOptions(&module, single_pass, allocator, .{ .bisect = spec });
+
+    // func[0]: constantFold was skipped — add still present.
+    switch (bisectTestAddOpAt(&module, 0)) {
+        .add => {},
+        else => |op| {
+            std.debug.print("expected .add for func[0], got {s}\n", .{@tagName(op)});
+            return error.TestUnexpectedResult;
+        },
+    }
+    // func[1]: constantFold ran — add was folded to iconst_32 7.
+    try std.testing.expectEqual(ir.Inst.Op{ .iconst_32 = 7 }, bisectTestAddOpAt(&module, 1));
+}
+
+test "PassBisectSpec: skip filter applies to all funcs when func_filter is null" {
+    const allocator = std.testing.allocator;
+    var module = try bisectTestBuildAddModule(allocator);
+    defer module.deinit();
+
+    const single_pass: []const PassFn = &.{&constantFold};
+    const spec: PassBisectSpec = .{
+        .skip = &.{.{ .pass_idx_lo = 0, .pass_idx_hi = 0, .func_filter = null }},
+    };
+    _ = try runPassesWithOptions(&module, single_pass, allocator, .{ .bisect = spec });
+
+    for (0..2) |fi| {
+        switch (bisectTestAddOpAt(&module, fi)) {
+            .add => {},
+            else => |op| {
+                std.debug.print("expected .add for func[{d}], got {s}\n", .{ fi, @tagName(op) });
+                return error.TestUnexpectedResult;
+            },
+        }
+    }
+}
+
+test "PassBisectSpec: effectiveLimit truncates pipeline per function" {
+    const allocator = std.testing.allocator;
+    var module = try bisectTestBuildAddModule(allocator);
+    defer module.deinit();
+
+    // Pipeline of [forwardLocalGet, constantFold]. With limit=1 on
+    // func[0], only forwardLocalGet runs there (no-op on this input);
+    // func[1] runs the full pipeline so the add folds to iconst.
+    const two_pass: []const PassFn = &.{ &forwardLocalGet, &constantFold };
+    const fn0_only = [_]u32{0};
+    const spec: PassBisectSpec = .{
+        .limit = .{ .n = 1, .func_filter = &fn0_only },
+    };
+    _ = try runPassesWithOptions(&module, two_pass, allocator, .{ .bisect = spec });
+
+    switch (bisectTestAddOpAt(&module, 0)) {
+        .add => {},
+        else => |op| {
+            std.debug.print("expected .add for func[0], got {s}\n", .{@tagName(op)});
+            return error.TestUnexpectedResult;
+        },
+    }
+    try std.testing.expectEqual(ir.Inst.Op{ .iconst_32 = 7 }, bisectTestAddOpAt(&module, 1));
+}
+
+test "PassBisectSpec: empty spec runs full pipeline (default no-op)" {
+    const allocator = std.testing.allocator;
+    var module = try bisectTestBuildAddModule(allocator);
+    defer module.deinit();
+
+    const single_pass: []const PassFn = &.{&constantFold};
+    _ = try runPassesWithOptions(&module, single_pass, allocator, .{});
+
+    for (0..2) |fi| {
+        try std.testing.expectEqual(ir.Inst.Op{ .iconst_32 = 7 }, bisectTestAddOpAt(&module, fi));
+    }
 }
 
 test "constantFold: eqz on constant" {

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -30,6 +30,16 @@ pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
+    // #761 / #743: stamp the process-global PassBisectSpec from
+    // WAMR_AOT_SKIP_PASS{,ES} / WAMR_AOT_PASSES_LIMIT. Both
+    // compile-paths (`runCompile`, `compileCoreWasm`) thread
+    // `wamr.aot_bisect.global` into `passes.RunOptions.bisect`.
+    // Use the process arena so the spec storage (tens of bytes) is
+    // reclaimed cleanly at exit without tripping the GPA leak
+    // detector — the spec is borrowed by every `runPassesWithOptions`
+    // call for the lifetime of the wamrc invocation.
+    wamr.aot_bisect.parseFromEnv(init.environ_map, init.arena.allocator());
+
     if (args.len < 2) {
         std.debug.print("error: missing subcommand — try `wamrc help`\n", .{});
         std.process.exit(1);
@@ -266,6 +276,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
                 .callback = Dumper.callback,
             },
             .verify_mode = verify_mode,
+            .bisect = wamr.aot_bisect.global,
         };
         const opt_changes = passes.runPassesWithOptions(&ir_module, passes.defaultPassesForTarget(target_arch), allocator, run_opts) catch |err| {
             // If the IR verifier tripped, surface its diagnostic before

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -28,6 +28,7 @@ const name_section_mod = @import("../runtime/common/name_section.zig");
 const core_types = @import("../runtime/common/types.zig");
 const interp_instance = @import("../runtime/interpreter/instance.zig");
 const config = @import("../config.zig");
+const aot_bisect = @import("../compiler/aot_bisect.zig");
 
 // Re-export the on-disk JSON schema from `aot.zig` so `precompileComponent`
 // and `loadManifest` agree on layout without duplicating the schema.
@@ -140,6 +141,13 @@ pub fn compileCoreWasm(
                     .after_each_pass
                 else
                     .off,
+                // #761 / #743: thread the global bisect spec through
+                // so `WAMR_AOT_SKIP_PASS=...:fn=<idx>` narrows the
+                // partial pipeline to one suspect function. The pass
+                // loop forces verify off per-function for any function
+                // affected by the spec to keep partial-pipeline IR
+                // states from tripping benign structural checks.
+                .bisect = aot_bisect.global,
             },
         ) catch |err| {
             logVerifierFailure(err);

--- a/src/root.zig
+++ b/src/root.zig
@@ -89,6 +89,10 @@ pub const aarch64_peephole = @import("compiler/codegen/aarch64/peephole.zig");
 /// AOT compiler optimization passes.
 pub const passes = @import("compiler/ir/passes.zig");
 
+/// AOT codegen bisection knobs — env-var parsing + process-global
+/// `PassBisectSpec` consumed by `runPassesWithOptions` (#761 / #743).
+pub const aot_bisect = @import("compiler/aot_bisect.zig");
+
 /// IR invariant checker run between passes (#624).
 pub const ir_verifier = @import("compiler/ir/verifier.zig");
 


### PR DESCRIPTION
Implements Phase 1 of #761 — per-function pass-skip + pipeline-limit env knobs so a bisect cycle for #743-class miscompiles can isolate behaviour to one suspect function without recompiling the rest of the module with a partial pipeline.

## Knobs

```
WAMR_AOT_SKIP_PASS=15:fn=11040           # one pass + one function
WAMR_AOT_SKIP_PASSES='15-19:fn=11040;7'  # range + multi-fn, ';'-joined multiple specs
WAMR_AOT_PASSES_LIMIT=30:fn=11040        # cap pipeline per function
```

Pass indices are positions in `passes.defaultPassesForTarget(target)`. `fn=` accepts single indices, comma lists, and inclusive ranges (`fn=11040,11050-11055`). Omit `fn=` for module-wide application.

## Why this matters for #743

Currently every bisect cycle for the 12 k-function keyvault component runs the full (modified) pipeline across every function — 8–40 min per cycle. With per-function skip the bug-localisation effect is confined to one function while the other ~12 k functions stay on the default pipeline (still correct, still fast in non-O(N²) passes). This unblocks fast pass bisection within one function without first having to land Phase 2 (selective recompile).

## Implementation highlights

- New `PassBisectSpec` in `src/compiler/ir/passes.zig` (`Skip` / `Limit` nested types, `shouldSkip` / `effectiveLimit` / `affectsFunction` / `isEmpty`). Plumbed via a new `bisect` field on `RunOptions`.
- Per-function consumption in `runPassesWithOptions`'s fixpoint loop: cap pipeline length by `effectiveLimit`, skip individual passes by `shouldSkip`.
- **Per-function verifier suppression** applied consistently at every `Verify.check` site (`promoteLocalsToSSA`, `lowerPhisToLocals`, the per-pass fixpoint, `scrubUnreachableBlocks`, and the module-level `inlineSmallFunctions` loop): partial pipelines can leave IR in states that later cleanups would normalise and trip benign structural checks; affected functions get `verify_mode = .off`, unaffected functions still verify normally.
- **Outer-iteration cap** when bisect is active (2 → 1): otherwise the second module-level `inlineSmallFunctions` round would observe partially-bisected IR and leak those effects across function boundaries, defeating per-function isolation.
- New `src/compiler/aot_bisect.zig` with pure parsers and a process-global `Spec`. **Atomic** multi-spec parsing — `WAMR_AOT_SKIP_PASSES='3;abc'` ignores the entire spec, not just the failing tail.
- Friendly warning when both `WAMR_AOT_SKIP_PASS` and `WAMR_AOT_SKIP_PASSES` are set.

## Tests

- **14 new unit tests** in `aot_bisect.zig` — every parser branch, atomic semantics, typo guard, embedded-`;` rejection, `Spec` method correctness.
- **4 new integration tests** in `passes.zig` — synthetic 2-function modules with `iconst 3; iconst 4; add; ret` body; assert per-function isolation by checking whether the `add` got constant-folded to `iconst 7` in each function under skip / limit / null-filter / empty-spec.

Full suite: `zig build test --summary all` → **68/68 steps, 3047/3054 passed** (was 3029/3036 baseline, +14 from new tests).

## End-to-end verification

```
$ WAMR_AOT_SKIP_PASS='15:fn=0' ./zig-out/bin/wamrc compile noop.wasm -o /tmp/n.cwasm
warning: [#761 bisect] SKIP pass 15 for 1 func(s)
…

$ WAMR_AOT_SKIP_PASSES='3;abc' ./zig-out/bin/wamrc compile noop.wasm -o /tmp/n.cwasm
warning: [#761 bisect] WAMR_AOT_SKIP_PASSES=3;abc: InvalidNumber — ignoring entire spec
… # (no partial application — atomic)

$ WAMR_AOT_SKIP_PASS=abc ./zig-out/bin/wamrc compile noop.wasm -o /tmp/n.cwasm
warning: [#761 bisect] WAMR_AOT_SKIP_PASS=abc: InvalidNumber — ignoring
… # (typo falls back to full pipeline, no crash)
```

## Docs

`docs/wamrc-bisect.md` — syntax, examples, diagnostics, the inlining-suppression caveat, verifier suppression, and what's out of scope for Phase 1 (Phase 2 = selective recompile / cwasm cache by function will follow in a separate PR).

## Out of scope

- Phase 2 (selective recompile) — separate PR; cwasm manifest format bump required.
- Infrastructure-pass skipping (`inlineSmallFunctions`, `promoteLocalsToSSA`, `lowerPhisToLocals`, `scrubUnreachableBlocks` aren't addressable by index).
- Pass reordering — the knobs only filter, not permute.

Refs #743.