### PR TITLE
wamrc: selective recompile via per-function codegen cache (#761 Phase 2)

### DIFF
--- a/.github/skills/aot-diff-debug/SKILL.md
+++ b/.github/skills/aot-diff-debug/SKILL.md
@@ -154,3 +154,15 @@ Once you have a minimal reproducer (ideally <10 lines of C):
 - `src/compiler/frontend.zig` — wasm-to-IR translation
 - `src/compiler/codegen/x86_64/compile.zig:277` — `emitMemBoundsCheck` (clobbers r11)
 - `src/compiler/codegen/x86_64/compile.zig:313` — `emitMemBoundsCheckDynamic` (clobbers r11)
+
+## Companion skill
+
+If after Phase 1 you've localized the bug to a specific function
+(`local_func[N]` in a trap, or via diff narrowing) but it goes away
+with `-O0` — i.e. the bug is somewhere in the IR optimization
+pipeline rather than in codegen itself — hand off to the
+**`aot-pass-bisect`** skill. That skill applies
+`WAMR_AOT_SKIP_PASS=...:fn=<N>` + `--cache-dir` to localize the
+responsible pass in ~5 cycles of seconds-each-when-cached
+recompiles, instead of the 8-40 min per cycle a full recompile
+takes on large components.

--- a/.github/skills/aot-pass-bisect/SKILL.md
+++ b/.github/skills/aot-pass-bisect/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: aot-pass-bisect
+description: Localize which IR optimization pass introduces an AOT codegen miscompile in a specific function. Use after the aot-diff-debug skill has narrowed the bug to a known function index but the responsible IR pass is unknown. Combines WAMR_AOT_SKIP_PASS env knobs (#762) with --cache / --cache-dir codegen reuse (#763) so each bisect cycle re-codegens only the suspect function and finishes in seconds instead of minutes.
+---
+# AOT IR-Pass Bisection
+
+Find the IR optimization pass responsible for an AOT miscompile in a
+specific function. This skill applies the **bisect knobs** added for
+issues #743 / #761 — once `aot-diff-debug` has identified a function
+that codegen mishandles, this skill narrows the responsibility down
+to a specific IR pass without spending 8-40 min per recompile cycle.
+
+## When to Use
+
+Use this skill when ALL of the following hold:
+
+- An AOT-compiled program produces wrong output (caught by
+  `aot-diff-debug` or by failing test output).
+- The bug **goes away with `-O0`** (single-module) or
+  `WAMR_AOT_PASSES_LIMIT=0` (any path) — proving the bug is in the
+  optimization pipeline, not the frontend / SSA / codegen.
+- You know (from `aot-diff-debug` Phase 3 or runtime `local_func[N]`
+  trap output) WHICH function carries the bug, but not WHICH pass
+  introduced it.
+- You're working with a **large component** (the keyvault repro for
+  #743 has ~12 k functions, recompile = 8-40 min) where re-running
+  the full pipeline per bisect cycle is the dominant cost.
+
+Do **not** use this skill when:
+
+- The bug reproduces with `-O0` — that means it's in the frontend /
+  SSA promotion / regalloc / codegen, not the passes. Go to
+  `aot-diff-debug` instead.
+- You don't yet know which function is at fault — find that first.
+
+## Prerequisite: localize the function
+
+If you only know "AOT output is wrong somewhere" and not which
+function trapped or computed a wrong value, run the `aot-diff-debug`
+skill first to narrow to a specific `local_func[N]`. Pass indices
+without a target function are still useful but produce many false
+positives across the module's 12 k functions.
+
+When wamr's AOT runtime traps it prints a `local_func[N]` decoration
+on the stack trace. Save that N — it's the bisect target.
+
+## Workflow
+
+### Step 1: Pin baseline behaviour
+
+Before bisecting, prove the bug is in the optimization pipeline and
+not somewhere else. Two cheap probes:
+
+```sh
+# Probe 1: does -O0 fix it?  If yes → bug is in optimization passes.
+wamrc compile-component -O0 input.wasm -o out.cwasm.json
+wamr <out> | check-output  # expect: bug gone
+
+# Probe 2: does limiting to 0 passes fix it?  Same answer.
+WAMR_AOT_PASSES_LIMIT=0 wamrc compile-component input.wasm -o out.cwasm.json
+wamr <out> | check-output  # expect: bug gone
+```
+
+If both probes still reproduce the bug, the responsible code is NOT
+in the optimization pipeline — go back to `aot-diff-debug`.
+
+### Step 2: Set up the codegen cache
+
+Bisecting without `--cache-dir` recompiles every function (12 k+ for
+keyvault) on every cycle, which is the 8-40 min cost the issue
+flagged. With `--cache-dir`, only the function whose pipeline you
+change re-codegens — every other function reuses its cached bytes.
+
+```sh
+# Single-module compile path.
+mkdir -p /tmp/bisect-cache
+wamrc compile --cache /tmp/bisect-cache/foo.cache \
+  input.wasm -o out.cwasm
+# Output line: "Codegen cache: 0 reused, K recompiled (of K functions)"
+
+# Component compile path (recommended for the #743 keyvault shape).
+mkdir -p /tmp/bisect-cache
+wamrc compile-component --cache-dir /tmp/bisect-cache \
+  input.wasm -o out.cwasm.json
+# Per-core cache files written as /tmp/bisect-cache/core0.cache etc.
+```
+
+The first invocation is full-cost (populates the cache). Every
+invocation after that with the same `--cache-dir` runs in
+seconds-per-bisect-cycle territory IF you only narrow the pipeline
+for one function via `WAMR_AOT_SKIP_PASS=...:fn=<N>`.
+
+Cache mismatches (different wamrc build, different `--target`,
+changed module structure) are detected via header checks and degrade
+to a clean "full recompile" with a warning. They're never errors —
+safe to leave `--cache-dir` set across unrelated runs.
+
+### Step 3: Identify the pipeline length
+
+```sh
+# Look up how many passes the current target has.
+grep -nE "pub fn defaultPassesForTarget" src/compiler/ir/passes.zig
+# Then count entries in `default_passes` / `x86_64_default_passes` (or
+# read off the warning text wamrc emits when WAMR_AOT_PASSES_LIMIT is
+# overshot).
+```
+
+For x86_64 the pipeline is roughly 20-30 passes. Each pass has a
+stable index in the slice returned by `defaultPassesForTarget`.
+
+### Step 4: Binary-search the responsible pass
+
+Use `WAMR_AOT_SKIP_PASS=<idx>:fn=<N>` to drop pass `<idx>` ONLY for
+the suspect function. Every other function keeps the full pipeline,
+so the rest of the module remains correct. Combined with
+`--cache-dir`, each cycle only re-codegens function N (≈ 1 second).
+
+Two-question binary search per round:
+
+```sh
+# Helper macro: each cycle is one wamrc invocation + one wamr run.
+bisect_cycle() {
+  local pass_idx="$1"
+  WAMR_AOT_SKIP_PASS="${pass_idx}:fn=11040" \
+    wamrc compile-component --cache-dir /tmp/bisect-cache \
+    input.wasm -o out.cwasm.json 2>&1 | grep "bisect\|reused"
+  wamr out.cwasm.json | check-output
+}
+
+# Round 1 — narrow to first or second half of the pipeline.
+bisect_cycle 0-14    # if bug GONE → responsible pass is in 0..14
+bisect_cycle 15-29   # else                                in 15..29
+
+# Round 2 — narrow further on whichever half the bug came from.
+bisect_cycle 0-7     # subdivide
+# ...repeat ~log₂(N_passes) ≈ 5 cycles total to localize one pass.
+```
+
+A "bug GONE" cycle confirms the responsible pass is in the skipped
+range. A "bug STILL REPRODUCES" cycle confirms it's elsewhere.
+
+Single-pass spec form (the final localization step):
+
+```sh
+WAMR_AOT_SKIP_PASS="15:fn=11040" wamrc compile-component --cache-dir ...
+```
+
+If the bug disappears with exactly one pass skipped, that pass is
+the culprit. Confirm by reading the pass name from the warning
+wamrc emits at startup:
+
+```
+warning: [#761 bisect] SKIP pass 15 for 1 func(s)
+```
+
+Map pass index → name by counting entries in
+`src/compiler/ir/passes.zig:defaultPassesForTarget` or by enabling
+`--dump-ir-after=<pass_name>` (which prints the canonical name in
+each dump filename).
+
+### Step 5: Confirm with a minimal reproducer
+
+Once you've named the pass:
+
+1. Dump pre-pass and post-pass IR for the suspect function:
+   ```sh
+   wamrc compile --dump-ir-after=initial \
+     --dump-ir-after=<bad_pass_name> \
+     --dump-ir-functions='func11040*' \
+     --dump-ir-out=/tmp/ir-dumps \
+     input.wasm -o /dev/null
+   ```
+2. Diff the two snapshots — the rewrite the pass performed on
+   function 11040 IS the bug (or at least sets up the bug).
+3. Hand the diff + the bisect spec
+   (`WAMR_AOT_SKIP_PASS=15:fn=11040` makes the bug go away) to a
+   maintainer or use it to build a unit test for the
+   passes_<pass_name>_test.zig sibling.
+
+## Multi-spec and pass-range syntax
+
+```sh
+# Single pass index.
+WAMR_AOT_SKIP_PASS=15
+
+# Pass index + function filter.
+WAMR_AOT_SKIP_PASS=15:fn=11040
+
+# Multiple functions for the same pass.
+WAMR_AOT_SKIP_PASS=15:fn=11040,11041,11050-11055
+
+# Inclusive pass-index range (skip 15 through 19 inclusive).
+WAMR_AOT_SKIP_PASS=15-19:fn=11040
+
+# Several independent skips (use the plural form, ';'-separated).
+WAMR_AOT_SKIP_PASSES="15;17:fn=11040;12-15"
+
+# Cap the per-function pipeline at the first N passes.
+WAMR_AOT_PASSES_LIMIT=30:fn=11040
+```
+
+Atomic parsing: a typo anywhere in a `WAMR_AOT_SKIP_PASSES` spec
+discards the entire spec with a one-line warning and falls back to
+the full pipeline. No silent partial application.
+
+## What the cache reuses (and what it does not)
+
+The `--cache-dir` cache stores **per-function codegen output**
+(native bytes + inter-function call patches). On a recompile cycle:
+
+- Functions with **unchanged IR** hit the cache and skip codegen
+  entirely — these are >99% of the module during a single-function
+  bisect.
+- Functions with **changed IR** (your bisect target) re-run the
+  filtered pipeline and re-codegen.
+- The IR optimization passes themselves are **not cached** — they
+  still run for every function every cycle. This is fast for most
+  passes; the dominant cost on large modules is regalloc + codegen,
+  which IS cached.
+
+Time savings estimate: bisect cycle drops from 8-40 min to ~1-20
+min on the #743 keyvault shape (codegen ≈ 50% of total compile
+time). Full pass-bisection across 25 cycles: ~3-17 hours → ~30 min
+- 8 hours.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Wastes Time | Do Instead |
+|---|---|---|
+| Bisecting without `--cache-dir` | Every cycle re-codegens all 12 k functions | Set up the cache first (Step 2) |
+| Bisecting without `:fn=<N>` | Module-global skips can mask the bug behind unrelated false negatives or trip other functions | Always scope the skip to the suspect function |
+| Skimming the cwasm bytes for clues | Codegen output is opaque post-regalloc | Dump IR before/after the suspect pass via `--dump-ir-after` |
+| Re-running a failing cycle "to make sure" | Bisect knobs are deterministic | Trust the result; spend the cycle on the next subdivision |
+| Stashing `WAMR_AOT_SKIP_PASS` in your shell rc | The next unrelated `wamrc` invocation will silently apply it | Use a one-shot `WAMR_AOT_SKIP_PASS=... wamrc ...` form per cycle |
+| Verifying pass-by-pass without first confirming `-O0` reproduces a fix | Bug might be in frontend or codegen; bisect won't converge | Always run Step 1 first |
+
+## References
+
+- `docs/wamrc-bisect.md` — full reference for the `WAMR_AOT_SKIP_PASS{,ES}`
+  / `WAMR_AOT_PASSES_LIMIT` knobs (syntax, semantics, verifier
+  suppression, inlining-round caveat).
+- `src/compiler/ir/passes.zig` — `defaultPassesForTarget` is the
+  source of truth for pass indices; the per-function fixpoint in
+  `runPassesWithOptions` is where the bisect filter is consumed.
+- `src/compiler/aot_bisect.zig` — env-var parser + process-global
+  `PassBisectSpec` (PR #762).
+- `src/compiler/codegen_cache.zig` — canonical IR hasher + cache
+  file format (PR #763).
+- Issue #743 — the keyvault miscompile this workflow was built to
+  unblock.
+- Issue #761 — the meta-issue covering the bisect-knob + cache
+  feature.
+
+## Companion skill
+
+If you don't yet know which function is at fault, run the
+**`aot-diff-debug`** skill first. That skill compares interpreter vs
+AOT output to identify the divergence and narrow to a specific
+function; this skill then takes over to localize the responsible
+pass.

--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -10,6 +10,7 @@ const emit = @import("emit.zig");
 const schedule = @import("schedule.zig");
 const coalesce_post = @import("coalesce_post.zig");
 const range_split = @import("../../ir/range_split.zig");
+const codegen_cache = @import("../../codegen_cache.zig");
 
 /// Compile-time debug flag: when true, print per-function range-split
 /// stats to stderr. Flip via `zig build -Drange-split-debug=true` after
@@ -8323,6 +8324,163 @@ pub fn compileModuleWithOptions(
     return .{
         .code = try all_code.toOwnedSlice(allocator),
         .offsets = try offsets.toOwnedSlice(allocator),
+    };
+}
+
+// ── #761 Phase 2: codegen cache integration ──────────────────────────────
+
+pub const CompileResultCached = codegen_cache.CompileResultCached;
+
+/// Same as `compileModuleWithOptions` but consults an optional `reuse`
+/// cache to skip per-function codegen for functions whose IR sha256
+/// matches the cached entry. Reused code's local-offset call patches
+/// are rebased to the new module layout; the existing BL patch
+/// resolution loop runs unchanged.
+pub fn compileModuleCached(
+    ir_module: *const ir.IrModule,
+    reuse: ?*const codegen_cache.Cache,
+    allocator: std.mem.Allocator,
+) !codegen_cache.CompileResultCached {
+    return compileModuleCachedWithOptions(ir_module, reuse, allocator, .{});
+}
+
+pub fn compileModuleCachedWithOptions(
+    ir_module: *const ir.IrModule,
+    reuse: ?*const codegen_cache.Cache,
+    allocator: std.mem.Allocator,
+    options: CompileOptions,
+) !codegen_cache.CompileResultCached {
+    var all_code: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer all_code.deinit(allocator);
+    var offsets: std.ArrayListUnmanaged(u32) = .empty;
+    errdefer offsets.deinit(allocator);
+
+    var global_call_patches: std.ArrayListUnmanaged(CallPatch) = .empty;
+    defer global_call_patches.deinit(allocator);
+
+    const func_count: usize = ir_module.functions.items.len;
+    var cache_funcs = try allocator.alloc(codegen_cache.CachedFunction, func_count);
+    var cache_init: usize = 0;
+    errdefer {
+        for (cache_funcs[0..cache_init]) |*f| {
+            allocator.free(f.code);
+            allocator.free(f.call_patches);
+        }
+        allocator.free(cache_funcs);
+    }
+
+    var stats: codegen_cache.CacheStats = .{};
+
+    for (ir_module.functions.items, 0..) |func, fi| {
+        const func_base: u32 = @intCast(all_code.items.len);
+        try offsets.append(allocator, func_base);
+
+        const ir_sha = codegen_cache.hashFunction(&func);
+
+        var reused = false;
+        var hit_code: []const u8 = undefined;
+        var hit_patches: []const codegen_cache.FuncCallPatch = undefined;
+        if (reuse) |r| {
+            if (fi < r.functions.len and
+                std.mem.eql(u8, &r.functions[fi].ir_sha256, &ir_sha))
+            {
+                hit_code = r.functions[fi].code;
+                hit_patches = r.functions[fi].call_patches;
+                reused = true;
+            }
+        }
+
+        var cache_code_owned: []u8 = undefined;
+        var cache_patches_owned: []codegen_cache.FuncCallPatch = undefined;
+
+        if (reused) {
+            cache_code_owned = try allocator.dupe(u8, hit_code);
+            errdefer allocator.free(cache_code_owned);
+            cache_patches_owned = try allocator.dupe(codegen_cache.FuncCallPatch, hit_patches);
+            try all_code.appendSlice(allocator, hit_code);
+            for (hit_patches) |p| {
+                try global_call_patches.append(allocator, .{
+                    .patch_offset = @as(usize, func_base) + @as(usize, p.patch_offset),
+                    .target_func_idx = p.target_func_idx,
+                });
+            }
+            stats.reused += 1;
+        } else {
+            var func_patches: std.ArrayListUnmanaged(CallPatch) = .empty;
+            defer func_patches.deinit(allocator);
+
+            const ctx: FuncCompileCtx = .{
+                .import_count = ir_module.import_count,
+                .call_patches = &func_patches,
+                .global_types = ir_module.global_types orelse &.{},
+                .global_offsets = ir_module.global_offsets orelse &.{},
+                .func_types = ir_module.func_types.items,
+                .func_type_indices = ir_module.func_type_indices.items,
+                .options = options,
+                .allocator = allocator,
+            };
+            const func_code = compileFunctionImpl(&func, ctx, allocator) catch |err| {
+                std.debug.print("Error compiling function {d} ({d} blocks, {d} vregs): {}\n", .{
+                    fi,
+                    func.blocks.items.len,
+                    func.next_vreg,
+                    err,
+                });
+                return err;
+            };
+
+            const new_patches = try allocator.alloc(codegen_cache.FuncCallPatch, func_patches.items.len);
+            errdefer allocator.free(new_patches);
+            for (func_patches.items, new_patches) |src, *dst| {
+                dst.* = .{
+                    .patch_offset = @intCast(src.patch_offset),
+                    .target_func_idx = src.target_func_idx,
+                };
+            }
+            cache_code_owned = func_code;
+            cache_patches_owned = new_patches;
+
+            for (func_patches.items) |p| {
+                try global_call_patches.append(allocator, .{
+                    .patch_offset = p.patch_offset + func_base,
+                    .target_func_idx = p.target_func_idx,
+                });
+            }
+            try all_code.appendSlice(allocator, func_code);
+            stats.recompiled += 1;
+        }
+
+        cache_funcs[fi] = .{
+            .ir_sha256 = ir_sha,
+            .code = cache_code_owned,
+            .call_patches = cache_patches_owned,
+        };
+        cache_init += 1;
+    }
+
+    // Resolve BL patches — identical logic to
+    // `compileModuleWithOptions` above.
+    for (global_call_patches.items) |p| {
+        if (p.target_func_idx >= offsets.items.len) return error.BadFuncIndex;
+        const target_off: i64 = @intCast(offsets.items[p.target_func_idx]);
+        const patch_off: i64 = @intCast(p.patch_offset);
+        const delta_bytes = target_off - patch_off;
+        if (@mod(delta_bytes, 4) != 0) return error.BranchMisaligned;
+        const word_off = @divExact(delta_bytes, 4);
+        const limit: i64 = 1 << 25;
+        if (word_off >= limit or word_off < -limit) return error.CallOutOfRange;
+        const bytes = all_code.items[p.patch_offset..][0..4];
+        const existing = std.mem.readInt(u32, bytes, .little);
+        const imm26: u26 = @bitCast(@as(i26, @intCast(word_off)));
+        const new_word: u32 = (existing & 0xFC000000) | imm26;
+        std.mem.writeInt(u32, bytes, new_word, .little);
+    }
+
+    return .{
+        .code = try all_code.toOwnedSlice(allocator),
+        .offsets = try offsets.toOwnedSlice(allocator),
+        .cache_functions = cache_funcs,
+        .stats = stats,
     };
 }
 

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -10,6 +10,7 @@ const builtin = @import("builtin");
 const ir = @import("../../ir/ir.zig");
 const passes = @import("../../ir/passes.zig");
 const emit = @import("emit.zig");
+const codegen_cache = @import("../../codegen_cache.zig");
 
 // ── Comptime codegen-trace knobs ────────────────────────────────────────
 //
@@ -1566,6 +1567,147 @@ const GlobalCallPatch = struct {
     patch_offset: usize,
     target_func_idx: u32,
 };
+
+// ── #761 Phase 2: codegen cache integration ──────────────────────────────
+
+/// Same as `compileModule` but consults an optional `reuse` cache to
+/// skip per-function codegen for any function whose IR sha256 matches
+/// the cached entry. The reused code's local-offset `call_patches` are
+/// rebased to the new module-level layout, and the existing inter-
+/// function patch resolution loop runs unchanged.
+///
+/// Always returns a fresh `cache_functions` slice — the caller persists
+/// it (along with module-epoch + build-id metadata) for the next
+/// recompile cycle. Ownership of `cache_functions[i].{code, call_patches}`
+/// transfers to the caller; free via `codegen_cache.Cache.deinit` or
+/// manually.
+pub fn compileModuleCached(
+    ir_module: *const ir.IrModule,
+    reuse: ?*const codegen_cache.Cache,
+    allocator: std.mem.Allocator,
+) !codegen_cache.CompileResultCached {
+    var all_code: std.ArrayList(u8) = .empty;
+    errdefer all_code.deinit(allocator);
+    var offsets: std.ArrayList(u32) = .empty;
+    errdefer offsets.deinit(allocator);
+    var global_call_patches: std.ArrayList(GlobalCallPatch) = .empty;
+    defer global_call_patches.deinit(allocator);
+
+    const func_count: usize = ir_module.functions.items.len;
+    var cache_funcs = try allocator.alloc(codegen_cache.CachedFunction, func_count);
+    var cache_init: usize = 0;
+    errdefer {
+        for (cache_funcs[0..cache_init]) |*f| {
+            allocator.free(f.code);
+            allocator.free(f.call_patches);
+        }
+        allocator.free(cache_funcs);
+    }
+
+    var stats: codegen_cache.CacheStats = .{};
+
+    for (ir_module.functions.items, 0..) |func, fi| {
+        const func_start: u32 = @intCast(all_code.items.len);
+        try offsets.append(allocator, func_start);
+
+        const ir_sha = codegen_cache.hashFunction(&func);
+
+        // Cache lookup: by function position AND ir_sha256. Position
+        // alone is unsafe because two same-shape modules could share
+        // sha256 for fn[3] but reuse against a different module's fn[3]
+        // would still be wrong. Position is fine here because the
+        // outer epoch check (in the caller) guarantees `func_count`
+        // and codegen-relevant module metadata match before any
+        // per-fn reuse is considered.
+        var reused = false;
+        var hit_code: []const u8 = undefined;
+        var hit_patches: []const codegen_cache.FuncCallPatch = undefined;
+        if (reuse) |r| {
+            if (fi < r.functions.len and
+                std.mem.eql(u8, &r.functions[fi].ir_sha256, &ir_sha))
+            {
+                hit_code = r.functions[fi].code;
+                hit_patches = r.functions[fi].call_patches;
+                reused = true;
+            }
+        }
+
+        var cache_code_owned: []u8 = undefined;
+        var cache_patches_owned: []codegen_cache.FuncCallPatch = undefined;
+
+        if (reused) {
+            // Dup so the new cache owns its own memory independent of
+            // the `reuse` lifetime.
+            cache_code_owned = try allocator.dupe(u8, hit_code);
+            errdefer allocator.free(cache_code_owned);
+            cache_patches_owned = try allocator.dupe(codegen_cache.FuncCallPatch, hit_patches);
+            try all_code.appendSlice(allocator, hit_code);
+            for (hit_patches) |p| {
+                try global_call_patches.append(allocator, .{
+                    .patch_offset = @as(usize, func_start) + @as(usize, p.patch_offset),
+                    .target_func_idx = p.target_func_idx,
+                });
+            }
+            stats.reused += 1;
+        } else {
+            const result = try compileFunctionRAWithGlobalOffsets(
+                &func,
+                ir_module.import_count,
+                ir_module.global_offsets orelse &.{},
+                allocator,
+            );
+            // `result.code` and `result.call_patches` are owned here.
+            // Convert internal CallPatch → public FuncCallPatch and
+            // hand both to the cache slot.
+            defer allocator.free(result.call_patches);
+            const new_patches = try allocator.alloc(codegen_cache.FuncCallPatch, result.call_patches.len);
+            errdefer allocator.free(new_patches);
+            for (result.call_patches, new_patches) |src, *dst| {
+                dst.* = .{
+                    .patch_offset = @intCast(src.patch_offset),
+                    .target_func_idx = src.target_func_idx,
+                };
+            }
+            cache_code_owned = result.code;
+            cache_patches_owned = new_patches;
+            try all_code.appendSlice(allocator, result.code);
+            for (result.call_patches) |patch| {
+                try global_call_patches.append(allocator, .{
+                    .patch_offset = func_start + patch.patch_offset,
+                    .target_func_idx = patch.target_func_idx,
+                });
+            }
+            stats.recompiled += 1;
+        }
+
+        cache_funcs[fi] = .{
+            .ir_sha256 = ir_sha,
+            .code = cache_code_owned,
+            .call_patches = cache_patches_owned,
+        };
+        cache_init += 1;
+    }
+
+    // Inter-function PC-relative E8 patches — identical logic to
+    // `compileModule` above so reused and fresh code share the same
+    // resolution pass.
+    for (global_call_patches.items) |patch| {
+        if (patch.target_func_idx < offsets.items.len) {
+            const target_off = offsets.items[patch.target_func_idx];
+            const rel: i32 = @intCast(@as(i64, @intCast(target_off)) - @as(i64, @intCast(patch.patch_offset + 4)));
+            std.mem.writeInt(i32, all_code.items[patch.patch_offset..][0..4], rel, .little);
+        }
+    }
+
+    return .{
+        .code = try all_code.toOwnedSlice(allocator),
+        .offsets = try offsets.toOwnedSlice(allocator),
+        .cache_functions = cache_funcs,
+        .stats = stats,
+    };
+}
+
+pub const CompileResultCached = codegen_cache.CompileResultCached;
 
 // ── Register-Allocated Compilation ────────────────────────────────────
 
@@ -4983,6 +5125,132 @@ test "compileModule: two functions have correct offsets" {
     try std.testing.expectEqual(@as(usize, 2), result.offsets.len);
     try std.testing.expectEqual(@as(u32, 0), result.offsets[0]);
     try std.testing.expect(result.offsets[1] > 0);
+}
+
+// ── #761 Phase 2 cache integration tests ──────────────────────────────────
+
+fn freeCachedFuncs(allocator: std.mem.Allocator, funcs: []codegen_cache.CachedFunction) void {
+    for (funcs) |*f| {
+        allocator.free(f.code);
+        allocator.free(f.call_patches);
+    }
+    allocator.free(funcs);
+}
+
+fn buildTwoFnAddModule(allocator: std.mem.Allocator) !ir.IrModule {
+    var ir_module = ir.IrModule.init(allocator);
+    errdefer ir_module.deinit();
+    inline for ([_]i32{ 1, 2 }) |k| {
+        var f = ir.IrFunction.init(allocator, 0, 1, 0);
+        errdefer f.deinit();
+        _ = try f.newBlock();
+        const v0 = f.newVReg();
+        try f.getBlock(0).append(.{ .op = .{ .iconst_32 = k }, .dest = v0 });
+        try f.getBlock(0).append(.{ .op = .{ .ret = v0 } });
+        _ = try ir_module.addFunction(f);
+    }
+    return ir_module;
+}
+
+test "compileModuleCached: no reuse produces same bytes as compileModule" {
+    const allocator = std.testing.allocator;
+    var m_a = try buildTwoFnAddModule(allocator);
+    defer m_a.deinit();
+    var m_b = try buildTwoFnAddModule(allocator);
+    defer m_b.deinit();
+
+    const baseline = try compileModule(&m_a, allocator);
+    defer allocator.free(baseline.code);
+    defer allocator.free(baseline.offsets);
+
+    const cached = try compileModuleCached(&m_b, null, allocator);
+    defer allocator.free(cached.code);
+    defer allocator.free(cached.offsets);
+    defer freeCachedFuncs(allocator, cached.cache_functions);
+
+    try std.testing.expectEqualSlices(u8, baseline.code, cached.code);
+    try std.testing.expectEqualSlices(u32, baseline.offsets, cached.offsets);
+    try std.testing.expectEqual(@as(u32, 0), cached.stats.reused);
+    try std.testing.expectEqual(@as(u32, 2), cached.stats.recompiled);
+    try std.testing.expectEqual(@as(usize, 2), cached.cache_functions.len);
+}
+
+test "compileModuleCached: warm cache reuses every function (byte-identical)" {
+    const allocator = std.testing.allocator;
+    var m_cold = try buildTwoFnAddModule(allocator);
+    defer m_cold.deinit();
+
+    // Cold compile to populate the cache.
+    const cold = try compileModuleCached(&m_cold, null, allocator);
+    defer allocator.free(cold.code);
+    defer allocator.free(cold.offsets);
+
+    // Build a Cache stub from the cold-compile output. Note: this test
+    // only exercises the per-fn cache table — module-epoch matching is
+    // verified at the CLI layer, not inside compileModuleCached.
+    const reuse: codegen_cache.Cache = .{
+        .wamr_build_id = "x",
+        .target_arch = .x86_64,
+        .target_abi = .x86_64_sysv,
+        .module_epoch = .{0} ** 32,
+        .functions = cold.cache_functions,
+    };
+
+    // Warm compile against a freshly-built (equivalent) module.
+    var m_warm = try buildTwoFnAddModule(allocator);
+    defer m_warm.deinit();
+    const warm = try compileModuleCached(&m_warm, &reuse, allocator);
+    defer allocator.free(warm.code);
+    defer allocator.free(warm.offsets);
+    defer freeCachedFuncs(allocator, warm.cache_functions);
+    // Free `cold.cache_functions` AFTER the assertions (defer) —
+    // `reuse.functions` borrows from it.
+    defer freeCachedFuncs(allocator, cold.cache_functions);
+
+    try std.testing.expectEqualSlices(u8, cold.code, warm.code);
+    try std.testing.expectEqualSlices(u32, cold.offsets, warm.offsets);
+    try std.testing.expectEqual(@as(u32, 2), warm.stats.reused);
+    try std.testing.expectEqual(@as(u32, 0), warm.stats.recompiled);
+}
+
+test "compileModuleCached: per-function IR mismatch recompiles only that function" {
+    const allocator = std.testing.allocator;
+    var m_cold = try buildTwoFnAddModule(allocator);
+    defer m_cold.deinit();
+
+    const cold = try compileModuleCached(&m_cold, null, allocator);
+    defer allocator.free(cold.code);
+    defer allocator.free(cold.offsets);
+
+    const reuse: codegen_cache.Cache = .{
+        .wamr_build_id = "x",
+        .target_arch = .x86_64,
+        .target_abi = .x86_64_sysv,
+        .module_epoch = .{0} ** 32,
+        .functions = cold.cache_functions,
+    };
+
+    // Edit fn[1] to return a different constant — IR hash mismatch on
+    // fn[1] only, fn[0] still reuses.
+    var m_warm = try buildTwoFnAddModule(allocator);
+    defer m_warm.deinit();
+    m_warm.functions.items[1].blocks.items[0].instructions.items[0].op = .{ .iconst_32 = 99 };
+
+    const warm = try compileModuleCached(&m_warm, &reuse, allocator);
+    defer allocator.free(warm.code);
+    defer allocator.free(warm.offsets);
+    defer freeCachedFuncs(allocator, warm.cache_functions);
+    // Note: free `cold.cache_functions` AFTER the assertions below —
+    // `reuse.functions` borrows from it, so freeing earlier would
+    // leave `reuse.functions[0].ir_sha256` reading 0xAA poison.
+    defer freeCachedFuncs(allocator, cold.cache_functions);
+
+    try std.testing.expectEqual(@as(u32, 1), warm.stats.reused);
+    try std.testing.expectEqual(@as(u32, 1), warm.stats.recompiled);
+    // fn[0]'s ir_sha256 in the new cache should match the cold-compile's
+    // (we re-hash inside compileModuleCached, so two equivalent IRs
+    // produce equal hashes).
+    try std.testing.expectEqualSlices(u8, &warm.cache_functions[0].ir_sha256, &reuse.functions[0].ir_sha256);
 }
 
 test "compileFunction: empty function produces prologue and epilogue" {

--- a/src/compiler/codegen_cache.zig
+++ b/src/compiler/codegen_cache.zig
@@ -69,6 +69,28 @@ pub const max_cache_file_bytes: usize = 256 * 1024 * 1024;
 pub const max_func_code_bytes: u32 = 16 * 1024 * 1024;
 pub const max_call_patches_per_func: u32 = 1 << 20;
 
+/// Per-compile-call statistics for diagnosis. Populated by
+/// `compileModuleCached` and surfaced by the CLI / tests.
+pub const CacheStats = struct {
+    reused: u32 = 0,
+    recompiled: u32 = 0,
+};
+
+/// Output of `<arch>.compileModuleCached`. Shared between backends so
+/// the CLI can dispatch without a per-arch wrapper type.
+pub const CompileResultCached = struct {
+    /// Concatenated native code for every function in the module,
+    /// inter-function PC-relative calls already resolved.
+    code: []u8,
+    /// Per-local-function byte offset into `code`.
+    offsets: []u32,
+    /// Per-function cache entries. Caller owns and must free each
+    /// entry's `code` + `call_patches` (or use the entries to build a
+    /// `Cache` and call `Cache.deinit`).
+    cache_functions: []CachedFunction,
+    stats: CacheStats,
+};
+
 /// Inter-function PC-relative call patch carried in a cached function.
 /// `patch_offset` is relative to the start of this function's code
 /// (not the module's global code blob); the reuse path re-bases by

--- a/src/compiler/codegen_cache.zig
+++ b/src/compiler/codegen_cache.zig
@@ -1,0 +1,886 @@
+//! AOT codegen cache (#761 Phase 2a — infrastructure).
+//!
+//! Per-function compiled code is fully position-independent modulo a
+//! list of inter-function PC-relative call patches. That lets us cache
+//! `(ir_sha256, code_bytes, call_patches)` per function in a sidecar
+//! file and, on a recompile, memcpy cached code into the new module
+//! layout while re-resolving the call patches against fresh offsets.
+//!
+//! This file owns the **infrastructure** for that scheme: the on-disk
+//! cache format (magic, version, header, per-function entries), the
+//! canonical IR hasher (`hashFunction`), the module-level epoch hasher
+//! (`hashModuleEpoch`), and the binary serialiser / deserialiser. It
+//! does **not** integrate with the codegen pipeline — that wires up in
+//! Phase 2b via `compileModuleCached` in each backend.
+//!
+//! ## Cache integrity model
+//!
+//! A cache is rejected wholesale (header mismatch) on any of:
+//!   - magic byte sequence mismatch
+//!   - format version mismatch
+//!   - wamr build id mismatch (different compiler binary)
+//!   - target arch + ABI mismatch (different machine code shape)
+//!   - module epoch mismatch (IrModule-level invariants codegen reads:
+//!     import_count, global_types, global_offsets, global_storage_size,
+//!     func_types, func_type_indices)
+//!   - func_count mismatch (functions added/removed)
+//!
+//! Within a valid cache, each per-function entry is reused iff its
+//! stored `ir_sha256` matches a freshly-computed hash of the IR
+//! function the caller hands in. Mismatches fall back to a normal
+//! codegen call for that function.
+//!
+//! ## Per-function `ir_sha256`
+//!
+//! We hash the IR **structurally** (not via the diagnostic printer in
+//! `print.zig`, which intentionally elides codegen-observable fields
+//! like SIMD lane indices and memory offsets to stay readable). The
+//! walker (`HashWriter.writeAny`) reflects over every field of every
+//! Inst.Op union variant via comptime, so adding a new op variant or
+//! payload field is automatically covered. Two explicit skip lists
+//! handle non-codegen-observable metadata:
+//!
+//!   - `IrFunction`: skip `name` (debug-only), `allocator`,
+//!     `next_vreg` (high-water mark recomputable from any block's
+//!     instructions), `owned_br_table_targets` (memory-pinning helper;
+//!     content lives inline on `Inst.Op.br_table.targets` and is
+//!     hashed there).
+//!   - `BasicBlock`: skip `allocator`, `predecessors` (recomputable
+//!     from any block's terminator).
+
+const std = @import("std");
+const builtin = @import("builtin");
+const ir = @import("ir/ir.zig");
+const passes = @import("ir/passes.zig");
+
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
+pub const cache_magic = "WAMRCAC\x00".*;
+pub const cache_format_version: u32 = 1;
+
+/// Sentinel cap on cache-file size we'll accept on load. 256 MiB is
+/// more than 10× the largest cwasm we've seen (#743 keyvault ≈ 37 MB
+/// + ~equal codegen output) and small enough to refuse pathological
+/// inputs without an OOM probe.
+pub const max_cache_file_bytes: usize = 256 * 1024 * 1024;
+
+/// Per-function entry's hard cap on emitted code length and patch
+/// count. Defensive deserialiser bound; real functions are kilobytes.
+pub const max_func_code_bytes: u32 = 16 * 1024 * 1024;
+pub const max_call_patches_per_func: u32 = 1 << 20;
+
+/// Inter-function PC-relative call patch carried in a cached function.
+/// `patch_offset` is relative to the start of this function's code
+/// (not the module's global code blob); the reuse path re-bases by
+/// adding `func_start_in_new_module`. `target_func_idx` is the
+/// **local** function index (post-import-offset) of the call target.
+pub const FuncCallPatch = extern struct {
+    patch_offset: u32,
+    target_func_idx: u32,
+};
+
+/// Identifies the platform ABI variant that affects codegen.
+/// `target_arch` alone is too weak — x86_64 SysV vs Win64 emit
+/// substantially different prologues / arg-reg sequences (see
+/// `x86_64_caller_saved_indices` in `compile.zig`).
+pub const TargetAbi = enum(u8) {
+    x86_64_sysv = 0,
+    x86_64_win64 = 1,
+    aarch64_aapcs = 2,
+
+    pub fn forHost(arch: passes.TargetArch) TargetAbi {
+        return switch (arch) {
+            .x86_64 => switch (builtin.os.tag) {
+                .windows => .x86_64_win64,
+                else => .x86_64_sysv,
+            },
+            .aarch64 => .aarch64_aapcs,
+        };
+    }
+};
+
+/// Inputs to `hashModuleEpoch`. All fields the codegen back-ends read
+/// from `IrModule` (directly or via `compileModuleWithOptions`) belong
+/// here — otherwise a cache could be reused against an IrModule that
+/// produces structurally-different code despite identical per-function
+/// IR.
+pub const ModuleEpochInputs = struct {
+    wamr_build_id: []const u8,
+    target_arch: passes.TargetArch,
+    target_abi: TargetAbi,
+    import_count: u32,
+    /// Optional; treated as empty slice when null.
+    global_types: ?[]const ir.IrType = null,
+    /// Optional; treated as empty slice when null.
+    global_offsets: ?[]const u32 = null,
+    global_storage_size: u32 = 0,
+    /// `IrFuncType` carries `params: []const IrType, results: []const IrType`.
+    func_types: []const ir.IrFuncType = &.{},
+    func_type_indices: []const u32 = &.{},
+};
+
+/// One cached function's codegen output.
+pub const CachedFunction = struct {
+    ir_sha256: [32]u8,
+    code: []u8,
+    call_patches: []FuncCallPatch,
+};
+
+/// In-memory representation of a cache file. All slices are owned by
+/// the allocator passed to `deserialize` (or the builder that
+/// constructed the cache); call `deinit` to free them.
+pub const Cache = struct {
+    wamr_build_id: []const u8,
+    target_arch: passes.TargetArch,
+    target_abi: TargetAbi,
+    module_epoch: [32]u8,
+    functions: []CachedFunction,
+
+    pub fn deinit(self: *Cache, allocator: std.mem.Allocator) void {
+        allocator.free(self.wamr_build_id);
+        for (self.functions) |*f| {
+            allocator.free(f.code);
+            allocator.free(f.call_patches);
+        }
+        allocator.free(self.functions);
+        self.* = undefined;
+    }
+};
+
+// ── Hashers ────────────────────────────────────────────────────────────────
+
+/// Compute the canonical SHA-256 of a function's codegen-observable
+/// IR. Deterministic across runs and platforms.
+pub fn hashFunction(func: *const ir.IrFunction) [32]u8 {
+    var sh = Sha256.init(.{});
+    var w: HashWriter = .{ .h = &sh };
+    w.writeIrFunction(func);
+    var out: [32]u8 = undefined;
+    sh.final(&out);
+    return out;
+}
+
+/// Compute the canonical SHA-256 of module-level codegen invariants.
+/// Mismatch invalidates the entire cache (per-function reuse becomes
+/// unsafe regardless of per-function IR equality).
+pub fn hashModuleEpoch(inputs: ModuleEpochInputs) [32]u8 {
+    var sh = Sha256.init(.{});
+    var w: HashWriter = .{ .h = &sh };
+    // Domain separator so this hash can never collide with hashFunction.
+    w.writeBytes("epoch\x00");
+    w.writeBytes(inputs.wamr_build_id);
+    w.writeInt(u8, 0); // separator after variable-length build id
+    w.writeInt(u32, @intFromEnum(inputs.target_arch));
+    w.writeInt(u8, @intFromEnum(inputs.target_abi));
+    w.writeInt(u32, inputs.import_count);
+    w.writeOptSliceEnum(ir.IrType, inputs.global_types);
+    w.writeOptSliceInt(u32, inputs.global_offsets);
+    w.writeInt(u32, inputs.global_storage_size);
+    w.writeInt(u32, @intCast(inputs.func_types.len));
+    for (inputs.func_types) |ft| {
+        w.writeInt(u32, @intCast(ft.params.len));
+        for (ft.params) |p| w.writeInt(u32, @intFromEnum(p));
+        w.writeInt(u32, @intCast(ft.results.len));
+        for (ft.results) |r| w.writeInt(u32, @intFromEnum(r));
+    }
+    w.writeInt(u32, @intCast(inputs.func_type_indices.len));
+    for (inputs.func_type_indices) |i| w.writeInt(u32, i);
+    var out: [32]u8 = undefined;
+    sh.final(&out);
+    return out;
+}
+
+/// Comptime-reflective canonical hasher. Writes a deterministic byte
+/// stream into the wrapped Sha256 by walking every field of every
+/// reachable struct / union / slice / enum / primitive — so adding a
+/// new `Inst.Op` variant or payload field is hashed automatically with
+/// no maintenance.
+const HashWriter = struct {
+    h: *Sha256,
+
+    fn writeBytes(self: HashWriter, b: []const u8) void {
+        self.h.update(b);
+    }
+    fn writeInt(self: HashWriter, comptime T: type, v: T) void {
+        var buf: [@sizeOf(T)]u8 = undefined;
+        std.mem.writeInt(T, &buf, v, .little);
+        self.h.update(&buf);
+    }
+    fn writeBool(self: HashWriter, v: bool) void {
+        self.h.update(&[_]u8{if (v) 1 else 0});
+    }
+    fn writeOptSliceEnum(self: HashWriter, comptime E: type, opt: ?[]const E) void {
+        if (opt) |s| {
+            self.writeInt(u8, 1);
+            self.writeInt(u32, @intCast(s.len));
+            for (s) |e| self.writeInt(u32, @intFromEnum(e));
+        } else {
+            self.writeInt(u8, 0);
+        }
+    }
+    fn writeOptSliceInt(self: HashWriter, comptime T: type, opt: ?[]const T) void {
+        if (opt) |s| {
+            self.writeInt(u8, 1);
+            self.writeInt(u32, @intCast(s.len));
+            for (s) |v| self.writeInt(T, v);
+        } else {
+            self.writeInt(u8, 0);
+        }
+    }
+
+    /// Manual walker for `IrFunction`: skips `name` (debug-only),
+    /// `allocator`, `next_vreg` (recomputable), and
+    /// `owned_br_table_targets` (memory-pin helper; content lives
+    /// inline on `Inst.Op.br_table.targets` and is hashed there).
+    fn writeIrFunction(self: HashWriter, func: *const ir.IrFunction) void {
+        self.writeBytes("func\x00");
+        self.writeInt(u32, func.param_count);
+        self.writeInt(u32, func.result_count);
+        self.writeInt(u32, func.local_count);
+        self.writeOptInt(u32, func.phi_synth_local_start);
+        self.writeOptInt(u32, func.phi_synth_local_end);
+        self.writeOptSliceEnum(ir.IrType, func.local_types);
+        self.writeInt(u32, @intCast(func.blocks.items.len));
+        for (func.blocks.items) |*blk| self.writeBasicBlock(blk);
+    }
+
+    fn writeOptInt(self: HashWriter, comptime T: type, opt: ?T) void {
+        if (opt) |v| {
+            self.writeInt(u8, 1);
+            self.writeInt(T, v);
+        } else {
+            self.writeInt(u8, 0);
+        }
+    }
+
+    /// Manual walker for `BasicBlock`: skips `allocator` and
+    /// `predecessors` (recomputable from any block's terminator —
+    /// passes may leave stale predecessors that codegen rebuilds).
+    fn writeBasicBlock(self: HashWriter, blk: *const ir.BasicBlock) void {
+        self.writeBytes("blk\x00");
+        self.writeInt(u32, blk.id);
+        self.writeInt(u32, @intCast(blk.instructions.items.len));
+        for (blk.instructions.items) |inst| self.writeAny(inst);
+    }
+
+    /// Reflective walker for any other type. Handles primitives,
+    /// enums, optionals, arrays, slices, structs, and **tagged**
+    /// unions. Refuses non-data types (pointers other than slices,
+    /// raw allocators, etc.) at comptime.
+    fn writeAny(self: HashWriter, value: anytype) void {
+        const T = @TypeOf(value);
+        const info = @typeInfo(T);
+        switch (info) {
+            .int => |i| {
+                // Promote arbitrary-width integers to u64 / i64 (sign
+                // preserving) so payload fields like `lane: u4`,
+                // `align: u8`, `width: u3` all hash deterministically
+                // without per-width specialisation. The wider field
+                // doesn't lose info because zero-/sign-extension is
+                // unique.
+                if (i.signedness == .signed) {
+                    const w: i64 = @intCast(value);
+                    self.writeInt(i64, w);
+                } else {
+                    if (i.bits <= 64) {
+                        const w: u64 = @intCast(value);
+                        self.writeInt(u64, w);
+                    } else if (i.bits == 128) {
+                        self.writeInt(u128, value);
+                    } else {
+                        @compileError("unsupported int bits: " ++ @typeName(T));
+                    }
+                }
+            },
+            .float => |f| switch (f.bits) {
+                32 => {
+                    const bits: u32 = @bitCast(value);
+                    self.writeInt(u32, bits);
+                },
+                64 => {
+                    const bits: u64 = @bitCast(value);
+                    self.writeInt(u64, bits);
+                },
+                else => @compileError("unsupported float bits: " ++ @typeName(T)),
+            },
+            .bool => self.writeBool(value),
+            .@"enum" => self.writeInt(u64, @intFromEnum(value)),
+            .void => {},
+            .optional => {
+                if (value) |v| {
+                    self.writeInt(u8, 1);
+                    self.writeAny(v);
+                } else {
+                    self.writeInt(u8, 0);
+                }
+            },
+            .array => for (value) |elem| self.writeAny(elem),
+            .pointer => |p| switch (p.size) {
+                .slice => {
+                    self.writeInt(u32, @intCast(value.len));
+                    if (p.child == u8) {
+                        self.writeBytes(value);
+                    } else {
+                        for (value) |elem| self.writeAny(elem);
+                    }
+                },
+                .one => self.writeAny(value.*),
+                else => @compileError("unsupported pointer size " ++ @tagName(p.size) ++ " for " ++ @typeName(T)),
+            },
+            .@"struct" => |s| {
+                inline for (s.fields) |f| {
+                    self.writeAny(@field(value, f.name));
+                }
+            },
+            .@"union" => |u| {
+                if (u.tag_type == null) @compileError("non-tagged unions not supported: " ++ @typeName(T));
+                self.writeInt(u32, @intFromEnum(std.meta.activeTag(value)));
+                switch (value) {
+                    inline else => |payload| self.writeAny(payload),
+                }
+            },
+            else => @compileError("unsupported type in canonical hash: " ++ @typeName(T)),
+        }
+    }
+};
+
+// ── Serialiser ─────────────────────────────────────────────────────────────
+//
+// On-disk format (little-endian throughout):
+//   magic              [8]u8 = "WAMRCAC\0"
+//   version            u32   (= cache_format_version)
+//   wamr_build_id_len  u32
+//   wamr_build_id      [N]u8
+//   target_arch        u8
+//   target_abi         u8
+//   module_epoch       [32]u8
+//   func_count         u32
+//   for each function:
+//     ir_sha256        [32]u8
+//     code_len         u32
+//     code             [L]u8
+//     call_patches_cnt u32
+//     call_patches     [P * 8]u8   (u32 patch_offset, u32 target_func_idx)
+
+pub const SerializeError = error{OutOfMemory};
+
+pub const DeserializeError = error{
+    Truncated,
+    BadMagic,
+    UnsupportedVersion,
+    OversizeField,
+    InvalidPatchOffset,
+    InvalidTargetFuncIdx,
+    InvalidTargetArch,
+    InvalidTargetAbi,
+    OutOfMemory,
+};
+
+pub fn serialize(cache: *const Cache, allocator: std.mem.Allocator) SerializeError![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    try buf.appendSlice(allocator, &cache_magic);
+    try appendU32(&buf, allocator, cache_format_version);
+    try appendU32(&buf, allocator, @intCast(cache.wamr_build_id.len));
+    try buf.appendSlice(allocator, cache.wamr_build_id);
+    try buf.append(allocator, @intFromEnum(cache.target_arch));
+    try buf.append(allocator, @intFromEnum(cache.target_abi));
+    try buf.appendSlice(allocator, &cache.module_epoch);
+    try appendU32(&buf, allocator, @intCast(cache.functions.len));
+    for (cache.functions) |f| {
+        try buf.appendSlice(allocator, &f.ir_sha256);
+        try appendU32(&buf, allocator, @intCast(f.code.len));
+        try buf.appendSlice(allocator, f.code);
+        try appendU32(&buf, allocator, @intCast(f.call_patches.len));
+        for (f.call_patches) |p| {
+            try appendU32(&buf, allocator, p.patch_offset);
+            try appendU32(&buf, allocator, p.target_func_idx);
+        }
+    }
+    return buf.toOwnedSlice(allocator);
+}
+
+pub fn deserialize(bytes: []const u8, allocator: std.mem.Allocator) DeserializeError!Cache {
+    if (bytes.len > max_cache_file_bytes) return error.OversizeField;
+    var r: Reader = .{ .buf = bytes, .pos = 0 };
+    const magic = try r.takeBytes(cache_magic.len);
+    if (!std.mem.eql(u8, magic, &cache_magic)) return error.BadMagic;
+    const version = try r.readU32();
+    if (version != cache_format_version) return error.UnsupportedVersion;
+
+    const build_id_len = try r.readU32();
+    if (build_id_len > 1024) return error.OversizeField;
+    const build_id_src = try r.takeBytes(build_id_len);
+    const build_id = try allocator.dupe(u8, build_id_src);
+    errdefer allocator.free(build_id);
+
+    const arch_byte = try r.readU8();
+    const arch: passes.TargetArch = switch (arch_byte) {
+        0 => .x86_64,
+        1 => .aarch64,
+        else => return error.InvalidTargetArch,
+    };
+    const abi_byte = try r.readU8();
+    const abi: TargetAbi = switch (abi_byte) {
+        0 => .x86_64_sysv,
+        1 => .x86_64_win64,
+        2 => .aarch64_aapcs,
+        else => return error.InvalidTargetAbi,
+    };
+    var module_epoch: [32]u8 = undefined;
+    @memcpy(&module_epoch, try r.takeBytes(32));
+
+    const func_count = try r.readU32();
+    if (func_count > (1 << 24)) return error.OversizeField;
+
+    var funcs = try allocator.alloc(CachedFunction, func_count);
+    // Track how many entries are fully initialised so the errdefer cleans
+    // up only those — partially-allocated tail entries must not be freed.
+    var initialised: usize = 0;
+    errdefer {
+        for (funcs[0..initialised]) |*f| {
+            allocator.free(f.code);
+            allocator.free(f.call_patches);
+        }
+        allocator.free(funcs);
+    }
+
+    for (funcs) |*f| {
+        var ir_sha256: [32]u8 = undefined;
+        @memcpy(&ir_sha256, try r.takeBytes(32));
+        const code_len = try r.readU32();
+        if (code_len > max_func_code_bytes) return error.OversizeField;
+        const code_src = try r.takeBytes(code_len);
+        const code = try allocator.dupe(u8, code_src);
+        errdefer allocator.free(code);
+
+        const patches_cnt = try r.readU32();
+        if (patches_cnt > max_call_patches_per_func) return error.OversizeField;
+        const patches = try allocator.alloc(FuncCallPatch, patches_cnt);
+        errdefer allocator.free(patches);
+        for (patches) |*p| {
+            p.patch_offset = try r.readU32();
+            p.target_func_idx = try r.readU32();
+            // Reject patches that would write outside this function's
+            // own code blob — the post-load assembler would otherwise
+            // corrupt a neighbour function's bytes during reuse.
+            if (@as(u64, p.patch_offset) + 4 > code_len) return error.InvalidPatchOffset;
+            if (p.target_func_idx >= func_count) return error.InvalidTargetFuncIdx;
+        }
+        f.* = .{ .ir_sha256 = ir_sha256, .code = code, .call_patches = patches };
+        initialised += 1;
+    }
+
+    if (r.pos != bytes.len) return error.Truncated;
+    return .{
+        .wamr_build_id = build_id,
+        .target_arch = arch,
+        .target_abi = abi,
+        .module_epoch = module_epoch,
+        .functions = funcs,
+    };
+}
+
+fn appendU32(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, v: u32) !void {
+    var tmp: [4]u8 = undefined;
+    std.mem.writeInt(u32, &tmp, v, .little);
+    try buf.appendSlice(allocator, &tmp);
+}
+
+const Reader = struct {
+    buf: []const u8,
+    pos: usize,
+
+    fn takeBytes(self: *Reader, n: usize) DeserializeError![]const u8 {
+        if (n > self.buf.len - self.pos) return error.Truncated;
+        const s = self.buf[self.pos .. self.pos + n];
+        self.pos += n;
+        return s;
+    }
+    fn readU8(self: *Reader) DeserializeError!u8 {
+        const s = try self.takeBytes(1);
+        return s[0];
+    }
+    fn readU32(self: *Reader) DeserializeError!u32 {
+        const s = try self.takeBytes(4);
+        return std.mem.readInt(u32, s[0..4], .little);
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+fn buildAddFunc(allocator: std.mem.Allocator) !ir.IrFunction {
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    errdefer func.deinit();
+    const b = try func.newBlock();
+    var blk = &func.blocks.items[b];
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try blk.append(.{ .op = .{ .iconst_32 = 3 }, .dest = v0 });
+    try blk.append(.{ .op = .{ .iconst_32 = 4 }, .dest = v1 });
+    try blk.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v2 });
+    try blk.append(.{ .op = .{ .ret = v2 } });
+    return func;
+}
+
+test "hashFunction: deterministic across two builds of equivalent IR" {
+    var a = try buildAddFunc(testing.allocator);
+    defer a.deinit();
+    var b = try buildAddFunc(testing.allocator);
+    defer b.deinit();
+    try testing.expectEqual(hashFunction(&a), hashFunction(&b));
+}
+
+test "hashFunction: insensitive to debug-only fields (name)" {
+    var a = try buildAddFunc(testing.allocator);
+    defer a.deinit();
+    var b = try buildAddFunc(testing.allocator);
+    defer b.deinit();
+    a.name = "alpha";
+    b.name = "beta";
+    try testing.expectEqual(hashFunction(&a), hashFunction(&b));
+}
+
+test "hashFunction: insensitive to next_vreg high-water mark" {
+    var a = try buildAddFunc(testing.allocator);
+    defer a.deinit();
+    var b = try buildAddFunc(testing.allocator);
+    defer b.deinit();
+    // Allocating extra vregs without using them should not affect codegen.
+    _ = b.newVReg();
+    _ = b.newVReg();
+    try testing.expectEqual(hashFunction(&a), hashFunction(&b));
+}
+
+test "hashFunction: insensitive to stale block predecessors" {
+    var a = try buildAddFunc(testing.allocator);
+    defer a.deinit();
+    var b = try buildAddFunc(testing.allocator);
+    defer b.deinit();
+    try b.blocks.items[0].addPredecessor(999);
+    try testing.expectEqual(hashFunction(&a), hashFunction(&b));
+}
+
+test "hashFunction: sensitive to a constant value change" {
+    var a = try buildAddFunc(testing.allocator);
+    defer a.deinit();
+    var b = try buildAddFunc(testing.allocator);
+    defer b.deinit();
+    b.blocks.items[0].instructions.items[0].op = .{ .iconst_32 = 5 };
+    try testing.expect(!std.mem.eql(u8, &hashFunction(&a), &hashFunction(&b)));
+}
+
+test "hashFunction: sensitive to local_count change" {
+    var a = try buildAddFunc(testing.allocator);
+    defer a.deinit();
+    var b = try buildAddFunc(testing.allocator);
+    defer b.deinit();
+    b.local_count += 1;
+    try testing.expect(!std.mem.eql(u8, &hashFunction(&a), &hashFunction(&b)));
+}
+
+test "hashFunction: sensitive to op-tag change (add → sub)" {
+    var a = try buildAddFunc(testing.allocator);
+    defer a.deinit();
+    var b = try buildAddFunc(testing.allocator);
+    defer b.deinit();
+    const add_inst = b.blocks.items[0].instructions.items[2];
+    const dest = add_inst.dest;
+    const Bin = @TypeOf(add_inst.op.add);
+    const lhs_rhs: Bin = add_inst.op.add;
+    b.blocks.items[0].instructions.items[2] = .{ .op = .{ .sub = lhs_rhs }, .dest = dest };
+    try testing.expect(!std.mem.eql(u8, &hashFunction(&a), &hashFunction(&b)));
+}
+
+test "hashFunction: SIMD lane-index sensitivity (i32x4_extract_lane)" {
+    // Regression for the rubber-duck finding that `print.formatFunc`
+    // would have collided on this case because it emits only the
+    // operand vregs for extract-lane ops. The canonical hasher walks
+    // the payload struct fields directly so distinct lane indices
+    // produce distinct hashes.
+    var a = ir.IrFunction.init(testing.allocator, 1, 1, 0);
+    defer a.deinit();
+    const b0 = try a.newBlock();
+    const v_in = a.newVReg();
+    const v_out = a.newVReg();
+    try a.blocks.items[b0].append(.{
+        .op = .{ .i32x4_extract_lane = .{ .vector = v_in, .lane = 0 } },
+        .dest = v_out,
+    });
+    try a.blocks.items[b0].append(.{ .op = .{ .ret = v_out } });
+
+    var b = ir.IrFunction.init(testing.allocator, 1, 1, 0);
+    defer b.deinit();
+    const c0 = try b.newBlock();
+    const w_in = b.newVReg();
+    const w_out = b.newVReg();
+    try b.blocks.items[c0].append(.{
+        .op = .{ .i32x4_extract_lane = .{ .vector = w_in, .lane = 2 } },
+        .dest = w_out,
+    });
+    try b.blocks.items[c0].append(.{ .op = .{ .ret = w_out } });
+
+    try testing.expect(!std.mem.eql(u8, &hashFunction(&a), &hashFunction(&b)));
+}
+
+test "hashFunction: SIMD memory-offset sensitivity (v128_load)" {
+    var a = ir.IrFunction.init(testing.allocator, 1, 1, 0);
+    defer a.deinit();
+    const b0 = try a.newBlock();
+    const vbase_a = a.newVReg();
+    const vdest_a = a.newVReg();
+    try a.blocks.items[b0].append(.{
+        .op = .{ .v128_load = .{ .base = vbase_a, .offset = 0, .alignment = 16 } },
+        .dest = vdest_a,
+        .type = .v128,
+    });
+    try a.blocks.items[b0].append(.{ .op = .{ .ret = vdest_a } });
+
+    var b = ir.IrFunction.init(testing.allocator, 1, 1, 0);
+    defer b.deinit();
+    const c0 = try b.newBlock();
+    const vbase_b = b.newVReg();
+    const vdest_b = b.newVReg();
+    try b.blocks.items[c0].append(.{
+        .op = .{ .v128_load = .{ .base = vbase_b, .offset = 16, .alignment = 16 } },
+        .dest = vdest_b,
+        .type = .v128,
+    });
+    try b.blocks.items[c0].append(.{ .op = .{ .ret = vdest_b } });
+
+    try testing.expect(!std.mem.eql(u8, &hashFunction(&a), &hashFunction(&b)));
+}
+
+test "hashModuleEpoch: deterministic for identical inputs" {
+    const ft = [_]ir.IrFuncType{.{ .params = &.{ .i32, .i32 }, .results = &.{.i32} }};
+    const tidxs = [_]u32{0};
+    const gtypes = [_]ir.IrType{ .i32, .i64 };
+    const goffs = [_]u32{ 0, 8 };
+    const e = ModuleEpochInputs{
+        .wamr_build_id = "test-build-1",
+        .target_arch = .x86_64,
+        .target_abi = .x86_64_sysv,
+        .import_count = 2,
+        .global_types = &gtypes,
+        .global_offsets = &goffs,
+        .global_storage_size = 16,
+        .func_types = &ft,
+        .func_type_indices = &tidxs,
+    };
+    try testing.expectEqual(hashModuleEpoch(e), hashModuleEpoch(e));
+}
+
+test "hashModuleEpoch: sensitive to import_count" {
+    const e1 = ModuleEpochInputs{
+        .wamr_build_id = "test-build-1",
+        .target_arch = .x86_64,
+        .target_abi = .x86_64_sysv,
+        .import_count = 2,
+    };
+    var e2 = e1;
+    e2.import_count = 3;
+    try testing.expect(!std.mem.eql(u8, &hashModuleEpoch(e1), &hashModuleEpoch(e2)));
+}
+
+test "hashModuleEpoch: sensitive to target_abi (sysv vs win64)" {
+    const e1 = ModuleEpochInputs{
+        .wamr_build_id = "test-build-1",
+        .target_arch = .x86_64,
+        .target_abi = .x86_64_sysv,
+        .import_count = 0,
+    };
+    var e2 = e1;
+    e2.target_abi = .x86_64_win64;
+    try testing.expect(!std.mem.eql(u8, &hashModuleEpoch(e1), &hashModuleEpoch(e2)));
+}
+
+test "hashModuleEpoch: sensitive to global_offsets contents" {
+    const g1 = [_]u32{ 0, 8 };
+    const g2 = [_]u32{ 0, 16 };
+    const e1 = ModuleEpochInputs{
+        .wamr_build_id = "test-build-1",
+        .target_arch = .x86_64,
+        .target_abi = .x86_64_sysv,
+        .import_count = 0,
+        .global_offsets = &g1,
+    };
+    var e2 = e1;
+    e2.global_offsets = &g2;
+    try testing.expect(!std.mem.eql(u8, &hashModuleEpoch(e1), &hashModuleEpoch(e2)));
+}
+
+test "hashModuleEpoch: epoch != hashFunction domain (separator works)" {
+    // Cheap sanity check: an empty module epoch and an empty
+    // (zero-block, zero-local) function should not produce the same
+    // hash because the two hashers use distinct domain separators.
+    var f = ir.IrFunction.init(testing.allocator, 0, 0, 0);
+    defer f.deinit();
+    const e = ModuleEpochInputs{
+        .wamr_build_id = "",
+        .target_arch = .x86_64,
+        .target_abi = .x86_64_sysv,
+        .import_count = 0,
+    };
+    try testing.expect(!std.mem.eql(u8, &hashFunction(&f), &hashModuleEpoch(e)));
+}
+
+// Serialiser round-trip and validation tests.
+
+fn buildSampleCache(allocator: std.mem.Allocator) !Cache {
+    const build_id = try allocator.dupe(u8, "wamr-test-0.1");
+    errdefer allocator.free(build_id);
+    var funcs = try allocator.alloc(CachedFunction, 2);
+    errdefer allocator.free(funcs);
+    funcs[0] = .{
+        .ir_sha256 = .{1} ** 32,
+        // 8 bytes of placeholder code so a patch at offset 0 has
+        // 4 bytes of room (0+4 <= 8) per the deserialiser's bounds
+        // check.
+        .code = try allocator.dupe(u8, &[_]u8{ 0xCC, 0xC3, 0x00, 0x00, 0x90, 0x90, 0x90, 0x90 }),
+        .call_patches = try allocator.dupe(FuncCallPatch, &.{
+            .{ .patch_offset = 0, .target_func_idx = 1 },
+        }),
+    };
+    errdefer {
+        allocator.free(funcs[0].code);
+        allocator.free(funcs[0].call_patches);
+    }
+    funcs[1] = .{
+        .ir_sha256 = .{2} ** 32,
+        .code = try allocator.dupe(u8, &[_]u8{ 0x90, 0x90, 0x90, 0x90, 0xC3 }),
+        .call_patches = try allocator.dupe(FuncCallPatch, &.{}),
+    };
+    return .{
+        .wamr_build_id = build_id,
+        .target_arch = .x86_64,
+        .target_abi = .x86_64_sysv,
+        .module_epoch = .{7} ** 32,
+        .functions = funcs,
+    };
+}
+
+test "serialize/deserialize: round-trip preserves all fields" {
+    const allocator = testing.allocator;
+    var cache = try buildSampleCache(allocator);
+    defer cache.deinit(allocator);
+    const bytes = try serialize(&cache, allocator);
+    defer allocator.free(bytes);
+    var got = try deserialize(bytes, allocator);
+    defer got.deinit(allocator);
+    try testing.expectEqualSlices(u8, cache.wamr_build_id, got.wamr_build_id);
+    try testing.expectEqual(cache.target_arch, got.target_arch);
+    try testing.expectEqual(cache.target_abi, got.target_abi);
+    try testing.expectEqualSlices(u8, &cache.module_epoch, &got.module_epoch);
+    try testing.expectEqual(@as(usize, 2), got.functions.len);
+    try testing.expectEqualSlices(u8, &cache.functions[0].ir_sha256, &got.functions[0].ir_sha256);
+    try testing.expectEqualSlices(u8, cache.functions[0].code, got.functions[0].code);
+    try testing.expectEqual(@as(usize, 1), got.functions[0].call_patches.len);
+    try testing.expectEqual(cache.functions[0].call_patches[0].patch_offset, got.functions[0].call_patches[0].patch_offset);
+    try testing.expectEqual(cache.functions[0].call_patches[0].target_func_idx, got.functions[0].call_patches[0].target_func_idx);
+    try testing.expectEqualSlices(u8, cache.functions[1].code, got.functions[1].code);
+    try testing.expectEqual(@as(usize, 0), got.functions[1].call_patches.len);
+}
+
+test "deserialize: rejects bad magic" {
+    const allocator = testing.allocator;
+    var cache = try buildSampleCache(allocator);
+    defer cache.deinit(allocator);
+    const bytes = try serialize(&cache, allocator);
+    defer allocator.free(bytes);
+    var mut = try allocator.dupe(u8, bytes);
+    defer allocator.free(mut);
+    mut[0] = 0xFF;
+    try testing.expectError(error.BadMagic, deserialize(mut, allocator));
+}
+
+test "deserialize: rejects wrong version" {
+    const allocator = testing.allocator;
+    var cache = try buildSampleCache(allocator);
+    defer cache.deinit(allocator);
+    const bytes = try serialize(&cache, allocator);
+    defer allocator.free(bytes);
+    var mut = try allocator.dupe(u8, bytes);
+    defer allocator.free(mut);
+    // version is at offset 8 (after 8-byte magic).
+    std.mem.writeInt(u32, mut[8..12], 999, .little);
+    try testing.expectError(error.UnsupportedVersion, deserialize(mut, allocator));
+}
+
+test "deserialize: rejects truncated input" {
+    const allocator = testing.allocator;
+    var cache = try buildSampleCache(allocator);
+    defer cache.deinit(allocator);
+    const bytes = try serialize(&cache, allocator);
+    defer allocator.free(bytes);
+    try testing.expectError(error.Truncated, deserialize(bytes[0 .. bytes.len - 5], allocator));
+}
+
+test "deserialize: rejects out-of-range patch_offset" {
+    const allocator = testing.allocator;
+    // Build a tiny cache by hand whose first function has a patch
+    // that points past the end of its code blob.
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    try buf.appendSlice(allocator, &cache_magic);
+    try appendU32(&buf, allocator, cache_format_version);
+    try appendU32(&buf, allocator, 0); // empty build id
+    try buf.append(allocator, @intFromEnum(passes.TargetArch.x86_64));
+    try buf.append(allocator, @intFromEnum(TargetAbi.x86_64_sysv));
+    try buf.appendSlice(allocator, &[_]u8{0} ** 32); // module_epoch
+    try appendU32(&buf, allocator, 1); // func_count
+    try buf.appendSlice(allocator, &[_]u8{0} ** 32); // ir_sha256
+    try appendU32(&buf, allocator, 4); // code_len = 4
+    try buf.appendSlice(allocator, &[_]u8{ 0, 0, 0, 0 });
+    try appendU32(&buf, allocator, 1); // patches_cnt
+    try appendU32(&buf, allocator, 5); // patch_offset = 5 (> 4-4 = 0; 5+4=9 > 4)
+    try appendU32(&buf, allocator, 0); // target_func_idx
+    try testing.expectError(error.InvalidPatchOffset, deserialize(buf.items, allocator));
+}
+
+test "deserialize: rejects target_func_idx >= func_count" {
+    const allocator = testing.allocator;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    try buf.appendSlice(allocator, &cache_magic);
+    try appendU32(&buf, allocator, cache_format_version);
+    try appendU32(&buf, allocator, 0);
+    try buf.append(allocator, @intFromEnum(passes.TargetArch.x86_64));
+    try buf.append(allocator, @intFromEnum(TargetAbi.x86_64_sysv));
+    try buf.appendSlice(allocator, &[_]u8{0} ** 32);
+    try appendU32(&buf, allocator, 1); // func_count = 1
+    try buf.appendSlice(allocator, &[_]u8{0} ** 32);
+    try appendU32(&buf, allocator, 8);
+    try buf.appendSlice(allocator, &[_]u8{0} ** 8);
+    try appendU32(&buf, allocator, 1);
+    try appendU32(&buf, allocator, 0);
+    try appendU32(&buf, allocator, 5); // target_func_idx = 5 >= func_count
+    try testing.expectError(error.InvalidTargetFuncIdx, deserialize(buf.items, allocator));
+}
+
+test "deserialize: rejects invalid arch / abi bytes" {
+    const allocator = testing.allocator;
+    var cache = try buildSampleCache(allocator);
+    defer cache.deinit(allocator);
+    const bytes = try serialize(&cache, allocator);
+    defer allocator.free(bytes);
+    {
+        var mut = try allocator.dupe(u8, bytes);
+        defer allocator.free(mut);
+        // Header layout:
+        //   magic [8] + version [4] + build_id_len [4] + build_id [N]
+        //   + arch [1] + abi [1] + module_epoch [32] + func_count [4] ...
+        const arch_off = 8 + 4 + 4 + cache.wamr_build_id.len;
+        mut[arch_off] = 99;
+        try testing.expectError(error.InvalidTargetArch, deserialize(mut, allocator));
+    }
+    {
+        var mut = try allocator.dupe(u8, bytes);
+        defer allocator.free(mut);
+        const abi_off = 8 + 4 + 4 + cache.wamr_build_id.len + 1;
+        mut[abi_off] = 99;
+        try testing.expectError(error.InvalidTargetAbi, deserialize(mut, allocator));
+    }
+}

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -12,6 +12,7 @@ const aarch64_compile = wamr.aarch64_compile;
 const passes = wamr.passes;
 const ir_print = wamr.ir_print;
 const ir = wamr.ir;
+const codegen_cache = wamr.codegen_cache;
 
 const TargetArch = passes.TargetArch;
 
@@ -82,6 +83,11 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         .aarch64 => .aarch64,
         else => .x86_64,
     };
+    // #761 Phase 2: optional per-function codegen cache (sidecar file).
+    // When set, wamrc reads <cache_path> at start (if it exists) and
+    // reuses cached per-function code for IR hashes that still match;
+    // writes the (possibly-updated) cache back to <cache_path> at end.
+    var cache_path: ?[]const u8 = null;
 
     // --dump-ir-after / --dump-ir-functions / --dump-ir-out collection.
     // `dump_pass_names` and `dump_func_globs` are owned by the arena
@@ -148,6 +154,11 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
             verify_mode = .paranoid;
         } else if (std.mem.eql(u8, a, "--no-verify-ir")) {
             verify_mode = .off;
+        } else if (std.mem.eql(u8, a, "--cache") and i + 1 < sub_args.len) {
+            i += 1;
+            cache_path = sub_args[i];
+        } else if (std.mem.startsWith(u8, a, "--cache=")) {
+            cache_path = a["--cache=".len..];
         } else if (a.len > 0 and a[0] == '-') {
             std.debug.print("error: unknown option '{s}' — try `wamrc compile help`\n", .{a});
             std.process.exit(1);
@@ -340,26 +351,73 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         }
     }
 
-    // 5. Compile IR to native code (target-dependent)
-    const CompileResult = x86_64_compile.CompileResult;
-    const compiled: CompileResult = switch (target_arch) {
-        .x86_64 => x86_64_compile.compileModule(&ir_module, allocator) catch |err| {
+    // 5. Compile IR to native code (target-dependent).
+    //
+    // #761 Phase 2: when `--cache <path>` was supplied, try to load
+    // the prior cache, validate every header field (magic / version /
+    // build id / arch / abi / module epoch / func count), and pass it
+    // to the cached codegen path. Any per-function ir_sha256 still
+    // matching the rebuilt IR reuses the cached native bytes; the
+    // rest fall back to full codegen. The new cache (always produced
+    // by compileModuleCached) is serialised + atomically written to
+    // <path> after a successful emit so the next bisect cycle can
+    // reuse it.
+    const target_abi = codegen_cache.TargetAbi.forHost(target_arch);
+    const epoch_inputs: codegen_cache.ModuleEpochInputs = .{
+        .wamr_build_id = wamr.version.string,
+        .target_arch = target_arch,
+        .target_abi = target_abi,
+        .import_count = ir_module.import_count,
+        .global_types = ir_module.global_types,
+        .global_offsets = ir_module.global_offsets,
+        .global_storage_size = ir_module.global_storage_size,
+        .func_types = ir_module.func_types.items,
+        .func_type_indices = ir_module.func_type_indices.items,
+    };
+    const module_epoch = codegen_cache.hashModuleEpoch(epoch_inputs);
+
+    var loaded_cache: ?codegen_cache.Cache = null;
+    defer if (loaded_cache) |*c| c.deinit(allocator);
+    if (cache_path) |cp| {
+        loaded_cache = loadCacheCompat(io, allocator, cp, .{
+            .wamr_build_id = wamr.version.string,
+            .target_arch = target_arch,
+            .target_abi = target_abi,
+            .module_epoch = module_epoch,
+            .func_count = @intCast(ir_module.functions.items.len),
+        });
+    }
+    const reuse_ptr: ?*const codegen_cache.Cache = if (loaded_cache) |*c| c else null;
+
+    const compiled: codegen_cache.CompileResultCached = switch (target_arch) {
+        .x86_64 => x86_64_compile.compileModuleCached(&ir_module, reuse_ptr, allocator) catch |err| {
             std.debug.print("Error compiling to x86-64: {}\n", .{err});
             std.process.exit(1);
         },
-        .aarch64 => blk: {
-            const r = aarch64_compile.compileModuleWithOptions(&ir_module, allocator, .{
-                .enable_scheduler = enable_aarch64_scheduler,
-                .enable_xreg_alloc = enable_aarch64_xreg_alloc,
-            }) catch |err| {
-                std.debug.print("Error compiling to AArch64: {}\n", .{err});
-                std.process.exit(1);
-            };
-            break :blk .{ .code = r.code, .offsets = r.offsets };
+        .aarch64 => aarch64_compile.compileModuleCachedWithOptions(&ir_module, reuse_ptr, allocator, .{
+            .enable_scheduler = enable_aarch64_scheduler,
+            .enable_xreg_alloc = enable_aarch64_xreg_alloc,
+        }) catch |err| {
+            std.debug.print("Error compiling to AArch64: {}\n", .{err});
+            std.process.exit(1);
         },
     };
     defer allocator.free(compiled.code);
     defer allocator.free(compiled.offsets);
+    defer {
+        for (compiled.cache_functions) |*f| {
+            allocator.free(f.code);
+            allocator.free(f.call_patches);
+        }
+        allocator.free(compiled.cache_functions);
+    }
+
+    if (cache_path != null) {
+        std.debug.print(
+            "Codegen cache: {d} reused, {d} recompiled (of {d} functions)\n",
+            .{ compiled.stats.reused, compiled.stats.recompiled, ir_module.functions.items.len },
+        );
+    }
 
     std.debug.print("Generated {d} bytes of native code\n", .{compiled.code.len});
 
@@ -616,6 +674,96 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
     };
 
     std.debug.print("Written {s} ({d} bytes)\n", .{ out_path, aot_binary.len });
+
+    // 8. Persist the codegen cache (Phase 2) if --cache was passed.
+    //    Write only after the cwasm itself is on disk so a partial
+    //    failure can't leave a cache pointing at an absent / older
+    //    artifact.
+    if (cache_path) |cp| {
+        const cache_to_write: codegen_cache.Cache = .{
+            .wamr_build_id = wamr.version.string,
+            .target_arch = target_arch,
+            .target_abi = target_abi,
+            .module_epoch = module_epoch,
+            .functions = compiled.cache_functions,
+        };
+        const cache_bytes = codegen_cache.serialize(&cache_to_write, allocator) catch |err| {
+            std.debug.print("warning: codegen cache: serialise failed: {} — cache not updated\n", .{err});
+            return;
+        };
+        defer allocator.free(cache_bytes);
+        writeFileAtomic(io, cp, cache_bytes) catch |err| {
+            std.debug.print("warning: codegen cache: write to {s} failed: {} — cache not updated\n", .{ cp, err });
+            return;
+        };
+        std.debug.print("Cache written {s} ({d} bytes)\n", .{ cp, cache_bytes.len });
+    }
+}
+
+/// Inputs for `loadCacheCompat`'s header-compatibility check.
+const CacheLoadCheck = struct {
+    wamr_build_id: []const u8,
+    target_arch: TargetArch,
+    target_abi: codegen_cache.TargetAbi,
+    module_epoch: [32]u8,
+    func_count: u32,
+};
+
+/// Try to read + deserialise + header-validate a codegen-cache sidecar.
+/// Returns null on any mismatch (with a one-line warning explaining
+/// which header field differed) so a fresh-but-incompatible cache
+/// degrades cleanly to "full recompile" instead of failing the build.
+fn loadCacheCompat(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    expect: CacheLoadCheck,
+) ?codegen_cache.Cache {
+    const cwd = std.Io.Dir.cwd();
+    const bytes = cwd.readFileAlloc(io, path, allocator, @enumFromInt(codegen_cache.max_cache_file_bytes)) catch |err| switch (err) {
+        error.FileNotFound => {
+            std.debug.print("Codegen cache: no existing cache at {s} — full recompile\n", .{path});
+            return null;
+        },
+        else => {
+            std.debug.print("warning: codegen cache: read {s} failed: {} — full recompile\n", .{ path, err });
+            return null;
+        },
+    };
+    defer allocator.free(bytes);
+
+    var cache = codegen_cache.deserialize(bytes, allocator) catch |err| {
+        std.debug.print("warning: codegen cache: {s} unreadable ({}) — full recompile\n", .{ path, err });
+        return null;
+    };
+    errdefer cache.deinit(allocator);
+
+    if (!std.mem.eql(u8, cache.wamr_build_id, expect.wamr_build_id)) {
+        std.debug.print("Codegen cache: build-id mismatch (cached={s}, current={s}) — full recompile\n", .{ cache.wamr_build_id, expect.wamr_build_id });
+        cache.deinit(allocator);
+        return null;
+    }
+    if (cache.target_arch != expect.target_arch) {
+        std.debug.print("Codegen cache: target-arch mismatch — full recompile\n", .{});
+        cache.deinit(allocator);
+        return null;
+    }
+    if (cache.target_abi != expect.target_abi) {
+        std.debug.print("Codegen cache: target-abi mismatch — full recompile\n", .{});
+        cache.deinit(allocator);
+        return null;
+    }
+    if (!std.mem.eql(u8, &cache.module_epoch, &expect.module_epoch)) {
+        std.debug.print("Codegen cache: module-epoch mismatch (imports/globals/types changed) — full recompile\n", .{});
+        cache.deinit(allocator);
+        return null;
+    }
+    if (cache.functions.len != expect.func_count) {
+        std.debug.print("Codegen cache: func-count mismatch (cached={d}, current={d}) — full recompile\n", .{ cache.functions.len, expect.func_count });
+        cache.deinit(allocator);
+        return null;
+    }
+    return cache;
 }
 
 fn defaultZeroValue(vt: wamr.types.ValType) wamr.types.Value {
@@ -669,6 +817,8 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
         .aarch64 => .aarch64,
         else => .x86_64,
     };
+    // #761 Phase 2: per-core codegen cache directory.
+    var cache_dir: ?[]const u8 = null;
 
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
@@ -692,6 +842,11 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
                 std.debug.print("error: unknown target '{s}'\n", .{v});
                 std.process.exit(1);
             }
+        } else if (std.mem.eql(u8, a, "--cache-dir") and i + 1 < sub_args.len) {
+            i += 1;
+            cache_dir = sub_args[i];
+        } else if (std.mem.startsWith(u8, a, "--cache-dir=")) {
+            cache_dir = a["--cache-dir=".len..];
         } else if (std.mem.startsWith(u8, a, "-")) {
             std.debug.print("error: unknown option '{s}'\n", .{a});
             std.process.exit(1);
@@ -732,6 +887,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
     var result = wamr.component_aot_compile.precompileComponent(allocator, component_data, manifest_path, .{
         .target_arch = target_arch,
         .optimize = optimize,
+        .cache_dir = cache_dir,
     }) catch |err| {
         std.debug.print("error: precompile failed: {s}\n", .{@errorName(err)});
         std.process.exit(1);
@@ -1193,6 +1349,16 @@ const compile_usage =
     \\                                 for release builds.
     \\  --no-verify-ir                Disable the IR verifier (overrides
     \\                                 the safety-build default).
+    \\  --cache <path>                #761 Phase 2 codegen cache sidecar.
+    \\                                 Read on entry (if exists) to reuse
+    \\                                 cached native code per function
+    \\                                 whose IR hash still matches; write
+    \\                                 the (possibly-updated) cache back
+    \\                                 to <path> after a successful emit.
+    \\                                 Cache is invalidated wholesale on
+    \\                                 any header mismatch (build id,
+    \\                                 target arch+abi, module-level
+    \\                                 codegen invariants, func count).
     \\
 ;
 
@@ -1210,6 +1376,13 @@ const compile_component_usage =
     \\  -o <manifest.json>            Manifest path (default: <input>.cwasm.json)
     \\  --target=<x86_64|aarch64>     Target architecture (default: host)
     \\  -O0                           Disable IR optimizations (every core)
+    \\  --cache-dir <dir>             #761 Phase 2 codegen cache root. Per
+    \\                                 core: read/write `<dir>/core<N>.cache`
+    \\                                 to reuse cached native code for any
+    \\                                 function whose IR hash still matches.
+    \\                                 Header-incompatible caches fall back
+    \\                                 to full recompile of that core
+    \\                                 (warn-only, never errors).
     \\
 ;
 

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -29,6 +29,7 @@ const core_types = @import("../runtime/common/types.zig");
 const interp_instance = @import("../runtime/interpreter/instance.zig");
 const config = @import("../config.zig");
 const aot_bisect = @import("../compiler/aot_bisect.zig");
+const codegen_cache = @import("../compiler/codegen_cache.zig");
 
 // Re-export the on-disk JSON schema from `aot.zig` so `precompileComponent`
 // and `loadManifest` agree on layout without duplicating the schema.
@@ -79,6 +80,26 @@ pub const PrecompileOptions = struct {
     /// `-O0` we know it's in the optimization pipeline; if it persists the
     /// bug is in the frontend / SSA / codegen.
     optimize: bool = true,
+    /// #761 Phase 2: per-core codegen cache directory. When non-null,
+    /// `precompileComponent` reads `<dir>/core<N>.cache` for each core
+    /// (if present, header-compatible) to reuse cached per-function
+    /// native code, and writes the updated cache back. Has no effect
+    /// on `compileCoreWasm` itself — use `compileCoreWasmCached`
+    /// directly for in-memory cache reuse.
+    cache_dir: ?[]const u8 = null,
+};
+
+/// Optional cache I/O for `compileCoreWasm` (#761 Phase 2).
+pub const CompileCacheCtx = struct {
+    /// Optional prior cache to consult for per-function reuse.
+    /// Borrowed; not freed by the callee.
+    reuse: ?*const codegen_cache.Cache = null,
+    /// When non-null, the freshly-built cache (along with build-id /
+    /// arch / abi / module_epoch suitable for the on-disk format) is
+    /// moved here. Caller owns and must call `Cache.deinit(allocator)`.
+    /// When null, the new cache is built and discarded internally
+    /// (zero observable change from old behaviour).
+    produced: ?*?codegen_cache.Cache = null,
 };
 
 /// AOT-compile a single core wasm module. Returns freshly-allocated
@@ -91,6 +112,18 @@ pub fn compileCoreWasm(
     allocator: std.mem.Allocator,
     wasm_bytes: []const u8,
     opts: PrecompileOptions,
+) PrecompileError![]u8 {
+    return compileCoreWasmCached(allocator, wasm_bytes, opts, .{});
+}
+
+/// Cache-aware variant of `compileCoreWasm`. Pass a `cache_ctx` to
+/// reuse cached per-function codegen from a prior compile and/or to
+/// capture the freshly-built cache for persisting next to the cwasm.
+pub fn compileCoreWasmCached(
+    allocator: std.mem.Allocator,
+    wasm_bytes: []const u8,
+    opts: PrecompileOptions,
+    cache_ctx: CompileCacheCtx,
 ) PrecompileError![]u8 {
     // Lifetime split mirrors `src/compiler/main.zig` (`wamrc compile`)
     // to bound peak memory on large modules (issue #640). The parsed
@@ -155,18 +188,63 @@ pub fn compileCoreWasm(
         };
     }
 
-    const code: []u8, const offsets: []u32 = switch (opts.target_arch) {
-        .aarch64 => blk: {
-            const r = aarch64_compile.compileModule(&ir_module, allocator) catch return error.CoreCompileFailed;
-            break :blk .{ r.code, r.offsets };
-        },
-        .x86_64 => blk: {
-            const r = x86_64_compile.compileModule(&ir_module, allocator) catch return error.CoreCompileFailed;
-            break :blk .{ r.code, r.offsets };
-        },
+    // #761 Phase 2: drive codegen through the cache-aware path so a
+    // caller-provided `reuse` short-circuits per-function compile for
+    // matching IR hashes, and the freshly-built cache can be moved
+    // back to the caller (typically the `wamrc compile-component
+    // --cache-dir <dir>` driver, which then persists one file per
+    // core). When `cache_ctx.reuse == null` and `cache_ctx.produced
+    // == null` the behaviour is identical to the historical
+    // non-cached path — we build the cache in memory and immediately
+    // free it on return.
+    const target_abi = codegen_cache.TargetAbi.forHost(opts.target_arch);
+    const epoch_inputs: codegen_cache.ModuleEpochInputs = .{
+        .wamr_build_id = config.version,
+        .target_arch = opts.target_arch,
+        .target_abi = target_abi,
+        .import_count = ir_module.import_count,
+        .global_types = ir_module.global_types,
+        .global_offsets = ir_module.global_offsets,
+        .global_storage_size = ir_module.global_storage_size,
+        .func_types = ir_module.func_types.items,
+        .func_type_indices = ir_module.func_type_indices.items,
     };
+    const module_epoch = codegen_cache.hashModuleEpoch(epoch_inputs);
+
+    const compiled: codegen_cache.CompileResultCached = switch (opts.target_arch) {
+        .aarch64 => aarch64_compile.compileModuleCached(&ir_module, cache_ctx.reuse, allocator) catch
+            return error.CoreCompileFailed,
+        .x86_64 => x86_64_compile.compileModuleCached(&ir_module, cache_ctx.reuse, allocator) catch
+            return error.CoreCompileFailed,
+    };
+    const code = compiled.code;
+    const offsets = compiled.offsets;
     defer allocator.free(code);
     defer allocator.free(offsets);
+
+    // Decide ownership of the freshly-built per-function cache entries.
+    // If the caller wants the cache, we move it into `*produced`;
+    // otherwise we own and free it on return.
+    var release_cache_funcs = true;
+    defer if (release_cache_funcs) {
+        for (compiled.cache_functions) |*f| {
+            allocator.free(f.code);
+            allocator.free(f.call_patches);
+        }
+        allocator.free(compiled.cache_functions);
+    };
+    if (cache_ctx.produced) |dst| {
+        const build_id_dup = allocator.dupe(u8, config.version) catch return error.OutOfMemory;
+        errdefer allocator.free(build_id_dup);
+        dst.* = codegen_cache.Cache{
+            .wamr_build_id = build_id_dup,
+            .target_arch = opts.target_arch,
+            .target_abi = target_abi,
+            .module_epoch = module_epoch,
+            .functions = compiled.cache_functions,
+        };
+        release_cache_funcs = false;
+    }
 
     // Short-lived arena for the emit-side field tables. `emit_aot.emit`
     // copies what it needs into its caller-owned output buffer, so
@@ -570,7 +648,39 @@ pub fn precompileComponent(
     entries.ensureTotalCapacity(ra, core_data_list.items.len) catch return error.OutOfMemory;
 
     for (core_data_list.items, 0..) |core_ref, idx| {
-        const cwasm = compileCoreWasm(allocator, core_ref.data, opts) catch |err| {
+        // #761 Phase 2: per-core codegen cache. Build the per-core
+        // cache path once; load+validate existing cache for reuse, and
+        // capture the freshly-built cache to persist back. Header
+        // mismatches are NOT errors — they just yield a warning + a
+        // full recompile for that core, matching the single-module
+        // `wamrc compile --cache` behaviour.
+        var per_core_cache_path: ?[]u8 = null;
+        defer if (per_core_cache_path) |p| allocator.free(p);
+        var loaded_cache: ?codegen_cache.Cache = null;
+        defer if (loaded_cache) |*c| c.deinit(allocator);
+        var produced_cache: ?codegen_cache.Cache = null;
+        defer if (produced_cache) |*c| c.deinit(allocator);
+
+        const cache_ctx: CompileCacheCtx = blk: {
+            const cd = opts.cache_dir orelse break :blk .{};
+            const p = std.fmt.allocPrint(allocator, "{s}/core{d}.cache", .{ cd, idx }) catch
+                return error.OutOfMemory;
+            per_core_cache_path = p;
+            cwd.createDirPath(io, cd) catch {};
+            // Best-effort load — any error degrades to full recompile
+            // for this core, with the new cache written below.
+            const bytes_or = cwd.readFileAlloc(io, p, allocator, @enumFromInt(codegen_cache.max_cache_file_bytes));
+            if (bytes_or) |bytes| {
+                defer allocator.free(bytes);
+                if (codegen_cache.deserialize(bytes, allocator)) |c| {
+                    loaded_cache = c;
+                } else |_| {}
+            } else |_| {}
+            const reuse_ptr: ?*const codegen_cache.Cache = if (loaded_cache) |*c| c else null;
+            break :blk .{ .reuse = reuse_ptr, .produced = &produced_cache };
+        };
+
+        const cwasm = compileCoreWasmCached(allocator, core_ref.data, opts, cache_ctx) catch |err| {
             std.log.err("precompileComponent: core {d} compile failed: {s}", .{ idx, @errorName(err) });
             return err;
         };
@@ -581,6 +691,22 @@ pub fn precompileComponent(
         dir.writeFile(io, .{ .sub_path = rel_path, .data = cwasm }) catch |err| {
             std.log.err("precompileComponent: write {s}/{s} failed: {s}", .{ parent_dir_path, rel_path, @errorName(err) });
             return error.WriteFailed;
+        };
+
+        // Persist the freshly-built cache (if any) AFTER the cwasm is
+        // on disk so a partial failure can't leave a cache that
+        // outlives its artifact.
+        if (per_core_cache_path) |p| if (produced_cache) |*pc| {
+            const bytes = codegen_cache.serialize(pc, allocator) catch |err| blk: {
+                std.log.warn("precompileComponent: core {d} cache serialise failed: {s}", .{ idx, @errorName(err) });
+                break :blk null;
+            };
+            if (bytes) |b| {
+                defer allocator.free(b);
+                cwd.writeFile(io, .{ .sub_path = p, .data = b }) catch |err| {
+                    std.log.warn("precompileComponent: core {d} cache write to {s} failed: {s}", .{ idx, p, @errorName(err) });
+                };
+            }
         };
 
         const hex = hexSha256(ra, cwasm) catch return error.OutOfMemory;

--- a/src/root.zig
+++ b/src/root.zig
@@ -93,6 +93,12 @@ pub const passes = @import("compiler/ir/passes.zig");
 /// `PassBisectSpec` consumed by `runPassesWithOptions` (#761 / #743).
 pub const aot_bisect = @import("compiler/aot_bisect.zig");
 
+/// AOT codegen cache (#761 Phase 2) — sidecar file format + canonical
+/// IR hasher + module-epoch hasher. Lets a recompile reuse cached
+/// native code for any function whose IR is unchanged from the
+/// previous build.
+pub const codegen_cache = @import("compiler/codegen_cache.zig");
+
 /// IR invariant checker run between passes (#624).
 pub const ir_verifier = @import("compiler/ir/verifier.zig");
 


### PR DESCRIPTION
Completes Phase 2 of #761 — sidecar codegen cache that lets a recompile reuse cached native code for any function whose IR sha256 still matches. Combined with the Phase 1 bisect knobs (#762), single-pass bisects on the #743 keyvault repro drop from minutes per cycle to seconds per cycle: only the suspect function re-codegens, the other ~12 k functions hit the cache.

**Per the user's instruction: NOT setting auto-merge — review wanted.**

## What this PR adds

Two commits:

1. **`compiler: codegen cache infrastructure (#761 Phase 2a)`** — pure-data module `src/compiler/codegen_cache.zig` with the on-disk cache format, the canonical IR hasher (`hashFunction`), and the module-level epoch hasher (`hashModuleEpoch`). 21 unit tests.

2. **`wamrc: --cache / --cache-dir codegen reuse (#761 Phase 2b)`** — `compileModuleCached` on both x86_64 and aarch64 backends; CLI flags on both compile entry points; per-core cache plumbing through `precompileComponent` via a new `compileCoreWasmCached` helper. 3 backend integration tests.

## CLI surface

```
wamrc compile --cache <path> input.wasm -o output.cwasm
wamrc compile-component --cache-dir <dir> input.wasm -o output.cwasm.json
```

Both flags are opt-in. Without them, behaviour is byte-identical to today.

## Key design decisions

* **Sidecar file, not embedded** — cwasm bytes are unchanged. The cache lives in a separate `<output>.cache` (single-module) or `<dir>/core<N>.cache` (per-component-core). No `manifest_format_version` bump needed.
* **`hashFunction` walks IR structurally, not via the printer** — `print.formatFunc` elides codegen-observable fields (SIMD lane indices, mem offsets, alignment, sign) and would cause silent false-positive cache hits. The structural hasher uses comptime reflection so new `Inst.Op` variants and payload fields are hashed automatically.
* **Wholesale rejection on header mismatch** — magic, version, wamr build id, target arch + ABI (sysv vs win64 generate substantially different code), module epoch (covers `import_count`, `global_types`, `global_offsets`, `global_storage_size`, `func_types`, `func_type_indices` — every IrModule field codegen reads), func count. Within a valid cache, per-function entries match by `ir_sha256`.
* **Per-function position-independence** verified by inspection: imports dispatch via `VmCtx`-indirect (no PC-rel), block branches + br_table intra-function, AArch64 conditional-branch relaxation runs inside `compileFunctionImpl` so cached bytes are post-relaxation. Only inter-function PC-relative calls need rebasing, and those are already exposed as `call_patches`.
* **Atomic write** — `writeFileAtomic` (tempfile + rename) so a crash mid-write can't leave a corrupt cache pointing at the freshly-written cwasm. The cache is written AFTER the cwasm itself succeeds.
* **Header-mismatch warnings never error** — a stale cache degrades to a full recompile with a one-line warning, so CI / users with old caches don't break.

## End-to-end verification

```
# Cold + warm single-module
$ rm -f /tmp/foo.cache
$ wamrc compile --cache /tmp/foo.cache tests/coldstart/noop.wasm -o /tmp/foo.cwasm
Codegen cache: no existing cache at /tmp/foo.cache — full recompile
Codegen cache: 0 reused, 1 recompiled (of 1 functions)
…
$ wamrc compile --cache /tmp/foo.cache tests/coldstart/noop.wasm -o /tmp/foo.cwasm
Codegen cache: 1 reused, 0 recompiled (of 1 functions)
…
$ cmp first.cwasm second.cwasm && echo BYTE-IDENTICAL
BYTE-IDENTICAL

# Cold + warm component (3 cores, all byte-identical)
$ wamrc compile-component --cache-dir /tmp/cache src/component/fixtures/stdio-echo.wasm -o /tmp/stdio.cwasm.json
$ wamrc compile-component --cache-dir /tmp/cache src/component/fixtures/stdio-echo.wasm -o /tmp/stdio2.cwasm.json
$ for i in 0 1 2; do cmp /tmp/stdio.$i.cwasm /tmp/stdio2.$i.cwasm && echo "core $i: byte-identical"; done
core 0: byte-identical
core 1: byte-identical
core 2: byte-identical

# Stale cache rejection — flip the build-id byte
$ python3 -c "d=bytearray(open('/tmp/foo.cache','rb').read()); d[16]^=1; open('/tmp/foo.cache','wb').write(d)"
$ wamrc compile --cache /tmp/foo.cache tests/coldstart/noop.wasm -o /tmp/foo.cwasm
Codegen cache: build-id mismatch (cached=eev, current=dev) — full recompile
Codegen cache: 0 reused, 1 recompiled (of 1 functions)
```

## Tests

* **21 unit tests** in `codegen_cache.zig` (commit 2a) — every parser branch, determinism, codegen-key sensitivity (SIMD lane / mem offset / op tag / const / locals), epoch sensitivity (arch / abi / import_count / globals), serialiser round-trip + 5 rejection paths.
* **3 backend integration tests** in `x86_64/compile.zig` (commit 2b) — no-reuse equals plain compileModule; warm cache reuses every function byte-identical; per-function IR mismatch recompiles only the changed one.

Full suite: `zig build test --summary all` → **68/68 steps, 3071/3078 passed** (was 3047/3054 baseline before Phase 2, +24 from new tests).

## Risk mitigations adopted from PR-1 design review

The Phase 2 design got a rubber-duck pass before implementation that flagged three blocking issues; all are fixed before this PR:

1. **`print.formatFunc` is not collision-safe** for codegen — fixed by writing a structural hasher with comptime reflection.
2. **`module_epoch` was too narrow** for aarch64 — now covers `global_types`, `global_storage_size`, `func_types`, `func_type_indices` too.
3. **`target_arch` alone is too weak** for x86_64 — added `TargetAbi` (`x86_64_sysv` / `x86_64_win64` / `aarch64_aapcs`) and stored separately in the cache header.

## Out of scope

* `--verify-cache` mode (re-run codegen on reused functions and assert byte-equal) — useful for defending against future codegen drift; deferred to a follow-up once Phase 2 sees real bisect cycles.
* Sharing caches across machines (paths are local).
* Parallel per-core codegen with shared cache (the current loop is sequential, matching today's `precompileComponent`).

Refs #743.