### PR TITLE
wamrc: differential-testing 'verify' subcommand (#757)

### DIFF
--- a/.github/skills/aot-diff-debug/SKILL.md
+++ b/.github/skills/aot-diff-debug/SKILL.md
@@ -1,20 +1,24 @@
 ---
 name: aot-diff-debug
-description: Debug AOT codegen mismatches by comparing interpreter vs AOT output on real wasm binaries. Use when AOT produces wrong results, CRC errors, garbled output, or any computation mismatch versus the interpreter.
+description: Debug AOT codegen mismatches by comparing wamr-AOT vs the wasmtime reference oracle on real wasm binaries. Use when AOT produces wrong results, CRC errors, garbled output, or any computation mismatch versus wasmtime.
 ---
 # AOT Differential Debugging
 
-Systematically find AOT codegen bugs by comparing interpreter and AOT execution of the same wasm binary. This skill encodes the lessons from debugging the CoreMark CRC bug (memory_fill r11 clobber, issue #109).
+Systematically find AOT codegen bugs by comparing wasmtime (the
+reference oracle) and wamr's AOT execution of the same wasm binary.
+This skill encodes the lessons from debugging the CoreMark CRC bug
+(memory_fill r11 clobber, issue #109) and the `String.prototype.slice`
+StarlingMonkey regression (#754).
 
 ## When to Use
 
 - AOT produces wrong numeric results, garbled text, or CRC errors
-- A wasm program works in the interpreter but fails in AOT
+- A wasm program works under wasmtime but fails under wamr's AOT
 - You suspect a codegen bug but don't know which instruction is wrong
 
 ## Core Principle
 
-**Use the interpreter as an oracle. Diff real outputs first, hypothesize second.**
+**Use wasmtime as an oracle. Diff real outputs first, hypothesize second.**
 
 Do NOT start by:
 - Reading codegen source code for suspicious patterns
@@ -22,55 +26,74 @@ Do NOT start by:
 - Auditing register allocation or spill/reload logic
 
 DO start by:
-- Running the same binary through both paths and comparing output
+- Running the same binary through both runtimes and comparing output
 
 ## Workflow
 
 ### Phase 1: Reproduce and Diff (do this FIRST, every time)
 
-1. **Identify the wasm binary** that produces wrong results in AOT.
+Use the built-in `wamrc verify` subcommand (#757). It compiles the
+wasm to AOT, runs it under both `wamr` and `wasmtime`, and prints
+the first-divergence offset with hex+ASCII context on each side:
 
-2. **Run through both paths** and capture output:
-   ```powershell
-   # Interpreter (the oracle — always correct)
-   .\zig-out\bin\wamr.exe program.wasm > interp-out.txt 2>&1
+```sh
+./zig-out/bin/wamrc verify program.wasm
+```
 
-   # AOT
-   .\zig-out\bin\wamrc.exe -o program.aot program.wasm
-   .\zig-out\bin\wamr.exe program.aot > aot-out.txt 2>&1
-   ```
+Exit codes:
+- `0` — outputs match
+- `1` — divergence found (the printed report names the offset)
+- `2` — setup error (e.g. wasmtime missing)
 
-3. **Diff the outputs** byte-by-byte. Find the FIRST divergence:
-   ```powershell
-   $interp = Get-Content interp-out.txt
-   $aot = Get-Content aot-out.txt
-   for ($i = 0; $i -lt [Math]::Min($interp.Count, $aot.Count); $i++) {
-       if ($interp[$i] -ne $aot[$i]) {
-           Write-Host "FIRST DIFF at line $($i+1):"
-           Write-Host "  INTERP: $($interp[$i])"
-           Write-Host "  AOT:    $($aot[$i])"
-           break
-       }
-   }
-   ```
+For a guest-arg-sensitive case:
 
-4. **Characterize the divergence**:
-   - Is it a wrong number? (codegen arithmetic bug)
-   - Is it garbled characters? (memory corruption or wrong pointer)
-   - Is it extra/missing output? (control flow bug)
-   - Is it a specific character that's always wrong? (lookup table or constant bug)
+```sh
+./zig-out/bin/wamrc verify program.wasm -- arg1 arg2
+```
+
+To also mount host directories or pass env vars (translated to the
+right flag spelling for each runtime):
+
+```sh
+./zig-out/bin/wamrc verify program.wasm --map-dir /host/data::/work --env LOG=trace
+```
+
+Run `wamrc verify help` for the full flag list (timeouts, JSON
+output for scripting, `--keep-cwasm` for post-mortem, etc.).
+
+**Characterize the divergence** from the report:
+- Is it a wrong number? (codegen arithmetic bug)
+- Is it garbled characters? (memory corruption or wrong pointer)
+- Is it extra/missing output? (control flow bug)
+- Is it a specific character that's always wrong? (lookup table or
+  constant bug)
+
+#### Fallback when wasmtime isn't available
+
+If wasmtime isn't on the box, run the wamr arm directly and diff
+against a previously-known-good capture from another runtime
+(wasmtime on another machine, or a known good wamr build for a
+regression bisect):
+
+```sh
+./zig-out/bin/wamrc run program.wasm > wamr-out.txt 2>&1
+diff wamr-out.txt golden-out.txt
+```
+
+Install wasmtime instead — `wamrc verify` is the right tool here —
+this fallback is for environments where that isn't possible.
 
 ### Phase 2: Build a Minimal Reproducer
 
-Once you know WHAT is wrong from Phase 1, build the smallest C program that reproduces it.
+Once you know WHAT is wrong from Phase 1, build the smallest C
+program that reproduces it.
 
-**Key technique**: compile C to wasm32-wasi, run through both paths:
-```powershell
-$zig = "path\to\zig.exe"
-& $zig build-exe test.c -target wasm32-wasi -lc -O ReleaseFast --name test
-.\zig-out\bin\wamr.exe test.wasm        # interpreter
-.\zig-out\bin\wamrc.exe -o test.aot test.wasm
-.\zig-out\bin\wamr.exe test.aot         # AOT
+**Key technique**: compile C to wasm32-wasi, run `wamrc verify`
+again on the minimal program:
+
+```sh
+zig build-exe test.c -target wasm32-wasi -lc -O ReleaseFast --name test
+./zig-out/bin/wamrc verify test.wasm
 ```
 
 **Minimization strategy** (in order):
@@ -122,19 +145,22 @@ Once you have a minimal reproducer (ideally <10 lines of C):
    ```
 
 2. **Run unit tests**: `zig build test`
-3. **Run the minimal reproducer** through both interpreter and AOT — outputs must match
-4. **Run the original failing program** (e.g., CoreMark) — CRCs/output must match
+3. **Re-run the diff**: `./zig-out/bin/wamrc verify test.wasm` — must
+   exit 0 (outputs match)
+4. **Re-run the original failing program** (e.g., CoreMark) through
+   `wamrc verify` — outputs must match
 5. **Run spec tests**: `zig build spec-tests-aot` (check for regressions)
 
 ## Anti-Patterns (things that waste time)
 
 | Anti-Pattern | Why It Wastes Time | Do Instead |
 |---|---|---|
-| Reading codegen handlers looking for bugs | Too many handlers, bug could be anywhere | Diff real output first |
+| Reading codegen handlers looking for bugs | Too many handlers, bug could be anywhere | Diff real output with `wamrc verify` first |
 | Building synthetic wasm tests for hypothesized opcodes | Tests pass because they don't exercise the real pattern | Build minimal C reproducer of the actual failure |
 | Testing with different register counts | Only eliminates allocatable-reg bugs, not scratch-reg bugs | Check scratch register clobbers in handlers |
 | Assuming "spec tests pass ∴ all opcodes correct" | Spec tests don't test libc internals or complex interactions | Test with real programs |
 | Hypothesizing before observing | Leads to confirmation bias | Always observe the divergence first |
+| Hand-building probe scripts to find the divergence | Hours of wiring vs one command | Use `wamrc verify` — that's literally what it's for (#754 spent 6 hours pre-verify, the actual fix was 13 lines) |
 
 ## Historical Bugs Found with This Approach
 
@@ -147,8 +173,23 @@ Once you have a minimal reproducer (ideally <10 lines of C):
 - **Time wasted before this approach**: ~8 hours of hypothesis-driven debugging
 - **Time with this approach**: <1 hour
 
+### `String.prototype.slice` regression (issue #754)
+- **Symptom**: jco-componentize-built JS guests returned `""` from
+  `"hello".slice(0, 3)` (expected `"hel"`) under wamr-AOT; wasmtime
+  was correct.
+- **Phase 1 (if `wamrc verify` had existed)**: one command — would
+  have shown the empty-string divergence at the first `slice`-shaped
+  line of `Math.min(3, 11) =` output. Bisect to the
+  `frontend.zig:lowerFunction` select-type fix-up's fixpoint loop
+  follows in ~30 min.
+- **Time wasted before this approach**: ~6 hours of probe-building.
+- **Time with `wamrc verify`**: estimated <30 min. The fixture is
+  preserved at `tests/regressions/754-slice/`.
+
 ## References
 
+- `src/compiler/verify.zig` — `wamrc verify` orchestrator (#757)
+- `src/compiler/verify_args.zig` — flag parser + per-runtime translation
 - `src/compiler/codegen/x86_64/compile.zig` — x86-64 instruction handlers
 - `src/compiler/codegen/x86_64/compile.zig:1298` — `dump_func_idx` / `dump_all` debug knobs
 - `src/compiler/frontend.zig` — wasm-to-IR translation

--- a/build.zig
+++ b/build.zig
@@ -509,6 +509,30 @@ pub fn build(b: *std.Build) void {
         }
     }
 
+    // #757 `wamrc verify` smoke (no wasmtime required):
+    //   * `verify help` → exit 0 + non-empty stdout.
+    //   * `verify --wasmtime-bin=/dev/null/nope <wasm>` → spawn fails →
+    //     exit 2 (setup error). Exercises the binary-resolution +
+    //     "spawn failed = setup error" wiring without needing
+    //     wasmtime on the test runner's PATH.
+    // Reuses the 339-byte `tests/regressions/760-aot-cli-exit/exit-ok.wasm`
+    // (a valid component the AOT precompile accepts) so the smoke
+    // gets past the precompile step before the wasmtime spawn fails.
+    if (aot_trampoline_pool_target) {
+        const verify_help = b.addRunArtifact(wamrc);
+        verify_help.addArgs(&.{ "verify", "help" });
+        verify_help.expectExitCode(0);
+        test_step.dependOn(&verify_help.step);
+
+        const verify_no_wasmtime = b.addRunArtifact(wamrc);
+        verify_no_wasmtime.addArgs(&.{ "verify", "--wasmtime-bin=/dev/null/nope-wamrc-757" });
+        verify_no_wasmtime.addFileArg(b.path("tests/regressions/760-aot-cli-exit/exit-ok.wasm"));
+        verify_no_wasmtime.setEnvironmentVariable("WAMR_BIN", b.getInstallPath(.bin, "wamr"));
+        verify_no_wasmtime.step.dependOn(b.getInstallStep());
+        verify_no_wasmtime.expectExitCode(2);
+        test_step.dependOn(&verify_no_wasmtime.step);
+    }
+
     // Compiler IR passes tests (separate module to avoid root/wamr conflict)
     const passes_test_module = b.createModule(.{
         .root_source_file = b.path("src/compiler/ir/passes.zig"),

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -16,12 +16,24 @@ const codegen_cache = wamr.codegen_cache;
 
 const TargetArch = passes.TargetArch;
 
-const Subcommand = enum { compile, compile_component, run, version, help };
+const verify_mod = @import("verify.zig");
+// Bring the unit tests in `verify.zig` and `verify_args.zig` into the
+// `wamrc_unit_tests` test runner's reachable set. Without this they
+// would only execute if some non-test code path imported them — which
+// is true for `verify_mod` itself, but `verify_args` is reached only
+// transitively through it, so the test discovery sweep needs an
+// explicit anchor.
+comptime {
+    _ = @import("verify_args.zig");
+}
+
+const Subcommand = enum { compile, compile_component, run, verify, version, help };
 
 fn parseSubcommand(s: []const u8) ?Subcommand {
     if (std.mem.eql(u8, s, "compile")) return .compile;
     if (std.mem.eql(u8, s, "compile-component")) return .compile_component;
     if (std.mem.eql(u8, s, "run")) return .run;
+    if (std.mem.eql(u8, s, "verify")) return .verify;
     if (std.mem.eql(u8, s, "version")) return .version;
     if (std.mem.eql(u8, s, "help")) return .help;
     return null;
@@ -57,6 +69,7 @@ pub fn main(init: std.process.Init) !void {
         .compile => try runCompile(init, allocator, args[2..]),
         .compile_component => try runCompileComponent(init, allocator, args[2..]),
         .run => try runRun(init, allocator, args[2..]),
+        .verify => try runVerify(init, allocator, args[2..]),
     }
 }
 
@@ -1098,6 +1111,48 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
     }
 }
 
+fn runVerify(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
+    if (sub_args.len == 1 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, verify_usage);
+        return;
+    }
+
+    var diag: verify_mod.ParseDiagnostic = .{};
+    var parsed = verify_mod.parse(allocator, sub_args, &diag) catch |err| {
+        switch (err) {
+            error.MissingInputPath => std.debug.print(
+                "error: missing input wasm file — try `wamrc verify help`\n",
+                .{},
+            ),
+            error.DuplicateInputPath => std.debug.print(
+                "error: unexpected extra positional '{s}' (only one input wasm allowed) — try `wamrc verify help`\n",
+                .{diag.value},
+            ),
+            error.UnknownOption => std.debug.print(
+                "error: unknown option '{s}' — try `wamrc verify help`\n",
+                .{diag.option},
+            ),
+            error.MissingValue => std.debug.print(
+                "error: option '{s}' requires a value — try `wamrc verify help`\n",
+                .{diag.option},
+            ),
+            error.InvalidIntegerArgument => std.debug.print(
+                "error: option '{s}' expects an integer, got '{s}' — try `wamrc verify help`\n",
+                .{ diag.option, diag.value },
+            ),
+            error.OutOfMemory => std.debug.print("error: out of memory parsing args\n", .{}),
+        }
+        std.process.exit(2);
+    };
+    defer parsed.deinit();
+
+    const exit_code = verify_mod.run(init, allocator, parsed.options) catch |err| {
+        std.debug.print("error: verify failed: {s}\n", .{@errorName(err)});
+        std.process.exit(2);
+    };
+    std.process.exit(exit_code);
+}
+
 fn parseTargetArchOrDie(s: []const u8) TargetArch {
     if (std.mem.eql(u8, s, "aarch64")) return .aarch64;
     if (std.mem.eql(u8, s, "x86_64") or std.mem.eql(u8, s, "x86-64")) return .x86_64;
@@ -1290,6 +1345,7 @@ const top_usage =
     \\  compile             Compile a .wasm module to a .cwasm AOT binary
     \\  compile-component   Precompile every embedded core of a component
     \\  run                 Compile (if needed) and execute via the wamr runtime
+    \\  verify              Differential-test wamr-AOT vs wasmtime on a wasm
     \\  version             Print version and exit
     \\  help                Print this help
     \\
@@ -1416,6 +1472,61 @@ const run_usage =
     \\                                 for components)
     \\  --force                       Recompile even if the artifact is fresh
     \\  --target=<x86_64|aarch64>     Target architecture (default: host)
+    \\
+;
+
+const verify_usage =
+    \\Usage: wamrc verify [options] <input.wasm> [-- <guest args...>]
+    \\
+    \\Differential-test wamr-AOT against wasmtime (the reference oracle)
+    \\on <input.wasm>. Compiles the wasm to AOT, runs it under both
+    \\runtimes with the same flags + guest argv, diffs stdout (by
+    \\default) / stderr / exit codes, and exits:
+    \\
+    \\  0  outputs match
+    \\  1  divergence found (first-difference offset is printed with
+    \\     hex+ASCII context on each side; see --hex-context)
+    \\  2  setup error (missing wasmtime, AOT compile failure, …)
+    \\
+    \\Why wasmtime: it's the de-facto reference implementation, already
+    \\installed on every wamr dev box, and a black-box oracle catches
+    \\the bigger bug class — things both wamr engines share (canon-lift
+    \\quirks, adapter bugs) that an interp-vs-AOT diff would miss.
+    \\
+    \\Motivating case: issue #754 took ~6 hours to bisect; the actual
+    \\fix was 13 lines. A built-in differential tester would have
+    \\shortened that to minutes. See also
+    \\`.github/skills/aot-diff-debug/SKILL.md`.
+    \\
+    \\Binary resolution:
+    \\  wasmtime: --wasmtime-bin → $WASMTIME_BIN → `wasmtime` on $PATH.
+    \\  wamr:     --wamr-bin → $WAMR_BIN → sibling-of-wamrc → `wamr` on $PATH.
+    \\
+    \\Options:
+    \\  --map-dir HOST::GUEST    Mount a host directory on both runs.
+    \\                           Translates to `--dir` for wasmtime and
+    \\                           `--map-dir` for wamr. Repeatable.
+    \\  --env KEY=VALUE          Pass an env var to both runs. Repeatable.
+    \\  --max-runtime <SEC>      Per-runtime watchdog (default 60).
+    \\                           Killed and reported as divergence if
+    \\                           exceeded. 0 disables the watchdog.
+    \\  --hex-context <N>        Bytes of hex+ASCII context shown on each
+    \\                           side of the first-diff offset (default 32).
+    \\  --stdout-only            Diff only stdout (default).
+    \\  --stderr-only            Diff only stderr.
+    \\  --diff-everything        Diff stdout AND stderr.
+    \\  --strict-exit            Require matching exit codes too. Off by
+    \\                           default — wamr's "successful run then
+    \\                           host SIGSEGV" failure class (#760) would
+    \\                           otherwise drown out codegen regressions.
+    \\  --keep-cwasm             Leave the precompiled artifacts in the
+    \\                           staging dir for post-mortem inspection.
+    \\                           Default: cleaned up on exit.
+    \\  --json                   Emit a single-line JSON report instead
+    \\                           of human-readable text. Exit-code
+    \\                           semantics are unchanged.
+    \\  --wasmtime-bin <path>    Override wasmtime resolution.
+    \\  --wamr-bin <path>        Override wamr resolution.
     \\
 ;
 

--- a/src/compiler/verify.zig
+++ b/src/compiler/verify.zig
@@ -1,0 +1,634 @@
+//! `wamrc verify <wasm>` — differential testing harness (issue #757).
+//!
+//! Compiles the input wasm under wamr-AOT, runs it under both wamr
+//! (the subject) and wasmtime (the oracle), and diffs stdout (by
+//! default), stderr, and exit codes. Exits 0 on match, 1 on
+//! divergence, 2 on setup error.
+//!
+//! Why wasmtime as the oracle (and not wamr's interpreter): wamr's
+//! interp may be removed entirely in the future — building tooling
+//! on top of it is wasted work. Black-box differential against an
+//! external runtime also catches the bigger bug class: things both
+//! wamr engines share (canon-lift quirks, adapter bugs, …) that an
+//! interp-vs-AOT diff would miss. wasmtime is already on every
+//! wamr dev box (`/home/g/.wasmtime/bin/wasmtime`) and CI runner.
+//!
+//! Why direct std.process subprocesses (and not re-using `wamrc run`
+//! recursively for the wamr arm): keeps the precompile step inside
+//! the same process so allocations and per-pass diagnostics stream
+//! through one allocator instead of two, and avoids the
+//! sibling-`.cwasm.json` discovery dance polluting the source tree
+//! (the temp staging dir under `/tmp/wamrc-verify-<pid>/` is wiped
+//! on exit unless `--keep-cwasm`).
+//!
+//! Motivating use case: #754 took ~6 hours to bisect. The actual fix
+//! was 13 lines. The slow part was building probes to localize
+//! divergence between wamr-AOT and wasmtime. A one-line
+//! `wamrc verify` would have shortened that to ~30 minutes.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const wamr = @import("wamr");
+const verify_args = @import("verify_args.zig");
+
+pub const Options = verify_args.Options;
+pub const ParseDiagnostic = verify_args.ParseDiagnostic;
+pub const ParseError = verify_args.ParseError;
+pub const parse = verify_args.parse;
+
+/// Top-level outcome reported through both human and JSON renderers.
+/// Exit codes:
+///   `.match`         → 0
+///   `.diverged`      → 1
+///   `.setup_error`   → 2
+pub const Outcome = enum { match, diverged, setup_error };
+
+/// One side's captured run shape.
+const RunCapture = struct {
+    stdout: []u8,
+    stderr: []u8,
+    /// Exit code if the runtime exited normally. `null` covers
+    /// signals, stops, unknown statuses, and timeout kills — every
+    /// case where there is no clean numeric code to compare against.
+    /// Pair with `term_tag` for the human-readable termination class.
+    exit_code: ?u8,
+    term_tag: TermTag,
+    elapsed_ms: i64,
+
+    pub fn deinit(self: *RunCapture, allocator: std.mem.Allocator) void {
+        allocator.free(self.stdout);
+        allocator.free(self.stderr);
+    }
+};
+
+const TermTag = enum {
+    exited,
+    signal,
+    stopped,
+    unknown,
+    timeout,
+    spawn_failed,
+
+    fn name(self: TermTag) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// Public entry point. Returns the exit code `wamrc` should
+/// propagate; never calls `std.process.exit` itself so the caller
+/// (`main.zig:runVerify`) keeps responsibility for top-level
+/// process termination semantics.
+pub fn run(
+    init: std.process.Init,
+    allocator: std.mem.Allocator,
+    options: Options,
+) !u8 {
+    // 1. Read the input wasm. `verify` only inspects bytes (component
+    //    vs core wasm + AOT precompile); the source file is also
+    //    handed verbatim to both runtimes' CLIs.
+    const io = init.io;
+    const cwd = std.Io.Dir.cwd();
+    const wasm_data = cwd.readFileAlloc(io, options.wasm_path, allocator, @enumFromInt(256 * 1024 * 1024)) catch |err| {
+        std.debug.print("[verify] error: failed to read '{s}': {s}\n", .{ options.wasm_path, @errorName(err) });
+        return 2;
+    };
+    defer allocator.free(wasm_data);
+
+    const is_component = wamr.component_aot.isComponent(wasm_data) catch {
+        std.debug.print("[verify] error: '{s}' is not a valid wasm module or component\n", .{options.wasm_path});
+        return 2;
+    };
+
+    // 2. Resolve runtime binaries. Errors here are setup errors
+    //    (exit 2) — a clear "install wasmtime ≥ 45 / set WASMTIME_BIN"
+    //    is the action item, not a divergence report.
+    const wasmtime_bin = try resolveWasmtimeBinary(allocator, init.environ_map, options.wasmtime_bin) orelse {
+        std.debug.print(
+            "[verify] error: wasmtime not found.\n" ++
+                "  Install wasmtime ≥ 45 (https://wasmtime.dev/install/),\n" ++
+                "  set $WASMTIME_BIN, or pass --wasmtime-bin <path>.\n",
+            .{},
+        );
+        return 2;
+    };
+    defer allocator.free(wasmtime_bin);
+
+    const wamr_bin = try resolveWamrBinary(allocator, io, init.environ_map, options.wamr_bin);
+    defer allocator.free(wamr_bin);
+
+    // 3. Stage AOT artifacts in a per-pid temp dir so the source
+    //    tree stays clean. The dir holds the manifest sidecar +
+    //    per-core .cwasm files for components, or the single .cwasm
+    //    for a core module. Cleaned up on return unless --keep-cwasm.
+    const stage = stageDir(allocator, io) catch |err| {
+        std.debug.print("[verify] error: failed to create staging dir: {s}\n", .{@errorName(err)});
+        return 2;
+    };
+    defer allocator.free(stage.dir);
+    defer if (!options.keep_cwasm) {
+        std.Io.Dir.cwd().deleteTree(io, stage.dir) catch |err| {
+            std.debug.print("[verify] warning: failed to clean up '{s}': {s}\n", .{ stage.dir, @errorName(err) });
+        };
+    };
+    if (options.keep_cwasm) {
+        std.debug.print("[verify] --keep-cwasm: artifacts staying in {s}\n", .{stage.dir});
+    }
+
+    // 4. AOT compile. Component path writes a sibling manifest +
+    //    .N.cwasm files inside `stage.dir`; core wasm writes one
+    //    `program.cwasm`. The wamr arm consumes those via
+    //    `--precompiled-manifest=` so it never auto-probes next to
+    //    the source.
+    std.debug.print("[verify] compiling AOT...\n", .{});
+    var precompiled_manifest_path: ?[]u8 = null;
+    defer if (precompiled_manifest_path) |p| allocator.free(p);
+    var core_cwasm_path: ?[]u8 = null;
+    defer if (core_cwasm_path) |p| allocator.free(p);
+
+    if (is_component) {
+        const mp = try std.fs.path.join(allocator, &.{ stage.dir, "manifest.cwasm.json" });
+        var result = wamr.component_aot_compile.precompileComponent(allocator, wasm_data, mp, .{}) catch |err| {
+            std.debug.print("[verify] error: AOT precompile failed: {s}\n", .{@errorName(err)});
+            allocator.free(mp);
+            return 2;
+        };
+        result.deinit();
+        precompiled_manifest_path = mp;
+    } else {
+        const cp = try std.fs.path.join(allocator, &.{ stage.dir, "program.cwasm" });
+        const cwasm_bytes = wamr.component_aot_compile.compileCoreWasm(allocator, wasm_data, .{}) catch |err| {
+            std.debug.print("[verify] error: AOT compile failed: {s}\n", .{@errorName(err)});
+            allocator.free(cp);
+            return 2;
+        };
+        defer allocator.free(cwasm_bytes);
+        cwd.writeFile(io, .{ .sub_path = cp, .data = cwasm_bytes }) catch |err| {
+            std.debug.print("[verify] error: failed to write {s}: {s}\n", .{ cp, @errorName(err) });
+            allocator.free(cp);
+            return 2;
+        };
+        core_cwasm_path = cp;
+    }
+    std.debug.print("[verify] AOT compile done\n", .{});
+
+    // 5. Run wasmtime (the oracle).
+    var oracle = try runWasmtime(allocator, io, wasmtime_bin, options);
+    defer oracle.deinit(allocator);
+    reportSide("wasmtime (oracle)", &oracle);
+    if (oracle.term_tag == .spawn_failed) return 2;
+
+    // 6. Run wamr (the subject).
+    var subject = try runWamr(
+        allocator,
+        io,
+        wamr_bin,
+        options,
+        precompiled_manifest_path,
+        core_cwasm_path,
+        is_component,
+    );
+    defer subject.deinit(allocator);
+    reportSide("wamr (subject)", &subject);
+    if (subject.term_tag == .spawn_failed) return 2;
+
+    // 7. Diff and report.
+    return diffAndReport(allocator, options, oracle, subject);
+}
+
+// ── Binary resolution ───────────────────────────────────────────────────
+
+fn resolveWasmtimeBinary(
+    allocator: std.mem.Allocator,
+    env: *const std.process.Environ.Map,
+    override: ?[]const u8,
+) !?[]u8 {
+    if (override) |p| {
+        if (p.len > 0) return try allocator.dupe(u8, p);
+    }
+    if (env.get("WASMTIME_BIN")) |p| {
+        if (p.len > 0) return try allocator.dupe(u8, p);
+    }
+    // Don't probe PATH ourselves — `spawn` does that. Returning the
+    // bare name lets the OS resolve it and surface a clearer
+    // FileNotFound if it really isn't installed.
+    return try allocator.dupe(u8, "wasmtime");
+}
+
+fn resolveWamrBinary(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    env: *const std.process.Environ.Map,
+    override: ?[]const u8,
+) ![]u8 {
+    if (override) |p| {
+        if (p.len > 0) return try allocator.dupe(u8, p);
+    }
+    if (env.get("WAMR_BIN")) |p| {
+        if (p.len > 0) return try allocator.dupe(u8, p);
+    }
+    // Sibling-next-to-wamrc fallback mirrors `runRun`'s
+    // `findWamrBinary` in main.zig — keeps behaviour consistent so
+    // a `wamrc verify` works without explicit configuration on a
+    // freshly-built tree.
+    var exe_buf: [std.fs.max_path_bytes]u8 = undefined;
+    if (std.process.executablePath(io, &exe_buf)) |n| {
+        const exe_path = exe_buf[0..n];
+        const dir = std.fs.path.dirname(exe_path) orelse "";
+        if (dir.len > 0) {
+            return try std.fs.path.join(allocator, &.{ dir, "wamr" });
+        }
+    } else |_| {}
+    return try allocator.dupe(u8, "wamr");
+}
+
+// ── Subprocess invocations ──────────────────────────────────────────────
+
+const StageInfo = struct { dir: []u8 };
+
+fn stageDir(allocator: std.mem.Allocator, io: std.Io) !StageInfo {
+    // `/tmp/wamrc-verify-<pid>` — the pid suffix prevents collisions
+    // between parallel `wamrc verify` invocations on the same box.
+    const pid: i64 = @intCast(std.os.linux.getpid());
+    const dir = try std.fmt.allocPrint(allocator, "/tmp/wamrc-verify-{d}", .{pid});
+    errdefer allocator.free(dir);
+    std.Io.Dir.cwd().createDirPath(io, dir) catch |err| switch (err) {
+        else => return err,
+    };
+    return .{ .dir = dir };
+}
+
+fn runWasmtime(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    wasmtime_bin: []const u8,
+    options: Options,
+) !RunCapture {
+    var args: std.ArrayList([]const u8) = .empty;
+    defer args.deinit(allocator);
+    try verify_args.buildWasmtimeArgs(allocator, options, wasmtime_bin, &args);
+    return spawnAndCapture(allocator, io, args.items, options.max_runtime_seconds);
+}
+
+fn runWamr(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    wamr_bin: []const u8,
+    options: Options,
+    precompiled_manifest_path: ?[]const u8,
+    core_cwasm_path: ?[]const u8,
+    is_component: bool,
+) !RunCapture {
+    var args: std.ArrayList([]const u8) = .empty;
+    defer args.deinit(allocator);
+
+    // `--precompiled-manifest=<staged path>` is the only argv slot
+    // that needs an allocation past the parsed-Options slice
+    // lifetimes — everything else either borrows from the caller's
+    // argv or the staging-dir paths we already own. Capture it here
+    // so its `defer free` lives in the same scope as the `spawn`.
+    var manifest_arg: ?[]u8 = null;
+    defer if (manifest_arg) |m| allocator.free(m);
+
+    // wamr CLI: `wamr run [--precompiled-manifest=<p>] [--map-dir A::B]
+    //                     [--env K=V] <input> [-- guest-args...]`.
+    // Build it longhand here instead of calling verify_args.buildWamrArgs
+    // because we also need to inject `--precompiled-manifest` (when the
+    // input is a component) or swap the input path for the precompiled
+    // `.cwasm` (when it's a core module) — those are verify-specific
+    // wirings, not shared with anything else.
+    try args.append(allocator, wamr_bin);
+    try args.append(allocator, "run");
+    if (is_component) {
+        if (precompiled_manifest_path) |p| {
+            manifest_arg = try std.fmt.allocPrint(allocator, "--precompiled-manifest={s}", .{p});
+            try args.append(allocator, manifest_arg.?);
+        }
+    }
+    for (options.map_dirs) |md| {
+        try args.append(allocator, "--map-dir");
+        try args.append(allocator, md);
+    }
+    for (options.env_vars) |ev| {
+        try args.append(allocator, "--env");
+        try args.append(allocator, ev);
+    }
+    if (is_component) {
+        try args.append(allocator, options.wasm_path);
+    } else if (core_cwasm_path) |p| {
+        try args.append(allocator, p);
+    } else {
+        try args.append(allocator, options.wasm_path);
+    }
+    if (options.guest_args.len > 0) {
+        try args.append(allocator, "--");
+        for (options.guest_args) |ga| try args.append(allocator, ga);
+    }
+
+    return spawnAndCapture(allocator, io, args.items, options.max_runtime_seconds);
+}
+
+fn nowMs(io: std.Io) i64 {
+    return std.Io.Clock.awake.now(io).toMilliseconds();
+}
+
+fn spawnAndCapture(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    argv: []const []const u8,
+    max_runtime_seconds: u32,
+) !RunCapture {
+    const start_ms = nowMs(io);
+    const timeout: std.Io.Timeout = if (max_runtime_seconds == 0)
+        .none
+    else
+        .{ .duration = .{ .raw = .fromSeconds(@intCast(max_runtime_seconds)), .clock = .awake } };
+    const result = std.process.run(allocator, io, .{
+        .argv = argv,
+        .timeout = timeout,
+    }) catch |err| {
+        const elapsed_ms = nowMs(io) - start_ms;
+        switch (err) {
+            error.Timeout => {
+                return .{
+                    .stdout = try allocator.alloc(u8, 0),
+                    .stderr = try allocator.alloc(u8, 0),
+                    .exit_code = null,
+                    .term_tag = .timeout,
+                    .elapsed_ms = elapsed_ms,
+                };
+            },
+            else => {
+                std.debug.print("[verify] error: spawn '{s}' failed: {s}\n", .{ argv[0], @errorName(err) });
+                return .{
+                    .stdout = try allocator.alloc(u8, 0),
+                    .stderr = try allocator.alloc(u8, 0),
+                    .exit_code = null,
+                    .term_tag = .spawn_failed,
+                    .elapsed_ms = elapsed_ms,
+                };
+            },
+        }
+    };
+    const elapsed_ms = nowMs(io) - start_ms;
+
+    var capture: RunCapture = .{
+        .stdout = result.stdout,
+        .stderr = result.stderr,
+        .exit_code = null,
+        .term_tag = .unknown,
+        .elapsed_ms = elapsed_ms,
+    };
+    switch (result.term) {
+        .exited => |code| {
+            capture.exit_code = code;
+            capture.term_tag = .exited;
+        },
+        .signal => capture.term_tag = .signal,
+        .stopped => capture.term_tag = .stopped,
+        .unknown => capture.term_tag = .unknown,
+    }
+    return capture;
+}
+
+// ── Diff + reporting ────────────────────────────────────────────────────
+
+fn diffAndReport(
+    allocator: std.mem.Allocator,
+    options: Options,
+    oracle: RunCapture,
+    subject: RunCapture,
+) !u8 {
+    const stdout_div: ?usize = firstDiff(oracle.stdout, subject.stdout);
+    const stderr_div: ?usize = firstDiff(oracle.stderr, subject.stderr);
+
+    const stdout_matches = stdout_div == null and oracle.stdout.len == subject.stdout.len;
+    const stderr_matches = stderr_div == null and oracle.stderr.len == subject.stderr.len;
+
+    const stream_matches = switch (options.diff_mode) {
+        .stdout_only => stdout_matches,
+        .stderr_only => stderr_matches,
+        .both => stdout_matches and stderr_matches,
+    };
+
+    const exit_matches = exitMatches(oracle, subject);
+    const overall_matches = stream_matches and (!options.strict_exit or exit_matches);
+
+    if (options.json) {
+        try emitJson(allocator, options, oracle, subject, stdout_div, stderr_div, overall_matches);
+    } else {
+        try emitHuman(allocator, options, oracle, subject, stdout_div, stderr_div, overall_matches, exit_matches);
+    }
+
+    return if (overall_matches) 0 else 1;
+}
+
+fn firstDiff(a: []const u8, b: []const u8) ?usize {
+    const n = @min(a.len, b.len);
+    var i: usize = 0;
+    while (i < n) : (i += 1) if (a[i] != b[i]) return i;
+    if (a.len != b.len) return n;
+    return null;
+}
+
+fn exitMatches(o: RunCapture, s: RunCapture) bool {
+    if (o.exit_code == null or s.exit_code == null) return false;
+    return o.exit_code.? == s.exit_code.?;
+}
+
+fn reportSide(label: []const u8, capture: *const RunCapture) void {
+    std.debug.print(
+        "[verify] running {s}... ({d} ms, {d} B stdout, {d} B stderr, {s}",
+        .{ label, capture.elapsed_ms, capture.stdout.len, capture.stderr.len, capture.term_tag.name() },
+    );
+    if (capture.exit_code) |c| std.debug.print(" {d}", .{c});
+    std.debug.print(")\n", .{});
+}
+
+fn emitHuman(
+    allocator: std.mem.Allocator,
+    options: Options,
+    oracle: RunCapture,
+    subject: RunCapture,
+    stdout_div: ?usize,
+    stderr_div: ?usize,
+    overall_matches: bool,
+    exit_matches: bool,
+) !void {
+    _ = allocator;
+    const want_stdout = options.diff_mode != .stderr_only;
+    const want_stderr = options.diff_mode != .stdout_only;
+
+    if (want_stdout) {
+        if (stdout_div) |off| {
+            try printDivergence("stdout", off, oracle.stdout, subject.stdout, options.hex_context);
+        } else if (oracle.stdout.len != subject.stdout.len) {
+            std.debug.print(
+                "[verify] stdout length mismatch: wasmtime={d}B wamr={d}B\n",
+                .{ oracle.stdout.len, subject.stdout.len },
+            );
+        }
+    }
+    if (want_stderr) {
+        if (stderr_div) |off| {
+            try printDivergence("stderr", off, oracle.stderr, subject.stderr, options.hex_context);
+        } else if (oracle.stderr.len != subject.stderr.len) {
+            std.debug.print(
+                "[verify] stderr length mismatch: wasmtime={d}B wamr={d}B\n",
+                .{ oracle.stderr.len, subject.stderr.len },
+            );
+        }
+    }
+
+    if (!exit_matches) {
+        const oc = if (oracle.exit_code) |c| @as(i32, c) else -1;
+        const sc = if (subject.exit_code) |c| @as(i32, c) else -1;
+        const kind: []const u8 = if (options.strict_exit) "DIVERGENCE" else "warning";
+        std.debug.print(
+            "[verify] exit-code {s}: wasmtime={d} ({s}) wamr={d} ({s})\n",
+            .{ kind, oc, oracle.term_tag.name(), sc, subject.term_tag.name() },
+        );
+    }
+
+    if (overall_matches) {
+        switch (options.diff_mode) {
+            .stdout_only => std.debug.print("[verify] OK stdout {d}B match (stderr/exit ignored)\n", .{oracle.stdout.len}),
+            .stderr_only => std.debug.print("[verify] OK stderr {d}B match (stdout/exit ignored)\n", .{oracle.stderr.len}),
+            .both => std.debug.print("[verify] OK stdout {d}B / stderr {d}B match\n", .{ oracle.stdout.len, oracle.stderr.len }),
+        }
+        if (options.strict_exit) std.debug.print("[verify] exit codes match\n", .{});
+    } else {
+        std.debug.print("[verify] FAIL\n", .{});
+        std.debug.print(
+            "  hint: codegen-shaped bug? see .github/skills/aot-diff-debug/SKILL.md\n",
+            .{},
+        );
+    }
+}
+
+fn printDivergence(
+    stream: []const u8,
+    offset: usize,
+    a: []const u8,
+    b: []const u8,
+    hex_context: u32,
+) !void {
+    std.debug.print("[verify] DIVERGENCE at {s} offset 0x{x} ({d} bytes in)\n", .{ stream, offset, offset });
+    try printHexLine("  wasmtime: ", a, offset, hex_context);
+    try printHexLine("  wamr:     ", b, offset, hex_context);
+}
+
+fn printHexLine(
+    label: []const u8,
+    buf: []const u8,
+    offset: usize,
+    hex_context: u32,
+) !void {
+    const ctx = hex_context;
+    const start = if (offset > ctx) offset - ctx else 0;
+    const end = @min(buf.len, offset + ctx);
+    std.debug.print("{s}", .{label});
+    if (start >= buf.len) {
+        std.debug.print("(stream ended before offset {d})\n", .{offset});
+        return;
+    }
+    // Hex bytes.
+    var i = start;
+    while (i < end) : (i += 1) {
+        std.debug.print("{x:0>2} ", .{buf[i]});
+    }
+    std.debug.print(" | ", .{});
+    // ASCII gloss with `.` for non-printable / space and a `^` marker
+    // immediately under the divergence byte.
+    i = start;
+    while (i < end) : (i += 1) {
+        const c = buf[i];
+        const printable: u8 = if (c >= 0x20 and c < 0x7f) c else '.';
+        std.debug.print("{c}", .{printable});
+    }
+    std.debug.print("\n", .{});
+}
+
+fn emitJson(
+    allocator: std.mem.Allocator,
+    options: Options,
+    oracle: RunCapture,
+    subject: RunCapture,
+    stdout_div: ?usize,
+    stderr_div: ?usize,
+    overall_matches: bool,
+) !void {
+    _ = allocator;
+    var stdout_file = std.Io.File.stdout();
+    var buf: [4096]u8 = undefined;
+    var w = std.Io.Writer.fixed(&buf);
+
+    try w.print(
+        "{{\"match\":{s},\"diff_mode\":\"{s}\",\"strict_exit\":{s}",
+        .{
+            if (overall_matches) "true" else "false",
+            @tagName(options.diff_mode),
+            if (options.strict_exit) "true" else "false",
+        },
+    );
+    try w.print(
+        ",\"wasmtime\":{{\"stdout_len\":{d},\"stderr_len\":{d},\"exit\":{d},\"term\":\"{s}\",\"elapsed_ms\":{d}}}",
+        .{
+            oracle.stdout.len,           oracle.stderr.len,
+            if (oracle.exit_code) |c| @as(i32, c) else -1,
+            oracle.term_tag.name(),      oracle.elapsed_ms,
+        },
+    );
+    try w.print(
+        ",\"wamr\":{{\"stdout_len\":{d},\"stderr_len\":{d},\"exit\":{d},\"term\":\"{s}\",\"elapsed_ms\":{d}}}",
+        .{
+            subject.stdout.len,           subject.stderr.len,
+            if (subject.exit_code) |c| @as(i32, c) else -1,
+            subject.term_tag.name(),      subject.elapsed_ms,
+        },
+    );
+    if (stdout_div) |off| try w.print(",\"stdout_first_diff\":{d}", .{off});
+    if (stderr_div) |off| try w.print(",\"stderr_first_diff\":{d}", .{off});
+    try w.print("}}\n", .{});
+
+    stdout_file.writeStreamingAll(std.Io.Threaded.global_single_threaded.io(), w.buffered()) catch {};
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+test "firstDiff: identical" {
+    try std.testing.expectEqual(@as(?usize, null), firstDiff("abc", "abc"));
+}
+
+test "firstDiff: different at index 0" {
+    try std.testing.expectEqual(@as(?usize, 0), firstDiff("xbc", "abc"));
+}
+
+test "firstDiff: different at middle index" {
+    try std.testing.expectEqual(@as(?usize, 2), firstDiff("abcd", "abxd"));
+}
+
+test "firstDiff: prefix shorter" {
+    try std.testing.expectEqual(@as(?usize, 3), firstDiff("abc", "abcd"));
+}
+
+test "firstDiff: prefix longer" {
+    try std.testing.expectEqual(@as(?usize, 3), firstDiff("abcd", "abc"));
+}
+
+test "exitMatches: both exited same → true" {
+    const o: RunCapture = .{ .stdout = &.{}, .stderr = &.{}, .exit_code = 0, .term_tag = .exited, .elapsed_ms = 0 };
+    const s: RunCapture = .{ .stdout = &.{}, .stderr = &.{}, .exit_code = 0, .term_tag = .exited, .elapsed_ms = 0 };
+    try std.testing.expect(exitMatches(o, s));
+}
+
+test "exitMatches: one missing → false" {
+    const o: RunCapture = .{ .stdout = &.{}, .stderr = &.{}, .exit_code = 0, .term_tag = .exited, .elapsed_ms = 0 };
+    const s: RunCapture = .{ .stdout = &.{}, .stderr = &.{}, .exit_code = null, .term_tag = .signal, .elapsed_ms = 0 };
+    try std.testing.expect(!exitMatches(o, s));
+}
+
+test "exitMatches: different codes → false" {
+    const o: RunCapture = .{ .stdout = &.{}, .stderr = &.{}, .exit_code = 0, .term_tag = .exited, .elapsed_ms = 0 };
+    const s: RunCapture = .{ .stdout = &.{}, .stderr = &.{}, .exit_code = 1, .term_tag = .exited, .elapsed_ms = 0 };
+    try std.testing.expect(!exitMatches(o, s));
+}

--- a/src/compiler/verify_args.zig
+++ b/src/compiler/verify_args.zig
@@ -1,0 +1,535 @@
+//! Argument parsing + per-runtime translation for `wamrc verify`
+//! (issue #757).
+//!
+//! Kept separate from `verify.zig` (the subprocess orchestrator) so
+//! the flag-translation table is easy to unit-test in-process,
+//! without spawning anything. Every public function here is pure on
+//! its inputs and returns owned slices the caller must free.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const DiffMode = enum {
+    /// Diff stdout only. The default — wamr emits more stderr noise
+    /// (`[aot dispatch] …`) than wasmtime, so a strict-stderr default
+    /// would surface false positives. Use `--strict-stderr` to opt in.
+    stdout_only,
+    /// Diff stderr only. Useful when the guest writes diagnostics to
+    /// stderr and the user wants to differentialise *just* that channel.
+    stderr_only,
+    /// Diff both streams.
+    both,
+};
+
+pub const Options = struct {
+    /// Path to the input `.wasm` file. The orchestrator hands this to
+    /// `wasmtime run` directly and to `wamrc compile-component` /
+    /// `wamr run` after AOT compilation.
+    wasm_path: []const u8,
+
+    /// `--wasmtime-bin <path>` override. Resolution order in
+    /// `verify.zig`: this field → `$WASMTIME_BIN` → `wasmtime` on `$PATH`.
+    wasmtime_bin: ?[]const u8 = null,
+
+    /// `--wamr-bin <path>` override. Resolution order in `verify.zig`:
+    /// this field → `$WAMR_BIN` → sibling-to-wamrc → `wamr` on `$PATH`.
+    wamr_bin: ?[]const u8 = null,
+
+    /// Each `--map-dir HOST::GUEST` flag. Slices borrow from the
+    /// caller's argv; lifetime is the caller's.
+    map_dirs: []const []const u8 = &.{},
+
+    /// Each `--env K=V` (or `--env K`) flag.
+    env_vars: []const []const u8 = &.{},
+
+    /// Guest argv after a literal `--` (`wamrc verify foo.wasm -- a b c`
+    /// → `["a", "b", "c"]`).
+    guest_args: []const []const u8 = &.{},
+
+    /// `--max-runtime <sec>` watchdog for each runtime invocation
+    /// (default 60). Zero disables the watchdog.
+    max_runtime_seconds: u32 = 60,
+
+    /// `--hex-context <N>` — bytes of hex+ASCII context to print on
+    /// each side of the first-divergence offset (default 32).
+    hex_context: u32 = 32,
+
+    diff_mode: DiffMode = .stdout_only,
+
+    /// `--strict-exit` — also diff the runtimes' exit codes. Without
+    /// it, a code mismatch is only a warning when the chosen stream(s)
+    /// match. Default off — wamr's "successful run then host SIGSEGV"
+    /// failure class (separate latent bug; see #760 for one instance)
+    /// would otherwise drown out genuine codegen regressions.
+    strict_exit: bool = false,
+
+    /// `--keep-cwasm` — leave the precompiled `<stem>.cwasm` and
+    /// `<stem>.cwasm.json` next to the input for post-mortem
+    /// inspection. Default: delete on exit.
+    keep_cwasm: bool = false,
+
+    /// `--json` — emit a single-line JSON report instead of the
+    /// human-readable shape. Exit code semantics are unchanged.
+    json: bool = false,
+};
+
+pub const ParseError = error{
+    MissingValue,
+    DuplicateInputPath,
+    UnknownOption,
+    MissingInputPath,
+    InvalidIntegerArgument,
+} || std.mem.Allocator.Error;
+
+/// In-memory error context populated by `parse` when it returns a
+/// `ParseError`. Callers print the surfaced `option` / `value` /
+/// `detail` fields together with their own usage hint.
+pub const ParseDiagnostic = struct {
+    option: []const u8 = "",
+    value: []const u8 = "",
+    detail: []const u8 = "",
+};
+
+/// Owns the variable-length slices `map_dirs`, `env_vars`, and
+/// `guest_args` allocated during parse. The string contents inside
+/// each slice borrow from the original argv (caller-owned).
+pub const ParsedOptions = struct {
+    options: Options,
+    map_dirs: std.ArrayList([]const u8),
+    env_vars: std.ArrayList([]const u8),
+    guest_args: std.ArrayList([]const u8),
+    allocator: Allocator,
+
+    pub fn deinit(self: *ParsedOptions) void {
+        self.map_dirs.deinit(self.allocator);
+        self.env_vars.deinit(self.allocator);
+        self.guest_args.deinit(self.allocator);
+    }
+};
+
+/// Parse `wamrc verify` subcommand arguments. `argv` excludes the
+/// `verify` token itself (matches the convention used by every other
+/// `wamrc` subcommand in `src/compiler/main.zig`).
+///
+/// On `ParseError.X` the `diag` is populated; the caller prints it +
+/// a `try wamrc verify help` line. The returned `ParsedOptions` owns
+/// its three slices and must be `.deinit()`'d on success.
+pub fn parse(
+    allocator: Allocator,
+    argv: []const []const u8,
+    diag: *ParseDiagnostic,
+) ParseError!ParsedOptions {
+    var parsed: ParsedOptions = .{
+        .allocator = allocator,
+        .options = .{ .wasm_path = "" },
+        .map_dirs = .empty,
+        .env_vars = .empty,
+        .guest_args = .empty,
+    };
+    errdefer parsed.deinit();
+
+    var input_path: ?[]const u8 = null;
+    var saw_dashdash = false;
+
+    var i: usize = 0;
+    while (i < argv.len) : (i += 1) {
+        const a = argv[i];
+
+        if (saw_dashdash) {
+            try parsed.guest_args.append(allocator, a);
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--")) {
+            saw_dashdash = true;
+            continue;
+        }
+
+        // ── Flags taking a value ────────────────────────────────────────
+        if (std.mem.eql(u8, a, "--map-dir")) {
+            const v = nextValue(argv, &i) catch {
+                diag.option = "--map-dir";
+                return ParseError.MissingValue;
+            };
+            try parsed.map_dirs.append(allocator, v);
+            continue;
+        }
+        if (std.mem.startsWith(u8, a, "--map-dir=")) {
+            try parsed.map_dirs.append(allocator, a["--map-dir=".len..]);
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--env")) {
+            const v = nextValue(argv, &i) catch {
+                diag.option = "--env";
+                return ParseError.MissingValue;
+            };
+            try parsed.env_vars.append(allocator, v);
+            continue;
+        }
+        if (std.mem.startsWith(u8, a, "--env=")) {
+            try parsed.env_vars.append(allocator, a["--env=".len..]);
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--max-runtime")) {
+            const v = nextValue(argv, &i) catch {
+                diag.option = "--max-runtime";
+                return ParseError.MissingValue;
+            };
+            parsed.options.max_runtime_seconds = parseU32(v) catch {
+                diag.option = "--max-runtime";
+                diag.value = v;
+                return ParseError.InvalidIntegerArgument;
+            };
+            continue;
+        }
+        if (std.mem.startsWith(u8, a, "--max-runtime=")) {
+            const v = a["--max-runtime=".len..];
+            parsed.options.max_runtime_seconds = parseU32(v) catch {
+                diag.option = "--max-runtime";
+                diag.value = v;
+                return ParseError.InvalidIntegerArgument;
+            };
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--hex-context")) {
+            const v = nextValue(argv, &i) catch {
+                diag.option = "--hex-context";
+                return ParseError.MissingValue;
+            };
+            parsed.options.hex_context = parseU32(v) catch {
+                diag.option = "--hex-context";
+                diag.value = v;
+                return ParseError.InvalidIntegerArgument;
+            };
+            continue;
+        }
+        if (std.mem.startsWith(u8, a, "--hex-context=")) {
+            const v = a["--hex-context=".len..];
+            parsed.options.hex_context = parseU32(v) catch {
+                diag.option = "--hex-context";
+                diag.value = v;
+                return ParseError.InvalidIntegerArgument;
+            };
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--wasmtime-bin")) {
+            parsed.options.wasmtime_bin = nextValue(argv, &i) catch {
+                diag.option = "--wasmtime-bin";
+                return ParseError.MissingValue;
+            };
+            continue;
+        }
+        if (std.mem.startsWith(u8, a, "--wasmtime-bin=")) {
+            parsed.options.wasmtime_bin = a["--wasmtime-bin=".len..];
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--wamr-bin")) {
+            parsed.options.wamr_bin = nextValue(argv, &i) catch {
+                diag.option = "--wamr-bin";
+                return ParseError.MissingValue;
+            };
+            continue;
+        }
+        if (std.mem.startsWith(u8, a, "--wamr-bin=")) {
+            parsed.options.wamr_bin = a["--wamr-bin=".len..];
+            continue;
+        }
+
+        // ── Boolean flags ───────────────────────────────────────────────
+        if (std.mem.eql(u8, a, "--stdout-only")) {
+            parsed.options.diff_mode = .stdout_only;
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--stderr-only")) {
+            parsed.options.diff_mode = .stderr_only;
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--diff-everything")) {
+            parsed.options.diff_mode = .both;
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--strict-exit")) {
+            parsed.options.strict_exit = true;
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--keep-cwasm")) {
+            parsed.options.keep_cwasm = true;
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--json")) {
+            parsed.options.json = true;
+            continue;
+        }
+
+        // ── Unknown options ─────────────────────────────────────────────
+        if (a.len > 0 and a[0] == '-') {
+            diag.option = a;
+            return ParseError.UnknownOption;
+        }
+
+        // ── Positional: the input .wasm path ────────────────────────────
+        if (input_path != null) {
+            diag.value = a;
+            return ParseError.DuplicateInputPath;
+        }
+        input_path = a;
+    }
+
+    parsed.options.wasm_path = input_path orelse return ParseError.MissingInputPath;
+    parsed.options.map_dirs = parsed.map_dirs.items;
+    parsed.options.env_vars = parsed.env_vars.items;
+    parsed.options.guest_args = parsed.guest_args.items;
+    return parsed;
+}
+
+fn nextValue(argv: []const []const u8, i: *usize) error{Missing}![]const u8 {
+    if (i.* + 1 >= argv.len) return error.Missing;
+    i.* += 1;
+    return argv[i.*];
+}
+
+fn parseU32(s: []const u8) !u32 {
+    return std.fmt.parseInt(u32, s, 10);
+}
+
+// ── Per-runtime argv builders ───────────────────────────────────────────
+//
+// `wasmtime run` and `wamr run` accept the same kinds of inputs
+// (mounts, env, the wasm path, then guest argv after `--`) but the
+// flag spelling differs:
+//
+//   | concept | wasmtime          | wamr               |
+//   |---------|-------------------|--------------------|
+//   | mount   | `--dir A::B`      | `--map-dir A::B`   |
+//   | envvar  | `--env K=V`       | `--env K=V`        |
+//
+// The builders below are pure functions of an `Options` value plus
+// the runtime's binary path; verify.zig calls them once per
+// invocation and hands the result straight to `std.process.run`.
+//
+// Each builder appends to a caller-owned `std.ArrayList`. The list
+// owns the spine; the strings inside are borrowed (they ultimately
+// trace back to the parsed argv).
+
+pub fn buildWasmtimeArgs(
+    allocator: Allocator,
+    options: Options,
+    wasmtime_path: []const u8,
+    list: *std.ArrayList([]const u8),
+) !void {
+    try list.append(allocator, wasmtime_path);
+    try list.append(allocator, "run");
+    for (options.map_dirs) |md| {
+        try list.append(allocator, "--dir");
+        try list.append(allocator, md);
+    }
+    for (options.env_vars) |ev| {
+        try list.append(allocator, "--env");
+        try list.append(allocator, ev);
+    }
+    try list.append(allocator, options.wasm_path);
+    if (options.guest_args.len > 0) {
+        try list.append(allocator, "--");
+        for (options.guest_args) |ga| try list.append(allocator, ga);
+    }
+}
+
+pub fn buildWamrArgs(
+    allocator: Allocator,
+    options: Options,
+    wamr_path: []const u8,
+    list: *std.ArrayList([]const u8),
+) !void {
+    try list.append(allocator, wamr_path);
+    try list.append(allocator, "run");
+    for (options.map_dirs) |md| {
+        try list.append(allocator, "--map-dir");
+        try list.append(allocator, md);
+    }
+    for (options.env_vars) |ev| {
+        try list.append(allocator, "--env");
+        try list.append(allocator, ev);
+    }
+    try list.append(allocator, options.wasm_path);
+    if (options.guest_args.len > 0) {
+        try list.append(allocator, "--");
+        for (options.guest_args) |ga| try list.append(allocator, ga);
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+test "parse: bare wasm path" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{"foo.wasm"};
+    var parsed = try parse(std.testing.allocator, &argv, &diag);
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("foo.wasm", parsed.options.wasm_path);
+    try std.testing.expectEqual(@as(usize, 0), parsed.options.map_dirs.len);
+    try std.testing.expectEqual(@as(usize, 0), parsed.options.env_vars.len);
+    try std.testing.expectEqual(@as(usize, 0), parsed.options.guest_args.len);
+    try std.testing.expectEqual(@as(u32, 60), parsed.options.max_runtime_seconds);
+    try std.testing.expectEqual(DiffMode.stdout_only, parsed.options.diff_mode);
+    try std.testing.expect(!parsed.options.strict_exit);
+    try std.testing.expect(!parsed.options.keep_cwasm);
+    try std.testing.expect(!parsed.options.json);
+}
+
+test "parse: --map-dir repeatable, space and = forms" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "foo.wasm", "--map-dir", "/a::/x", "--map-dir=/b::/y" };
+    var parsed = try parse(std.testing.allocator, &argv, &diag);
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(usize, 2), parsed.options.map_dirs.len);
+    try std.testing.expectEqualStrings("/a::/x", parsed.options.map_dirs[0]);
+    try std.testing.expectEqualStrings("/b::/y", parsed.options.map_dirs[1]);
+}
+
+test "parse: --env repeatable" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "foo.wasm", "--env", "K=V", "--env=X=Y" };
+    var parsed = try parse(std.testing.allocator, &argv, &diag);
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(usize, 2), parsed.options.env_vars.len);
+    try std.testing.expectEqualStrings("K=V", parsed.options.env_vars[0]);
+    try std.testing.expectEqualStrings("X=Y", parsed.options.env_vars[1]);
+}
+
+test "parse: -- guest args" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "foo.wasm", "--", "a", "b", "--bogus" };
+    var parsed = try parse(std.testing.allocator, &argv, &diag);
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(usize, 3), parsed.options.guest_args.len);
+    try std.testing.expectEqualStrings("a", parsed.options.guest_args[0]);
+    try std.testing.expectEqualStrings("b", parsed.options.guest_args[1]);
+    try std.testing.expectEqualStrings("--bogus", parsed.options.guest_args[2]);
+}
+
+test "parse: bool flags" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "foo.wasm", "--strict-exit", "--keep-cwasm", "--json", "--stderr-only" };
+    var parsed = try parse(std.testing.allocator, &argv, &diag);
+    defer parsed.deinit();
+    try std.testing.expect(parsed.options.strict_exit);
+    try std.testing.expect(parsed.options.keep_cwasm);
+    try std.testing.expect(parsed.options.json);
+    try std.testing.expectEqual(DiffMode.stderr_only, parsed.options.diff_mode);
+}
+
+test "parse: --diff-everything overrides default" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "foo.wasm", "--diff-everything" };
+    var parsed = try parse(std.testing.allocator, &argv, &diag);
+    defer parsed.deinit();
+    try std.testing.expectEqual(DiffMode.both, parsed.options.diff_mode);
+}
+
+test "parse: --max-runtime and --hex-context parse u32" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "foo.wasm", "--max-runtime", "120", "--hex-context=8" };
+    var parsed = try parse(std.testing.allocator, &argv, &diag);
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(u32, 120), parsed.options.max_runtime_seconds);
+    try std.testing.expectEqual(@as(u32, 8), parsed.options.hex_context);
+}
+
+test "parse: missing input path" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{"--strict-exit"};
+    try std.testing.expectError(ParseError.MissingInputPath, parse(std.testing.allocator, &argv, &diag));
+}
+
+test "parse: duplicate input path" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "a.wasm", "b.wasm" };
+    try std.testing.expectError(ParseError.DuplicateInputPath, parse(std.testing.allocator, &argv, &diag));
+    try std.testing.expectEqualStrings("b.wasm", diag.value);
+}
+
+test "parse: unknown option populates diag" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "foo.wasm", "--unknown-flag" };
+    try std.testing.expectError(ParseError.UnknownOption, parse(std.testing.allocator, &argv, &diag));
+    try std.testing.expectEqualStrings("--unknown-flag", diag.option);
+}
+
+test "parse: missing value populates diag" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "foo.wasm", "--map-dir" };
+    try std.testing.expectError(ParseError.MissingValue, parse(std.testing.allocator, &argv, &diag));
+    try std.testing.expectEqualStrings("--map-dir", diag.option);
+}
+
+test "parse: invalid integer for --max-runtime populates diag" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "foo.wasm", "--max-runtime", "abc" };
+    try std.testing.expectError(ParseError.InvalidIntegerArgument, parse(std.testing.allocator, &argv, &diag));
+    try std.testing.expectEqualStrings("--max-runtime", diag.option);
+    try std.testing.expectEqualStrings("abc", diag.value);
+}
+
+test "parse: --wasmtime-bin and --wamr-bin overrides" {
+    var diag: ParseDiagnostic = .{};
+    const argv = [_][]const u8{ "foo.wasm", "--wasmtime-bin", "/opt/wt", "--wamr-bin=/opt/wamr" };
+    var parsed = try parse(std.testing.allocator, &argv, &diag);
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("/opt/wt", parsed.options.wasmtime_bin.?);
+    try std.testing.expectEqualStrings("/opt/wamr", parsed.options.wamr_bin.?);
+}
+
+test "buildWasmtimeArgs: shape" {
+    var list: std.ArrayList([]const u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const opts: Options = .{
+        .wasm_path = "foo.wasm",
+        .map_dirs = &.{"/h::/g"},
+        .env_vars = &.{"K=V"},
+        .guest_args = &.{ "a", "b" },
+    };
+    try buildWasmtimeArgs(std.testing.allocator, opts, "/usr/bin/wasmtime", &list);
+    try std.testing.expectEqualSlices([]const u8, &.{
+        "/usr/bin/wasmtime", "run",
+        "--dir",             "/h::/g",
+        "--env",             "K=V",
+        "foo.wasm",          "--",
+        "a",                 "b",
+    }, list.items);
+}
+
+test "buildWasmtimeArgs: no guest args → no trailing --" {
+    var list: std.ArrayList([]const u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const opts: Options = .{ .wasm_path = "foo.wasm" };
+    try buildWasmtimeArgs(std.testing.allocator, opts, "wasmtime", &list);
+    try std.testing.expectEqualSlices([]const u8, &.{ "wasmtime", "run", "foo.wasm" }, list.items);
+}
+
+test "buildWamrArgs: shape with --map-dir not --dir" {
+    var list: std.ArrayList([]const u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const opts: Options = .{
+        .wasm_path = "foo.wasm",
+        .map_dirs = &.{"/h::/g"},
+        .env_vars = &.{"K=V"},
+    };
+    try buildWamrArgs(std.testing.allocator, opts, "/usr/bin/wamr", &list);
+    try std.testing.expectEqualSlices([]const u8, &.{
+        "/usr/bin/wamr", "run",
+        "--map-dir",     "/h::/g",
+        "--env",         "K=V",
+        "foo.wasm",
+    }, list.items);
+}
+
+test "buildWamrArgs: guest args after --" {
+    var list: std.ArrayList([]const u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const opts: Options = .{
+        .wasm_path = "foo.wasm",
+        .guest_args = &.{ "x", "y" },
+    };
+    try buildWamrArgs(std.testing.allocator, opts, "wamr", &list);
+    try std.testing.expectEqualSlices([]const u8, &.{
+        "wamr", "run", "foo.wasm", "--", "x", "y",
+    }, list.items);
+}

--- a/tests/regressions/754-slice/README.md
+++ b/tests/regressions/754-slice/README.md
@@ -53,6 +53,22 @@ zig build -Doptimize=ReleaseSafe
 ./zig-out/bin/wamr run repro.wasm   # → "FAIL slice=\"\""
 ```
 
+## One-command differential (#757)
+
+Had `wamrc verify` (issue #757) existed at the time of the original
+bisect, the single command that would have surfaced the bug — and
+saved most of the ~6 hours of probe-building — is:
+
+```sh
+./zig-out/bin/wamrc verify repro.wasm
+```
+
+That spawns both `wasmtime run repro.wasm` and `wamr run repro.wasm`
+under the hood, captures both stdouts, and prints the first-divergence
+offset with hex+ASCII context on each side. Exit 1 on divergence,
+0 on match, 2 on setup error. See `.github/skills/aot-diff-debug/SKILL.md`
+for the broader workflow.
+
 ## Bisect status (in progress)
 
 - ✅ Disproved: WASI fs, IR-opt passes, canon-lift/lower, `memory.grow`


### PR DESCRIPTION
Adds 'wamrc verify <wasm> [-- guest-args...]' — compiles the wasm
under wamr-AOT, runs it under both wamr (the subject) and wasmtime
(the reference oracle), and diffs stdout (by default), stderr, and
exit codes. Exits:

  0  outputs match
  1  divergence found (first-difference offset + hex+ASCII context
     on each side; --hex-context tunes the window)
  2  setup error (missing wasmtime, AOT precompile failure, spawn
     failure, …)

## Why this

Issue #754 took ~6 hours to bisect. The actual fix was 13 lines.
The slow part was hand-building probes to localize divergence
between wamr-AOT and wasmtime. 'wamrc verify' makes that a one-line
command — see the updated 754-slice/README.md + aot-diff-debug
skill, both of which now point at the new tool.

## Why wasmtime as the oracle (not wamr's interp)

- wamr's interp may be removed entirely in the future; building
  tooling on top of it is wasted work.
- Black-box differential against an external runtime catches the
  bigger bug class: things both wamr engines share (canon-lift
  quirks, adapter bugs, …) that an interp-vs-AOT diff would miss.
- wasmtime is already on every wamr dev box / CI runner.

## Why direct std.process (not 'wamrc run' recursively)

- Keeps the precompile step inside the same process so allocations
  and per-pass diagnostics stream through one allocator.
- Avoids the sibling-cwasm.json discovery dance polluting the
  source tree — artifacts are staged under '/tmp/wamrc-verify-<pid>/'
  and wiped on exit (unless --keep-cwasm).

## Files

- 'src/compiler/verify_args.zig' (new) — Options struct + flag
  parser + per-runtime argv builders (--map-dir → --dir for wasmtime,
  same flag for wamr; --env passes through to both). 14 unit tests
  cover spelling, repeatables, '--', diagnostic populate, integer
  validation, and exact argv shapes.
- 'src/compiler/verify.zig' (new) — orchestrator + diff core. Pure
  on its inputs; never calls std.process.exit (returns the code the
  caller should propagate). 5 unit tests cover the diff primitives.
- 'src/compiler/main.zig' — new 'verify' Subcommand variant +
  'runVerify' dispatch + 'verify' line in the top-level usage +
  full 'wamrc verify help' usage block.
- 'build.zig' — two e2e smoke steps (gated on
  aot_trampoline_pool_target to skip Windows / macOS-aarch64): one
  asserts 'wamrc verify help' exits 0; the other asserts
  'wamrc verify --wasmtime-bin=/dev/null/nope <wasm>' exits 2
  (setup error). Both exercise the framework without requiring
  wasmtime on the test runner's PATH.
- '.github/skills/aot-diff-debug/SKILL.md' — rewritten Phase 1 to
  use 'wamrc verify' instead of the broken
  '.\zig-out\bin\wamr.exe program.wasm' interpreter assumption.
  Added a #754 historical entry next to the CoreMark one.
- 'tests/regressions/754-slice/README.md' — added the
  'one-command differential' section pointing at 'wamrc verify'.

## Tests

Full 'zig build test' passes 3093/3100 (+17 over the post-#760
baseline of 3076: 14 unit tests in verify_args.zig, 5 in
verify.zig, 2 e2e steps in build.zig). 7 pre-existing skips
unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
