### PR TITLE
ir: add optimizer property tests

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -617,6 +617,18 @@ pub fn build(b: *std.Build) void {
     const run_ir_interp_tests = b.addRunArtifact(ir_interp_tests);
     test_step.dependOn(&run_ir_interp_tests.step);
 
+    // IR deterministic generator tests (#736).
+    const ir_fuzz_test_module = b.createModule(.{
+        .root_source_file = b.path("src/compiler/ir/fuzz.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const ir_fuzz_tests = b.addTest(.{
+        .root_module = ir_fuzz_test_module,
+    });
+    const run_ir_fuzz_tests = b.addRunArtifact(ir_fuzz_tests);
+    test_step.dependOn(&run_ir_fuzz_tests.step);
+
     // Dominator-aware redundant-load forwarder tests (#391).
     const dom_frl_test_module = b.createModule(.{
         .root_source_file = b.path("src/compiler/ir/forward_redundant_loads_dominator.zig"),

--- a/build.zig
+++ b/build.zig
@@ -605,6 +605,18 @@ pub fn build(b: *std.Build) void {
     const run_verifier_tests = b.addRunArtifact(verifier_tests);
     test_step.dependOn(&run_verifier_tests.step);
 
+    // IR interpreter tests (#736).
+    const ir_interp_test_module = b.createModule(.{
+        .root_source_file = b.path("src/compiler/ir/interp.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const ir_interp_tests = b.addTest(.{
+        .root_module = ir_interp_test_module,
+    });
+    const run_ir_interp_tests = b.addRunArtifact(ir_interp_tests);
+    test_step.dependOn(&run_ir_interp_tests.step);
+
     // Dominator-aware redundant-load forwarder tests (#391).
     const dom_frl_test_module = b.createModule(.{
         .root_source_file = b.path("src/compiler/ir/forward_redundant_loads_dominator.zig"),

--- a/build.zig
+++ b/build.zig
@@ -46,6 +46,7 @@ pub fn build(b: *std.Build) void {
     const link_libc = b.option(bool, "link-libc", "Link libc") orelse
         (stack_protector or target.result.os.tag == .wasi);
     const version_string = b.option([]const u8, "version", "Version string") orelse "dev";
+    const ir_property_iterations = b.option(u32, "ir-property-iters", "IR optimizer property-test iterations per shape/pass") orelse 8;
 
     // ── Feature flags ──────────────────────────────────────────────────
     const options = b.addOptions();
@@ -628,6 +629,21 @@ pub fn build(b: *std.Build) void {
     });
     const run_ir_fuzz_tests = b.addRunArtifact(ir_fuzz_tests);
     test_step.dependOn(&run_ir_fuzz_tests.step);
+
+    // IR optimizer property tests (#736).
+    const ir_property_test_module = b.createModule(.{
+        .root_source_file = b.path("src/compiler/ir/property_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const ir_property_options = b.addOptions();
+    ir_property_options.addOption(u32, "iterations", ir_property_iterations);
+    ir_property_test_module.addImport("ir_property_options", ir_property_options.createModule());
+    const ir_property_tests = b.addTest(.{
+        .root_module = ir_property_test_module,
+    });
+    const run_ir_property_tests = b.addRunArtifact(ir_property_tests);
+    test_step.dependOn(&run_ir_property_tests.step);
 
     // Dominator-aware redundant-load forwarder tests (#391).
     const dom_frl_test_module = b.createModule(.{

--- a/docs/ir-property-testing.md
+++ b/docs/ir-property-testing.md
@@ -1,0 +1,37 @@
+# IR optimizer property tests
+
+Issue #736 adds an in-process IR interpreter and deterministic IR generators so
+optimizer passes can be checked by behavior instead of output shape alone.
+
+`zig build test` runs a small CI-sized matrix:
+
+```sh
+unset ZIG_LOCAL_CACHE_DIR
+export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
+zig build test --summary failures
+```
+
+For a larger local/nightly run, increase the per-pass/per-shape iteration count:
+
+```sh
+unset ZIG_LOCAL_CACHE_DIR
+export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
+zig build test -Dir-property-iters=100 --summary failures
+```
+
+On mismatch, `src/compiler/ir/property_test.zig` prints:
+
+```text
+IR property mismatch: pass=<pass> seed=0x<seed> shape=<shape>
+```
+
+To promote a failing case into a named regression, add a focused test to
+`property_test.zig` that calls `checkPassPreservesCase` with the reported
+`seed`, `shape`, and pass. Keep the generated shape deterministic rather than
+serializing IR text.
+
+Current scope is intentionally scalar: i32/i64 arithmetic, locals/globals,
+memory, branches, phis, parallel copies, and mock calls as memory barriers.
+Floats, SIMD, EH, tables, atomics, and bulk-memory ops are outside this first
+oracle slice and should either remain ungenerated or return `unsupported` from
+the interpreter until explicitly modeled.

--- a/src/compiler/ir/fuzz.zig
+++ b/src/compiler/ir/fuzz.zig
@@ -82,12 +82,6 @@ fn finishCase(
     inputs: []interp.Value,
     memory: []u8,
 ) !Case {
-    errdefer {
-        var f = func;
-        f.deinit();
-        allocator.free(inputs);
-        allocator.free(memory);
-    }
     try verifier.verifyFunction(&func, 0, .after_each_pass, allocator);
     return .{ .seed = seed, .shape = shape, .func = func, .inputs = inputs, .memory = memory };
 }

--- a/src/compiler/ir/fuzz.zig
+++ b/src/compiler/ir/fuzz.zig
@@ -1,0 +1,316 @@
+//! Deterministic IR generators for optimizer property tests (#736).
+//!
+//! The generators intentionally stay within the scalar subset supported by
+//! `interp.zig`: i32/i64 integer ops, locals/globals, memory, branches, phis,
+//! and mock calls as barriers. Every generated function is expected to pass the
+//! verifier before it is used as an optimizer oracle input.
+
+const std = @import("std");
+const ir = @import("ir.zig");
+const interp = @import("interp.zig");
+const verifier = @import("verifier.zig");
+
+pub const Shape = enum {
+    linear,
+    diamond,
+    nested_diamond,
+    counted_loop,
+    memory_barrier,
+
+    pub const all = [_]Shape{ .linear, .diamond, .nested_diamond, .counted_loop, .memory_barrier };
+};
+
+pub const Case = struct {
+    seed: u64,
+    shape: Shape,
+    func: ir.IrFunction,
+    inputs: []interp.Value,
+    memory: []u8,
+
+    pub fn deinit(self: *Case, allocator: std.mem.Allocator) void {
+        self.func.deinit();
+        allocator.free(self.inputs);
+        allocator.free(self.memory);
+        self.* = undefined;
+    }
+};
+
+pub fn generate(allocator: std.mem.Allocator, seed: u64, shape: Shape) !Case {
+    var prng = std.Random.DefaultPrng.init(seed);
+    const random = prng.random();
+    return switch (shape) {
+        .linear => generateLinear(allocator, seed, random),
+        .diamond => generateDiamond(allocator, seed, random),
+        .nested_diamond => generateNestedDiamond(allocator, seed, random),
+        .counted_loop => generateCountedLoop(allocator, seed, random),
+        .memory_barrier => generateMemoryBarrier(allocator, seed, random),
+    };
+}
+
+fn initFunc(allocator: std.mem.Allocator, param_count: u32, result_count: u32, local_count: u32) !ir.IrFunction {
+    var func = ir.IrFunction.init(allocator, param_count, result_count, local_count);
+    errdefer func.deinit();
+    const local_types = try allocator.alloc(ir.IrType, local_count);
+    @memset(local_types, .i32);
+    func.local_types = local_types;
+    var i: u32 = 0;
+    while (i < param_count) : (i += 1) _ = func.newVReg();
+    return func;
+}
+
+fn makeInputs(allocator: std.mem.Allocator, random: std.Random, n: usize) ![]interp.Value {
+    const inputs = try allocator.alloc(interp.Value, n);
+    for (inputs) |*v| {
+        // Keep values small to avoid accidental OOB addresses in generated IR;
+        // arithmetic still wraps once passes start rewriting expressions.
+        v.* = interp.Value.u32v(random.intRangeLessThan(u32, 0, 16));
+    }
+    return inputs;
+}
+
+fn makeMemory(allocator: std.mem.Allocator, random: std.Random) ![]u8 {
+    const memory = try allocator.alloc(u8, 64);
+    for (memory) |*b| b.* = random.int(u8);
+    return memory;
+}
+
+fn finishCase(
+    allocator: std.mem.Allocator,
+    seed: u64,
+    shape: Shape,
+    func: ir.IrFunction,
+    inputs: []interp.Value,
+    memory: []u8,
+) !Case {
+    errdefer {
+        var f = func;
+        f.deinit();
+        allocator.free(inputs);
+        allocator.free(memory);
+    }
+    try verifier.verifyFunction(&func, 0, .after_each_pass, allocator);
+    return .{ .seed = seed, .shape = shape, .func = func, .inputs = inputs, .memory = memory };
+}
+
+fn generateLinear(allocator: std.mem.Allocator, seed: u64, random: std.Random) !Case {
+    var func = try initFunc(allocator, 2, 1, 4);
+    errdefer func.deinit();
+    const inputs = try makeInputs(allocator, random, 2);
+    errdefer allocator.free(inputs);
+    const memory = try makeMemory(allocator, random);
+    errdefer allocator.free(memory);
+
+    const b0 = try func.newBlock();
+    const k = func.newVReg();
+    const sum = func.newVReg();
+    const mix = func.newVReg();
+    const shifted = func.newVReg();
+    const reloaded = func.newVReg();
+    const out = func.newVReg();
+    try func.getBlock(b0).append(.{ .dest = k, .type = .i32, .op = .{ .iconst_32 = @intCast(random.intRangeLessThan(u32, 1, 8)) } });
+    try func.getBlock(b0).append(.{ .dest = sum, .type = .i32, .op = .{ .add = .{ .lhs = 0, .rhs = k } } });
+    try func.getBlock(b0).append(.{ .dest = mix, .type = .i32, .op = .{ .xor = .{ .lhs = sum, .rhs = 1 } } });
+    try func.getBlock(b0).append(.{ .op = .{ .local_set = .{ .idx = 2, .val = mix } } });
+    try func.getBlock(b0).append(.{ .dest = reloaded, .type = .i32, .op = .{ .local_get = 2 } });
+    try func.getBlock(b0).append(.{ .dest = shifted, .type = .i32, .op = .{ .shl = .{ .lhs = reloaded, .rhs = k } } });
+    try func.getBlock(b0).append(.{ .dest = out, .type = .i32, .op = .{ .@"or" = .{ .lhs = shifted, .rhs = reloaded } } });
+    try func.getBlock(b0).append(.{ .op = .{ .ret = out } });
+
+    return finishCase(allocator, seed, .linear, func, inputs, memory);
+}
+
+fn generateDiamond(allocator: std.mem.Allocator, seed: u64, random: std.Random) !Case {
+    var func = try initFunc(allocator, 2, 1, 3);
+    errdefer func.deinit();
+    const inputs = try makeInputs(allocator, random, 2);
+    errdefer allocator.free(inputs);
+    const memory = try makeMemory(allocator, random);
+    errdefer allocator.free(memory);
+
+    const entry = try func.newBlock();
+    const left = try func.newBlock();
+    const right = try func.newBlock();
+    const merge = try func.newBlock();
+    try func.getBlock(left).addPredecessor(entry);
+    try func.getBlock(right).addPredecessor(entry);
+    try func.getBlock(merge).addPredecessor(left);
+    try func.getBlock(merge).addPredecessor(right);
+
+    const cond = func.newVReg();
+    try func.getBlock(entry).append(.{ .dest = cond, .type = .i32, .op = .{ .eqz = 0 } });
+    try func.getBlock(entry).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = left, .else_block = right } } });
+
+    const left_v = func.newVReg();
+    try func.getBlock(left).append(.{ .dest = left_v, .type = .i32, .op = .{ .add = .{ .lhs = 0, .rhs = 1 } } });
+    try func.getBlock(left).append(.{ .op = .{ .br = merge } });
+
+    const right_v = func.newVReg();
+    try func.getBlock(right).append(.{ .dest = right_v, .type = .i32, .op = .{ .sub = .{ .lhs = 0, .rhs = 1 } } });
+    try func.getBlock(right).append(.{ .op = .{ .br = merge } });
+
+    const edges = try allocator.dupe(ir.Inst.PhiEdge, &.{ .{ .block = left, .val = left_v }, .{ .block = right, .val = right_v } });
+    const phi = func.newVReg();
+    const out = func.newVReg();
+    try func.getBlock(merge).append(.{ .dest = phi, .type = .i32, .op = .{ .phi = edges } });
+    try func.getBlock(merge).append(.{ .dest = out, .type = .i32, .op = .{ .xor = .{ .lhs = phi, .rhs = 1 } } });
+    try func.getBlock(merge).append(.{ .op = .{ .ret = out } });
+
+    return finishCase(allocator, seed, .diamond, func, inputs, memory);
+}
+
+fn generateNestedDiamond(allocator: std.mem.Allocator, seed: u64, random: std.Random) !Case {
+    var func = try initFunc(allocator, 2, 1, 3);
+    errdefer func.deinit();
+    const inputs = try makeInputs(allocator, random, 2);
+    errdefer allocator.free(inputs);
+    const memory = try makeMemory(allocator, random);
+    errdefer allocator.free(memory);
+
+    const entry = try func.newBlock();
+    const outer_then = try func.newBlock();
+    const outer_else = try func.newBlock();
+    const inner_left = try func.newBlock();
+    const inner_right = try func.newBlock();
+    const inner_merge = try func.newBlock();
+    const final_merge = try func.newBlock();
+    try func.getBlock(outer_then).addPredecessor(entry);
+    try func.getBlock(outer_else).addPredecessor(entry);
+    try func.getBlock(inner_left).addPredecessor(outer_then);
+    try func.getBlock(inner_right).addPredecessor(outer_then);
+    try func.getBlock(inner_merge).addPredecessor(inner_left);
+    try func.getBlock(inner_merge).addPredecessor(inner_right);
+    try func.getBlock(final_merge).addPredecessor(inner_merge);
+    try func.getBlock(final_merge).addPredecessor(outer_else);
+
+    const outer_cond = func.newVReg();
+    try func.getBlock(entry).append(.{ .dest = outer_cond, .type = .i32, .op = .{ .@"and" = .{ .lhs = 0, .rhs = 1 } } });
+    try func.getBlock(entry).append(.{ .op = .{ .br_if = .{ .cond = outer_cond, .then_block = outer_then, .else_block = outer_else } } });
+
+    const inner_cond = func.newVReg();
+    try func.getBlock(outer_then).append(.{ .dest = inner_cond, .type = .i32, .op = .{ .eqz = 1 } });
+    try func.getBlock(outer_then).append(.{ .op = .{ .br_if = .{ .cond = inner_cond, .then_block = inner_left, .else_block = inner_right } } });
+
+    const left_v = func.newVReg();
+    try func.getBlock(inner_left).append(.{ .dest = left_v, .type = .i32, .op = .{ .mul = .{ .lhs = 0, .rhs = 1 } } });
+    try func.getBlock(inner_left).append(.{ .op = .{ .br = inner_merge } });
+
+    const right_v = func.newVReg();
+    try func.getBlock(inner_right).append(.{ .dest = right_v, .type = .i32, .op = .{ .xor = .{ .lhs = 0, .rhs = 1 } } });
+    try func.getBlock(inner_right).append(.{ .op = .{ .br = inner_merge } });
+
+    const inner_edges = try allocator.dupe(ir.Inst.PhiEdge, &.{ .{ .block = inner_left, .val = left_v }, .{ .block = inner_right, .val = right_v } });
+    const inner_phi = func.newVReg();
+    try func.getBlock(inner_merge).append(.{ .dest = inner_phi, .type = .i32, .op = .{ .phi = inner_edges } });
+    try func.getBlock(inner_merge).append(.{ .op = .{ .br = final_merge } });
+
+    const else_v = func.newVReg();
+    try func.getBlock(outer_else).append(.{ .dest = else_v, .type = .i32, .op = .{ .@"or" = .{ .lhs = 0, .rhs = 1 } } });
+    try func.getBlock(outer_else).append(.{ .op = .{ .br = final_merge } });
+
+    const final_edges = try allocator.dupe(ir.Inst.PhiEdge, &.{ .{ .block = inner_merge, .val = inner_phi }, .{ .block = outer_else, .val = else_v } });
+    const final_phi = func.newVReg();
+    try func.getBlock(final_merge).append(.{ .dest = final_phi, .type = .i32, .op = .{ .phi = final_edges } });
+    try func.getBlock(final_merge).append(.{ .op = .{ .ret = final_phi } });
+
+    return finishCase(allocator, seed, .nested_diamond, func, inputs, memory);
+}
+
+fn generateCountedLoop(allocator: std.mem.Allocator, seed: u64, random: std.Random) !Case {
+    var func = try initFunc(allocator, 1, 1, 2);
+    errdefer func.deinit();
+    const inputs = try makeInputs(allocator, random, 1);
+    errdefer allocator.free(inputs);
+    const memory = try makeMemory(allocator, random);
+    errdefer allocator.free(memory);
+
+    const bound_value: i32 = @intCast(random.intRangeLessThan(u32, 1, 6));
+    const entry = try func.newBlock();
+    const header = try func.newBlock();
+    const body = try func.newBlock();
+    const exit = try func.newBlock();
+    try func.getBlock(header).addPredecessor(entry);
+    try func.getBlock(header).addPredecessor(body);
+    try func.getBlock(body).addPredecessor(header);
+    try func.getBlock(exit).addPredecessor(header);
+
+    const zero = func.newVReg();
+    const bound = func.newVReg();
+    try func.getBlock(entry).append(.{ .dest = zero, .type = .i32, .op = .{ .iconst_32 = 0 } });
+    try func.getBlock(entry).append(.{ .dest = bound, .type = .i32, .op = .{ .iconst_32 = bound_value } });
+    try func.getBlock(entry).append(.{ .op = .{ .br = header } });
+
+    const phi_i = func.newVReg();
+    const phi_sum = func.newVReg();
+    const inc = func.newVReg();
+    const sum_next = func.newVReg();
+    const i_edges = try allocator.dupe(ir.Inst.PhiEdge, &.{ .{ .block = entry, .val = zero }, .{ .block = body, .val = inc } });
+    const sum_edges = try allocator.dupe(ir.Inst.PhiEdge, &.{ .{ .block = entry, .val = 0 }, .{ .block = body, .val = sum_next } });
+    const cond = func.newVReg();
+    try func.getBlock(header).append(.{ .dest = phi_i, .type = .i32, .op = .{ .phi = i_edges } });
+    try func.getBlock(header).append(.{ .dest = phi_sum, .type = .i32, .op = .{ .phi = sum_edges } });
+    try func.getBlock(header).append(.{ .dest = cond, .type = .i32, .op = .{ .lt_u = .{ .lhs = phi_i, .rhs = bound } } });
+    try func.getBlock(header).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = body, .else_block = exit } } });
+
+    const one = func.newVReg();
+    try func.getBlock(body).append(.{ .dest = one, .type = .i32, .op = .{ .iconst_32 = 1 } });
+    try func.getBlock(body).append(.{ .dest = sum_next, .type = .i32, .op = .{ .add = .{ .lhs = phi_sum, .rhs = phi_i } } });
+    try func.getBlock(body).append(.{ .dest = inc, .type = .i32, .op = .{ .add = .{ .lhs = phi_i, .rhs = one } } });
+    try func.getBlock(body).append(.{ .op = .{ .br = header } });
+
+    try func.getBlock(exit).append(.{ .op = .{ .ret = phi_sum } });
+
+    return finishCase(allocator, seed, .counted_loop, func, inputs, memory);
+}
+
+fn generateMemoryBarrier(allocator: std.mem.Allocator, seed: u64, random: std.Random) !Case {
+    var func = try initFunc(allocator, 1, 1, 1);
+    errdefer func.deinit();
+    const inputs = try makeInputs(allocator, random, 1);
+    errdefer allocator.free(inputs);
+    const memory = try makeMemory(allocator, random);
+    errdefer allocator.free(memory);
+
+    const entry = try func.newBlock();
+    const call_block = try func.newBlock();
+    const direct_block = try func.newBlock();
+    const merge = try func.newBlock();
+    try func.getBlock(call_block).addPredecessor(entry);
+    try func.getBlock(direct_block).addPredecessor(entry);
+    try func.getBlock(merge).addPredecessor(call_block);
+    try func.getBlock(merge).addPredecessor(direct_block);
+
+    const base = func.newVReg();
+    const cond = func.newVReg();
+    try func.getBlock(entry).append(.{ .dest = base, .type = .i32, .op = .{ .iconst_32 = 0 } });
+    try func.getBlock(entry).append(.{ .op = .{ .store = .{ .base = base, .offset = 0, .size = 4, .val = 0 } } });
+    try func.getBlock(entry).append(.{ .dest = cond, .type = .i32, .op = .{ .eqz = 0 } });
+    try func.getBlock(entry).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = direct_block, .else_block = call_block } } });
+
+    try func.getBlock(call_block).append(.{ .op = .{ .call = .{ .func_idx = 3, .args = &.{} } }, .type = .void });
+    try func.getBlock(call_block).append(.{ .op = .{ .br = merge } });
+
+    try func.getBlock(direct_block).append(.{ .op = .{ .br = merge } });
+
+    const loaded = func.newVReg();
+    try func.getBlock(merge).append(.{ .dest = loaded, .type = .i32, .op = .{ .load = .{ .base = base, .offset = 0, .size = 4 } } });
+    try func.getBlock(merge).append(.{ .op = .{ .ret = loaded } });
+
+    return finishCase(allocator, seed, .memory_barrier, func, inputs, memory);
+}
+
+test "fuzz: generated cases verify and interpret" {
+    const a = std.testing.allocator;
+    for (Shape.all, 0..) |shape, i| {
+        var case = try generate(a, 0x7360 + i, shape);
+        defer case.deinit(a);
+
+        var outcome = try interp.run(a, &case.func, .{
+            .params = case.inputs,
+            .memory = case.memory,
+            .fuel = 1_000,
+        });
+        defer outcome.deinit(a);
+        try std.testing.expect(outcome == .returned);
+        try std.testing.expect(outcome.returned.results.len <= 1);
+    }
+}

--- a/src/compiler/ir/interp.zig
+++ b/src/compiler/ir/interp.zig
@@ -340,8 +340,9 @@ fn execInst(machine: *Machine, inst: ir.Inst) !?Outcome {
         },
         .ret => |maybe_v| {
             const results = if (maybe_v) |v| blk: {
+                const value = (try machine.getVReg(v)).normalized();
                 const out = try machine.allocator.alloc(Value, 1);
-                out[0] = (try machine.getVReg(v)).normalized();
+                out[0] = value;
                 break :blk out;
             } else try machine.allocator.alloc(Value, 0);
             machine.memory_transferred = true;
@@ -349,6 +350,7 @@ fn execInst(machine: *Machine, inst: ir.Inst) !?Outcome {
         },
         .ret_multi => |vregs| {
             const results = try machine.allocator.alloc(Value, vregs.len);
+            errdefer machine.allocator.free(results);
             for (vregs, 0..) |v, i| results[i] = (try machine.getVReg(v)).normalized();
             machine.memory_transferred = true;
             return .{ .returned = .{ .results = results, .memory = machine.memory } };

--- a/src/compiler/ir/interp.zig
+++ b/src/compiler/ir/interp.zig
@@ -95,6 +95,7 @@ const Machine = struct {
     locals: []Value,
     globals: []Value,
     memory: []u8,
+    memory_transferred: bool = false,
     fuel: u32,
     block: ir.BlockId = 0,
     prev_block: ?ir.BlockId = null,
@@ -105,6 +106,7 @@ const Machine = struct {
         self.allocator.free(self.vreg_init);
         self.allocator.free(self.locals);
         self.allocator.free(self.globals);
+        if (!self.memory_transferred) self.allocator.free(self.memory);
     }
 
     fn stepFuel(self: *Machine) ?Outcome {
@@ -189,6 +191,39 @@ const Machine = struct {
         }
         if (dest) |d| try self.setVReg(d, .{ .ty = ty, .bits = acc });
     }
+
+    fn processPhiGroup(self: *Machine) !void {
+        const block = &self.func.blocks.items[self.block];
+        if (self.inst_index >= block.instructions.items.len) return;
+        if (block.instructions.items[self.inst_index].op != .phi) return;
+        const pred = self.prev_block orelse return error.InvalidPhi;
+
+        const start = self.inst_index;
+        var end = start;
+        while (end < block.instructions.items.len and block.instructions.items[end].op == .phi) : (end += 1) {}
+        const count = end - start;
+
+        const values = try self.allocator.alloc(Value, count);
+        defer self.allocator.free(values);
+        const dests = try self.allocator.alloc(ir.VReg, count);
+        defer self.allocator.free(dests);
+
+        for (block.instructions.items[start..end], 0..) |inst, i| {
+            dests[i] = inst.dest orelse return error.InvalidPhi;
+            const edges = inst.op.phi;
+            for (edges) |edge| {
+                if (edge.block == pred) {
+                    values[i] = .{ .ty = inst.type, .bits = (try self.getVReg(edge.val)).bits };
+                    break;
+                }
+            } else {
+                return error.InvalidPhi;
+            }
+        }
+
+        for (dests, values) |dest, value| try self.setVReg(dest, value);
+        self.inst_index = end;
+    }
 };
 
 pub fn run(allocator: std.mem.Allocator, func: *const ir.IrFunction, options: RunOptions) !Outcome {
@@ -210,7 +245,6 @@ pub fn run(allocator: std.mem.Allocator, func: *const ir.IrFunction, options: Ru
         .memory = try allocator.dupe(u8, options.memory),
         .fuel = options.fuel,
     };
-    errdefer allocator.free(machine.memory);
     defer machine.deinitScratch();
     @memset(machine.vregs, .{});
     @memset(machine.vreg_init, false);
@@ -225,6 +259,11 @@ pub fn run(allocator: std.mem.Allocator, func: *const ir.IrFunction, options: Ru
     while (true) {
         if (machine.stepFuel()) |outcome| return outcome;
         const block = &func.blocks.items[machine.block];
+        machine.processPhiGroup() catch |err| switch (err) {
+            error.UninitializedVReg => return .{ .trapped = .uninitialized_vreg },
+            error.InvalidPhi => return .{ .trapped = .invalid_phi },
+            else => return err,
+        };
         if (machine.inst_index >= block.instructions.items.len) {
             return .{ .trapped = .invalid_branch };
         }
@@ -305,24 +344,17 @@ fn execInst(machine: *Machine, inst: ir.Inst) !?Outcome {
                 out[0] = (try machine.getVReg(v)).normalized();
                 break :blk out;
             } else try machine.allocator.alloc(Value, 0);
+            machine.memory_transferred = true;
             return .{ .returned = .{ .results = results, .memory = machine.memory } };
         },
         .ret_multi => |vregs| {
             const results = try machine.allocator.alloc(Value, vregs.len);
             for (vregs, 0..) |v, i| results[i] = (try machine.getVReg(v)).normalized();
+            machine.memory_transferred = true;
             return .{ .returned = .{ .results = results, .memory = machine.memory } };
         },
         .@"unreachable" => return .{ .trapped = .unreachable_reached },
-        .phi => |edges| {
-            const pred = machine.prev_block orelse return error.InvalidPhi;
-            for (edges) |edge| {
-                if (edge.block == pred) {
-                    if (inst.dest) |d| try machine.setVReg(d, .{ .ty = inst.type, .bits = (try machine.getVReg(edge.val)).bits });
-                    return null;
-                }
-            }
-            return error.InvalidPhi;
-        },
+        .phi => return error.InvalidPhi,
         .parallel_copy => |pairs| {
             var scratch = try machine.allocator.alloc(Value, pairs.len);
             defer machine.allocator.free(scratch);
@@ -489,6 +521,48 @@ test "interp: diamond phi selects incoming predecessor" {
     var right_out = try run(a, &func, .{ .params = &.{Value.i32v(0)} });
     defer right_out.deinit(a);
     try std.testing.expectEqual(@as(u64, 22), right_out.returned.results[0].bits);
+}
+
+test "interp: phi groups read incoming values in parallel" {
+    const a = std.testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 1, 0);
+    defer func.deinit();
+
+    const entry = try func.newBlock();
+    const header = try func.newBlock();
+    const body = try func.newBlock();
+    const exit = try func.newBlock();
+    try func.getBlock(header).addPredecessor(entry);
+    try func.getBlock(header).addPredecessor(body);
+    try func.getBlock(body).addPredecessor(header);
+    try func.getBlock(exit).addPredecessor(header);
+
+    const zero = func.newVReg();
+    const bound = func.newVReg();
+    try func.getBlock(entry).append(.{ .dest = zero, .type = .i32, .op = .{ .iconst_32 = 0 } });
+    try func.getBlock(entry).append(.{ .dest = bound, .type = .i32, .op = .{ .iconst_32 = 3 } });
+    try func.getBlock(entry).append(.{ .op = .{ .br = header } });
+
+    const phi_i = func.newVReg();
+    const phi_prev_i = func.newVReg();
+    const inc = func.newVReg();
+    const i_edges = try a.dupe(ir.Inst.PhiEdge, &.{ .{ .block = entry, .val = zero }, .{ .block = body, .val = inc } });
+    const prev_edges = try a.dupe(ir.Inst.PhiEdge, &.{ .{ .block = entry, .val = zero }, .{ .block = body, .val = phi_i } });
+    const cond = func.newVReg();
+    try func.getBlock(header).append(.{ .dest = phi_i, .type = .i32, .op = .{ .phi = i_edges } });
+    try func.getBlock(header).append(.{ .dest = phi_prev_i, .type = .i32, .op = .{ .phi = prev_edges } });
+    try func.getBlock(header).append(.{ .dest = cond, .type = .i32, .op = .{ .lt_u = .{ .lhs = phi_i, .rhs = bound } } });
+    try func.getBlock(header).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = body, .else_block = exit } } });
+
+    const one = func.newVReg();
+    try func.getBlock(body).append(.{ .dest = one, .type = .i32, .op = .{ .iconst_32 = 1 } });
+    try func.getBlock(body).append(.{ .dest = inc, .type = .i32, .op = .{ .add = .{ .lhs = phi_i, .rhs = one } } });
+    try func.getBlock(body).append(.{ .op = .{ .br = header } });
+    try func.getBlock(exit).append(.{ .op = .{ .ret = phi_prev_i } });
+
+    var outcome = try run(a, &func, .{ .fuel = 100 });
+    defer outcome.deinit(a);
+    try std.testing.expectEqual(@as(u64, 2), outcome.returned.results[0].bits);
 }
 
 test "interp: load and store round-trip memory" {

--- a/src/compiler/ir/interp.zig
+++ b/src/compiler/ir/interp.zig
@@ -1,0 +1,533 @@
+//! Small in-process interpreter for compiler IR property tests (#736).
+//!
+//! This is an optimizer oracle, not a production runtime. It executes a
+//! deliberately bounded scalar subset with explicit outcomes for traps,
+//! unsupported operations, and fuel exhaustion so property tests can compare
+//! behavior without panicking or hanging.
+
+const std = @import("std");
+const ir = @import("ir.zig");
+
+pub const Value = struct {
+    ty: ir.IrType = .i32,
+    bits: u64 = 0,
+
+    pub fn i32v(x: i32) Value {
+        return .{ .ty = .i32, .bits = @as(u32, @bitCast(x)) };
+    }
+
+    pub fn u32v(x: u32) Value {
+        return .{ .ty = .i32, .bits = x };
+    }
+
+    pub fn i64v(x: i64) Value {
+        return .{ .ty = .i64, .bits = @bitCast(x) };
+    }
+
+    pub fn u64v(x: u64) Value {
+        return .{ .ty = .i64, .bits = x };
+    }
+
+    fn asI64(self: Value) i64 {
+        return @bitCast(self.bits);
+    }
+
+    fn normalized(self: Value) Value {
+        return switch (self.ty) {
+            .i32 => .{ .ty = .i32, .bits = @as(u32, @truncate(self.bits)) },
+            .i64 => .{ .ty = .i64, .bits = self.bits },
+            else => self,
+        };
+    }
+};
+
+pub const Trap = enum {
+    unreachable_reached,
+    integer_divide_by_zero,
+    integer_overflow,
+    out_of_bounds_memory,
+    uninitialized_vreg,
+    invalid_local,
+    invalid_global,
+    invalid_phi,
+    invalid_branch,
+};
+
+pub const Returned = struct {
+    results: []Value,
+    memory: []u8,
+};
+
+pub const Inconclusive = enum {
+    fuel_exhausted,
+};
+
+pub const Outcome = union(enum) {
+    returned: Returned,
+    trapped: Trap,
+    unsupported: []const u8,
+    inconclusive: Inconclusive,
+
+    pub fn deinit(self: *Outcome, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .returned => |r| {
+                allocator.free(r.results);
+                allocator.free(r.memory);
+            },
+            else => {},
+        }
+        self.* = .{ .unsupported = "deinitialized" };
+    }
+};
+
+pub const RunOptions = struct {
+    params: []const Value = &.{},
+    globals: []const Value = &.{},
+    memory: []const u8 = &.{},
+    fuel: u32 = 10_000,
+};
+
+const Machine = struct {
+    allocator: std.mem.Allocator,
+    func: *const ir.IrFunction,
+    vregs: []Value,
+    vreg_init: []bool,
+    locals: []Value,
+    globals: []Value,
+    memory: []u8,
+    fuel: u32,
+    block: ir.BlockId = 0,
+    prev_block: ?ir.BlockId = null,
+    inst_index: usize = 0,
+
+    fn deinitScratch(self: *Machine) void {
+        self.allocator.free(self.vregs);
+        self.allocator.free(self.vreg_init);
+        self.allocator.free(self.locals);
+        self.allocator.free(self.globals);
+    }
+
+    fn stepFuel(self: *Machine) ?Outcome {
+        if (self.fuel == 0) return .{ .inconclusive = .fuel_exhausted };
+        self.fuel -= 1;
+        return null;
+    }
+
+    fn getVReg(self: *Machine, v: ir.VReg) !Value {
+        if (v >= self.vregs.len or !self.vreg_init[v]) return error.UninitializedVReg;
+        return self.vregs[v].normalized();
+    }
+
+    fn setVReg(self: *Machine, v: ir.VReg, value: Value) !void {
+        if (v >= self.vregs.len) return error.UninitializedVReg;
+        self.vregs[v] = value.normalized();
+        self.vreg_init[v] = true;
+    }
+
+    fn getLocal(self: *Machine, idx: u32) !Value {
+        if (idx >= self.locals.len) return error.InvalidLocal;
+        return self.locals[idx].normalized();
+    }
+
+    fn setLocal(self: *Machine, idx: u32, value: Value) !void {
+        if (idx >= self.locals.len) return error.InvalidLocal;
+        self.locals[idx] = value.normalized();
+    }
+
+    fn getGlobal(self: *Machine, idx: u32) !Value {
+        if (idx >= self.globals.len) return error.InvalidGlobal;
+        return self.globals[idx].normalized();
+    }
+
+    fn setGlobal(self: *Machine, idx: u32, value: Value) !void {
+        if (idx >= self.globals.len) return error.InvalidGlobal;
+        self.globals[idx] = value.normalized();
+    }
+
+    fn branchTo(self: *Machine, target: ir.BlockId) !void {
+        if (target >= self.func.blocks.items.len) return error.InvalidBranch;
+        self.prev_block = self.block;
+        self.block = target;
+        self.inst_index = 0;
+    }
+
+    fn readMem(self: *Machine, ptr: u64, size: u8, sign_extend: bool) !Value {
+        const start: usize = std.math.cast(usize, ptr) orelse return error.OutOfBoundsMemory;
+        const end = start + @as(usize, size);
+        if (size == 0 or size > 8 or end > self.memory.len) return error.OutOfBoundsMemory;
+
+        var bits: u64 = 0;
+        for (self.memory[start..end], 0..) |b, i| {
+            bits |= @as(u64, b) << @intCast(i * 8);
+        }
+        if (sign_extend and size < 8) {
+            const shift: u6 = @intCast((8 - size) * 8);
+            bits = @bitCast((@as(i64, @bitCast(bits << shift))) >> shift);
+        }
+        return .{ .ty = if (size <= 4) .i32 else .i64, .bits = bits };
+    }
+
+    fn writeMem(self: *Machine, ptr: u64, size: u8, value: Value) !void {
+        const start: usize = std.math.cast(usize, ptr) orelse return error.OutOfBoundsMemory;
+        const end = start + @as(usize, size);
+        if (size == 0 or size > 8 or end > self.memory.len) return error.OutOfBoundsMemory;
+
+        var bits = value.bits;
+        for (self.memory[start..end]) |*b| {
+            b.* = @truncate(bits);
+            bits >>= 8;
+        }
+    }
+
+    fn mockCall(self: *Machine, cl: anytype, dest: ?ir.VReg, ty: ir.IrType) !void {
+        var acc: u64 = @as(u64, cl.func_idx) *% 0x9e37_79b9;
+        for (cl.args) |arg| {
+            acc = (acc *% 0x1000_0000_01b3) ^ (try self.getVReg(arg)).bits;
+        }
+        if (self.memory.len > 0) {
+            self.memory[0] +%= @truncate(acc);
+        }
+        if (dest) |d| try self.setVReg(d, .{ .ty = ty, .bits = acc });
+    }
+};
+
+pub fn run(allocator: std.mem.Allocator, func: *const ir.IrFunction, options: RunOptions) !Outcome {
+    if (options.params.len != func.param_count) return error.InvalidArgs;
+    if (func.blocks.items.len == 0) {
+        return .{ .returned = .{
+            .results = &.{},
+            .memory = try allocator.dupe(u8, options.memory),
+        } };
+    }
+
+    var machine = Machine{
+        .allocator = allocator,
+        .func = func,
+        .vregs = try allocator.alloc(Value, func.next_vreg),
+        .vreg_init = try allocator.alloc(bool, func.next_vreg),
+        .locals = try allocator.alloc(Value, @max(func.local_count, func.param_count)),
+        .globals = try allocator.dupe(Value, options.globals),
+        .memory = try allocator.dupe(u8, options.memory),
+        .fuel = options.fuel,
+    };
+    errdefer allocator.free(machine.memory);
+    defer machine.deinitScratch();
+    @memset(machine.vregs, .{});
+    @memset(machine.vreg_init, false);
+    @memset(machine.locals, .{});
+
+    for (options.params, 0..) |param, i| {
+        const normalized = param.normalized();
+        machine.locals[i] = normalized;
+        try machine.setVReg(@intCast(i), normalized);
+    }
+
+    while (true) {
+        if (machine.stepFuel()) |outcome| return outcome;
+        const block = &func.blocks.items[machine.block];
+        if (machine.inst_index >= block.instructions.items.len) {
+            return .{ .trapped = .invalid_branch };
+        }
+        const inst = block.instructions.items[machine.inst_index];
+        machine.inst_index += 1;
+
+        const maybe_outcome = execInst(&machine, inst) catch |err| switch (err) {
+            error.UninitializedVReg => return .{ .trapped = .uninitialized_vreg },
+            error.InvalidLocal => return .{ .trapped = .invalid_local },
+            error.InvalidGlobal => return .{ .trapped = .invalid_global },
+            error.InvalidPhi => return .{ .trapped = .invalid_phi },
+            error.InvalidBranch => return .{ .trapped = .invalid_branch },
+            error.OutOfBoundsMemory => return .{ .trapped = .out_of_bounds_memory },
+            error.DivideByZero => return .{ .trapped = .integer_divide_by_zero },
+            error.IntegerOverflow => return .{ .trapped = .integer_overflow },
+            else => return err,
+        };
+        if (maybe_outcome) |outcome| return outcome;
+    }
+}
+
+fn execInst(machine: *Machine, inst: ir.Inst) !?Outcome {
+    switch (inst.op) {
+        .iconst_32 => |x| if (inst.dest) |d| try machine.setVReg(d, Value.i32v(x)),
+        .iconst_64 => |x| if (inst.dest) |d| try machine.setVReg(d, Value.i64v(x)),
+        .add, .sub, .mul, .div_s, .div_u, .rem_s, .rem_u, .@"and", .@"or", .xor, .shl, .shr_s, .shr_u, .rotl, .rotr, .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u => |bin| {
+            const lhs = try machine.getVReg(bin.lhs);
+            const rhs = try machine.getVReg(bin.rhs);
+            const bits = try evalBinOp(inst.op, lhs.asI64(), rhs.asI64(), inst.type);
+            if (inst.dest) |d| try machine.setVReg(d, .{ .ty = resultTypeForBinOp(inst.op, inst.type), .bits = @bitCast(bits) });
+        },
+        .clz, .ctz, .popcnt, .eqz => |v| {
+            const x = try machine.getVReg(v);
+            const bits: u64 = switch (inst.op) {
+                .clz => if (inst.type == .i64) @clz(x.bits) else @clz(@as(u32, @truncate(x.bits))),
+                .ctz => if (inst.type == .i64) @ctz(x.bits) else @ctz(@as(u32, @truncate(x.bits))),
+                .popcnt => if (inst.type == .i64) @popCount(x.bits) else @popCount(@as(u32, @truncate(x.bits))),
+                .eqz => @intFromBool(x.bits == 0),
+                else => unreachable,
+            };
+            if (inst.dest) |d| try machine.setVReg(d, .{ .ty = if (inst.op == .eqz) .i32 else inst.type, .bits = bits });
+        },
+        .select => |sel| {
+            const cond = try machine.getVReg(sel.cond);
+            const chosen = if (cond.bits != 0) try machine.getVReg(sel.if_true) else try machine.getVReg(sel.if_false);
+            if (inst.dest) |d| try machine.setVReg(d, .{ .ty = inst.type, .bits = chosen.bits });
+        },
+        .local_get => |idx| {
+            if (inst.dest) |d| try machine.setVReg(d, .{ .ty = inst.type, .bits = (try machine.getLocal(idx)).bits });
+        },
+        .local_set => |ls| try machine.setLocal(ls.idx, try machine.getVReg(ls.val)),
+        .global_get => |idx| {
+            if (inst.dest) |d| try machine.setVReg(d, .{ .ty = inst.type, .bits = (try machine.getGlobal(idx)).bits });
+        },
+        .global_set => |gs| try machine.setGlobal(gs.idx, try machine.getVReg(gs.val)),
+        .load => |ld| {
+            const base = try machine.getVReg(ld.base);
+            const ptr = base.bits +% ld.offset;
+            if (inst.dest) |d| try machine.setVReg(d, try machine.readMem(ptr, ld.size, ld.sign_extend));
+        },
+        .store => |st| {
+            const base = try machine.getVReg(st.base);
+            const ptr = base.bits +% st.offset;
+            try machine.writeMem(ptr, st.size, try machine.getVReg(st.val));
+        },
+        .br => |target| try machine.branchTo(target),
+        .br_if => |bi| {
+            const cond = try machine.getVReg(bi.cond);
+            try machine.branchTo(if (cond.bits != 0) bi.then_block else bi.else_block);
+        },
+        .br_table => |bt| {
+            const idx: usize = @truncate((try machine.getVReg(bt.index)).bits);
+            try machine.branchTo(if (idx < bt.targets.len) bt.targets[idx] else bt.default);
+        },
+        .ret => |maybe_v| {
+            const results = if (maybe_v) |v| blk: {
+                const out = try machine.allocator.alloc(Value, 1);
+                out[0] = (try machine.getVReg(v)).normalized();
+                break :blk out;
+            } else try machine.allocator.alloc(Value, 0);
+            return .{ .returned = .{ .results = results, .memory = machine.memory } };
+        },
+        .ret_multi => |vregs| {
+            const results = try machine.allocator.alloc(Value, vregs.len);
+            for (vregs, 0..) |v, i| results[i] = (try machine.getVReg(v)).normalized();
+            return .{ .returned = .{ .results = results, .memory = machine.memory } };
+        },
+        .@"unreachable" => return .{ .trapped = .unreachable_reached },
+        .phi => |edges| {
+            const pred = machine.prev_block orelse return error.InvalidPhi;
+            for (edges) |edge| {
+                if (edge.block == pred) {
+                    if (inst.dest) |d| try machine.setVReg(d, .{ .ty = inst.type, .bits = (try machine.getVReg(edge.val)).bits });
+                    return null;
+                }
+            }
+            return error.InvalidPhi;
+        },
+        .parallel_copy => |pairs| {
+            var scratch = try machine.allocator.alloc(Value, pairs.len);
+            defer machine.allocator.free(scratch);
+            for (pairs, 0..) |p, i| scratch[i] = try machine.getVReg(p.src);
+            for (pairs, 0..) |p, i| try machine.setVReg(p.dst, .{ .ty = p.ty, .bits = scratch[i].bits });
+        },
+        .call => |cl| try machine.mockCall(cl, inst.dest, inst.type),
+        else => return .{ .unsupported = @tagName(inst.op) },
+    }
+    return null;
+}
+
+fn resultTypeForBinOp(op: ir.Inst.Op, operand_ty: ir.IrType) ir.IrType {
+    return switch (op) {
+        .eq, .ne, .lt_s, .lt_u, .gt_s, .gt_u, .le_s, .le_u, .ge_s, .ge_u => .i32,
+        else => operand_ty,
+    };
+}
+
+fn evalBinOp(op: ir.Inst.Op, lhs: i64, rhs: i64, ty: ir.IrType) !i64 {
+    const mask: u64 = if (ty == .i64) 63 else 31;
+    return switch (op) {
+        .add => lhs +% rhs,
+        .sub => lhs -% rhs,
+        .mul => lhs *% rhs,
+        .@"and" => lhs & rhs,
+        .@"or" => lhs | rhs,
+        .xor => lhs ^ rhs,
+        .shl => blk: {
+            const n: u6 = @intCast(@as(u64, @bitCast(rhs)) & mask);
+            break :blk @bitCast(@as(u64, @bitCast(lhs)) << n);
+        },
+        .shr_s => blk: {
+            const n: u6 = @intCast(@as(u64, @bitCast(rhs)) & mask);
+            if (ty == .i64) break :blk lhs >> n;
+            const l32: i32 = @truncate(lhs);
+            break :blk @as(i64, l32 >> @as(u5, @intCast(n)));
+        },
+        .shr_u => blk: {
+            const n: u6 = @intCast(@as(u64, @bitCast(rhs)) & mask);
+            if (ty == .i64) break :blk @bitCast(@as(u64, @bitCast(lhs)) >> n);
+            const l32: u32 = @truncate(@as(u64, @bitCast(lhs)));
+            break :blk @as(i64, l32 >> @as(u5, @intCast(n)));
+        },
+        .rotl => blk: {
+            const n: u6 = @intCast(@as(u64, @bitCast(rhs)) & mask);
+            if (ty == .i64) break :blk @bitCast(std.math.rotl(u64, @bitCast(lhs), n));
+            const l32: u32 = @truncate(@as(u64, @bitCast(lhs)));
+            break :blk @as(i64, std.math.rotl(u32, l32, n));
+        },
+        .rotr => blk: {
+            const n: u6 = @intCast(@as(u64, @bitCast(rhs)) & mask);
+            if (ty == .i64) break :blk @bitCast(std.math.rotr(u64, @bitCast(lhs), n));
+            const l32: u32 = @truncate(@as(u64, @bitCast(lhs)));
+            break :blk @as(i64, std.math.rotr(u32, l32, n));
+        },
+        .eq => @intFromBool(lhs == rhs),
+        .ne => @intFromBool(lhs != rhs),
+        .lt_s => if (ty == .i64) @intFromBool(lhs < rhs) else @intFromBool(@as(i32, @truncate(lhs)) < @as(i32, @truncate(rhs))),
+        .gt_s => if (ty == .i64) @intFromBool(lhs > rhs) else @intFromBool(@as(i32, @truncate(lhs)) > @as(i32, @truncate(rhs))),
+        .le_s => if (ty == .i64) @intFromBool(lhs <= rhs) else @intFromBool(@as(i32, @truncate(lhs)) <= @as(i32, @truncate(rhs))),
+        .ge_s => if (ty == .i64) @intFromBool(lhs >= rhs) else @intFromBool(@as(i32, @truncate(lhs)) >= @as(i32, @truncate(rhs))),
+        .lt_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) < @as(u64, @bitCast(rhs))) else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) < @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
+        .gt_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) > @as(u64, @bitCast(rhs))) else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) > @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
+        .le_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) <= @as(u64, @bitCast(rhs))) else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) <= @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
+        .ge_u => if (ty == .i64) @intFromBool(@as(u64, @bitCast(lhs)) >= @as(u64, @bitCast(rhs))) else @intFromBool(@as(u32, @truncate(@as(u64, @bitCast(lhs)))) >= @as(u32, @truncate(@as(u64, @bitCast(rhs))))),
+        .div_s => blk: {
+            if (rhs == 0) return error.DivideByZero;
+            if (ty == .i64) {
+                if (lhs == std.math.minInt(i64) and rhs == -1) return error.IntegerOverflow;
+                break :blk @divTrunc(lhs, rhs);
+            }
+            const l32: i32 = @truncate(lhs);
+            const r32: i32 = @truncate(rhs);
+            if (l32 == std.math.minInt(i32) and r32 == -1) return error.IntegerOverflow;
+            break :blk @as(i64, @divTrunc(l32, r32));
+        },
+        .div_u => blk: {
+            if (rhs == 0) return error.DivideByZero;
+            if (ty == .i64) break :blk @bitCast(@as(u64, @bitCast(lhs)) / @as(u64, @bitCast(rhs)));
+            const l32: u32 = @truncate(@as(u64, @bitCast(lhs)));
+            const r32: u32 = @truncate(@as(u64, @bitCast(rhs)));
+            break :blk @as(i64, l32 / r32);
+        },
+        .rem_s => blk: {
+            if (rhs == 0) return error.DivideByZero;
+            if (ty == .i64) {
+                if (lhs == std.math.minInt(i64) and rhs == -1) break :blk 0;
+                break :blk @rem(lhs, rhs);
+            }
+            const l32: i32 = @truncate(lhs);
+            const r32: i32 = @truncate(rhs);
+            if (l32 == std.math.minInt(i32) and r32 == -1) break :blk 0;
+            break :blk @as(i64, @rem(l32, r32));
+        },
+        .rem_u => blk: {
+            if (rhs == 0) return error.DivideByZero;
+            if (ty == .i64) break :blk @bitCast(@as(u64, @bitCast(lhs)) % @as(u64, @bitCast(rhs)));
+            const l32: u32 = @truncate(@as(u64, @bitCast(lhs)));
+            const r32: u32 = @truncate(@as(u64, @bitCast(rhs)));
+            break :blk @as(i64, l32 % r32);
+        },
+        else => unreachable,
+    };
+}
+
+test "interp: straight-line arithmetic returns i32" {
+    const a = std.testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 1, 0);
+    defer func.deinit();
+
+    const b = try func.newBlock();
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try func.getBlock(b).append(.{ .dest = v0, .type = .i32, .op = .{ .iconst_32 = 40 } });
+    try func.getBlock(b).append(.{ .dest = v1, .type = .i32, .op = .{ .iconst_32 = 2 } });
+    try func.getBlock(b).append(.{ .dest = v2, .type = .i32, .op = .{ .add = .{ .lhs = v0, .rhs = v1 } } });
+    try func.getBlock(b).append(.{ .op = .{ .ret = v2 } });
+
+    var outcome = try run(a, &func, .{});
+    defer outcome.deinit(a);
+    try std.testing.expect(outcome == .returned);
+    try std.testing.expectEqual(@as(usize, 1), outcome.returned.results.len);
+    try std.testing.expectEqual(@as(u64, 42), outcome.returned.results[0].bits);
+}
+
+test "interp: diamond phi selects incoming predecessor" {
+    const a = std.testing.allocator;
+    var func = ir.IrFunction.init(a, 1, 1, 1);
+    defer func.deinit();
+    _ = func.newVReg(); // param v0 / local 0
+
+    const entry = try func.newBlock();
+    const left = try func.newBlock();
+    const right = try func.newBlock();
+    const merge = try func.newBlock();
+    try func.getBlock(left).addPredecessor(entry);
+    try func.getBlock(right).addPredecessor(entry);
+    try func.getBlock(merge).addPredecessor(left);
+    try func.getBlock(merge).addPredecessor(right);
+
+    const cond = func.newVReg();
+    try func.getBlock(entry).append(.{ .dest = cond, .type = .i32, .op = .{ .local_get = 0 } });
+    try func.getBlock(entry).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = left, .else_block = right } } });
+
+    const v_left = func.newVReg();
+    try func.getBlock(left).append(.{ .dest = v_left, .type = .i32, .op = .{ .iconst_32 = 11 } });
+    try func.getBlock(left).append(.{ .op = .{ .br = merge } });
+
+    const v_right = func.newVReg();
+    try func.getBlock(right).append(.{ .dest = v_right, .type = .i32, .op = .{ .iconst_32 = 22 } });
+    try func.getBlock(right).append(.{ .op = .{ .br = merge } });
+
+    const edges = try a.dupe(ir.Inst.PhiEdge, &.{ .{ .block = left, .val = v_left }, .{ .block = right, .val = v_right } });
+    const v_phi = func.newVReg();
+    try func.getBlock(merge).append(.{ .dest = v_phi, .type = .i32, .op = .{ .phi = edges } });
+    try func.getBlock(merge).append(.{ .op = .{ .ret = v_phi } });
+
+    var left_out = try run(a, &func, .{ .params = &.{Value.i32v(1)} });
+    defer left_out.deinit(a);
+    try std.testing.expectEqual(@as(u64, 11), left_out.returned.results[0].bits);
+
+    var right_out = try run(a, &func, .{ .params = &.{Value.i32v(0)} });
+    defer right_out.deinit(a);
+    try std.testing.expectEqual(@as(u64, 22), right_out.returned.results[0].bits);
+}
+
+test "interp: load and store round-trip memory" {
+    const a = std.testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 1, 0);
+    defer func.deinit();
+
+    const b = try func.newBlock();
+    const base = func.newVReg();
+    const val = func.newVReg();
+    const loaded = func.newVReg();
+    try func.getBlock(b).append(.{ .dest = base, .type = .i32, .op = .{ .iconst_32 = 4 } });
+    try func.getBlock(b).append(.{ .dest = val, .type = .i32, .op = .{ .iconst_32 = 0x11223344 } });
+    try func.getBlock(b).append(.{ .op = .{ .store = .{ .base = base, .offset = 0, .size = 4, .val = val } } });
+    try func.getBlock(b).append(.{ .dest = loaded, .type = .i32, .op = .{ .load = .{ .base = base, .offset = 0, .size = 4 } } });
+    try func.getBlock(b).append(.{ .op = .{ .ret = loaded } });
+
+    var outcome = try run(a, &func, .{ .memory = &([_]u8{0} ** 16) });
+    defer outcome.deinit(a);
+    try std.testing.expectEqual(@as(u64, 0x11223344), outcome.returned.results[0].bits);
+    try std.testing.expectEqualSlices(u8, &.{ 0x44, 0x33, 0x22, 0x11 }, outcome.returned.memory[4..8]);
+}
+
+test "interp: traps and fuel are explicit outcomes" {
+    const a = std.testing.allocator;
+    var func = ir.IrFunction.init(a, 0, 0, 0);
+    defer func.deinit();
+    const b = try func.newBlock();
+    try func.getBlock(b).append(.{ .op = .{ .br = b } });
+
+    var outcome = try run(a, &func, .{ .fuel = 3 });
+    defer outcome.deinit(a);
+    try std.testing.expectEqual(Inconclusive.fuel_exhausted, outcome.inconclusive);
+
+    var trap_func = ir.IrFunction.init(a, 0, 0, 0);
+    defer trap_func.deinit();
+    const tb = try trap_func.newBlock();
+    try trap_func.getBlock(tb).append(.{ .op = .{ .@"unreachable" = {} } });
+    var trap = try run(a, &trap_func, .{});
+    defer trap.deinit(a);
+    try std.testing.expectEqual(Trap.unreachable_reached, trap.trapped);
+}

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -1042,7 +1042,102 @@ pub const IrFunction = struct {
     pub fn getBlock(self: *IrFunction, id: BlockId) *BasicBlock {
         return &self.blocks.items[id];
     }
+
+    /// Deep-copy this function into `allocator`.
+    ///
+    /// `IrFunction` owns several instruction payload slices with two
+    /// different lifetimes: most are block-owned and freed by
+    /// `BasicBlock.deinit`, while `br_table.targets` slices are tracked in
+    /// `owned_br_table_targets` and freed by `IrFunction.deinit`. Preserve
+    /// that split so clones can be mutated and destroyed independently.
+    pub fn clone(self: *const IrFunction, allocator: std.mem.Allocator) !IrFunction {
+        var out = IrFunction.init(allocator, self.param_count, self.result_count, self.local_count);
+        errdefer out.deinit();
+
+        out.name = self.name;
+        out.phi_synth_local_start = self.phi_synth_local_start;
+        out.phi_synth_local_end = self.phi_synth_local_end;
+        out.next_vreg = self.next_vreg;
+        if (self.local_types) |lt| {
+            out.local_types = try allocator.dupe(IrType, lt);
+        }
+
+        try out.blocks.ensureTotalCapacity(allocator, self.blocks.items.len);
+        for (self.blocks.items) |*block| {
+            var copied = BasicBlock.init(block.id, allocator);
+            errdefer copied.deinit();
+
+            try copied.predecessors.appendSlice(allocator, block.predecessors.items);
+            try copied.instructions.ensureTotalCapacity(allocator, block.instructions.items.len);
+            for (block.instructions.items) |inst| {
+                try copied.instructions.append(allocator, try cloneInst(inst, allocator, &out));
+            }
+
+            out.blocks.appendAssumeCapacity(copied);
+        }
+
+        return out;
+    }
 };
