### PR TITLE
compiler/aot_bisect: add prelude skip knobs

### DIFF
--- a/src/compiler/aot_bisect.zig
+++ b/src/compiler/aot_bisect.zig
@@ -17,6 +17,7 @@
 //! WAMR_AOT_PASSES_LIMIT=30:mod=4             # cap only in module 4
 //! WAMR_AOT_SKIP_INLINE_SMALL=mod=4            # skip inlineSmallFunctions in module 4
 //! WAMR_AOT_SKIP_PROMOTE_SSA=1                 # skip promoteLocalsToSSA in every module
+//! WAMR_AOT_SKIP_PROMOTE_SSA=mod=4:fn=0-5999   # skip promote in module 4 funcs 0-5999
 //! WAMR_AOT_SKIP_PHIS_TO_LOCALS=mod=4          # skip lowerPhisToLocals in module 4
 //! ```
 //!
@@ -25,7 +26,7 @@
 //!   skip_spec   := <pass_idx_or_range> { ':' filter }
 //!   limit_spec  := <usize>             { ':' filter }
 //!   filter      := 'fn=' <fn_list> | 'mod=' <fn_list>
-//!   prelude     := '' | '1' | 'true' | 'all' | 'mod=' <fn_list>
+//!   prelude     := '' | '1' | 'true' | 'all' | { filter }
 //!   pass_idx_or_range := <usize> [ '-' <usize> ]
 //!   fn_list     := <fn_item> { ',' <fn_item> }
 //!   fn_item     := <usize> [ '-' <usize> ]
@@ -39,16 +40,17 @@
 //! `:mod=N` filter with `N != 0` never matches there.
 //! Prelude skip env vars use the `prelude` grammar above: set the env
 //! var to `1`, `true`, `all`, or an empty value to skip in every module;
-//! set it to `mod=...` to narrow by module. Skipping
+//! set it to `mod=...` and/or `fn=...` to narrow by module/function
+//! (the module-level inliner accepts only `mod=...`). Skipping
 //! `lowerPhisToLocals` also skips `promoteLocalsToSSA` for the same
-//! modules so the pipeline cannot leave SSA phi nodes for later codegen.
+//! scope so the pipeline cannot leave SSA phi nodes for later codegen.
 //!
 //! Multiple `Skip` entries may be supplied via `WAMR_AOT_SKIP_PASSES`
 //! by joining specs with `;`. The single-spec form
 //! (`WAMR_AOT_SKIP_PASS`) is an alias accepting at most one spec.
 //!
 //! All parsing is pure (`parseSkipSpec` / `parseLimitSpec` /
-//! `parsePreludeModFilter` / `parseFnList`) and unit-tested without
+//! `parsePreludeFilter` / `parseFnList`) and unit-tested without
 //! env-var I/O. `parseFromEnv` is a thin wrapper that pulls the env
 //! vars and stamps the result into the process-global `global` for
 //! `runPassesWithOptions` to consult via `passes.RunOptions.bisect`.
@@ -59,6 +61,7 @@ const passes = @import("ir/passes.zig");
 pub const Spec = passes.PassBisectSpec;
 pub const Skip = passes.PassBisectSpec.Skip;
 pub const Limit = passes.PassBisectSpec.Limit;
+pub const PreludeFilter = passes.PassBisectSpec.PreludeFilter;
 
 pub const ParseError = error{
     EmptyInput,
@@ -127,9 +130,9 @@ pub fn parseFromEnv(env: *const std.process.Environ.Map, gpa: std.mem.Allocator)
         }
     }
 
-    parsePreludeSkipFromEnv(env, "WAMR_AOT_SKIP_INLINE_SMALL", "inlineSmallFunctions", &global.skip_inline_small, gpa);
-    parsePreludeSkipFromEnv(env, "WAMR_AOT_SKIP_PROMOTE_SSA", "promoteLocalsToSSA", &global.skip_promote_ssa, gpa);
-    parsePreludeSkipFromEnv(env, "WAMR_AOT_SKIP_PHIS_TO_LOCALS", "lowerPhisToLocals", &global.skip_phis_to_locals, gpa);
+    parsePreludeModuleSkipFromEnv(env, "WAMR_AOT_SKIP_INLINE_SMALL", "inlineSmallFunctions", &global.skip_inline_small, gpa);
+    parsePreludeFunctionSkipFromEnv(env, "WAMR_AOT_SKIP_PROMOTE_SSA", "promoteLocalsToSSA", &global.skip_promote_ssa, gpa);
+    parsePreludeFunctionSkipFromEnv(env, "WAMR_AOT_SKIP_PHIS_TO_LOCALS", "lowerPhisToLocals", &global.skip_phis_to_locals, gpa);
     if (global.lowerPhisSkipForcesPromote()) {
         std.log.warn(
             "[#761 bisect] WAMR_AOT_SKIP_PHIS_TO_LOCALS also skips promoteLocalsToSSA for matching modules to avoid leaving SSA phis in IR",
@@ -138,7 +141,7 @@ pub fn parseFromEnv(env: *const std.process.Environ.Map, gpa: std.mem.Allocator)
     }
 }
 