+
+fn cloneInst(inst: Inst, allocator: std.mem.Allocator, owner: *IrFunction) !Inst {
+    var out = inst;
+    out.op = try cloneOp(inst.op, allocator, owner);
+    return out;
+}
+
+fn cloneVRegSlice(allocator: std.mem.Allocator, values: []const VReg) ![]const VReg {
+    if (values.len == 0) return &.{};
+    return try allocator.dupe(VReg, values);
+}
+
+fn cloneOp(op: Inst.Op, allocator: std.mem.Allocator, owner: *IrFunction) !Inst.Op {
+    return switch (op) {
+        .br_table => |bt| blk: {
+            const targets = try allocator.dupe(BlockId, bt.targets);
+            errdefer allocator.free(targets);
+            try owner.owned_br_table_targets.append(allocator, targets);
+            break :blk .{ .br_table = .{
+                .index = bt.index,
+                .targets = targets,
+                .default = bt.default,
+            } };
+        },
+        .ret_multi => |vregs| .{ .ret_multi = try cloneVRegSlice(allocator, vregs) },
+        .call => |cl| .{ .call = .{
+            .func_idx = cl.func_idx,
+            .args = try cloneVRegSlice(allocator, cl.args),
+            .extra_results = cl.extra_results,
+            .tail = cl.tail,
+        } },
+        .call_indirect => |ci| .{ .call_indirect = .{
+            .type_idx = ci.type_idx,
+            .elem_idx = ci.elem_idx,
+            .args = try cloneVRegSlice(allocator, ci.args),
+            .extra_results = ci.extra_results,
+            .table_idx = ci.table_idx,
+            .tail = ci.tail,
+        } },
+        .call_ref => |cr| .{ .call_ref = .{
+            .type_idx = cr.type_idx,
+            .func_ref = cr.func_ref,
+            .args = try cloneVRegSlice(allocator, cr.args),
+            .extra_results = cr.extra_results,
+            .tail = cr.tail,
+        } },
+        .phi => |edges| .{ .phi = try allocator.dupe(Inst.PhiEdge, edges) },
+        .parallel_copy => |pairs| .{ .parallel_copy = try allocator.dupe(Inst.ParallelCopy, pairs) },
+        .try_table_begin => |tt| .{ .try_table_begin = .{
+            .result_arity = tt.result_arity,
+            .clauses = if (tt.clauses.len == 0) &.{} else try allocator.dupe(Inst.CatchClause, tt.clauses),
+        } },
+        .throw => |th| .{ .throw = .{
+            .tag_idx = th.tag_idx,
+            .args = try cloneVRegSlice(allocator, th.args),
+        } },
+        else => op,
+    };
+}
 
 /// Function type metadata copied from the Wasm type section. Slices are owned
 /// by the containing `IrModule`.
@@ -1149,6 +1244,101 @@ test "IrFunction: newVReg returns sequential values" {
     try std.testing.expectEqual(@as(VReg, 2), func.newVReg());
     try std.testing.expectEqual(@as(VReg, 3), func.newVReg());
     try std.testing.expectEqual(@as(VReg, 4), func.next_vreg);
+}
+
+test "IrFunction: clone deep-copies owned slices" {
+    const allocator = std.testing.allocator;
+
+    var func = IrFunction.init(allocator, 2, 1, 3);
+    defer func.deinit();
+    func.name = "clone-source";
+    func.local_types = try allocator.dupe(IrType, &.{ .i32, .i64, .i32, .i32, .i64 });
+    func.phi_synth_local_start = 3;
+    func.phi_synth_local_end = 5;
+    _ = func.newVReg();
+    _ = func.newVReg();
+    _ = func.newVReg();
+
+    const entry = try func.newBlock();
+    const join = try func.newBlock();
+    try func.getBlock(join).addPredecessor(entry);
+
+    const targets = try allocator.dupe(BlockId, &.{join});
+    try func.owned_br_table_targets.append(allocator, targets);
+    const call_args = try allocator.dupe(VReg, &.{ 0, 1 });
+    try func.getBlock(entry).append(.{
+        .op = .{ .call = .{ .func_idx = 7, .args = call_args, .extra_results = 1, .tail = true } },
+        .dest = 2,
+        .type = .i32,
+    });
+    try func.getBlock(entry).append(.{
+        .op = .{ .br_table = .{ .index = 0, .targets = targets, .default = join } },
+        .type = .void,
+    });
+
+    const phi_edges = try allocator.dupe(Inst.PhiEdge, &.{.{ .block = entry, .val = 2 }});
+    try func.getBlock(join).append(.{ .op = .{ .phi = phi_edges }, .dest = 3, .type = .i32 });
+    const copies = try allocator.dupe(Inst.ParallelCopy, &.{.{ .dst = 4, .src = 3, .ty = .i32 }});
+    try func.getBlock(join).append(.{ .op = .{ .parallel_copy = copies }, .type = .void });
+    const ret_vals = try allocator.dupe(VReg, &.{ 3, 4 });
+    try func.getBlock(join).append(.{ .op = .{ .ret_multi = ret_vals }, .type = .void });
+    const clauses = try allocator.dupe(Inst.CatchClause, &.{.{ .kind = 0, .tag_idx = 9, .handler = join }});
+    try func.getBlock(join).append(.{ .op = .{ .try_table_begin = .{ .result_arity = 0, .clauses = clauses } }, .type = .void });
+    const throw_args = try allocator.dupe(VReg, &.{3});
+    try func.getBlock(join).append(.{ .op = .{ .throw = .{ .tag_idx = 9, .args = throw_args } }, .type = .void });
+
+    var copy = try func.clone(allocator);
+    defer copy.deinit();
+
+    try std.testing.expectEqualStrings(func.name.?, copy.name.?);
+    try std.testing.expectEqual(func.param_count, copy.param_count);
+    try std.testing.expectEqual(func.result_count, copy.result_count);
+    try std.testing.expectEqual(func.local_count, copy.local_count);
+    try std.testing.expectEqual(func.next_vreg, copy.next_vreg);
+    try std.testing.expectEqual(func.phi_synth_local_start, copy.phi_synth_local_start);
+    try std.testing.expectEqual(func.phi_synth_local_end, copy.phi_synth_local_end);
+    try std.testing.expectEqualSlices(IrType, func.local_types.?, copy.local_types.?);
+    try std.testing.expect(@intFromPtr(func.local_types.?.ptr) != @intFromPtr(copy.local_types.?.ptr));
+
+    try std.testing.expectEqual(func.blocks.items.len, copy.blocks.items.len);
+    try std.testing.expectEqualSlices(BlockId, func.getBlock(join).predecessors.items, copy.getBlock(join).predecessors.items);
+
+    const src_call = func.getBlock(entry).instructions.items[0].op.call;
+    const dst_call = copy.getBlock(entry).instructions.items[0].op.call;
+    try std.testing.expectEqualSlices(VReg, src_call.args, dst_call.args);
+    try std.testing.expect(@intFromPtr(src_call.args.ptr) != @intFromPtr(dst_call.args.ptr));
+
+    const src_bt = func.getBlock(entry).instructions.items[1].op.br_table;
+    const dst_bt = copy.getBlock(entry).instructions.items[1].op.br_table;
+    try std.testing.expectEqualSlices(BlockId, src_bt.targets, dst_bt.targets);
+    try std.testing.expect(@intFromPtr(src_bt.targets.ptr) != @intFromPtr(dst_bt.targets.ptr));
+    try std.testing.expectEqual(@as(usize, 1), copy.owned_br_table_targets.items.len);
+    try std.testing.expectEqual(@intFromPtr(dst_bt.targets.ptr), @intFromPtr(copy.owned_br_table_targets.items[0].ptr));
+
+    const src_phi = func.getBlock(join).instructions.items[0].op.phi;
+    const dst_phi = copy.getBlock(join).instructions.items[0].op.phi;
+    try std.testing.expectEqualSlices(Inst.PhiEdge, src_phi, dst_phi);
+    try std.testing.expect(@intFromPtr(src_phi.ptr) != @intFromPtr(dst_phi.ptr));
+
+    const src_pc = func.getBlock(join).instructions.items[1].op.parallel_copy;
+    const dst_pc = copy.getBlock(join).instructions.items[1].op.parallel_copy;
+    try std.testing.expectEqualSlices(Inst.ParallelCopy, src_pc, dst_pc);
+    try std.testing.expect(@intFromPtr(src_pc.ptr) != @intFromPtr(dst_pc.ptr));
+
+    const src_ret = func.getBlock(join).instructions.items[2].op.ret_multi;
+    const dst_ret = copy.getBlock(join).instructions.items[2].op.ret_multi;
+    try std.testing.expectEqualSlices(VReg, src_ret, dst_ret);
+    try std.testing.expect(@intFromPtr(src_ret.ptr) != @intFromPtr(dst_ret.ptr));
+
+    const src_tt = func.getBlock(join).instructions.items[3].op.try_table_begin;
+    const dst_tt = copy.getBlock(join).instructions.items[3].op.try_table_begin;
+    try std.testing.expectEqualSlices(Inst.CatchClause, src_tt.clauses, dst_tt.clauses);
+    try std.testing.expect(@intFromPtr(src_tt.clauses.ptr) != @intFromPtr(dst_tt.clauses.ptr));
+
+    const src_throw = func.getBlock(join).instructions.items[4].op.throw;
+    const dst_throw = copy.getBlock(join).instructions.items[4].op.throw;
+    try std.testing.expectEqualSlices(VReg, src_throw.args, dst_throw.args);
+    try std.testing.expect(@intFromPtr(src_throw.args.ptr) != @intFromPtr(dst_throw.args.ptr));
 }
 
 test "IrType: v128 uses 16 bytes and two spill slots" {

--- a/src/compiler/ir/property_test.zig
+++ b/src/compiler/ir/property_test.zig
@@ -1,0 +1,140 @@
+//! Property tests for optimizer passes using the in-process IR interpreter.
+//! Completes the #736 oracle loop: generate verifier-valid IR, execute it,
+//! clone + optimize, verify again, execute again, and compare observables.
+
+const std = @import("std");
+const ir = @import("ir.zig");
+const interp = @import("interp.zig");
+const fuzz = @import("fuzz.zig");
+const passes = @import("passes.zig");
+const verifier = @import("verifier.zig");
+const dead_store = @import("dead_store_elimination.zig");
+const frl_dom = @import("forward_redundant_loads_dominator.zig");
+const property_options = @import("ir_property_options");
+
+const PassFn = *const fn (*ir.IrFunction, std.mem.Allocator) anyerror!bool;
+
+const PassCase = struct {
+    name: []const u8,
+    func: PassFn,
+};
+
+const property_passes = [_]PassCase{
+    .{ .name = "constantFold", .func = passes.constantFold },
+    .{ .name = "algebraicSimplify", .func = passes.algebraicSimplify },
+    .{ .name = "deadCodeElimination", .func = passes.deadCodeElimination },
+    .{ .name = "deadStoreElimination", .func = dead_store.deadStoreElimination },
+    .{ .name = "commonSubexprElimination", .func = passes.commonSubexprElimination },
+    .{ .name = "globalValueNumbering", .func = passes.globalValueNumbering },
+    .{ .name = "forwardRedundantLoadsDominator", .func = frl_dom.forwardRedundantLoadsDominator },
+};
+
+fn setInputVector(inputs: []interp.Value, seed: u64, vector: u32) void {
+    var x = seed ^ (@as(u64, vector) *% 0x9e37_79b9_7f4a_7c15);
+    for (inputs, 0..) |*v, i| {
+        x = x *% 0xd134_2543_de82_ef95 +% 0x94d0_49bb_1331_11eb +% i;
+        var value: u32 = @truncate(x >> 32);
+        value &= 0x0f;
+        // Force both sides of branch-heavy shapes across the input vectors.
+        if (i == 0) value = if ((vector & 1) == 0) 0 else @max(value, 1);
+        v.* = interp.Value.u32v(value);
+    }
+}
+
+fn expectEquivalent(
+    pass_name: []const u8,
+    seed: u64,
+    shape: fuzz.Shape,
+    expected: interp.Outcome,
+    observed: interp.Outcome,
+) !void {
+    if (!outcomesEqual(expected, observed)) {
+        std.debug.print(
+            "IR property mismatch: pass={s} seed=0x{x} shape={s}\n",
+            .{ pass_name, seed, @tagName(shape) },
+        );
+        try std.testing.expect(false);
+    }
+}
+
+fn outcomesEqual(a: interp.Outcome, b: interp.Outcome) bool {
+    if (std.meta.activeTag(a) != std.meta.activeTag(b)) return false;
+    return switch (a) {
+        .returned => |ar| blk: {
+            const br = b.returned;
+            if (ar.results.len != br.results.len) break :blk false;
+            for (ar.results, br.results) |av, bv| {
+                if (av.ty != bv.ty or av.bits != bv.bits) break :blk false;
+            }
+            break :blk std.mem.eql(u8, ar.memory, br.memory);
+        },
+        .trapped => |at| at == b.trapped,
+        .unsupported => true,
+        .inconclusive => true,
+    };
+}
+
+fn checkPassPreservesCase(
+    allocator: std.mem.Allocator,
+    pass: PassCase,
+    seed: u64,
+    shape: fuzz.Shape,
+    vector_count: u32,
+) !void {
+    var case = try fuzz.generate(allocator, seed, shape);
+    defer case.deinit(allocator);
+
+    var optimized = try case.func.clone(allocator);
+    defer optimized.deinit();
+    _ = try pass.func(&optimized, allocator);
+    try verifier.verifyFunction(&optimized, 0, .after_each_pass, allocator);
+
+    var vector: u32 = 0;
+    while (vector < vector_count) : (vector += 1) {
+        setInputVector(case.inputs, seed, vector);
+
+        var expected = try interp.run(allocator, &case.func, .{
+            .params = case.inputs,
+            .memory = case.memory,
+            .fuel = 10_000,
+        });
+        defer expected.deinit(allocator);
+
+        var observed = try interp.run(allocator, &optimized, .{
+            .params = case.inputs,
+            .memory = case.memory,
+            .fuel = 10_000,
+        });
+        defer observed.deinit(allocator);
+
+        try expectEquivalent(pass.name, seed, shape, expected, observed);
+    }
+}
+
+test "property: scalar optimizer passes preserve interpreted behavior" {
+    const allocator = std.testing.allocator;
+    const iterations = property_options.iterations;
+    const vectors_per_case: u32 = 4;
+
+    for (property_passes) |pass| {
+        var iter: u32 = 0;
+        while (iter < iterations) : (iter += 1) {
+            for (fuzz.Shape.all, 0..) |shape, shape_idx| {
+                const seed = 0x7360_0000 + (@as(u64, iter) << 8) + shape_idx;
+                try checkPassPreservesCase(allocator, pass, seed, shape, vectors_per_case);
+            }
+        }
+    }
+}
+
+test "property: named memory-barrier regression seed exercises call path" {
+    const allocator = std.testing.allocator;
+    const seed = 0x7360_00ff;
+    try checkPassPreservesCase(
+        allocator,
+        .{ .name = "forwardRedundantLoadsDominator", .func = frl_dom.forwardRedundantLoadsDominator },
+        seed,
+        .memory_barrier,
+        2,
+    );
+}


### PR DESCRIPTION
## Summary
- add a deep `IrFunction.clone` for test/oracle workflows
- add an in-process scalar IR interpreter with explicit return/trap/unsupported/inconclusive outcomes
- add deterministic IR generators and optimizer property tests for constantFold, algebraicSimplify, DCE, DSE, CSE, GVN, and FRLDominator
- document seed reproduction and the `-Dir-property-iters=` scaling knob

Closes #736.

## Testing
- `zig build test --summary failures`
- `zig build test -Dir-property-iters=32 --summary failures`