-fn parsePreludeSkipFromEnv(
+fn parsePreludeModuleSkipFromEnv(
     env: *const std.process.Environ.Map,
     key: []const u8,
     pass_name: []const u8,
@@ -148,7 +151,24 @@ fn parsePreludeSkipFromEnv(
     if (env.get(key)) |v| {
         if (parsePreludeModFilter(v, gpa)) |filter| {
             out.* = filter;
-            logPreludeSkip(pass_name, filter);
+            logPreludeModuleSkip(pass_name, filter);
+        } else |e| {
+            std.log.warn("[#761 bisect] {s}={s}: {s} — ignoring", .{ key, v, @errorName(e) });
+        }
+    }
+}
+
+fn parsePreludeFunctionSkipFromEnv(
+    env: *const std.process.Environ.Map,
+    key: []const u8,
+    pass_name: []const u8,
+    out: *?PreludeFilter,
+    gpa: std.mem.Allocator,
+) void {
+    if (env.get(key)) |v| {
+        if (parsePreludeFilter(v, gpa)) |filter| {
+            out.* = filter;
+            logPreludeFunctionSkip(pass_name, filter);
         } else |e| {
             std.log.warn("[#761 bisect] {s}={s}: {s} — ignoring", .{ key, v, @errorName(e) });
         }
@@ -225,16 +245,34 @@ pub fn parseLimitSpec(text: []const u8, gpa: std.mem.Allocator) ParseError!Limit
 /// Parse the value of a prelude skip env var. `null` means "all
 /// modules"; a non-empty slice means "only those module indices".
 pub fn parsePreludeModFilter(text: []const u8, gpa: std.mem.Allocator) ParseError!?[]const u32 {
+    const filter = try parsePreludeFilter(text, gpa);
+    errdefer {
+        if (filter.func_filter) |f| gpa.free(f);
+        if (filter.mod_filter) |m| gpa.free(m);
+    }
+    if (filter.func_filter != null) return error.UnknownTrailing;
+    return filter.mod_filter;
+}
+
+/// Parse the value of a function-level prelude skip env var. `null`
+/// fields mean "all"; non-null slices narrow by module/function.
+pub fn parsePreludeFilter(text: []const u8, gpa: std.mem.Allocator) ParseError!PreludeFilter {
     const trimmed = std.mem.trim(u8, text, " \t");
     if (trimmed.len == 0 or
         std.ascii.eqlIgnoreCase(trimmed, "1") or
         std.ascii.eqlIgnoreCase(trimmed, "true") or
         std.ascii.eqlIgnoreCase(trimmed, "all"))
     {
-        return null;
+        return .{};
     }
-    if (stripModPrefix(trimmed)) |mod_text| return try parseFnList(mod_text, gpa);
-    return error.UnknownTrailing;
+    var fn_filter: ?[]const u32 = null;
+    var mod_filter: ?[]const u32 = null;
+    errdefer {
+        if (fn_filter) |f| gpa.free(f);
+        if (mod_filter) |m| gpa.free(m);
+    }
+    try parseFnAndModFilters(trimmed, gpa, &fn_filter, &mod_filter);
+    return .{ .func_filter = fn_filter, .mod_filter = mod_filter };
 }
 
 /// Parse the trailing `fn=...[:mod=...]` or `mod=...[:fn=...]` after
@@ -382,7 +420,7 @@ fn logLimit(lim: Limit) void {
     );
 }
 
-fn logPreludeSkip(pass_name: []const u8, mod_filter: ?[]const u32) void {
+fn logPreludeModuleSkip(pass_name: []const u8, mod_filter: ?[]const u32) void {
     if (mod_filter) |list| {
         std.log.warn(
             "[#761 bisect] SKIP {s} in {d} module(s)",
@@ -394,6 +432,24 @@ fn logPreludeSkip(pass_name: []const u8, mod_filter: ?[]const u32) void {
             .{pass_name},
         );
     }
+}
+
+fn logPreludeFunctionSkip(pass_name: []const u8, filter: PreludeFilter) void {
+    var fn_buf: [64]u8 = undefined;
+    var mod_buf: [64]u8 = undefined;
+    const fn_part = if (filter.func_filter) |list|
+        std.fmt.bufPrint(&fn_buf, " for {d} func(s)", .{list.len}) catch ""
+    else
+        "";
+    const mod_part = if (filter.mod_filter) |list|
+        std.fmt.bufPrint(&mod_buf, " in {d} module(s)", .{list.len}) catch ""
+    else
+        "";
+    const scope_suffix = if (fn_part.len == 0 and mod_part.len == 0) " (all funcs, all modules)" else "";
+    std.log.warn(
+        "[#761 bisect] SKIP {s}{s}{s}{s}",
+        .{ pass_name, fn_part, mod_part, scope_suffix },
+    );
 }
 
 // ---------------------------------------------------------------------
@@ -532,12 +588,35 @@ test "parsePreludeModFilter: all modules and mod filters" {
     try testing.expectError(error.UnknownTrailing, parsePreludeModFilter("fn=1", testing.allocator));
 }
 
-test "parseFromEnv: prelude skip env vars honour module filters" {
+test "parsePreludeFilter: function and module filters" {
+    {
+        const filter = try parsePreludeFilter("1", testing.allocator);
+        try testing.expectEqual(@as(?[]const u32, null), filter.mod_filter);
+        try testing.expectEqual(@as(?[]const u32, null), filter.func_filter);
+    }
+    {
+        const filter = try parsePreludeFilter("mod=4:fn=0-2,9", testing.allocator);
+        defer testing.allocator.free(filter.mod_filter.?);
+        defer testing.allocator.free(filter.func_filter.?);
+        try testing.expectEqualSlices(u32, &.{4}, filter.mod_filter.?);
+        try testing.expectEqualSlices(u32, &.{ 0, 1, 2, 9 }, filter.func_filter.?);
+    }
+    {
+        const filter = try parsePreludeFilter("fn=7:mod=2", testing.allocator);
+        defer testing.allocator.free(filter.mod_filter.?);
+        defer testing.allocator.free(filter.func_filter.?);
+        try testing.expectEqualSlices(u32, &.{2}, filter.mod_filter.?);
+        try testing.expectEqualSlices(u32, &.{7}, filter.func_filter.?);
+    }
+    try testing.expectError(error.UnknownTrailing, parsePreludeFilter("mod=1:mod=2", testing.allocator));
+}
+
+test "parseFromEnv: prelude skip env vars honour module and function filters" {
     var env = std.process.Environ.Map.init(testing.allocator);
     defer env.deinit();
     try env.put("WAMR_AOT_SKIP_INLINE_SMALL", "mod=4");
-    try env.put("WAMR_AOT_SKIP_PROMOTE_SSA", "1");
-    try env.put("WAMR_AOT_SKIP_PHIS_TO_LOCALS", "mod=0,4");
+    try env.put("WAMR_AOT_SKIP_PROMOTE_SSA", "mod=4:fn=1-2");
+    try env.put("WAMR_AOT_SKIP_PHIS_TO_LOCALS", "mod=0,4:fn=9");
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -547,12 +626,14 @@ test "parseFromEnv: prelude skip env vars honour module filters" {
 
     try testing.expect(!global.skipsInlineSmall(0));
     try testing.expect(global.skipsInlineSmall(4));
-    try testing.expect(global.skipsPromoteSSA(0));
-    try testing.expect(global.skipsPromoteSSA(4));
-    try testing.expect(global.skipsPromoteSSA(99));
-    try testing.expect(global.skipsPhisToLocals(0));
-    try testing.expect(global.skipsPhisToLocals(4));
-    try testing.expect(!global.skipsPhisToLocals(1));
+    try testing.expect(!global.skipsPromoteSSA(0, 1));
+    try testing.expect(global.skipsPromoteSSA(4, 1));
+    try testing.expect(global.skipsPromoteSSA(4, 2));
+    try testing.expect(!global.skipsPromoteSSA(4, 3));
+    try testing.expect(global.skipsPromoteSSA(0, 9)); // lower skip forces promote for matching funcs
+    try testing.expect(global.skipsPhisToLocals(0, 9));
+    try testing.expect(global.skipsPhisToLocals(4, 9));
+    try testing.expect(!global.skipsPhisToLocals(4, 8));
 }
 
 test "Spec.shouldSkip + effectiveLimit + affectsFunction" {
@@ -666,21 +747,28 @@ test "Spec prelude skip helpers honour module filters" {
 
 test "Spec lowerPhis skip forces matching promote skip" {
     const mod4 = [_]u32{4};
-    const lower_only: Spec = .{ .skip_phis_to_locals = &mod4 };
+    const lower_only: Spec = .{ .skip_phis_to_locals = .{ .mod_filter = &mod4 } };
 
     try testing.expect(lower_only.lowerPhisSkipForcesPromote());
-    try testing.expect(!lower_only.skipsPromoteSSA(0));
-    try testing.expect(lower_only.skipsPromoteSSA(4));
-    try testing.expect(!lower_only.skipsPhisToLocals(0));
-    try testing.expect(lower_only.skipsPhisToLocals(4));
+    try testing.expect(!lower_only.skipsPromoteSSA(0, 0));
+    try testing.expect(lower_only.skipsPromoteSSA(4, 0));
+    try testing.expect(!lower_only.skipsPhisToLocals(0, 0));
+    try testing.expect(lower_only.skipsPhisToLocals(4, 0));
 
     const promote_covers_lower: Spec = .{
-        .skip_promote_ssa = null,
-        .skip_phis_to_locals = &mod4,
+        .skip_promote_ssa = .{},
+        .skip_phis_to_locals = .{ .mod_filter = &mod4 },
     };
     try testing.expect(!promote_covers_lower.lowerPhisSkipForcesPromote());
-    try testing.expect(promote_covers_lower.skipsPromoteSSA(0));
-    try testing.expect(promote_covers_lower.skipsPromoteSSA(4));
+    try testing.expect(promote_covers_lower.skipsPromoteSSA(0, 0));
+    try testing.expect(promote_covers_lower.skipsPromoteSSA(4, 0));
+
+    const funcs = [_]u32{ 1, 2 };
+    const fn_scoped: Spec = .{ .skip_promote_ssa = .{ .mod_filter = &mod4, .func_filter = &funcs } };
+    try testing.expect(!fn_scoped.skipsPromoteSSA(4, 0));
+    try testing.expect(fn_scoped.skipsPromoteSSA(4, 1));
+    try testing.expect(fn_scoped.skipsPromoteSSA(4, 2));
+    try testing.expect(!fn_scoped.skipsPromoteSSA(0, 1));
 }
 
 test "Spec.isEmpty default" {

--- a/src/compiler/aot_bisect.zig
+++ b/src/compiler/aot_bisect.zig
@@ -1,8 +1,9 @@
 //! AOT codegen bisection knobs (#761 / #743).
 //!
-//! `wamrc` exposes three env vars to let bisects narrow a suspected
-//! IR-optimisation miscompile down to a single (pass, function) pair
-//! without recompiling the rest of the module with a partial pipeline:
+//! `wamrc` exposes env vars to let bisects narrow a suspected
+//! IR-optimisation miscompile down to a single (pass, function) pair,
+//! or to one of the module/function-level prelude passes, without
+//! recompiling the rest of the module with a partial pipeline:
 //!
 //! ```
 //! WAMR_AOT_SKIP_PASS=15                      # skip pass 15 in every func
@@ -14,6 +15,9 @@
 //! WAMR_AOT_PASSES_LIMIT=30                   # cap pipeline at 30 passes
 //! WAMR_AOT_PASSES_LIMIT=30:fn=11040,11041    # cap only listed funcs
 //! WAMR_AOT_PASSES_LIMIT=30:mod=4             # cap only in module 4
+//! WAMR_AOT_SKIP_INLINE_SMALL=mod=4            # skip inlineSmallFunctions in module 4
+//! WAMR_AOT_SKIP_PROMOTE_SSA=1                 # skip promoteLocalsToSSA in every module
+//! WAMR_AOT_SKIP_PHIS_TO_LOCALS=mod=4          # skip lowerPhisToLocals in module 4
 //! ```
 //!
 //! Grammar (single env var):
@@ -21,6 +25,7 @@
 //!   skip_spec   := <pass_idx_or_range> { ':' filter }
 //!   limit_spec  := <usize>             { ':' filter }
 //!   filter      := 'fn=' <fn_list> | 'mod=' <fn_list>
+//!   prelude     := '' | '1' | 'true' | 'all' | 'mod=' <fn_list>
 //!   pass_idx_or_range := <usize> [ '-' <usize> ]
 //!   fn_list     := <fn_item> { ',' <fn_item> }
 //!   fn_item     := <usize> [ '-' <usize> ]
@@ -32,16 +37,21 @@
 //! assigned by `wamrc compile-component`; the single-module
 //! `wamrc compile` path treats every spec as module 0, so a
 //! `:mod=N` filter with `N != 0` never matches there.
+//! Prelude skip env vars use the `prelude` grammar above: set the env
+//! var to `1`, `true`, `all`, or an empty value to skip in every module;
+//! set it to `mod=...` to narrow by module. Skipping
+//! `lowerPhisToLocals` also skips `promoteLocalsToSSA` for the same
+//! modules so the pipeline cannot leave SSA phi nodes for later codegen.
 //!
 //! Multiple `Skip` entries may be supplied via `WAMR_AOT_SKIP_PASSES`
 //! by joining specs with `;`. The single-spec form
 //! (`WAMR_AOT_SKIP_PASS`) is an alias accepting at most one spec.
 //!
 //! All parsing is pure (`parseSkipSpec` / `parseLimitSpec` /
-//! `parseFnList`) and unit-tested without env-var I/O. `parseFromEnv`
-//! is a thin wrapper that pulls the three keys and stamps the result
-//! into the process-global `global` for `runPassesWithOptions` to
-//! consult via `passes.RunOptions.bisect`.
+//! `parsePreludeModFilter` / `parseFnList`) and unit-tested without
+//! env-var I/O. `parseFromEnv` is a thin wrapper that pulls the env
+//! vars and stamps the result into the process-global `global` for
+//! `runPassesWithOptions` to consult via `passes.RunOptions.bisect`.
 
 const std = @import("std");
 const passes = @import("ir/passes.zig");
@@ -68,7 +78,7 @@ pub const ParseError = error{
 /// short-lived CLI tool and these are tens of bytes.
 pub var global: Spec = .{};
 
-/// Pull the three env vars out of `env` and stamp `global` with the
+/// Pull the bisect env vars out of `env` and stamp `global` with the
 /// resulting spec. Logs `[#761 bisect] …` warnings for each active
 /// knob and `[#761 bisect] WARN: …` on parse errors (env-var typos
 /// silently degrading to "full pipeline" is the failure mode users
@@ -76,6 +86,8 @@ pub var global: Spec = .{};
 ///
 /// Allocations live in `gpa` and are never freed.
 pub fn parseFromEnv(env: *const std.process.Environ.Map, gpa: std.mem.Allocator) void {
+    global = .{};
+
     // Warn if both forms are set — we silently prefer the strictly-
     // more-expressive `_PASSES`, but a contradiction is worth
     // surfacing so users aren't confused by which spec is active.
@@ -112,6 +124,33 @@ pub fn parseFromEnv(env: *const std.process.Environ.Map, gpa: std.mem.Allocator)
             logLimit(lim);
         } else |e| {
             std.log.warn("[#761 bisect] WAMR_AOT_PASSES_LIMIT={s}: {s} — ignoring", .{ v, @errorName(e) });
+        }
+    }
+
+    parsePreludeSkipFromEnv(env, "WAMR_AOT_SKIP_INLINE_SMALL", "inlineSmallFunctions", &global.skip_inline_small, gpa);
+    parsePreludeSkipFromEnv(env, "WAMR_AOT_SKIP_PROMOTE_SSA", "promoteLocalsToSSA", &global.skip_promote_ssa, gpa);
+    parsePreludeSkipFromEnv(env, "WAMR_AOT_SKIP_PHIS_TO_LOCALS", "lowerPhisToLocals", &global.skip_phis_to_locals, gpa);
+    if (global.lowerPhisSkipForcesPromote()) {
+        std.log.warn(
+            "[#761 bisect] WAMR_AOT_SKIP_PHIS_TO_LOCALS also skips promoteLocalsToSSA for matching modules to avoid leaving SSA phis in IR",
+            .{},
+        );
+    }
+}
+
+fn parsePreludeSkipFromEnv(
+    env: *const std.process.Environ.Map,
+    key: []const u8,
+    pass_name: []const u8,
+    out: *?[]const u32,
+    gpa: std.mem.Allocator,
+) void {
+    if (env.get(key)) |v| {
+        if (parsePreludeModFilter(v, gpa)) |filter| {
+            out.* = filter;
+            logPreludeSkip(pass_name, filter);
+        } else |e| {
+            std.log.warn("[#761 bisect] {s}={s}: {s} — ignoring", .{ key, v, @errorName(e) });
         }
     }
 }
@@ -178,8 +217,24 @@ pub fn parseLimitSpec(text: []const u8, gpa: std.mem.Allocator) ParseError!Limit
         if (fn_filter) |f| gpa.free(f);
         if (mod_filter) |m| gpa.free(m);
     }
+
     if (rest) |r| try parseFnAndModFilters(r, gpa, &fn_filter, &mod_filter);
     return .{ .n = n, .func_filter = fn_filter, .mod_filter = mod_filter };
+}
+
+/// Parse the value of a prelude skip env var. `null` means "all
+/// modules"; a non-empty slice means "only those module indices".
+pub fn parsePreludeModFilter(text: []const u8, gpa: std.mem.Allocator) ParseError!?[]const u32 {
+    const trimmed = std.mem.trim(u8, text, " \t");
+    if (trimmed.len == 0 or
+        std.ascii.eqlIgnoreCase(trimmed, "1") or
+        std.ascii.eqlIgnoreCase(trimmed, "true") or
+        std.ascii.eqlIgnoreCase(trimmed, "all"))
+    {
+        return null;
+    }
+    if (stripModPrefix(trimmed)) |mod_text| return try parseFnList(mod_text, gpa);
+    return error.UnknownTrailing;
 }
 
 /// Parse the trailing `fn=...[:mod=...]` or `mod=...[:fn=...]` after
@@ -327,6 +382,20 @@ fn logLimit(lim: Limit) void {
     );
 }
 
+fn logPreludeSkip(pass_name: []const u8, mod_filter: ?[]const u32) void {
+    if (mod_filter) |list| {
+        std.log.warn(
+            "[#761 bisect] SKIP {s} in {d} module(s)",
+            .{ pass_name, list.len },
+        );
+    } else {
+        std.log.warn(
+            "[#761 bisect] SKIP {s} (all modules)",
+            .{pass_name},
+        );
+    }
+}
+
 // ---------------------------------------------------------------------
 // Tests — pure, no env-var or filesystem I/O.
 // ---------------------------------------------------------------------
@@ -442,6 +511,50 @@ test "parseLimitSpec: limit + mod filter" {
     try testing.expectEqualSlices(u32, &.{4}, lim.mod_filter.?);
 }
 
+test "parsePreludeModFilter: all modules and mod filters" {
+    {
+        const filter = try parsePreludeModFilter("1", testing.allocator);
+        try testing.expectEqual(@as(?[]const u32, null), filter);
+    }
+    {
+        const filter = try parsePreludeModFilter("true", testing.allocator);
+        try testing.expectEqual(@as(?[]const u32, null), filter);
+    }
+    {
+        const filter = try parsePreludeModFilter("all", testing.allocator);
+        try testing.expectEqual(@as(?[]const u32, null), filter);
+    }
+    {
+        const filter = try parsePreludeModFilter("mod=0,4-5", testing.allocator);
+        defer testing.allocator.free(filter.?);
+        try testing.expectEqualSlices(u32, &.{ 0, 4, 5 }, filter.?);
+    }
+    try testing.expectError(error.UnknownTrailing, parsePreludeModFilter("fn=1", testing.allocator));
+}
+
+test "parseFromEnv: prelude skip env vars honour module filters" {
+    var env = std.process.Environ.Map.init(testing.allocator);
+    defer env.deinit();
+    try env.put("WAMR_AOT_SKIP_INLINE_SMALL", "mod=4");
+    try env.put("WAMR_AOT_SKIP_PROMOTE_SSA", "1");
+    try env.put("WAMR_AOT_SKIP_PHIS_TO_LOCALS", "mod=0,4");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    defer global = .{};
+
+    parseFromEnv(&env, arena.allocator());
+
+    try testing.expect(!global.skipsInlineSmall(0));
+    try testing.expect(global.skipsInlineSmall(4));
+    try testing.expect(global.skipsPromoteSSA(0));
+    try testing.expect(global.skipsPromoteSSA(4));
+    try testing.expect(global.skipsPromoteSSA(99));
+    try testing.expect(global.skipsPhisToLocals(0));
+    try testing.expect(global.skipsPhisToLocals(4));
+    try testing.expect(!global.skipsPhisToLocals(1));
+}
+
 test "Spec.shouldSkip + effectiveLimit + affectsFunction" {
     const funcs = [_]u32{11040};
     const spec: Spec = .{
@@ -485,6 +598,8 @@ test "Spec.shouldSkip honours mod_filter" {
     // affectsFunction matches the module
     try testing.expect(spec.affectsFunction(4, 0));
     try testing.expect(!spec.affectsFunction(0, 0));
+    try testing.expect(spec.affectsModule(4));
+    try testing.expect(!spec.affectsModule(0));
 }
 
 test "Spec.shouldSkip with both mod_filter AND func_filter" {
@@ -516,6 +631,49 @@ test "Spec.effectiveLimit honours mod_filter" {
     try testing.expectEqual(@as(?u32, 5), spec.effectiveLimit(4, 9999));
     try testing.expectEqual(@as(?u32, null), spec.effectiveLimit(0, 0));
     try testing.expectEqual(@as(?u32, null), spec.effectiveLimit(1, 0));
+    try testing.expect(spec.affectsModule(4));
+    try testing.expect(!spec.affectsModule(0));
+}
+
+test "Spec prelude skip helpers honour module filters" {
+    const mod4 = [_]u32{4};
+    const mod0_and_4 = [_]u32{ 0, 4 };
+
+    try testing.expect(!(Spec{}).skipsInlineSmall(4));
+
+    const all_modules: Spec = .{ .skip_inline_small = null };
+    try testing.expect(all_modules.skipsInlineSmall(0));
+    try testing.expect(all_modules.skipsInlineSmall(4));
+
+    const module_4_only: Spec = .{ .skip_inline_small = &mod4 };
+    try testing.expect(!module_4_only.skipsInlineSmall(0));
+    try testing.expect(module_4_only.skipsInlineSmall(4));
+    try testing.expect(!module_4_only.affectsModule(0));
+    try testing.expect(module_4_only.affectsModule(4));
+
+    const module_0_and_4: Spec = .{ .skip_inline_small = &mod0_and_4 };
+    try testing.expect(module_0_and_4.skipsInlineSmall(0));
+    try testing.expect(module_0_and_4.skipsInlineSmall(4));
+    try testing.expect(!module_0_and_4.skipsInlineSmall(1));
+}
+
+test "Spec lowerPhis skip forces matching promote skip" {
+    const mod4 = [_]u32{4};
+    const lower_only: Spec = .{ .skip_phis_to_locals = &mod4 };
+
+    try testing.expect(lower_only.lowerPhisSkipForcesPromote());
+    try testing.expect(!lower_only.skipsPromoteSSA(0));
+    try testing.expect(lower_only.skipsPromoteSSA(4));
+    try testing.expect(!lower_only.skipsPhisToLocals(0));
+    try testing.expect(lower_only.skipsPhisToLocals(4));
+
+    const promote_covers_lower: Spec = .{
+        .skip_promote_ssa = null,
+        .skip_phis_to_locals = &mod4,
+    };
+    try testing.expect(!promote_covers_lower.lowerPhisSkipForcesPromote());
+    try testing.expect(promote_covers_lower.skipsPromoteSSA(0));
+    try testing.expect(promote_covers_lower.skipsPromoteSSA(4));
 }
 
 test "Spec.isEmpty default" {

--- a/src/compiler/aot_bisect.zig
+++ b/src/compiler/aot_bisect.zig
@@ -579,6 +579,8 @@ test "Spec.shouldSkip + effectiveLimit + affectsFunction" {
     try testing.expect(spec.affectsFunction(0, 11040));
     try testing.expect(spec.affectsFunction(0, 0)); // hit by pass-17 all-funcs skip
     try testing.expect(spec.affectsFunction(0, 99999)); // same
+    try testing.expect(spec.hasPassPipelineFilterInModule(0));
+    try testing.expect(spec.hasPassPipelineFilterInModule(4));
 }
 
 test "Spec.shouldSkip honours mod_filter" {
@@ -600,6 +602,8 @@ test "Spec.shouldSkip honours mod_filter" {
     try testing.expect(!spec.affectsFunction(0, 0));
     try testing.expect(spec.affectsModule(4));
     try testing.expect(!spec.affectsModule(0));
+    try testing.expect(spec.hasPassPipelineFilterInModule(4));
+    try testing.expect(!spec.hasPassPipelineFilterInModule(0));
 }
 
 test "Spec.shouldSkip with both mod_filter AND func_filter" {
@@ -633,6 +637,8 @@ test "Spec.effectiveLimit honours mod_filter" {
     try testing.expectEqual(@as(?u32, null), spec.effectiveLimit(1, 0));
     try testing.expect(spec.affectsModule(4));
     try testing.expect(!spec.affectsModule(0));
+    try testing.expect(spec.hasPassPipelineFilterInModule(4));
+    try testing.expect(!spec.hasPassPipelineFilterInModule(0));
 }
 
 test "Spec prelude skip helpers honour module filters" {
@@ -650,6 +656,7 @@ test "Spec prelude skip helpers honour module filters" {
     try testing.expect(module_4_only.skipsInlineSmall(4));
     try testing.expect(!module_4_only.affectsModule(0));
     try testing.expect(module_4_only.affectsModule(4));
+    try testing.expect(!module_4_only.hasPassPipelineFilterInModule(4));
 
     const module_0_and_4: Spec = .{ .skip_inline_small = &mod0_and_4 };
     try testing.expect(module_0_and_4.skipsInlineSmall(0));

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -2729,27 +2729,32 @@ pub const PassBisectSpec = struct {
         func_filter: ?[]const u32 = null,
         mod_filter: ?[]const u32 = null,
     };
+    /// Scope for function-level prelude skips. `null` filters mean "all
+    /// functions/modules"; non-null slices narrow to the listed indices.
+    pub const PreludeFilter = struct {
+        func_filter: ?[]const u32 = null,
+        mod_filter: ?[]const u32 = null,
+    };
 
     skip: []const Skip = &.{},
     limit: ?Limit = null,
-    /// Prelude skip module filters. `&.{}` means disabled, `null`
-    /// means every module, and a non-empty slice means only those
-    /// module indices. They intentionally do not have per-function
-    /// filters because these passes are either module-scoped
-    /// (`inlineSmallFunctions`) or must run consistently for the whole
-    /// module's local/phi form (`promoteLocalsToSSA`,
-    /// `lowerPhisToLocals`).
+    /// Module-level prelude skip for `inlineSmallFunctions`. `&.{}`
+    /// means disabled, `null` means every module, and a non-empty slice
+    /// means only those module indices.
     skip_inline_small: ?[]const u32 = &.{},
-    skip_promote_ssa: ?[]const u32 = &.{},
-    skip_phis_to_locals: ?[]const u32 = &.{},
+    /// Function-level prelude skips. `null` means disabled; `.{}`
+    /// means every module/function; non-null fields inside the struct
+    /// narrow to the listed module/function indices.
+    skip_promote_ssa: ?PreludeFilter = null,
+    skip_phis_to_locals: ?PreludeFilter = null,
 
     /// True when no filtering is configured anywhere.
     pub fn isEmpty(self: PassBisectSpec) bool {
         return self.skip.len == 0 and
             self.limit == null and
             !preludeFilterEnabled(self.skip_inline_small) and
-            !preludeFilterEnabled(self.skip_promote_ssa) and
-            !preludeFilterEnabled(self.skip_phis_to_locals);
+            self.skip_promote_ssa == null and
+            self.skip_phis_to_locals == null;
     }
 
     /// True when this spec may alter any function in `module_idx`.
@@ -2757,7 +2762,12 @@ pub const PassBisectSpec = struct {
     /// different `:mod=N` must leave this module's optimization loop
     /// byte-for-byte equivalent to the unfiltered path.
     pub fn affectsModule(self: PassBisectSpec, module_idx: u32) bool {
-        if (self.skipsInlineSmall(module_idx) or self.skipsPromoteSSA(module_idx)) return true;
+        if (self.skipsInlineSmall(module_idx) or
+            preludeFilterMatchesModule(self.skip_promote_ssa, module_idx) or
+            preludeFilterMatchesModule(self.skip_phis_to_locals, module_idx))
+        {
+            return true;
+        }
         return self.hasPassPipelineFilterInModule(module_idx);
     }
 
@@ -2802,18 +2812,19 @@ pub const PassBisectSpec = struct {
         return preludeMatches(self.skip_inline_small, module_idx);
     }
 
-    pub fn skipsPromoteSSA(self: PassBisectSpec, module_idx: u32) bool {
-        return preludeMatches(self.skip_promote_ssa, module_idx) or
-            preludeMatches(self.skip_phis_to_locals, module_idx);
+    pub fn skipsPromoteSSA(self: PassBisectSpec, module_idx: u32, func_idx: u32) bool {
+        return preludeFilterMatchesFunction(self.skip_promote_ssa, module_idx, func_idx) or
+            preludeFilterMatchesFunction(self.skip_phis_to_locals, module_idx, func_idx);
     }
 
-    pub fn skipsPhisToLocals(self: PassBisectSpec, module_idx: u32) bool {
-        return preludeMatches(self.skip_phis_to_locals, module_idx);
+    pub fn skipsPhisToLocals(self: PassBisectSpec, module_idx: u32, func_idx: u32) bool {
+        return preludeFilterMatchesFunction(self.skip_phis_to_locals, module_idx, func_idx);
     }
 
     pub fn lowerPhisSkipForcesPromote(self: PassBisectSpec) bool {
-        return preludeFilterEnabled(self.skip_phis_to_locals) and
-            !preludeFilterSubset(self.skip_phis_to_locals, self.skip_promote_ssa);
+        const lower = self.skip_phis_to_locals orelse return false;
+        const promote = self.skip_promote_ssa orelse return true;
+        return !preludeFilterCovers(promote, lower);
     }
 
     /// True when this spec narrows behaviour for `func_idx` in
@@ -2822,7 +2833,7 @@ pub const PassBisectSpec = struct {
     /// in a state later cleanups would normalise, tripping benign
     /// structural checks.
     pub fn affectsFunction(self: PassBisectSpec, module_idx: u32, func_idx: u32) bool {
-        if (self.skipsInlineSmall(module_idx) or self.skipsPromoteSSA(module_idx)) return true;
+        if (self.skipsInlineSmall(module_idx) or self.skipsPromoteSSA(module_idx, func_idx)) return true;
         if (self.effectiveLimit(module_idx, func_idx) != null) return true;
         for (self.skip) |s| {
             if (!modMatches(s.mod_filter, module_idx)) continue;
@@ -2855,13 +2866,33 @@ pub const PassBisectSpec = struct {
         return false;
     }
 
-    fn preludeFilterSubset(needle: ?[]const u32, haystack: ?[]const u32) bool {
-        if (!preludeFilterEnabled(needle)) return true;
-        if (!preludeFilterEnabled(haystack)) return false;
-        if (haystack == null) return true;
-        if (needle == null) return false;
-        for (needle.?) |m| {
-            if (!preludeMatches(haystack, m)) return false;
+    fn preludeFilterMatchesModule(filter: ?PreludeFilter, module_idx: u32) bool {
+        const f = filter orelse return false;
+        return modMatches(f.mod_filter, module_idx);
+    }
+
+    fn preludeFilterMatchesFunction(filter: ?PreludeFilter, module_idx: u32, func_idx: u32) bool {
+        const f = filter orelse return false;
+        return modMatches(f.mod_filter, module_idx) and funcMatches(f.func_filter, func_idx);
+    }
+
+    fn preludeFilterCovers(cover: PreludeFilter, covered: PreludeFilter) bool {
+        return filterDimensionCovers(cover.mod_filter, covered.mod_filter) and
+            filterDimensionCovers(cover.func_filter, covered.func_filter);
+    }
+
+    fn filterDimensionCovers(cover: ?[]const u32, covered: ?[]const u32) bool {
+        if (cover == null) return true;
+        const covered_list = covered orelse return false;
+        for (covered_list) |item| {
+            var found = false;
+            for (cover.?) |cover_item| {
+                if (cover_item == item) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) return false;
         }
         return true;
     }
@@ -6905,7 +6936,7 @@ pub fn runPassesWithOptions(
             // later rounds the function is already past mem2reg and any new
             // local_set/get inserted by inlining is handled by
             // `forwardLocalGet` + `deadLocalSetElimination`.
-            if (outer_iter == 0 and !opts.bisect.skipsPromoteSSA(opts.module_idx)) {
+            if (outer_iter == 0 and !opts.bisect.skipsPromoteSSA(opts.module_idx, func_idx)) {
                 if (try promoteLocalsToSSA(func, allocator)) {
                     total_changes += 1;
                     try Verify.check(effective_verify_mode, "promoteLocalsToSSA", func, func_idx, allocator);
@@ -6919,7 +6950,7 @@ pub fn runPassesWithOptions(
                             .outer_iter = outer_iter,
                         });
                     }
-                    if (!opts.bisect.skipsPhisToLocals(opts.module_idx) and try lowerPhisToLocals(func, allocator)) {
+                    if (!opts.bisect.skipsPhisToLocals(opts.module_idx, func_idx) and try lowerPhisToLocals(func, allocator)) {
                         total_changes += 1;
                         try Verify.check(effective_verify_mode, "lowerPhisToLocals", func, func_idx, allocator);
                         if (opts.dump_hook) |hook| {
@@ -7847,12 +7878,32 @@ test "PassBisectSpec: skip_promote_ssa gates SSA prelude" {
         var module = try bisectTestBuildLoopModule(allocator);
         defer module.deinit();
 
-        const spec: PassBisectSpec = .{ .skip_promote_ssa = null };
+        const spec: PassBisectSpec = .{ .skip_promote_ssa = .{} };
         _ = try runPassesWithOptions(&module, no_passes, allocator, .{ .bisect = spec });
 
         try std.testing.expectEqual(@as(u32, 1), module.functions.items[0].local_count);
         try std.testing.expect(!bisectTestModuleHasPhi(&module));
     }
+}
+
+test "PassBisectSpec: skip_promote_ssa func_filter only gates matching funcs" {
+    const allocator = std.testing.allocator;
+    const no_passes: []const PassFn = &.{};
+    var module = try bisectTestBuildLoopModule(allocator);
+    defer module.deinit();
+
+    var second = try bisectTestBuildLoopModule(allocator);
+    defer second.deinit();
+    var second_func = second.functions.pop().?;
+    errdefer second_func.deinit();
+    try module.functions.append(allocator, second_func);
+
+    const fn1 = [_]u32{1};
+    const spec: PassBisectSpec = .{ .skip_promote_ssa = .{ .func_filter = &fn1 } };
+    _ = try runPassesWithOptions(&module, no_passes, allocator, .{ .bisect = spec });
+
+    try std.testing.expect(module.functions.items[0].local_count > 1);
+    try std.testing.expectEqual(@as(u32, 1), module.functions.items[1].local_count);
 }
 
 test "PassBisectSpec: skip_phis_to_locals forces promote skip in run loop" {
@@ -7861,7 +7912,7 @@ test "PassBisectSpec: skip_phis_to_locals forces promote skip in run loop" {
     var module = try bisectTestBuildLoopModule(allocator);
     defer module.deinit();
 
-    const spec: PassBisectSpec = .{ .skip_phis_to_locals = null };
+    const spec: PassBisectSpec = .{ .skip_phis_to_locals = .{} };
     _ = try runPassesWithOptions(&module, no_passes, allocator, .{ .bisect = spec });
 
     try std.testing.expectEqual(@as(u32, 1), module.functions.items[0].local_count);

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -2758,6 +2758,14 @@ pub const PassBisectSpec = struct {
     /// byte-for-byte equivalent to the unfiltered path.
     pub fn affectsModule(self: PassBisectSpec, module_idx: u32) bool {
         if (self.skipsInlineSmall(module_idx) or self.skipsPromoteSSA(module_idx)) return true;
+        return self.hasPassPipelineFilterInModule(module_idx);
+    }
+
+    /// True when the per-function pass slice is filtered in
+    /// `module_idx`. Unlike prelude skips, these filters can affect only
+    /// a subset of functions, so the outer inlining loop must be capped
+    /// to avoid propagating partial-pipeline effects into callers.
+    pub fn hasPassPipelineFilterInModule(self: PassBisectSpec, module_idx: u32) bool {
         if (self.limit) |lim| {
             if (modMatches(lim.mod_filter, module_idx)) return true;
         }
@@ -6821,15 +6829,15 @@ pub fn runPassesWithOptions(
     // constant-argument-specialisation cases that motivate this loop,
     // without exploding compile time.
     //
-    // #761: when the current module is affected by a bisect spec, force
-    // a single outer iteration. The second iteration re-runs
-    // module-level `inlineSmallFunctions` on IR that the first
-    // per-function pass round has already filtered, which would leak
-    // the partial pipeline's effects into otherwise-unaffected
-    // callers/callees and defeat the per-function isolation promise.
-    // A spec whose `:mod=N` filter does not match this module must not
-    // shorten the normal two-round schedule.
-    const outer_max: u32 = if (opts.bisect.affectsModule(opts.module_idx)) 1 else 2;
+    // #761: when the current module has a per-function pass-pipeline
+    // bisect filter, force a single outer iteration. The second
+    // iteration re-runs module-level `inlineSmallFunctions` on IR that
+    // the first per-function pass round has already filtered, which
+    // would leak the partial pipeline's effects into otherwise-
+    // unaffected callers/callees and defeat the per-function isolation
+    // promise. Prelude skips are module-wide, so they keep the normal
+    // two-round schedule.
+    const outer_max: u32 = if (opts.bisect.hasPassPipelineFilterInModule(opts.module_idx)) 1 else 2;
     var outer_iter: u32 = 0;
     while (outer_iter < outer_max) : (outer_iter += 1) {
         // Module-level: inline small leaf callees. Iterate to fixpoint so

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -2679,9 +2679,9 @@ pub const RunOptions = struct {
     /// release builds pay nothing. Callers in debug / fuzz contexts
     /// should set this to `.after_each_pass`.
     verify_mode: verifier.VerifyMode = .off,
-    /// Optional per-function pass-pipeline filter used to bisect AOT
-    /// codegen miscompiles (#743 / #761). Default `.{}` means "no
-    /// filtering" — the full pipeline runs for every function.
+    /// Optional pass/prelude filter used to bisect AOT codegen
+    /// miscompiles (#743 / #761). Default `.{}` means "no filtering" —
+    /// the full pipeline runs for every function.
     bisect: PassBisectSpec = .{},
     /// Module index used to narrow `bisect.skip`/`bisect.limit` entries
     /// whose `mod_filter` is non-null. Defaults to 0; single-module
@@ -2691,18 +2691,18 @@ pub const RunOptions = struct {
     module_idx: u32 = 0,
 };
 
-/// Filter that selectively skips IR optimisation passes or caps the
-/// pipeline length for specific functions. Used by `wamrc` bisection
-/// knobs (`WAMR_AOT_SKIP_PASS` / `WAMR_AOT_PASSES_LIMIT`) to narrow a
-/// suspected codegen miscompile to a single pass + function pair
-/// without recompiling the rest of the module with a partial pipeline.
+/// Filter that selectively skips IR optimisation passes, caps the
+/// pipeline length for specific functions, or skips the prelude passes
+/// that run outside the per-function pass slice. Used by `wamrc`
+/// bisection knobs (`WAMR_AOT_SKIP_PASS` / `WAMR_AOT_PASSES_LIMIT` /
+/// `WAMR_AOT_SKIP_*`) to narrow a suspected codegen miscompile.
 ///
 /// `pass_idx` here refers to the index into the per-function pipeline
 /// slice handed to `runPassesWithOptions` (typically the slice
-/// returned by `defaultPassesForTarget`). The infrastructure passes
-/// (`inlineSmallFunctions`, `promoteLocalsToSSA`, `lowerPhisToLocals`,
-/// `scrubUnreachableBlocks`) live outside that slice and are never
-/// affected by this filter.
+/// returned by `defaultPassesForTarget`). The prelude skip fields below
+/// handle `inlineSmallFunctions`, `promoteLocalsToSSA`, and
+/// `lowerPhisToLocals`; `scrubUnreachableBlocks` is deliberately not
+/// filtered.
 ///
 /// Lifetime: `Skip.func_filter` / `Limit.func_filter` are borrowed
 /// slices. Callers (typically `aot_bisect.global`) keep them live for
@@ -2732,11 +2732,39 @@ pub const PassBisectSpec = struct {
 
     skip: []const Skip = &.{},
     limit: ?Limit = null,
+    /// Prelude skip module filters. `&.{}` means disabled, `null`
+    /// means every module, and a non-empty slice means only those
+    /// module indices. They intentionally do not have per-function
+    /// filters because these passes are either module-scoped
+    /// (`inlineSmallFunctions`) or must run consistently for the whole
+    /// module's local/phi form (`promoteLocalsToSSA`,
+    /// `lowerPhisToLocals`).
+    skip_inline_small: ?[]const u32 = &.{},
+    skip_promote_ssa: ?[]const u32 = &.{},
+    skip_phis_to_locals: ?[]const u32 = &.{},
 
-    /// True when no filtering is configured — fast path for callers
-    /// that want to skip per-pass overhead checks.
+    /// True when no filtering is configured anywhere.
     pub fn isEmpty(self: PassBisectSpec) bool {
-        return self.skip.len == 0 and self.limit == null;
+        return self.skip.len == 0 and
+            self.limit == null and
+            !preludeFilterEnabled(self.skip_inline_small) and
+            !preludeFilterEnabled(self.skip_promote_ssa) and
+            !preludeFilterEnabled(self.skip_phis_to_locals);
+    }
+
+    /// True when this spec may alter any function in `module_idx`.
+    /// Used for module-level scheduling decisions: a spec scoped to a
+    /// different `:mod=N` must leave this module's optimization loop
+    /// byte-for-byte equivalent to the unfiltered path.
+    pub fn affectsModule(self: PassBisectSpec, module_idx: u32) bool {
+        if (self.skipsInlineSmall(module_idx) or self.skipsPromoteSSA(module_idx)) return true;
+        if (self.limit) |lim| {
+            if (modMatches(lim.mod_filter, module_idx)) return true;
+        }
+        for (self.skip) |s| {
+            if (modMatches(s.mod_filter, module_idx)) return true;
+        }
+        return false;
     }
 
     /// True when pass index `pass_idx` should be skipped for function
@@ -2762,12 +2790,31 @@ pub const PassBisectSpec = struct {
         return lim.n;
     }
 
+    pub fn skipsInlineSmall(self: PassBisectSpec, module_idx: u32) bool {
+        return preludeMatches(self.skip_inline_small, module_idx);
+    }
+
+    pub fn skipsPromoteSSA(self: PassBisectSpec, module_idx: u32) bool {
+        return preludeMatches(self.skip_promote_ssa, module_idx) or
+            preludeMatches(self.skip_phis_to_locals, module_idx);
+    }
+
+    pub fn skipsPhisToLocals(self: PassBisectSpec, module_idx: u32) bool {
+        return preludeMatches(self.skip_phis_to_locals, module_idx);
+    }
+
+    pub fn lowerPhisSkipForcesPromote(self: PassBisectSpec) bool {
+        return preludeFilterEnabled(self.skip_phis_to_locals) and
+            !preludeFilterSubset(self.skip_phis_to_locals, self.skip_promote_ssa);
+    }
+
     /// True when this spec narrows behaviour for `func_idx` in
     /// `module_idx` at all. Used to decide per-function verifier
     /// suppression: partial pipelines on a function can leave its IR
     /// in a state later cleanups would normalise, tripping benign
     /// structural checks.
     pub fn affectsFunction(self: PassBisectSpec, module_idx: u32, func_idx: u32) bool {
+        if (self.skipsInlineSmall(module_idx) or self.skipsPromoteSSA(module_idx)) return true;
         if (self.effectiveLimit(module_idx, func_idx) != null) return true;
         for (self.skip) |s| {
             if (!modMatches(s.mod_filter, module_idx)) continue;
@@ -2786,6 +2833,29 @@ pub const PassBisectSpec = struct {
         const list = filter orelse return true;
         for (list) |m| if (m == module_idx) return true;
         return false;
+    }
+
+    fn preludeFilterEnabled(filter: ?[]const u32) bool {
+        const list = filter orelse return true;
+        return list.len != 0;
+    }
+
+    fn preludeMatches(filter: ?[]const u32, module_idx: u32) bool {
+        const list = filter orelse return true;
+        if (list.len == 0) return false;
+        for (list) |m| if (m == module_idx) return true;
+        return false;
+    }
+
+    fn preludeFilterSubset(needle: ?[]const u32, haystack: ?[]const u32) bool {
+        if (!preludeFilterEnabled(needle)) return true;
+        if (!preludeFilterEnabled(haystack)) return false;
+        if (haystack == null) return true;
+        if (needle == null) return false;
+        for (needle.?) |m| {
+            if (!preludeMatches(haystack, m)) return false;
+        }
+        return true;
     }
 };
 
@@ -6751,48 +6821,49 @@ pub fn runPassesWithOptions(
     // constant-argument-specialisation cases that motivate this loop,
     // without exploding compile time.
     //
-    // #761: when a per-function bisect spec is active, force a single
-    // outer iteration. The second iteration re-runs module-level
-    // `inlineSmallFunctions` on IR that the first per-function pass
-    // round has already filtered, which would leak the partial
-    // pipeline's effects into otherwise-unaffected callers/callees and
-    // defeat the per-function isolation promise. One outer round still
-    // runs full inlining first (over vanilla post-frontend IR), so
-    // unaffected functions retain the same inlining behaviour as
-    // without the bisect.
-    const outer_max: u32 = if (opts.bisect.isEmpty()) 2 else 1;
+    // #761: when the current module is affected by a bisect spec, force
+    // a single outer iteration. The second iteration re-runs
+    // module-level `inlineSmallFunctions` on IR that the first
+    // per-function pass round has already filtered, which would leak
+    // the partial pipeline's effects into otherwise-unaffected
+    // callers/callees and defeat the per-function isolation promise.
+    // A spec whose `:mod=N` filter does not match this module must not
+    // shorten the normal two-round schedule.
+    const outer_max: u32 = if (opts.bisect.affectsModule(opts.module_idx)) 1 else 2;
     var outer_iter: u32 = 0;
     while (outer_iter < outer_max) : (outer_iter += 1) {
         // Module-level: inline small leaf callees. Iterate to fixpoint so
         // callers of callers also benefit within a single outer round.
         var inline_iter: u32 = 0;
         var inlined_count: u32 = 0;
-        while (inline_iter < 4) : (inline_iter += 1) {
-            const iter_inlined = try inlineSmallFunctionsCount(module, allocator);
-            if (iter_inlined == 0) break;
-            inlined_count += iter_inlined;
-            total_changes += 1;
+        if (!opts.bisect.skipsInlineSmall(opts.module_idx)) {
+            while (inline_iter < 4) : (inline_iter += 1) {
+                const iter_inlined = try inlineSmallFunctionsCount(module, allocator);
+                if (iter_inlined == 0) break;
+                inlined_count += iter_inlined;
+                total_changes += 1;
 
-            if (opts.verify_mode != .off) {
-                for (module.functions.items, 0..) |*f, fi| {
-                    const fi32: u32 = @intCast(fi);
-                    // #761: suppress verifier on bisect-affected funcs.
-                    const vm: verifier.VerifyMode =
-                        if (opts.bisect.affectsFunction(opts.module_idx, fi32)) .off else opts.verify_mode;
-                    try Verify.check(vm, "inlineSmallFunctions", f, fi32, allocator);
+                if (opts.verify_mode != .off) {
+                    for (module.functions.items, 0..) |*f, fi| {
+                        const fi32: u32 = @intCast(fi);
+                        // #761: suppress verifier on bisect-affected funcs.
+                        const vm: verifier.VerifyMode =
+                            if (opts.bisect.affectsFunction(opts.module_idx, fi32)) .off else opts.verify_mode;
+                        try Verify.check(vm, "inlineSmallFunctions", f, fi32, allocator);
+                    }
                 }
-            }
 
-            if (opts.dump_hook) |hook| {
-                for (module.functions.items, 0..) |*f, fi| {
-                    try hook.callback(hook.ctx, .{
-                        .pass_name = "inlineSmallFunctions",
-                        .func = f,
-                        .func_index = @intCast(fi),
-                        .changed = true,
-                        .iter = inline_iter,
-                        .outer_iter = outer_iter,
-                    });
+                if (opts.dump_hook) |hook| {
+                    for (module.functions.items, 0..) |*f, fi| {
+                        try hook.callback(hook.ctx, .{
+                            .pass_name = "inlineSmallFunctions",
+                            .func = f,
+                            .func_index = @intCast(fi),
+                            .changed = true,
+                            .iter = inline_iter,
+                            .outer_iter = outer_iter,
+                        });
+                    }
                 }
             }
         }
@@ -6826,7 +6897,7 @@ pub fn runPassesWithOptions(
             // later rounds the function is already past mem2reg and any new
             // local_set/get inserted by inlining is handled by
             // `forwardLocalGet` + `deadLocalSetElimination`.
-            if (outer_iter == 0) {
+            if (outer_iter == 0 and !opts.bisect.skipsPromoteSSA(opts.module_idx)) {
                 if (try promoteLocalsToSSA(func, allocator)) {
                     total_changes += 1;
                     try Verify.check(effective_verify_mode, "promoteLocalsToSSA", func, func_idx, allocator);
@@ -6840,7 +6911,7 @@ pub fn runPassesWithOptions(
                             .outer_iter = outer_iter,
                         });
                     }
-                    if (try lowerPhisToLocals(func, allocator)) {
+                    if (!opts.bisect.skipsPhisToLocals(opts.module_idx) and try lowerPhisToLocals(func, allocator)) {
                         total_changes += 1;
                         try Verify.check(effective_verify_mode, "lowerPhisToLocals", func, func_idx, allocator);
                         if (opts.dump_hook) |hook| {
@@ -6934,7 +7005,8 @@ pub const default_passes: []const PassFn = &.{
     &inductionVariableSimplification,
     &hoistLoopInvariantCode,
     &unrollSmallFixedLoops,
-    &@import("forward_redundant_loads.zig").forwardRedundantLoads,@import("forward_redundant_loads.zig").forwardRedundantLoads,
+    &@import("forward_redundant_loads.zig").forwardRedundantLoads,
+    @import("forward_redundant_loads.zig").forwardRedundantLoads,
     &@import("forward_redundant_loads_dominator.zig").forwardRedundantLoadsDominator,
     &deadStoreElimination,
     &deadCodeElimination,
@@ -6943,7 +7015,6 @@ pub const default_passes: []const PassFn = &.{
     &elideRedundantBoundsChecks,
     &foldLoadStoreOffset,
 };
-
 
 /// Default optimization pipeline for x86-64.
 ///
@@ -6973,7 +7044,8 @@ const x86_64_default_passes: []const PassFn = &.{
     &foldWrapOfExtend,
     &globalValueNumbering,
     &hoistLoopInvariantCode,
-    &@import("forward_redundant_loads.zig").forwardRedundantLoads,@import("forward_redundant_loads.zig").forwardRedundantLoads,
+    &@import("forward_redundant_loads.zig").forwardRedundantLoads,
+    @import("forward_redundant_loads.zig").forwardRedundantLoads,
     &@import("forward_redundant_loads_dominator.zig").forwardRedundantLoadsDominator,
     &deadStoreElimination,
     &deadCodeElimination,
@@ -6984,56 +7056,56 @@ const x86_64_default_passes: []const PassFn = &.{
 };
 
 const default_passes_no_iv: []const PassFn = &.{
-    &forwardLocalGet,                  &constantFold,            &algebraicSimplify,      &strengthReduceMul,
-    &strengthReduceMulShiftAdd,        &strengthReduceDivRem,    &foldConstantBranches,   &foldInverseCompareEqz,
-    &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,        &foldSignExtendingLoad,
-    &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,   &hoistLoopInvariantCode,
+    &forwardLocalGet,                  &constantFold,            &algebraicSimplify,       &strengthReduceMul,
+    &strengthReduceMulShiftAdd,        &strengthReduceDivRem,    &foldConstantBranches,    &foldInverseCompareEqz,
+    &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,         &foldSignExtendingLoad,
+    &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,    &hoistLoopInvariantCode,
     &unrollSmallFixedLoops,            &deadCodeElimination,     &deadLocalSetElimination, &hoistLoopBoundsChecks,
     &elideRedundantBoundsChecks,       &foldLoadStoreOffset,
 };
 
 const default_passes_no_unroll: []const PassFn = &.{
-    &forwardLocalGet,                  &constantFold,            &algebraicSimplify,               &strengthReduceMul,
-    &strengthReduceMulShiftAdd,        &strengthReduceDivRem,    &foldConstantBranches,            &foldInverseCompareEqz,
-    &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,                 &foldSignExtendingLoad,
-    &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,            &inductionVariableSimplification,
-    &hoistLoopInvariantCode,           &deadCodeElimination,     &deadLocalSetElimination,         &hoistLoopBoundsChecks,
+    &forwardLocalGet,                  &constantFold,            &algebraicSimplify,       &strengthReduceMul,
+    &strengthReduceMulShiftAdd,        &strengthReduceDivRem,    &foldConstantBranches,    &foldInverseCompareEqz,
+    &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,         &foldSignExtendingLoad,
+    &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,    &inductionVariableSimplification,
+    &hoistLoopInvariantCode,           &deadCodeElimination,     &deadLocalSetElimination, &hoistLoopBoundsChecks,
     &elideRedundantBoundsChecks,       &foldLoadStoreOffset,
 };
 
 const default_passes_no_iv_no_unroll: []const PassFn = &.{
-    &forwardLocalGet,                  &constantFold,            &algebraicSimplify,          &strengthReduceMul,
-    &strengthReduceMulShiftAdd,        &strengthReduceDivRem,    &foldConstantBranches,       &foldInverseCompareEqz,
-    &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,            &foldSignExtendingLoad,
-    &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,       &hoistLoopInvariantCode,
-    &deadCodeElimination,              &deadLocalSetElimination, &hoistLoopBoundsChecks,      &elideRedundantBoundsChecks,
+    &forwardLocalGet,                  &constantFold,            &algebraicSimplify,     &strengthReduceMul,
+    &strengthReduceMulShiftAdd,        &strengthReduceDivRem,    &foldConstantBranches,  &foldInverseCompareEqz,
+    &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,       &foldSignExtendingLoad,
+    &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,  &hoistLoopInvariantCode,
+    &deadCodeElimination,              &deadLocalSetElimination, &hoistLoopBoundsChecks, &elideRedundantBoundsChecks,
     &foldLoadStoreOffset,
 };
 
 const x86_64_default_passes_no_iv: []const PassFn = &.{
-    &forwardLocalGet,            &constantFold,                     &algebraicSimplify,       &strengthReduceMul,
-    &strengthReduceMulShiftAdd,  &strengthReduceDivRem,             &foldConstantBranches,    &foldInverseCompareEqz,
-    &foldBranchOnEqz,            &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,
-    &foldSignExtendingLoad,      &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,
-    &hoistLoopInvariantCode,     &unrollSmallFixedLoops,            &deadCodeElimination,     &deadLocalSetElimination,
-    &hoistLoopBoundsChecks,      &elideRedundantBoundsChecks,       &foldLoadStoreOffset,
-};
-
-const x86_64_default_passes_no_unroll: []const PassFn = &.{
-    &forwardLocalGet,            &constantFold,                     &algebraicSimplify,       &strengthReduceMul,
-    &strengthReduceMulShiftAdd,  &strengthReduceDivRem,             &foldConstantBranches,    &foldInverseCompareEqz,
-    &foldBranchOnEqz,            &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,
-    &foldSignExtendingLoad,      &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,
-    &inductionVariableSimplification, &hoistLoopInvariantCode,      &deadCodeElimination,     &deadLocalSetElimination,
-    &hoistLoopBoundsChecks,      &elideRedundantBoundsChecks,       &foldLoadStoreOffset,
-};
-
-const x86_64_default_passes_no_iv_no_unroll: []const PassFn = &.{
     &forwardLocalGet,           &constantFold,                     &algebraicSimplify,       &strengthReduceMul,
     &strengthReduceMulShiftAdd, &strengthReduceDivRem,             &foldConstantBranches,    &foldInverseCompareEqz,
     &foldBranchOnEqz,           &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,
     &foldSignExtendingLoad,     &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,
-    &hoistLoopInvariantCode,    &deadCodeElimination,              &deadLocalSetElimination, &hoistLoopBoundsChecks,
+    &hoistLoopInvariantCode,    &unrollSmallFixedLoops,            &deadCodeElimination,     &deadLocalSetElimination,
+    &hoistLoopBoundsChecks,     &elideRedundantBoundsChecks,       &foldLoadStoreOffset,
+};
+
+const x86_64_default_passes_no_unroll: []const PassFn = &.{
+    &forwardLocalGet,                 &constantFold,                     &algebraicSimplify,       &strengthReduceMul,
+    &strengthReduceMulShiftAdd,       &strengthReduceDivRem,             &foldConstantBranches,    &foldInverseCompareEqz,
+    &foldBranchOnEqz,                 &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,
+    &foldSignExtendingLoad,           &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,
+    &inductionVariableSimplification, &hoistLoopInvariantCode,           &deadCodeElimination,     &deadLocalSetElimination,
+    &hoistLoopBoundsChecks,           &elideRedundantBoundsChecks,       &foldLoadStoreOffset,
+};
+
+const x86_64_default_passes_no_iv_no_unroll: []const PassFn = &.{
+    &forwardLocalGet,            &constantFold,                     &algebraicSimplify,       &strengthReduceMul,
+    &strengthReduceMulShiftAdd,  &strengthReduceDivRem,             &foldConstantBranches,    &foldInverseCompareEqz,
+    &foldBranchOnEqz,            &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,
+    &foldSignExtendingLoad,      &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,
+    &hoistLoopInvariantCode,     &deadCodeElimination,              &deadLocalSetElimination, &hoistLoopBoundsChecks,
     &elideRedundantBoundsChecks, &foldLoadStoreOffset,
 };
 
@@ -7510,6 +7582,87 @@ fn bisectTestBuildAddModule(allocator: std.mem.Allocator) !ir.IrModule {
     return module;
 }
 
+fn bisectTestBuildInlineModule(allocator: std.mem.Allocator) !ir.IrModule {
+    var module = ir.IrModule.init(allocator);
+    errdefer module.deinit();
+
+    try module.functions.append(allocator, ir.IrFunction.init(allocator, 1, 1, 1));
+    {
+        const callee = &module.functions.items[0];
+        const cb = try callee.newBlock();
+        _ = callee.newVReg();
+        const v_get = callee.newVReg();
+        try callee.getBlock(cb).append(.{ .op = .{ .local_get = 0 }, .dest = v_get, .type = .i32 });
+        try callee.getBlock(cb).append(.{ .op = .{ .ret = v_get } });
+    }
+
+    try module.functions.append(allocator, ir.IrFunction.init(allocator, 0, 1, 0));
+    const args = try allocator.alloc(ir.VReg, 1);
+    {
+        const caller = &module.functions.items[1];
+        const mb = try caller.newBlock();
+        const v_arg = caller.newVReg();
+        const v_ret = caller.newVReg();
+        try caller.getBlock(mb).append(.{ .op = .{ .iconst_32 = 42 }, .dest = v_arg, .type = .i32 });
+        args[0] = v_arg;
+        try caller.getBlock(mb).append(.{ .op = .{ .call = .{ .func_idx = 0, .args = args } }, .dest = v_ret, .type = .i32 });
+        try caller.getBlock(mb).append(.{ .op = .{ .ret = v_ret } });
+    }
+
+    return module;
+}
+
+fn bisectTestBuildLoopModule(allocator: std.mem.Allocator) !ir.IrModule {
+    var module = ir.IrModule.init(allocator);
+    errdefer module.deinit();
+
+    try module.functions.append(allocator, ir.IrFunction.init(allocator, 0, 1, 1));
+    const func = &module.functions.items[0];
+    const lt = try allocator.alloc(ir.IrType, 1);
+    lt[0] = .i32;
+    func.local_types = lt;
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+
+    const v_three = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 3 }, .dest = v_three });
+    try func.getBlock(b0).append(.{ .op = .{ .local_set = .{ .idx = 0, .val = v_three } } });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    const v_ctr = func.newVReg();
+    const v_eqz = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .local_get = 0 }, .dest = v_ctr, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .eqz = v_ctr }, .dest = v_eqz });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_eqz, .then_block = b2, .else_block = b3 } } });
+
+    const v_one = func.newVReg();
+    const v_dec = func.newVReg();
+    try func.getBlock(b3).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_one });
+    try func.getBlock(b3).append(.{ .op = .{ .sub = .{ .lhs = v_ctr, .rhs = v_one } }, .dest = v_dec });
+    try func.getBlock(b3).append(.{ .op = .{ .local_set = .{ .idx = 0, .val = v_dec } } });
+    try func.getBlock(b3).append(.{ .op = .{ .br = b1 } });
+
+    const v_result = func.newVReg();
+    try func.getBlock(b2).append(.{ .op = .{ .local_get = 0 }, .dest = v_result, .type = .i32 });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_result } });
+
+    return module;
+}
+
+fn bisectTestModuleHasPhi(module: *const ir.IrModule) bool {
+    for (module.functions.items) |func| {
+        for (func.blocks.items) |block| {
+            for (block.instructions.items) |inst| {
+                if (inst.op == .phi) return true;
+            }
+        }
+    }
+    return false;
+}
+
 fn bisectTestAddOpAt(module: *const ir.IrModule, func_idx: usize) ir.Inst.Op {
     return module.functions.items[func_idx].blocks.items[0].instructions.items[2].op;
 }
@@ -7641,6 +7794,70 @@ test "PassBisectSpec: skip honours mod_filter — matching module skips" {
             },
         }
     }
+}
+
+test "PassBisectSpec: skip_inline_small gates module prelude" {
+    const allocator = std.testing.allocator;
+    const no_passes: []const PassFn = &.{};
+
+    {
+        var module = try bisectTestBuildInlineModule(allocator);
+        defer module.deinit();
+
+        const mod4 = [_]u32{4};
+        const spec: PassBisectSpec = .{ .skip_inline_small = &mod4 };
+        _ = try runPassesWithOptions(&module, no_passes, allocator, .{ .bisect = spec, .module_idx = 0 });
+
+        try std.testing.expect(module.functions.items[1].blocks.items.len > 1);
+    }
+    {
+        var module = try bisectTestBuildInlineModule(allocator);
+        defer module.deinit();
+
+        const spec: PassBisectSpec = .{ .skip_inline_small = null };
+        _ = try runPassesWithOptions(&module, no_passes, allocator, .{ .bisect = spec, .module_idx = 0 });
+
+        try std.testing.expectEqual(@as(usize, 1), module.functions.items[1].blocks.items.len);
+        try std.testing.expect(module.functions.items[1].blocks.items[0].instructions.items[1].op == .call);
+    }
+}
+
+test "PassBisectSpec: skip_promote_ssa gates SSA prelude" {
+    const allocator = std.testing.allocator;
+    const no_passes: []const PassFn = &.{};
+
+    {
+        var module = try bisectTestBuildLoopModule(allocator);
+        defer module.deinit();
+
+        _ = try runPassesWithOptions(&module, no_passes, allocator, .{});
+
+        try std.testing.expect(module.functions.items[0].local_count > 1);
+        try std.testing.expect(!bisectTestModuleHasPhi(&module));
+    }
+    {
+        var module = try bisectTestBuildLoopModule(allocator);
+        defer module.deinit();
+
+        const spec: PassBisectSpec = .{ .skip_promote_ssa = null };
+        _ = try runPassesWithOptions(&module, no_passes, allocator, .{ .bisect = spec });
+
+        try std.testing.expectEqual(@as(u32, 1), module.functions.items[0].local_count);
+        try std.testing.expect(!bisectTestModuleHasPhi(&module));
+    }
+}
+
+test "PassBisectSpec: skip_phis_to_locals forces promote skip in run loop" {
+    const allocator = std.testing.allocator;
+    const no_passes: []const PassFn = &.{};
+    var module = try bisectTestBuildLoopModule(allocator);
+    defer module.deinit();
+
+    const spec: PassBisectSpec = .{ .skip_phis_to_locals = null };
+    _ = try runPassesWithOptions(&module, no_passes, allocator, .{ .bisect = spec });
+
+    try std.testing.expectEqual(@as(u32, 1), module.functions.items[0].local_count);
+    try std.testing.expect(!bisectTestModuleHasPhi(&module));
 }
 
 test "constantFold: eqz on constant" {
@@ -10754,7 +10971,7 @@ test "inlineSmallFunctions: br_table callee gets inlined with remapped targets" 
     try std.testing.expectEqual(module.functions.items[1].blocks.items[0].instructions.items[0].dest.?, bt.index);
 }
 
-test "runPasses: re-runs inlining after first per-function fixpoint" {
+test "runPasses: non-matching mod filter preserves second inlining round" {
     // Scenario: a caller invokes a small leaf callee with an argument that
     // is itself the result of a small chain (local.get → constant fold).
     // After the first per-function fixpoint round the call survives, but
@@ -10819,7 +11036,9 @@ test "runPasses: re-runs inlining after first per-function fixpoint" {
         &constantFold,
         &deadCodeElimination,
     };
-    _ = try runPasses(&module, &test_passes, allocator);
+    const mod4_only = [_]u32{4};
+    const spec: PassBisectSpec = .{ .skip_inline_small = &mod4_only };
+    _ = try runPassesWithOptions(&module, &test_passes, allocator, .{ .bisect = spec, .module_idx = 0 });
 
     // After two outer rounds, f2 must contain no `.call` instructions:
     // f0 was inlined into f1 during the first outer round, and the now
@@ -13632,7 +13851,6 @@ test "CSE load: call in sibling block invalidates dominator-cached load on merge
     try std.testing.expectEqual(ir.Inst.Op{ .ret = v_tail }, func.getBlock(tail).instructions.items[1].op);
     try std.testing.expect(func.getBlock(tail).instructions.items[0].op == .load);
 }
-
 
 test "GVN load (cell C): call AFTER load in same block prevents fusion of later load (#734)" {
     // entry: load p[0]; call barrier; load p[0]; ret second load.


### PR DESCRIPTION
## Summary
- Add WAMR_AOT_SKIP_INLINE_SMALL, WAMR_AOT_SKIP_PROMOTE_SSA, and WAMR_AOT_SKIP_PHIS_TO_LOCALS.
- Support optional mod= filters for the new prelude controls.
- Preserve normal outer optimization scheduling for modules not matched by a mod filter.
- Add parser and run-loop coverage for the new controls.

Refs #743.

## Testing
- zig build test --summary all