### PR TITLE
Draft: progress fixes for WAMR #743

### DIFF
--- a/src/compiler/ir/alias_class.zig
+++ b/src/compiler/ir/alias_class.zig
@@ -27,8 +27,33 @@ pub fn memKeyFromLoad(ld: anytype) MemKey {
     };
 }
 
+/// Identifies the byte range written by a linear-memory store.
+pub const StoreRange = struct {
+    base: ir.VReg,
+    offset: u32,
+    size: u8,
+};
+
+/// Build a store range for a full 128-bit SIMD store.
+pub fn storeRangeFromV128Store(st: anytype) StoreRange {
+    return .{
+        .base = st.base,
+        .offset = st.offset,
+        .size = 16,
+    };
+}
+
+/// Build a store range for a SIMD lane store.
+pub fn storeRangeFromV128StoreLane(st: anytype) StoreRange {
+    return .{
+        .base = st.base,
+        .offset = st.offset,
+        .size = st.accessSize(),
+    };
+}
+
 /// True iff a store at `(st.base, st.offset, st.size)` may overlap a load
-/// keyed at `key`. Conservative: same base register, byte ranges overlap.
+/// keyed at `key`. Precise helper for same base registers and byte ranges.
 pub fn storeAliases(key: MemKey, st: anytype) bool {
     if (key.base != st.base) return false;
     const key_end: u64 = @as(u64, key.offset) + @as(u64, key.size);
@@ -40,8 +65,11 @@ pub fn storeAliases(key: MemKey, st: anytype) bool {
 /// wasm linear-memory loads and wasm-local-slot reads in one table.
 ///
 /// `mem` and `local` are disjoint alias classes:
-///   * A linear-memory `store` invalidates only overlapping `.mem`
-///     entries — never `.local`.
+///   * A linear-memory `store` never invalidates `.local`.
+///   * For `.mem`, stores with the same base VReg use precise byte-range
+///     overlap; stores with a different base VReg invalidate conservatively
+///     because distinct guest-address VRegs can still evaluate to the same
+///     address.
 ///   * A `local_set i, v` invalidates only `.local = i` — never `.mem`,
 ///     and never `.local = j` for `j != i` (wasm locals are not aliased
 ///     across distinct indices).
@@ -57,10 +85,12 @@ pub const LoadKey = union(enum) {
 
 /// True iff a memory store may invalidate a value held under `key`.
 /// `.local` entries are never invalidated by memory stores.
+/// `.mem` entries use precise byte-range overlap for the same base VReg and
+/// conservative invalidation for different base VRegs.
 pub fn storeAliasesLoad(key: LoadKey, st: anytype) bool {
     return switch (key) {
-        .mem => |m| storeAliases(m, st),
         .local => false,
+        .mem => |m| if (m.base == st.base) storeAliases(m, st) else true,
     };
 }
 

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -6,6 +6,194 @@
 const std = @import("std");
 const ir = @import("ir.zig");
 
+pub const TimingOptions = struct {
+    enabled: bool = false,
+    threshold_ns: u64 = 100 * std.time.ns_per_ms,
+    module_filter: ?u32 = null,
+    func_filter: ?u32 = null,
+
+    fn contextMatches(self: TimingOptions, ctx: TimingContext) bool {
+        if (!self.enabled) return false;
+        if (self.module_filter) |want| {
+            if (ctx.module_idx == null or ctx.module_idx.? != want) return false;
+        }
+        if (self.func_filter) |want| {
+            if (ctx.func_idx == null or ctx.func_idx.? != want) return false;
+        }
+        return true;
+    }
+};
+
+pub const TimingContext = struct {
+    module_idx: ?u32 = null,
+    func_idx: ?u32 = null,
+    phase: []const u8 = "-",
+    pass_idx: ?u32 = null,
+    pass_name: []const u8 = "-",
+};
+
+const TimingState = struct {
+    options: TimingOptions = .{},
+    context: TimingContext = .{},
+    build_successors_calls: u64 = 0,
+    compute_dominators_calls: u64 = 0,
+};
+
+threadlocal var timing_state: TimingState = .{};
+
+pub fn setTimingOptions(options: TimingOptions) TimingOptions {
+    const previous = timing_state.options;
+    timing_state.options = options;
+    if (!options.enabled) timing_state.context = .{};
+    return previous;
+}
+
+pub const TimingContextScope = struct {
+    previous: TimingContext,
+
+    pub fn deinit(self: *TimingContextScope) void {
+        timing_state.context = self.previous;
+    }
+};
+
+pub fn pushTimingContext(context: TimingContext) TimingContextScope {
+    const previous = timing_state.context;
+    timing_state.context = context;
+    return .{ .previous = previous };
+}
+
+const TimingKind = enum {
+    build_successors,
+    compute_dominators,
+
+    fn label(self: TimingKind) []const u8 {
+        return switch (self) {
+            .build_successors => "buildSuccessors",
+            .compute_dominators => "computeDominators",
+        };
+    }
+};
+
+const TimingSample = struct {
+    kind: TimingKind,
+    enabled: bool = false,
+    call_index: u64 = 0,
+    start_ns: u64 = 0,
+
+    fn finish(self: TimingSample, func: *const ir.IrFunction) void {
+        if (!self.enabled) return;
+        const elapsed_ns = elapsedTimingNsSince(self.start_ns);
+        if (elapsed_ns < timing_state.options.threshold_ns) return;
+        printAnalysisTiming(self.kind, self.call_index, func, elapsed_ns);
+    }
+};
+
+fn beginTiming(kind: TimingKind) TimingSample {
+    const options = timing_state.options;
+    if (!options.contextMatches(timing_state.context)) {
+        return .{ .kind = kind };
+    }
+    const call_index = switch (kind) {
+        .build_successors => blk: {
+            timing_state.build_successors_calls += 1;
+            break :blk timing_state.build_successors_calls;
+        },
+        .compute_dominators => blk: {
+            timing_state.compute_dominators_calls += 1;
+            break :blk timing_state.compute_dominators_calls;
+        },
+    };
+    return .{
+        .kind = kind,
+        .enabled = true,
+        .call_index = call_index,
+        .start_ns = timingNowNs(),
+    };
+}
+
+fn timingNowNs() u64 {
+    return switch (comptime @import("builtin").os.tag) {
+        .linux => blk: {
+            const linux = std.os.linux;
+            var ts: linux.timespec = undefined;
+            const rc = linux.clock_gettime(.MONOTONIC, &ts);
+            if (rc != 0) return 0;
+            break :blk @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+        },
+        .macos, .ios, .tvos, .watchos, .visionos => blk: {
+            var ts: std.c.timespec = undefined;
+            if (std.c.clock_gettime(.MONOTONIC, &ts) != 0) return 0;
+            break :blk @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+        },
+        .windows => blk: {
+            const ntdll = std.os.windows.ntdll;
+            var counter: std.os.windows.LARGE_INTEGER = undefined;
+            var freq: std.os.windows.LARGE_INTEGER = undefined;
+            _ = ntdll.RtlQueryPerformanceCounter(&counter);
+            _ = ntdll.RtlQueryPerformanceFrequency(&freq);
+            const ticks: u128 = @intCast(counter);
+            const hz: u128 = @intCast(freq);
+            break :blk @as(u64, @truncate(ticks * std.time.ns_per_s / hz));
+        },
+        else => 0,
+    };
+}
+
+fn elapsedTimingNsSince(start_ns: u64) u64 {
+    const now_ns = timingNowNs();
+    return if (now_ns >= start_ns) now_ns - start_ns else 0;
+}
+
+fn countInstructions(func: *const ir.IrFunction) usize {
+    var total: usize = 0;
+    for (func.blocks.items) |*block| total += block.instructions.items.len;
+    return total;
+}
+
+fn printAnalysisTiming(
+    kind: TimingKind,
+    call_index: u64,
+    func: *const ir.IrFunction,
+    elapsed_ns: u64,
+) void {
+    const ctx = timing_state.context;
+    var module_buf: [16]u8 = undefined;
+    const module_text = if (ctx.module_idx) |idx|
+        std.fmt.bufPrint(&module_buf, "{d}", .{idx}) catch "?"
+    else
+        "-";
+    var func_buf: [16]u8 = undefined;
+    const func_text = if (ctx.func_idx) |idx|
+        std.fmt.bufPrint(&func_buf, "{d}", .{idx}) catch "?"
+    else
+        "-";
+    var pass_idx_buf: [16]u8 = undefined;
+    const pass_idx_text = if (ctx.pass_idx) |idx|
+        std.fmt.bufPrint(&pass_idx_buf, "{d}", .{idx}) catch "?"
+    else
+        "-";
+    const func_name = func.name orelse "-";
+    const elapsed_ms = elapsed_ns / std.time.ns_per_ms;
+    const elapsed_ms_frac = (elapsed_ns % std.time.ns_per_ms) / std.time.ns_per_us;
+    std.debug.print(
+        "[aot-analysis-timing] analysis={s} call={d} mod={s} local_func={s} phase={s} pass={s} pass_name={s} func_name={s} elapsed_ms={d}.{d:0>3} blocks={d} insts={d}\n",
+        .{
+            kind.label(),
+            call_index,
+            module_text,
+            func_text,
+            ctx.phase,
+            pass_idx_text,
+            ctx.pass_name,
+            func_name,
+            elapsed_ms,
+            elapsed_ms_frac,
+            func.blocks.items.len,
+            countInstructions(func),
+        },
+    );
+}
+
 // ── CFG: Successor computation ──────────────────────────────────────────
 
 /// Compute successor block IDs for each block by scanning branch instructions.
@@ -13,6 +201,19 @@ pub fn buildSuccessors(
     func: *const ir.IrFunction,
     allocator: std.mem.Allocator,
 ) !std.AutoHashMap(ir.BlockId, []const ir.BlockId) {
+    if (currentCfgAnalysisCache()) |cache| {
+        return cloneBlockIdMap(try cache.getSuccessors(func), allocator);
+    }
+    return buildSuccessorsFresh(func, allocator);
+}
+
+fn buildSuccessorsFresh(
+    func: *const ir.IrFunction,
+    allocator: std.mem.Allocator,
+) !std.AutoHashMap(ir.BlockId, []const ir.BlockId) {
+    const timing = beginTiming(.build_successors);
+    defer timing.finish(func);
+
     var successors = std.AutoHashMap(ir.BlockId, []const ir.BlockId).init(allocator);
 
     for (func.blocks.items, 0..) |block, idx| {
@@ -34,6 +235,27 @@ pub fn buildSuccessors(
         try successors.put(@intCast(idx), try succs.toOwnedSlice(allocator));
     }
     return successors;
+}
+
+pub fn freeBlockIdMap(map: *std.AutoHashMap(ir.BlockId, []const ir.BlockId), allocator: std.mem.Allocator) void {
+    var it = map.iterator();
+    while (it.next()) |entry| allocator.free(entry.value_ptr.*);
+    map.deinit();
+}
+
+pub fn cloneBlockIdMap(
+    source: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+    allocator: std.mem.Allocator,
+) !std.AutoHashMap(ir.BlockId, []const ir.BlockId) {
+    var result = std.AutoHashMap(ir.BlockId, []const ir.BlockId).init(allocator);
+    errdefer freeBlockIdMap(&result, allocator);
+
+    var it = @constCast(source).iterator();
+    while (it.next()) |entry| {
+        const owned = try allocator.dupe(ir.BlockId, entry.value_ptr.*);
+        try result.put(entry.key_ptr.*, owned);
+    }
+    return result;
 }
 
 // ── Liveness analysis ───────────────────────────────────────────────────
@@ -1095,6 +1317,106 @@ pub const DomTree = struct {
     }
 };
 
+pub fn cloneDomTree(source: *const DomTree, allocator: std.mem.Allocator) !DomTree {
+    const idom = try allocator.dupe(?ir.BlockId, source.idom);
+    errdefer allocator.free(idom);
+    const post_num = try allocator.dupe(?u32, source.post_num);
+    errdefer allocator.free(post_num);
+    const post_order = try allocator.dupe(ir.BlockId, source.post_order);
+    errdefer allocator.free(post_order);
+    return .{
+        .idom = idom,
+        .post_num = post_num,
+        .post_order = post_order,
+        .allocator = allocator,
+    };
+}
+
+pub const CfgAnalysisCache = struct {
+    allocator: std.mem.Allocator,
+    successors: ?std.AutoHashMap(ir.BlockId, []const ir.BlockId) = null,
+    predecessors: ?std.AutoHashMap(ir.BlockId, []const ir.BlockId) = null,
+    dominators: ?DomTree = null,
+
+    pub fn init(allocator: std.mem.Allocator) CfgAnalysisCache {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *CfgAnalysisCache) void {
+        self.invalidate();
+    }
+
+    pub fn invalidate(self: *CfgAnalysisCache) void {
+        if (self.dominators) |*dom| {
+            dom.deinit();
+            self.dominators = null;
+        }
+        if (self.predecessors) |*preds| {
+            freeBlockIdMap(preds, self.allocator);
+            self.predecessors = null;
+        }
+        if (self.successors) |*succs| {
+            freeBlockIdMap(succs, self.allocator);
+            self.successors = null;
+        }
+    }
+
+    pub fn getSuccessors(
+        self: *CfgAnalysisCache,
+        func: *const ir.IrFunction,
+    ) !*const std.AutoHashMap(ir.BlockId, []const ir.BlockId) {
+        if (self.successors == null) {
+            self.successors = try buildSuccessorsFresh(func, self.allocator);
+        }
+        return &self.successors.?;
+    }
+
+    pub fn getPredecessors(
+        self: *CfgAnalysisCache,
+        func: *const ir.IrFunction,
+    ) !*const std.AutoHashMap(ir.BlockId, []const ir.BlockId) {
+        if (self.predecessors == null) {
+            const successors = try self.getSuccessors(func);
+            self.predecessors = try buildPredecessorsFromSuccessors(func, self.allocator, successors);
+        }
+        return &self.predecessors.?;
+    }
+
+    pub fn getDominators(
+        self: *CfgAnalysisCache,
+        func: *const ir.IrFunction,
+    ) !*const DomTree {
+        if (self.dominators == null) {
+            const timing = beginTiming(.compute_dominators);
+            defer timing.finish(func);
+            const successors = try self.getSuccessors(func);
+            const predecessors = try self.getPredecessors(func);
+            self.dominators = try computeDominatorsFromCfg(func, self.allocator, successors, predecessors);
+        }
+        return &self.dominators.?;
+    }
+};
+
+threadlocal var scoped_cfg_cache: ?*CfgAnalysisCache = null;
+
+pub const CfgAnalysisCacheScope = struct {
+    previous: ?*CfgAnalysisCache,
+
+    pub fn deinit(self: *CfgAnalysisCacheScope) void {
+        scoped_cfg_cache = self.previous;
+    }
+};
+
+pub fn pushCfgAnalysisCache(cache: *CfgAnalysisCache) CfgAnalysisCacheScope {
+    const previous = scoped_cfg_cache;
+    scoped_cfg_cache = cache;
+    return .{ .previous = previous };
+}
+
+pub fn currentCfgAnalysisCache() ?*CfgAnalysisCache {
+    return scoped_cfg_cache;
+}
+
 /// Compute predecessors for each block from `buildSuccessors`. The
 /// `BasicBlock.predecessors` field is not guaranteed to be populated by
 /// all IR producers, so passes that need predecessors should use this.
@@ -1102,13 +1424,20 @@ pub fn buildPredecessors(
     func: *const ir.IrFunction,
     allocator: std.mem.Allocator,
 ) !std.AutoHashMap(ir.BlockId, []const ir.BlockId) {
-    const successors = try buildSuccessors(func, allocator);
-    defer {
-        var it = successors.iterator();
-        while (it.next()) |entry| allocator.free(entry.value_ptr.*);
-        @constCast(&successors).deinit();
+    if (currentCfgAnalysisCache()) |cache| {
+        return cloneBlockIdMap(try cache.getPredecessors(func), allocator);
     }
+    var successors = try buildSuccessorsFresh(func, allocator);
+    defer freeBlockIdMap(&successors, allocator);
 
+    return buildPredecessorsFromSuccessors(func, allocator, &successors);
+}
+
+fn buildPredecessorsFromSuccessors(
+    func: *const ir.IrFunction,
+    allocator: std.mem.Allocator,
+    successors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+) !std.AutoHashMap(ir.BlockId, []const ir.BlockId) {
     var lists = std.AutoHashMap(ir.BlockId, std.ArrayList(ir.BlockId)).init(allocator);
     defer {
         var it = lists.iterator();
@@ -1119,7 +1448,7 @@ pub fn buildPredecessors(
         try lists.put(@intCast(idx), .empty);
     }
 
-    var sit = successors.iterator();
+    var sit = @constCast(successors).iterator();
     while (sit.next()) |entry| {
         const from = entry.key_ptr.*;
         for (entry.value_ptr.*) |to| {
@@ -1167,12 +1496,10 @@ pub fn refreshBlockPredecessors(
     func: *ir.IrFunction,
     allocator: std.mem.Allocator,
 ) !void {
-    var preds = try buildPredecessors(func, allocator);
-    defer {
-        var it = preds.iterator();
-        while (it.next()) |entry| allocator.free(entry.value_ptr.*);
-        preds.deinit();
-    }
+    var successors = try buildSuccessorsFresh(func, allocator);
+    defer freeBlockIdMap(&successors, allocator);
+    var preds = try buildPredecessorsFromSuccessors(func, allocator, &successors);
+    defer freeBlockIdMap(&preds, allocator);
 
     for (func.blocks.items, 0..) |*block, idx| {
         block.predecessors.clearRetainingCapacity();
@@ -1186,20 +1513,28 @@ pub fn computeDominators(
     func: *const ir.IrFunction,
     allocator: std.mem.Allocator,
 ) !DomTree {
-    const nblocks = func.blocks.items.len;
+    if (currentCfgAnalysisCache()) |cache| {
+        return cloneDomTree(try cache.getDominators(func), allocator);
+    }
 
-    const successors = try buildSuccessors(func, allocator);
-    defer {
-        var sit = successors.iterator();
-        while (sit.next()) |entry| allocator.free(entry.value_ptr.*);
-        @constCast(&successors).deinit();
-    }
-    var predecessors = try buildPredecessors(func, allocator);
-    defer {
-        var pit = predecessors.iterator();
-        while (pit.next()) |entry| allocator.free(entry.value_ptr.*);
-        predecessors.deinit();
-    }
+    const timing = beginTiming(.compute_dominators);
+    defer timing.finish(func);
+
+    var successors = try buildSuccessorsFresh(func, allocator);
+    defer freeBlockIdMap(&successors, allocator);
+    var predecessors = try buildPredecessorsFromSuccessors(func, allocator, &successors);
+    defer freeBlockIdMap(&predecessors, allocator);
+
+    return computeDominatorsFromCfg(func, allocator, &successors, &predecessors);
+}
+
+fn computeDominatorsFromCfg(
+    func: *const ir.IrFunction,
+    allocator: std.mem.Allocator,
+    successors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+    predecessors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+) !DomTree {
+    const nblocks = func.blocks.items.len;
 
     // ── Iterative DFS to produce post-order from entry (block 0) ──
     var post_order: std.ArrayList(ir.BlockId) = .empty;
@@ -1436,20 +1771,48 @@ pub fn computeLoops(
     dom: *const DomTree,
     allocator: std.mem.Allocator,
 ) !LoopForest {
-    const nblocks = func.blocks.items.len;
+    if (currentCfgAnalysisCache()) |cache| {
+        return computeLoopsCached(func, dom, allocator, cache);
+    }
 
-    const successors = try buildSuccessors(func, allocator);
-    defer {
-        var sit = successors.iterator();
-        while (sit.next()) |entry| allocator.free(entry.value_ptr.*);
-        @constCast(&successors).deinit();
+    return computeLoopsFresh(func, dom, allocator);
+}
+
+fn computeLoopsFresh(
+    func: *const ir.IrFunction,
+    dom: *const DomTree,
+    allocator: std.mem.Allocator,
+) !LoopForest {
+    var successors = try buildSuccessorsFresh(func, allocator);
+    defer freeBlockIdMap(&successors, allocator);
+    var predecessors = try buildPredecessorsFromSuccessors(func, allocator, &successors);
+    defer freeBlockIdMap(&predecessors, allocator);
+
+    return computeLoopsFromCfg(func, dom, allocator, &successors, &predecessors);
+}
+
+pub fn computeLoopsCached(
+    func: *const ir.IrFunction,
+    dom: *const DomTree,
+    allocator: std.mem.Allocator,
+    cache: ?*CfgAnalysisCache,
+) !LoopForest {
+    if (cache) |c| {
+        const successors = try c.getSuccessors(func);
+        const predecessors = try c.getPredecessors(func);
+        return computeLoopsFromCfg(func, dom, allocator, successors, predecessors);
     }
-    var predecessors = try buildPredecessors(func, allocator);
-    defer {
-        var pit = predecessors.iterator();
-        while (pit.next()) |entry| allocator.free(entry.value_ptr.*);
-        predecessors.deinit();
-    }
+    return computeLoopsFresh(func, dom, allocator);
+}
+
+fn computeLoopsFromCfg(
+    func: *const ir.IrFunction,
+    dom: *const DomTree,
+    allocator: std.mem.Allocator,
+    successors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+    predecessors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+) !LoopForest {
+    const nblocks = func.blocks.items.len;
 
     // ── Collect back-edges per header ──
     // A back-edge is t → h where h dominates t. Both ends must be
@@ -1703,7 +2066,6 @@ pub fn computeBlockFrequencies(
     return freq;
 }
 
-
 // ── Tests ───────────────────────────────────────────────────────────────
 
 test "buildSuccessors: linear block" {
@@ -1956,6 +2318,57 @@ test "buildPredecessors: diamond" {
     try std.testing.expectEqual(@as(usize, 1), preds.get(b1).?.len);
     try std.testing.expectEqual(@as(usize, 1), preds.get(b2).?.len);
     try std.testing.expectEqual(@as(usize, 2), preds.get(b3).?.len);
+}
+
+test "CfgAnalysisCache: predecessor cache deduplicates repeated br_table targets" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const idx = func.newVReg();
+    const targets = try allocator.dupe(ir.BlockId, &.{ b1, b1 });
+    try func.owned_br_table_targets.append(allocator, targets);
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 0 }, .dest = idx });
+    try func.getBlock(b0).append(.{ .op = .{ .br_table = .{ .index = idx, .targets = targets, .default = b1 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .ret = null } });
+
+    var cache = CfgAnalysisCache.init(allocator);
+    defer cache.deinit();
+
+    const preds = try cache.getPredecessors(&func);
+    try std.testing.expectEqual(@as(usize, 1), preds.get(b1).?.len);
+    try std.testing.expectEqual(b0, preds.get(b1).?[0]);
+}
+
+test "CfgAnalysisCache: invalidate refreshes dominators after branch retarget" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const cond = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = cond });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = b1, .else_block = b2 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = null } });
+
+    var cache = CfgAnalysisCache.init(allocator);
+    defer cache.deinit();
+
+    const dom_before = try cache.getDominators(&func);
+    try std.testing.expectEqual(@as(?ir.BlockId, b0), dom_before.idom[b3]);
+
+    func.getBlock(b0).instructions.items[1].op.br_if.else_block = b1;
+    cache.invalidate();
+
+    const dom_after = try cache.getDominators(&func);
+    try std.testing.expectEqual(@as(?ir.BlockId, b1), dom_after.idom[b3]);
 }
 
 test "computeDominators: linear chain" {
@@ -2367,7 +2780,6 @@ test "computeLiveRanges: max_loop_depth is 0 for ranges outside any loop" {
         try std.testing.expectEqual(@as(u8, 0), r.max_loop_depth);
     }
 }
-
 
 test "computeBlockFrequencies: single block has frequency 1.0" {
     const allocator = std.testing.allocator;

--- a/src/compiler/ir/forward_redundant_loads.zig
+++ b/src/compiler/ir/forward_redundant_loads.zig
@@ -3,12 +3,16 @@ const ir = @import("ir.zig");
 const passes = @import("passes.zig");
 const alias_class = @import("alias_class.zig");
 
-const LoadKey = alias_class.LoadKey;
+const LoadEpoch = u64;
+
+const MemCacheEntry = struct {
+    vreg: ir.VReg,
+    epoch: LoadEpoch,
+};
 
 /// Forward redundant loads within a basic block.
 ///
-/// Two alias classes are tracked in a single value-table keyed by
-/// `alias_class.LoadKey`:
+/// Two disjoint alias classes are tracked in split caches:
 ///
 ///   * `mem` — wasm linear-memory loads keyed by
 ///     `(base, offset, size, sign_extend)`. A redundant load at the
@@ -27,10 +31,11 @@ const LoadKey = alias_class.LoadKey;
 ///     `local_set j` (j ≠ i) does NOT invalidate `local: i` — wasm
 ///     locals are not aliased across distinct indices.
 ///
-/// Cross-class invalidation rules (see `alias_class.storeAliasesLoad`):
-///   * `store` invalidates only the overlapping `.mem` entries.
+/// Cross-class invalidation rules:
+///   * `store` / SIMD stores bump the memory epoch, making all older `.mem`
+///     entries stale in O(1), and never invalidate `.local` entries.
 ///   * Calls and other barriers (atomic ops, `memory_*` bulk ops)
-///     clear the entire table. Wasm semantics technically allow
+///     clear both caches. Wasm semantics technically allow
 ///     preserving `.local` entries across calls (a callee cannot
 ///     mutate the caller's locals), but we stay conservative here
 ///     until inter-procedural escape analysis lands. `forwardLocalGet`
@@ -41,55 +46,72 @@ const LoadKey = alias_class.LoadKey;
 ///
 /// Single-block scope only — cross-block forwarding is handled by
 /// `forward_redundant_loads_dominator.zig` (#391).
-pub fn forwardRedundantLoads(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
-    var value_table = std.AutoHashMap(LoadKey, ir.VReg).init(allocator);
-    defer value_table.deinit();
+fn bumpMemEpoch(
+    mem_cache: *std.AutoHashMap(alias_class.MemKey, MemCacheEntry),
+    mem_epoch: *LoadEpoch,
+) void {
+    if (mem_epoch.* == std.math.maxInt(LoadEpoch)) {
+        mem_cache.clearRetainingCapacity();
+        mem_epoch.* = 0;
+    } else {
+        mem_epoch.* += 1;
+    }
+}
 
-    var aliasing_keys: std.ArrayList(LoadKey) = .empty;
-    defer aliasing_keys.deinit(allocator);
+fn clearCaches(
+    mem_cache: *std.AutoHashMap(alias_class.MemKey, MemCacheEntry),
+    local_cache: *std.AutoHashMap(u32, ir.VReg),
+    mem_epoch: *LoadEpoch,
+) void {
+    mem_cache.clearRetainingCapacity();
+    local_cache.clearRetainingCapacity();
+    mem_epoch.* = 0;
+}
+
+pub fn forwardRedundantLoads(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    var mem_cache = std.AutoHashMap(alias_class.MemKey, MemCacheEntry).init(allocator);
+    defer mem_cache.deinit();
+
+    var local_cache = std.AutoHashMap(u32, ir.VReg).init(allocator);
+    defer local_cache.deinit();
 
     var changed = false;
 
     for (func.blocks.items) |*block| {
-        value_table.clearRetainingCapacity();
+        var mem_epoch: LoadEpoch = 0;
+        clearCaches(&mem_cache, &local_cache, &mem_epoch);
 
         var i: usize = 0;
         while (i < block.instructions.items.len) {
             const inst = &block.instructions.items[i];
             switch (inst.op) {
                 .load => |ld| {
-                    const key: LoadKey = .{ .mem = alias_class.memKeyFromLoad(ld) };
-                    if (value_table.get(key)) |held_vreg| {
-                        if (inst.dest) |dest| {
-                            passes.replaceVReg(func, dest, held_vreg);
+                    const key = alias_class.memKeyFromLoad(ld);
+                    if (mem_cache.get(key)) |held| {
+                        if (held.epoch == mem_epoch) {
+                            if (inst.dest) |dest| {
+                                passes.replaceVReg(func, dest, held.vreg);
+                            }
+                            _ = block.instructions.orderedRemove(i);
+                            changed = true;
+                            continue;
                         }
-                        _ = block.instructions.orderedRemove(i);
-                        changed = true;
-                        continue;
                     }
                     if (inst.dest) |dest| {
-                        try value_table.put(key, dest);
+                        try mem_cache.put(key, .{ .vreg = dest, .epoch = mem_epoch });
                     }
                 },
-                .store => |st| {
-                    aliasing_keys.clearRetainingCapacity();
-                    var it = value_table.iterator();
-                    while (it.next()) |entry| {
-                        if (alias_class.storeAliasesLoad(entry.key_ptr.*, st)) {
-                            try aliasing_keys.append(allocator, entry.key_ptr.*);
-                        }
-                    }
-                    for (aliasing_keys.items) |k| _ = value_table.remove(k);
-                },
+                .store,
+                .v128_store,
+                .v128_store_lane,
+                => bumpMemEpoch(&mem_cache, &mem_epoch),
                 .local_set => |ls| {
-                    // Only invalidate this exact slot; wasm locals are
-                    // not aliased across distinct indices.
-                    _ = value_table.remove(.{ .local = ls.idx });
-                    try value_table.put(.{ .local = ls.idx }, ls.val);
+                    // Replace only this exact slot; wasm locals are not
+                    // aliased across distinct indices.
+                    try local_cache.put(ls.idx, ls.val);
                 },
                 .local_get => |idx| {
-                    const key: LoadKey = .{ .local = idx };
-                    if (value_table.get(key)) |held_vreg| {
+                    if (local_cache.get(idx)) |held_vreg| {
                         if (inst.dest) |dest| {
                             passes.replaceVReg(func, dest, held_vreg);
                         }
@@ -98,27 +120,14 @@ pub fn forwardRedundantLoads(func: *ir.IrFunction, allocator: std.mem.Allocator)
                         continue;
                     }
                     if (inst.dest) |dest| {
-                        try value_table.put(key, dest);
+                        try local_cache.put(idx, dest);
                     }
                 },
-                .call,
-                .call_indirect,
-                .call_ref,
-                .atomic_load,
-                .atomic_store,
-                .atomic_rmw,
-                .atomic_cmpxchg,
-                .atomic_fence,
-                .atomic_notify,
-                .atomic_wait,
-                .memory_copy,
-                .memory_fill,
-                .memory_init,
-                .memory_grow,
-                => {
-                    value_table.clearRetainingCapacity();
+                else => {
+                    if (passes.opIsLoadBarrier(inst.op)) {
+                        clearCaches(&mem_cache, &local_cache, &mem_epoch);
+                    }
                 },
-                else => {},
             }
             i += 1;
         }

--- a/src/compiler/ir/forward_redundant_loads_dominator.zig
+++ b/src/compiler/ir/forward_redundant_loads_dominator.zig
@@ -4,23 +4,22 @@
 //! dominator-tree walk. The algorithm (per #391):
 //!
 //!   1. DFS the dominator tree from the entry block.
-//!   2. On entry to each block, push a fresh `(LoadKey -> VReg)` map.
+//!   2. On entry to each block, push a fresh split memory/local cache frame.
 //!   3. While scanning instructions, lookups walk the stack from
 //!      innermost to outermost frame. A hit means an ancestor (or this
 //!      block) already loaded the same `(base, offset, size, sign_extend)`
 //!      and no aliasing store / call / barrier has run since.
-//!   4. Stores invalidate aliasing entries in every active frame (a
-//!      store anywhere on a dominator path kills cached values seen by
-//!      dominated blocks). Calls and barriers clear every frame fully.
+//!   4. Stores bump the memory epoch in every active frame (a store anywhere
+//!      on a dominator path kills cached memory values seen by dominated
+//!      blocks in O(1)). Calls and barriers clear every frame fully.
 //!   5. On exit from a block, pop its frame.
 //!
-//! Invalidation rules mirror `forward_redundant_loads.zig`; the `LoadKey`
-//! type lives in `alias_class.zig` and is managed by the shared driver.
+//! Invalidation rules mirror `forward_redundant_loads.zig`; memory and local
+//! cache state is managed by the shared driver in `passes.zig`.
 //!
-//! Sibling-block invariance: stores in one branch of a diamond do not
-//! propagate up into the dominator's frame (we only invalidate frames
-//! that are on the current DFS path), so the unrelated sibling-then-
-//! merge block still observes the dominator's load.
+//! Sibling-block invariance: stores only bump memory epochs in frames that are
+//! active on the current DFS path. Popped sibling frames are not revisited or
+//! mutated.
 //!
 //! Sibling-block BARRIER soundness (#719): a barrier (call / atomic /
 //! bulk-memory) on one diamond branch DOES need to wipe ancestor

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -5,6 +5,7 @@
 //! it made any changes (for fixpoint iteration).
 
 const std = @import("std");
+const builtin = @import("builtin");
 const ir = @import("ir.zig");
 const analysis = @import("analysis.zig");
 const alias_class = @import("alias_class.zig");
@@ -13,22 +14,22 @@ const verifier = @import("verifier.zig");
 
 pub const LoadKey = alias_class.LoadKey;
 
-/// Stack of per-dominator-level load value tables, shared by
+/// Stack of per-dominator-level load value caches, shared by
 /// `commonSubexprElimination`, `globalValueNumbering`, and
 /// `forwardRedundantLoadsDominator` when handling `load` / `local_get` /
 /// `local_set` (issue #541).
 ///
-/// Each frame maps a `LoadKey` to the VReg that holds its current
-/// value at this point on the dominator path. Lookup walks top→bottom
-/// (innermost scope wins). Stores, `local_set`, and barriers (calls,
-/// atomics, bulk-memory) invalidate matching entries across every
-/// active frame.
+/// Each frame keeps split memory/local maps. Memory entries carry the
+/// frame's memory epoch from the time they were recorded; memory stores bump
+/// the epoch in every active frame instead of scanning/removing entries.
+/// Lookup walks top→bottom (innermost scope wins) and ignores memory entries
+/// whose recorded epoch no longer matches the frame epoch. `local_set`
+/// invalidates only matching local-map entries. Barriers (calls, atomics,
+/// bulk-memory) clear both maps in every active frame.
 ///
 /// Sibling-dominator-branch handling has two cases:
-///   * STORES on a sibling branch leave the dominator's frame alone
-///     — only frames on the current DFS path are invalidated. Sound
-///     because a sibling-branch store does not execute on the
-///     execution path through the other branch.
+///   * STORES bump memory epochs only in frames on the current DFS path.
+///     Popped sibling frames are not revisited or mutated.
 ///   * BARRIERS on a sibling branch must wipe ancestor frames too,
 ///     since a merge block dominated by the branch head IS reachable
 ///     via the barrier-containing branch on some execution path
@@ -37,28 +38,63 @@ pub const LoadKey = alias_class.LoadKey;
 ///     `BarrierOrderedDomChildren` so barrier subtrees are visited
 ///     before their non-barrier siblings.
 pub const LoadFrameStack = struct {
-    frames: std.ArrayList(std.AutoHashMap(LoadKey, ir.VReg)),
+    const LoadEpoch = u64;
+
+    const MemEntry = struct {
+        vreg: ir.VReg,
+        epoch: LoadEpoch,
+    };
+
+    const Frame = struct {
+        mem: std.AutoHashMap(alias_class.MemKey, MemEntry),
+        locals: std.AutoHashMap(u32, ir.VReg),
+        mem_epoch: LoadEpoch = 0,
+
+        fn init(alloc: std.mem.Allocator) Frame {
+            return .{
+                .mem = std.AutoHashMap(alias_class.MemKey, MemEntry).init(alloc),
+                .locals = std.AutoHashMap(u32, ir.VReg).init(alloc),
+            };
+        }
+
+        fn deinit(self: *Frame) void {
+            self.mem.deinit();
+            self.locals.deinit();
+        }
+
+        fn bumpMemEpoch(self: *Frame) void {
+            if (self.mem_epoch == std.math.maxInt(LoadEpoch)) {
+                self.mem.clearRetainingCapacity();
+                self.mem_epoch = 0;
+            } else {
+                self.mem_epoch += 1;
+            }
+        }
+
+        fn clearAll(self: *Frame) void {
+            self.mem.clearRetainingCapacity();
+            self.locals.clearRetainingCapacity();
+            self.mem_epoch = 0;
+        }
+    };
+
+    frames: std.ArrayList(Frame),
     alloc: std.mem.Allocator,
-    /// Scratch buffer for `invalidateMem` to avoid allocating one map's
-    /// worth of keys per store.
-    scratch: std.ArrayList(LoadKey),
 
     pub fn init(alloc: std.mem.Allocator) LoadFrameStack {
         return .{
             .frames = .empty,
             .alloc = alloc,
-            .scratch = .empty,
         };
     }
 
     pub fn deinit(self: *LoadFrameStack) void {
         for (self.frames.items) |*f| f.deinit();
         self.frames.deinit(self.alloc);
-        self.scratch.deinit(self.alloc);
     }
 
     pub fn push(self: *LoadFrameStack) !void {
-        try self.frames.append(self.alloc, std.AutoHashMap(LoadKey, ir.VReg).init(self.alloc));
+        try self.frames.append(self.alloc, Frame.init(self.alloc));
     }
 
     pub fn pop(self: *LoadFrameStack) void {
@@ -68,44 +104,56 @@ pub const LoadFrameStack = struct {
 
     /// Search top→bottom for a current binding of `key`.
     pub fn lookup(self: *LoadFrameStack, key: LoadKey) ?ir.VReg {
-        var i = self.frames.items.len;
-        while (i > 0) {
-            i -= 1;
-            if (self.frames.items[i].get(key)) |v| return v;
+        switch (key) {
+            .mem => |mem_key| {
+                var i = self.frames.items.len;
+                while (i > 0) {
+                    i -= 1;
+                    const frame = &self.frames.items[i];
+                    if (frame.mem.get(mem_key)) |entry| {
+                        if (entry.epoch == frame.mem_epoch) return entry.vreg;
+                    }
+                }
+                return null;
+            },
+            .local => |idx| {
+                var i = self.frames.items.len;
+                while (i > 0) {
+                    i -= 1;
+                    if (self.frames.items[i].locals.get(idx)) |v| return v;
+                }
+                return null;
+            },
         }
-        return null;
     }
 
     /// Add `(key -> vreg)` to the current (top) frame.
     pub fn record(self: *LoadFrameStack, key: LoadKey, vreg: ir.VReg) !void {
-        try self.frames.items[self.frames.items.len - 1].put(key, vreg);
+        const frame = &self.frames.items[self.frames.items.len - 1];
+        switch (key) {
+            .mem => |mem_key| try frame.mem.put(mem_key, .{ .vreg = vreg, .epoch = frame.mem_epoch }),
+            .local => |idx| try frame.locals.put(idx, vreg),
+        }
     }
 
-    /// Drop entries in every active frame whose `.mem` keys overlap the
-    /// store. `.local` entries are never affected.
-    pub fn invalidateMem(self: *LoadFrameStack, st: anytype) !void {
+    /// Invalidate memory entries in every active frame by bumping each frame's
+    /// memory epoch. `.local` entries are never affected.
+    pub fn invalidateMem(self: *LoadFrameStack, _: anytype) !void {
         for (self.frames.items) |*frame| {
-            self.scratch.clearRetainingCapacity();
-            var it = frame.iterator();
-            while (it.next()) |entry| {
-                if (alias_class.storeAliasesLoad(entry.key_ptr.*, st)) {
-                    try self.scratch.append(self.alloc, entry.key_ptr.*);
-                }
-            }
-            for (self.scratch.items) |k| _ = frame.remove(k);
+            frame.bumpMemEpoch();
         }
     }
 
     /// Drop `.local = idx` from every active frame.
     pub fn invalidateLocal(self: *LoadFrameStack, idx: u32) void {
         for (self.frames.items) |*frame| {
-            _ = frame.remove(.{ .local = idx });
+            _ = frame.locals.remove(idx);
         }
     }
 
     /// Coarse barrier (call, atomic, bulk-memory): clear all frames.
     pub fn clearAll(self: *LoadFrameStack) void {
-        for (self.frames.items) |*frame| frame.clearRetainingCapacity();
+        for (self.frames.items) |*frame| frame.clearAll();
     }
 };
 
@@ -251,6 +299,8 @@ pub fn LoadForwardingDomWalk(comptime Visitor: type) type {
                             }
                         },
                         .store => |st| try load_frames.invalidateMem(st),
+                        .v128_store => |st| try load_frames.invalidateMem(alias_class.storeRangeFromV128Store(st)),
+                        .v128_store_lane => |st| try load_frames.invalidateMem(alias_class.storeRangeFromV128StoreLane(st)),
                         else => {
                             if (opIsLoadBarrier(inst.op)) load_frames.clearAll();
                         },
@@ -835,11 +885,24 @@ const BoundedVRegList = struct {
 
 /// Replace all uses of `old` VReg with `new` VReg in a function.
 pub fn replaceVReg(func: *ir.IrFunction, old: ir.VReg, new: ir.VReg) void {
+    _ = replaceVRegCount(func, old, new);
+}
+
+/// Replace all uses of `old` VReg with `new` VReg in a function.
+/// Returns the number of operand slots that were actually rewritten.
+pub fn replaceVRegCount(func: *ir.IrFunction, old: ir.VReg, new: ir.VReg) u32 {
+    if (old == new) return 0;
+
+    var replacements: u32 = 0;
     for (func.blocks.items) |*block| {
         for (block.instructions.items) |*inst| {
+            const inst_replacements = countUsesInInst(inst.*, old);
+            if (inst_replacements == 0) continue;
             replaceInInst(inst, old, new);
+            replacements += inst_replacements;
         }
     }
+    return replacements;
 }
 
 /// Count the number of operand slots in `func` that currently reference
@@ -850,11 +913,51 @@ pub fn countUsesOfVReg(func: *const ir.IrFunction, vreg: ir.VReg) u32 {
     var count: u32 = 0;
     for (func.blocks.items) |block| {
         for (block.instructions.items) |inst| {
-            for (getUsedVRegs(inst).slice()) |u| {
-                if (u == vreg) count += 1;
-            }
+            count += countUsesInInst(inst, vreg);
         }
     }
+    return count;
+}
+
+fn countVRegSliceUses(vregs: []const ir.VReg, vreg: ir.VReg) u32 {
+    var count: u32 = 0;
+    for (vregs) |u| {
+        if (u == vreg) count += 1;
+    }
+    return count;
+}
+
+fn countUsesInInst(inst: ir.Inst, vreg: ir.VReg) u32 {
+    var count: u32 = 0;
+    for (getUsedVRegs(inst).slice()) |u| {
+        if (u == vreg) count += 1;
+    }
+
+    switch (inst.op) {
+        .ret_multi => |vregs| count += countVRegSliceUses(vregs, vreg),
+        .call => |cl| count += countVRegSliceUses(cl.args, vreg),
+        .call_indirect => |ci| {
+            if (ci.elem_idx == vreg) count += 1;
+            count += countVRegSliceUses(ci.args, vreg);
+        },
+        .call_ref => |cr| {
+            if (cr.func_ref == vreg) count += 1;
+            count += countVRegSliceUses(cr.args, vreg);
+        },
+        .phi => |edges| {
+            for (edges) |edge| {
+                if (edge.val == vreg) count += 1;
+            }
+        },
+        .parallel_copy => |pairs| {
+            for (pairs) |p| {
+                if (p.src == vreg) count += 1;
+            }
+        },
+        .throw => |th| count += countVRegSliceUses(th.args, vreg),
+        else => {},
+    }
+
     return count;
 }
 
@@ -2618,8 +2721,8 @@ pub fn globalValueNumbering(func: *ir.IrFunction, allocator: std.mem.Allocator) 
             }
 
             if (found) |earlier_vreg| {
-                replaceVReg(ir_func, inst.dest.?, earlier_vreg);
-                return .changed;
+                const replacements = replaceVRegCount(ir_func, inst.dest.?, earlier_vreg);
+                return if (replacements > 0) .changed else .unchanged;
             }
 
             try self.table.append(self.allocator, .{ .inst = inst.*, .vreg = inst.dest.? });
@@ -2689,7 +2792,226 @@ pub const RunOptions = struct {
     /// component AOT driver (`wamrc compile-component`) passes the
     /// per-core index so `:mod=N` filters resolve correctly.
     module_idx: u32 = 0,
+    /// Optional stderr timing/progress diagnostics for the optimization
+    /// pass loop. Off by default; `wamrc` populates this from
+    /// `WAMR_AOT_PASS_TIMING*` environment variables.
+    pass_timing: PassTimingOptions = .{},
 };
+
+pub const PassTimingOptions = struct {
+    enabled: bool = false,
+    threshold_ns: u64 = 100 * std.time.ns_per_ms,
+    every_n_functions: u32 = 0,
+    module_filter: ?u32 = null,
+    func_filter: ?u32 = null,
+    log_starts: bool = false,
+
+    fn moduleMatches(self: PassTimingOptions, module_idx: u32) bool {
+        return self.module_filter == null or self.module_filter.? == module_idx;
+    }
+
+    fn functionMatches(self: PassTimingOptions, module_idx: u32, func_idx: u32) bool {
+        if (!self.enabled or !self.moduleMatches(module_idx)) return false;
+        return self.func_filter == null or self.func_filter.? == func_idx;
+    }
+
+    fn shouldLogElapsed(self: PassTimingOptions, elapsed_ns: u64) bool {
+        return self.enabled and elapsed_ns >= self.threshold_ns;
+    }
+
+    fn shouldLogFunctionProgress(self: PassTimingOptions, func_idx: u32) bool {
+        return self.enabled and self.every_n_functions != 0 and func_idx % self.every_n_functions == 0;
+    }
+};
+
+/// Parse env-gated pass timing diagnostics. `WAMR_AOT_PASS_TIMING=1`
+/// enables logging; `0`, `false`, `no`, `off`, or an empty value keep it
+/// disabled. Optional knobs:
+///
+///   - `WAMR_AOT_PASS_TIMING_THRESHOLD_MS` (default: 100)
+///   - `WAMR_AOT_PASS_TIMING_EVERY_N_FUNCS` (function progress cadence)
+///   - `WAMR_AOT_PASS_TIMING_MODULE` (component core/module index)
+///   - `WAMR_AOT_PASS_TIMING_FUNC` (local IR function index)
+///   - `WAMR_AOT_PASS_TIMING_LOG_STARTS` (emit pass/verify start lines)
+pub fn passTimingOptionsFromEnv(env: *const std.process.Environ.Map) PassTimingOptions {
+    const gate = env.get("WAMR_AOT_PASS_TIMING") orelse return .{};
+    if (!envFlagEnabled(gate)) return .{};
+
+    var out = PassTimingOptions{ .enabled = true };
+    if (parseEnvU64(env, "WAMR_AOT_PASS_TIMING_THRESHOLD_MS")) |ms| {
+        const max_ms = std.math.maxInt(u64) / std.time.ns_per_ms;
+        out.threshold_ns = if (ms > max_ms) std.math.maxInt(u64) else ms * std.time.ns_per_ms;
+    }
+    if (parseEnvU32(env, "WAMR_AOT_PASS_TIMING_EVERY_N_FUNCS")) |n| out.every_n_functions = n;
+    if (parseEnvU32(env, "WAMR_AOT_PASS_TIMING_MODULE")) |m| out.module_filter = m;
+    if (parseEnvU32(env, "WAMR_AOT_PASS_TIMING_FUNC")) |f| out.func_filter = f;
+    if (env.get("WAMR_AOT_PASS_TIMING_LOG_STARTS")) |v| out.log_starts = envFlagEnabled(v);
+    return out;
+}
+
+fn envFlagEnabled(value: []const u8) bool {
+    return value.len != 0 and
+        !std.mem.eql(u8, value, "0") and
+        !std.ascii.eqlIgnoreCase(value, "false") and
+        !std.ascii.eqlIgnoreCase(value, "no") and
+        !std.ascii.eqlIgnoreCase(value, "off");
+}
+
+fn parseEnvU64(env: *const std.process.Environ.Map, name: []const u8) ?u64 {
+    const value = env.get(name) orelse return null;
+    return std.fmt.parseInt(u64, value, 10) catch |err| {
+        std.debug.print("[aot-pass-timing] ignoring {s}={s}: {s}\n", .{ name, value, @errorName(err) });
+        return null;
+    };
+}
+
+fn parseEnvU32(env: *const std.process.Environ.Map, name: []const u8) ?u32 {
+    const value = env.get(name) orelse return null;
+    return std.fmt.parseInt(u32, value, 10) catch |err| {
+        std.debug.print("[aot-pass-timing] ignoring {s}={s}: {s}\n", .{ name, value, @errorName(err) });
+        return null;
+    };
+}
+
+const PassTimingStats = struct {
+    blocks: usize = 0,
+    instructions: usize = 0,
+};
+
+fn collectPassTimingStats(func: *const ir.IrFunction) PassTimingStats {
+    var stats = PassTimingStats{ .blocks = func.blocks.items.len };
+    for (func.blocks.items) |*block| stats.instructions += block.instructions.items.len;
+    return stats;
+}
+
+fn passTimingNowNs() u64 {
+    return switch (comptime builtin.os.tag) {
+        .linux => blk: {
+            const linux = std.os.linux;
+            var ts: linux.timespec = undefined;
+            const rc = linux.clock_gettime(.MONOTONIC, &ts);
+            if (rc != 0) return 0;
+            break :blk @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+        },
+        .macos, .ios, .tvos, .watchos, .visionos => blk: {
+            var ts: std.c.timespec = undefined;
+            if (std.c.clock_gettime(.MONOTONIC, &ts) != 0) return 0;
+            break :blk @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+        },
+        .windows => blk: {
+            const ntdll = std.os.windows.ntdll;
+            var counter: std.os.windows.LARGE_INTEGER = undefined;
+            var freq: std.os.windows.LARGE_INTEGER = undefined;
+            _ = ntdll.RtlQueryPerformanceCounter(&counter);
+            _ = ntdll.RtlQueryPerformanceFrequency(&freq);
+            const ticks: u128 = @intCast(counter);
+            const hz: u128 = @intCast(freq);
+            break :blk @as(u64, @truncate(ticks * std.time.ns_per_s / hz));
+        },
+        else => 0,
+    };
+}
+
+fn elapsedNsSince(start_ns: u64) u64 {
+    const now_ns = passTimingNowNs();
+    return if (now_ns >= start_ns) now_ns - start_ns else 0;
+}
+
+fn printPassTiming(
+    phase: []const u8,
+    module: *const ir.IrModule,
+    module_idx: u32,
+    func: *const ir.IrFunction,
+    func_idx: u32,
+    outer_iter: u32,
+    iter: u32,
+    pass_idx: ?u32,
+    pass_name: []const u8,
+    changed: bool,
+    elapsed_ns: u64,
+    before: PassTimingStats,
+    after: PassTimingStats,
+) void {
+    var pass_idx_buf: [16]u8 = undefined;
+    const pass_idx_text = if (pass_idx) |idx|
+        std.fmt.bufPrint(&pass_idx_buf, "{d}", .{idx}) catch "?"
+    else
+        "-";
+    const func_name = func.name orelse "-";
+    const elapsed_ms = elapsed_ns / std.time.ns_per_ms;
+    const elapsed_ms_frac = (elapsed_ns % std.time.ns_per_ms) / std.time.ns_per_us;
+    std.debug.print(
+        "[aot-pass-timing] phase={s} mod={d} local_func={d} wasm_func={d} func_name={s} outer={d} iter={d} pass={s} pass_name={s} changed={} elapsed_ms={d}.{d:0>3} blocks={d}->{d} insts={d}->{d}\n",
+        .{
+            phase,
+            module_idx,
+            func_idx,
+            module.import_count + func_idx,
+            func_name,
+            outer_iter,
+            iter,
+            pass_idx_text,
+            pass_name,
+            changed,
+            elapsed_ms,
+            elapsed_ms_frac,
+            before.blocks,
+            after.blocks,
+            before.instructions,
+            after.instructions,
+        },
+    );
+}
+
+fn maybePrintPassTiming(
+    timing: PassTimingOptions,
+    phase: []const u8,
+    module: *const ir.IrModule,
+    module_idx: u32,
+    func: *const ir.IrFunction,
+    func_idx: u32,
+    outer_iter: u32,
+    iter: u32,
+    pass_idx: ?u32,
+    pass_name: []const u8,
+    changed: bool,
+    elapsed_ns: u64,
+    before: PassTimingStats,
+) void {
+    if (!timing.shouldLogElapsed(elapsed_ns)) return;
+    printPassTiming(
+        phase,
+        module,
+        module_idx,
+        func,
+        func_idx,
+        outer_iter,
+        iter,
+        pass_idx,
+        pass_name,
+        changed,
+        elapsed_ns,
+        before,
+        collectPassTimingStats(func),
+    );
+}
+
+fn printPassTimingStart(
+    timing: PassTimingOptions,
+    phase: []const u8,
+    module: *const ir.IrModule,
+    module_idx: u32,
+    func: *const ir.IrFunction,
+    func_idx: u32,
+    outer_iter: u32,
+    iter: u32,
+    pass_idx: ?u32,
+    pass_name: []const u8,
+) void {
+    if (!timing.log_starts) return;
+    const stats = collectPassTimingStats(func);
+    printPassTiming(phase, module, module_idx, func, func_idx, outer_iter, iter, pass_idx, pass_name, false, 0, stats, stats);
+}
 
 /// Filter that selectively skips IR optimisation passes, caps the
 /// pipeline length for specific functions, or skips the prelude passes
@@ -4198,12 +4520,26 @@ fn patchSegment(seg_first: *std.AutoHashMap(ir.VReg, SegEntry)) bool {
         };
         if (se.max_end > own_end) {
             switch (se.inst.op) {
-                .load => |*ld| ld.checked_end = se.max_end,
-                .v128_load_extend => |*ld| ld.checked_end = se.max_end,
-                .store => |*st| st.checked_end = se.max_end,
+                .load => |*ld| {
+                    if (ld.checked_end != se.max_end) {
+                        ld.checked_end = se.max_end;
+                        patched = true;
+                    }
+                },
+                .v128_load_extend => |*ld| {
+                    if (ld.checked_end != se.max_end) {
+                        ld.checked_end = se.max_end;
+                        patched = true;
+                    }
+                },
+                .store => |*st| {
+                    if (st.checked_end != se.max_end) {
+                        st.checked_end = se.max_end;
+                        patched = true;
+                    }
+                },
                 else => unreachable,
             }
-            patched = true;
         }
     }
     return patched;
@@ -6869,6 +7205,19 @@ pub fn runPassesWithOptions(
     // promise. Prelude skips are module-wide, so they keep the normal
     // two-round schedule.
     const outer_max: u32 = if (opts.bisect.hasPassPipelineFilterInModule(opts.module_idx)) 1 else 2;
+    const timing = opts.pass_timing;
+    if (timing.enabled and timing.moduleMatches(opts.module_idx)) {
+        std.debug.print(
+            "[aot-pass-timing] begin mod={d} funcs={d} passes={d} threshold_ms={d} every_n_funcs={d}\n",
+            .{
+                opts.module_idx,
+                module.functions.items.len,
+                passes.len,
+                timing.threshold_ns / std.time.ns_per_ms,
+                timing.every_n_functions,
+            },
+        );
+    }
     var outer_iter: u32 = 0;
     while (outer_iter < outer_max) : (outer_iter += 1) {
         // Module-level: inline small leaf callees. Iterate to fixpoint so
@@ -6920,6 +7269,26 @@ pub fn runPassesWithOptions(
 
         for (module.functions.items, 0..) |*func, func_idx_usize| {
             const func_idx: u32 = @intCast(func_idx_usize);
+            const timing_for_func = timing.functionMatches(opts.module_idx, func_idx);
+            const function_start_ns = if (timing_for_func) passTimingNowNs() else 0;
+            const function_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};
+            if (timing_for_func and timing.shouldLogFunctionProgress(func_idx)) {
+                printPassTiming(
+                    "function-start",
+                    module,
+                    opts.module_idx,
+                    func,
+                    func_idx,
+                    outer_iter,
+                    0,
+                    null,
+                    "function",
+                    false,
+                    0,
+                    function_start_stats,
+                    function_start_stats,
+                );
+            }
             // #761: per-function verifier suppression — skipping a
             // pass (or capping the pipeline) on a function can leave
             // IR in a state that later cleanups would normalise,
@@ -6937,9 +7306,54 @@ pub fn runPassesWithOptions(
             // local_set/get inserted by inlining is handled by
             // `forwardLocalGet` + `deadLocalSetElimination`.
             if (outer_iter == 0 and !opts.bisect.skipsPromoteSSA(opts.module_idx, func_idx)) {
-                if (try promoteLocalsToSSA(func, allocator)) {
+                const pass_start_ns = if (timing_for_func) passTimingNowNs() else 0;
+                const pass_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};
+                if (timing_for_func) {
+                    printPassTimingStart(timing, "pass-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "promoteLocalsToSSA");
+                }
+                const promote_changed = try promoteLocalsToSSA(func, allocator);
+                if (timing_for_func) {
+                    maybePrintPassTiming(
+                        timing,
+                        "pass",
+                        module,
+                        opts.module_idx,
+                        func,
+                        func_idx,
+                        outer_iter,
+                        0,
+                        null,
+                        "promoteLocalsToSSA",
+                        promote_changed,
+                        elapsedNsSince(pass_start_ns),
+                        pass_start_stats,
+                    );
+                }
+                if (promote_changed) {
                     total_changes += 1;
+                    const verify_start_ns = if (timing_for_func) passTimingNowNs() else 0;
+                    const verify_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};
+                    if (timing_for_func) {
+                        printPassTimingStart(timing, "verify-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "promoteLocalsToSSA");
+                    }
                     try Verify.check(effective_verify_mode, "promoteLocalsToSSA", func, func_idx, allocator);
+                    if (timing_for_func) {
+                        maybePrintPassTiming(
+                            timing,
+                            "verify",
+                            module,
+                            opts.module_idx,
+                            func,
+                            func_idx,
+                            outer_iter,
+                            0,
+                            null,
+                            "promoteLocalsToSSA",
+                            false,
+                            elapsedNsSince(verify_start_ns),
+                            verify_start_stats,
+                        );
+                    }
                     if (opts.dump_hook) |hook| {
                         try hook.callback(hook.ctx, .{
                             .pass_name = "promoteLocalsToSSA",
@@ -6950,18 +7364,65 @@ pub fn runPassesWithOptions(
                             .outer_iter = outer_iter,
                         });
                     }
-                    if (!opts.bisect.skipsPhisToLocals(opts.module_idx, func_idx) and try lowerPhisToLocals(func, allocator)) {
-                        total_changes += 1;
-                        try Verify.check(effective_verify_mode, "lowerPhisToLocals", func, func_idx, allocator);
-                        if (opts.dump_hook) |hook| {
-                            try hook.callback(hook.ctx, .{
-                                .pass_name = "lowerPhisToLocals",
-                                .func = func,
-                                .func_index = func_idx,
-                                .changed = true,
-                                .iter = 0,
-                                .outer_iter = outer_iter,
-                            });
+                    if (!opts.bisect.skipsPhisToLocals(opts.module_idx, func_idx)) {
+                        const lower_start_ns = if (timing_for_func) passTimingNowNs() else 0;
+                        const lower_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};
+                        if (timing_for_func) {
+                            printPassTimingStart(timing, "pass-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "lowerPhisToLocals");
+                        }
+                        const lower_changed = try lowerPhisToLocals(func, allocator);
+                        if (timing_for_func) {
+                            maybePrintPassTiming(
+                                timing,
+                                "pass",
+                                module,
+                                opts.module_idx,
+                                func,
+                                func_idx,
+                                outer_iter,
+                                0,
+                                null,
+                                "lowerPhisToLocals",
+                                lower_changed,
+                                elapsedNsSince(lower_start_ns),
+                                lower_start_stats,
+                            );
+                        }
+                        if (lower_changed) {
+                            total_changes += 1;
+                            const lower_verify_start_ns = if (timing_for_func) passTimingNowNs() else 0;
+                            const lower_verify_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};
+                            if (timing_for_func) {
+                                printPassTimingStart(timing, "verify-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "lowerPhisToLocals");
+                            }
+                            try Verify.check(effective_verify_mode, "lowerPhisToLocals", func, func_idx, allocator);
+                            if (timing_for_func) {
+                                maybePrintPassTiming(
+                                    timing,
+                                    "verify",
+                                    module,
+                                    opts.module_idx,
+                                    func,
+                                    func_idx,
+                                    outer_iter,
+                                    0,
+                                    null,
+                                    "lowerPhisToLocals",
+                                    false,
+                                    elapsedNsSince(lower_verify_start_ns),
+                                    lower_verify_start_stats,
+                                );
+                            }
+                            if (opts.dump_hook) |hook| {
+                                try hook.callback(hook.ctx, .{
+                                    .pass_name = "lowerPhisToLocals",
+                                    .func = func,
+                                    .func_index = func_idx,
+                                    .changed = true,
+                                    .iter = 0,
+                                    .outer_iter = outer_iter,
+                                });
+                            }
                         }
                     }
                 }
@@ -6985,17 +7446,62 @@ pub fn runPassesWithOptions(
                 for (passes[0..effective_passes_len], 0..) |pass, pass_idx_usize| {
                     const pass_idx: u32 = @intCast(pass_idx_usize);
                     if (opts.bisect.shouldSkip(opts.module_idx, func_idx, pass_idx)) continue;
+                    const pass_label = passName(pass);
+                    const pass_start_ns = if (timing_for_func) passTimingNowNs() else 0;
+                    const pass_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};
+                    if (timing_for_func) {
+                        printPassTimingStart(timing, "pass-start", module, opts.module_idx, func, func_idx, outer_iter, iter, pass_idx, pass_label);
+                    }
                     const changed = try pass(func, allocator);
+                    if (timing_for_func) {
+                        maybePrintPassTiming(
+                            timing,
+                            "pass",
+                            module,
+                            opts.module_idx,
+                            func,
+                            func_idx,
+                            outer_iter,
+                            iter,
+                            pass_idx,
+                            pass_label,
+                            changed,
+                            elapsedNsSince(pass_start_ns),
+                            pass_start_stats,
+                        );
+                    }
                     if (changed) {
                         any_changed = true;
                         total_changes += 1;
                     }
                     if (changed) {
-                        try Verify.check(effective_verify_mode, passName(pass), func, func_idx, allocator);
+                        const verify_start_ns = if (timing_for_func) passTimingNowNs() else 0;
+                        const verify_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};
+                        if (timing_for_func) {
+                            printPassTimingStart(timing, "verify-start", module, opts.module_idx, func, func_idx, outer_iter, iter, pass_idx, pass_label);
+                        }
+                        try Verify.check(effective_verify_mode, pass_label, func, func_idx, allocator);
+                        if (timing_for_func) {
+                            maybePrintPassTiming(
+                                timing,
+                                "verify",
+                                module,
+                                opts.module_idx,
+                                func,
+                                func_idx,
+                                outer_iter,
+                                iter,
+                                pass_idx,
+                                pass_label,
+                                false,
+                                elapsedNsSince(verify_start_ns),
+                                verify_start_stats,
+                            );
+                        }
                     }
                     if (opts.dump_hook) |hook| {
                         try hook.callback(hook.ctx, .{
-                            .pass_name = passName(pass),
+                            .pass_name = pass_label,
                             .func = func,
                             .func_index = func_idx,
                             .changed = changed,
@@ -7015,9 +7521,74 @@ pub fn runPassesWithOptions(
             // ops were never neutralised by `promoteLocalsToSSA`'s
             // dom-tree DFS — feeding `error.UnboundVReg` at codegen
             // (issue #620).
-            if (try scrubUnreachableBlocks(func, allocator)) {
+            const scrub_start_ns = if (timing_for_func) passTimingNowNs() else 0;
+            const scrub_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};
+            if (timing_for_func) {
+                printPassTimingStart(timing, "pass-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "scrubUnreachableBlocks");
+            }
+            const scrub_changed = try scrubUnreachableBlocks(func, allocator);
+            if (timing_for_func) {
+                maybePrintPassTiming(
+                    timing,
+                    "pass",
+                    module,
+                    opts.module_idx,
+                    func,
+                    func_idx,
+                    outer_iter,
+                    0,
+                    null,
+                    "scrubUnreachableBlocks",
+                    scrub_changed,
+                    elapsedNsSince(scrub_start_ns),
+                    scrub_start_stats,
+                );
+            }
+            if (scrub_changed) {
                 total_changes += 1;
+                const scrub_verify_start_ns = if (timing_for_func) passTimingNowNs() else 0;
+                const scrub_verify_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};
+                if (timing_for_func) {
+                    printPassTimingStart(timing, "verify-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "scrubUnreachableBlocks");
+                }
                 try Verify.check(effective_verify_mode, "scrubUnreachableBlocks", func, func_idx, allocator);
+                if (timing_for_func) {
+                    maybePrintPassTiming(
+                        timing,
+                        "verify",
+                        module,
+                        opts.module_idx,
+                        func,
+                        func_idx,
+                        outer_iter,
+                        0,
+                        null,
+                        "scrubUnreachableBlocks",
+                        false,
+                        elapsedNsSince(scrub_verify_start_ns),
+                        scrub_verify_start_stats,
+                    );
+                }
+            }
+            if (timing_for_func) {
+                const elapsed_ns = elapsedNsSince(function_start_ns);
+                if (timing.shouldLogElapsed(elapsed_ns) or timing.shouldLogFunctionProgress(func_idx)) {
+                    printPassTiming(
+                        "function",
+                        module,
+                        opts.module_idx,
+                        func,
+                        func_idx,
+                        outer_iter,
+                        0,
+                        null,
+                        "function",
+                        false,
+                        elapsed_ns,
+                        function_start_stats,
+                        collectPassTimingStats(func),
+                    );
+                }
             }
         }
     }
@@ -8513,6 +9084,25 @@ test "replaceVReg: updates all uses" {
     try std.testing.expectEqual(v1, add.rhs); // was already v1
 }
 
+test "replaceVRegCount: reports only actual rewritten uses" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const block_id = try func.newBlock();
+    var block = &func.blocks.items[block_id];
+
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0 });
+    try block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = v1 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v2 });
+    try block.append(.{ .op = .{ .ret = v2 } });
+
+    try std.testing.expectEqual(@as(u32, 1), replaceVRegCount(&func, v0, v1));
+    try std.testing.expectEqual(@as(u32, 0), replaceVRegCount(&func, v0, v1));
+}
+
 // ── Block Reordering Tests ─────────────────────────────────────────────────
 
 test "reorderBlocks: single block → identity" {
@@ -9272,6 +9862,9 @@ test "elideRedundantBoundsChecks: back-to-back loads on same base" {
     try std.testing.expectEqual(@as(u64, 8), block.instructions.items[1].op.load.checked_end);
     try std.testing.expect(block.instructions.items[2].op.load.bounds_known);
     try std.testing.expect(block.instructions.items[3].op.load.bounds_known);
+
+    const changed_again = try elideRedundantBoundsChecks(&func, allocator);
+    try std.testing.expect(!changed_again);
 }
 
 test "hoistLoopInvariantCode: pure add with invariant operands hoisted" {
@@ -13672,6 +14265,25 @@ test "GVN: cross-block load forwarded from dominator (#541)" {
     const changed = try globalValueNumbering(&func, allocator);
     try std.testing.expect(changed);
     try std.testing.expectEqual(ir.Inst.Op{ .ret = v_dom }, func.getBlock(tail).instructions.items[0].op);
+}
+
+test "GVN: unused duplicate does not report changed" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    var block = func.getBlock(block_id);
+    const v_dom = func.newVReg();
+    const v_unused = func.newVReg();
+
+    try block.append(.{ .op = .{ .iconst_32 = 7 }, .dest = v_dom, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 7 }, .dest = v_unused, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v_dom } });
+
+    const changed = try globalValueNumbering(&func, allocator);
+    try std.testing.expect(!changed);
+    try std.testing.expectEqual(ir.Inst.Op{ .iconst_32 = 7 }, block.instructions.items[1].op);
 }
 
 test "CSE: diamond — add v0,v1 in both arms hoisted to dominator (#541)" {

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -229,8 +229,10 @@ pub const LoadForwardingDomWalkInstructionResult = enum {
 /// DFS stack, `LoadFrameStack` push/pop, load/store/barrier dispatch, and the
 /// optional visitor snapshot/restore protocol. The visitor owns any pass-local
 /// tables plus `onInstruction`, returning whether it changed or removed the
-/// current instruction. Set `pub const forward_destless_loads = true` only for
-/// visitors that intentionally remove redundant dest-less loads.
+/// current instruction. Visitors may provide `canonicalizeVReg` and
+/// `onForwardedLoad` to batch load-forwarding rewrites themselves. Set
+/// `pub const forward_destless_loads = true` only for visitors that
+/// intentionally remove redundant dest-less loads.
 pub fn LoadForwardingDomWalk(comptime Visitor: type) type {
     return struct {
         const Frame = struct {
@@ -246,10 +248,16 @@ pub fn LoadForwardingDomWalk(comptime Visitor: type) type {
         ) !bool {
             if (func.blocks.items.len == 0) return false;
 
-            var dom = try analysis.computeDominators(func, allocator);
-            defer dom.deinit();
+            var owned_dom: ?analysis.DomTree = null;
+            defer if (owned_dom) |*dom| dom.deinit();
+            const dom: *const analysis.DomTree = if (analysis.currentCfgAnalysisCache()) |cache|
+                try cache.getDominators(func)
+            else blk: {
+                owned_dom = try analysis.computeDominators(func, allocator);
+                break :blk &owned_dom.?;
+            };
 
-            var dom_children = try BarrierOrderedDomChildren.build(func, &dom, allocator);
+            var dom_children = try BarrierOrderedDomChildren.build(func, dom, allocator);
             defer dom_children.deinit();
 
             if (dom.idom[0] == null) return false;
@@ -288,14 +296,30 @@ pub fn LoadForwardingDomWalk(comptime Visitor: type) type {
                     switch (inst.op) {
                         .load => |ld| {
                             if (inst.dest != null or forward_destless_loads) {
-                                const key: LoadKey = .{ .mem = alias_class.memKeyFromLoad(ld) };
-                                if (load_frames.lookup(key)) |held| {
-                                    if (inst.dest) |dest| replaceVReg(func, dest, held);
-                                    _ = block.instructions.orderedRemove(i);
-                                    changed = true;
-                                    continue;
+                                var key_ld = ld;
+                                if (comptime @hasDecl(Visitor, "canonicalizeVReg")) {
+                                    key_ld.base = visitor.canonicalizeVReg(key_ld.base);
                                 }
-                                if (inst.dest) |dest| try load_frames.record(key, dest);
+                                const key: LoadKey = .{ .mem = alias_class.memKeyFromLoad(key_ld) };
+                                if (load_frames.lookup(key)) |held| {
+                                    if (comptime @hasDecl(Visitor, "onForwardedLoad")) {
+                                        switch (try visitor.onForwardedLoad(func, bid, i, inst, inst.dest, held, &load_frames)) {
+                                            .unchanged => {},
+                                            .changed => changed = true,
+                                            .removed => {
+                                                changed = true;
+                                                continue;
+                                            },
+                                        }
+                                    } else {
+                                        if (inst.dest) |dest| replaceVReg(func, dest, held);
+                                        _ = block.instructions.orderedRemove(i);
+                                        changed = true;
+                                        continue;
+                                    }
+                                } else if (inst.dest) |dest| {
+                                    try load_frames.record(key, dest);
+                                }
                             }
                         },
                         .store => |st| try load_frames.invalidateMem(st),
@@ -905,6 +929,104 @@ pub fn replaceVRegCount(func: *ir.IrFunction, old: ir.VReg, new: ir.VReg) u32 {
     return replacements;
 }
 
+pub const VRegAliasMap = std.AutoHashMap(ir.VReg, ir.VReg);
+
+fn canonicalVReg(aliases: *const VRegAliasMap, vreg: ir.VReg) ir.VReg {
+    var cur = vreg;
+    var remaining = aliases.count();
+    while (remaining > 0) : (remaining -= 1) {
+        const next = aliases.get(cur) orelse return cur;
+        if (next == cur) return cur;
+        cur = next;
+    }
+    return cur;
+}
+
+fn putVRegAlias(aliases: *VRegAliasMap, old: ir.VReg, new: ir.VReg) !void {
+    const replacement = canonicalVReg(aliases, new);
+    if (old == replacement) {
+        _ = aliases.remove(old);
+        return;
+    }
+    try aliases.put(old, replacement);
+}
+
+fn aliasedVReg(aliases: *const VRegAliasMap, vreg: ir.VReg) ?ir.VReg {
+    const replacement = canonicalVReg(aliases, vreg);
+    return if (replacement == vreg) null else replacement;
+}
+
+fn replaceAliasedVRegSlot(aliases: *const VRegAliasMap, slot: *ir.VReg) u32 {
+    if (aliasedVReg(aliases, slot.*)) |replacement| {
+        slot.* = replacement;
+        return 1;
+    }
+    return 0;
+}
+
+fn replaceAliasedVRegSlice(aliases: *const VRegAliasMap, vregs: []ir.VReg) u32 {
+    var replacements: u32 = 0;
+    for (vregs) |*vreg| {
+        replacements += replaceAliasedVRegSlot(aliases, vreg);
+    }
+    return replacements;
+}
+
+fn replaceAliasesInInstCount(inst: *ir.Inst, aliases: *const VRegAliasMap) u32 {
+    if (aliases.count() == 0) return 0;
+
+    var replacements: u32 = 0;
+    const used_vregs = getUsedVRegs(inst.*);
+    for (used_vregs.slice()) |used| {
+        const replacement = aliasedVReg(aliases, used) orelse continue;
+        const inst_replacements = countUsesInInst(inst.*, used);
+        if (inst_replacements == 0) continue;
+        replaceInInst(inst, used, replacement);
+        replacements += inst_replacements;
+    }
+
+    switch (inst.op) {
+        .ret_multi => |vregs| replacements += replaceAliasedVRegSlice(aliases, @constCast(vregs)),
+        .call => |cl| replacements += replaceAliasedVRegSlice(aliases, @constCast(cl.args)),
+        .call_indirect => |*ci| {
+            replacements += replaceAliasedVRegSlot(aliases, &ci.elem_idx);
+            replacements += replaceAliasedVRegSlice(aliases, @constCast(ci.args));
+        },
+        .call_ref => |*cr| {
+            replacements += replaceAliasedVRegSlot(aliases, &cr.func_ref);
+            replacements += replaceAliasedVRegSlice(aliases, @constCast(cr.args));
+        },
+        .phi => |edges| {
+            for (@constCast(edges)) |*edge| {
+                replacements += replaceAliasedVRegSlot(aliases, &edge.val);
+            }
+        },
+        .parallel_copy => |pairs| {
+            for (@constCast(pairs)) |*p| {
+                replacements += replaceAliasedVRegSlot(aliases, &p.src);
+            }
+        },
+        .throw => |*th| replacements += replaceAliasedVRegSlice(aliases, @constCast(th.args)),
+        else => {},
+    }
+
+    return replacements;
+}
+
+/// Apply all VReg aliases with a single function scan.
+/// Returns the number of operand slots that were actually rewritten.
+pub fn replaceVRegsCount(func: *ir.IrFunction, aliases: *const VRegAliasMap) u32 {
+    if (aliases.count() == 0) return 0;
+
+    var replacements: u32 = 0;
+    for (func.blocks.items) |*block| {
+        for (block.instructions.items) |*inst| {
+            replacements += replaceAliasesInInstCount(inst, aliases);
+        }
+    }
+    return replacements;
+}
+
 /// Count the number of operand slots in `func` that currently reference
 /// `vreg`. Cheap O(N) scan; used by passes that need to detect whether
 /// a rewrite would actually change anything (for idempotent fixpoint
@@ -917,6 +1039,52 @@ pub fn countUsesOfVReg(func: *const ir.IrFunction, vreg: ir.VReg) u32 {
         }
     }
     return count;
+}
+
+/// Map of VReg -> number of operand slots referencing it, tallied in a single
+/// pass over `func`. Use this when a pass needs the use count of *many* VRegs:
+/// one lookup is O(1), whereas calling `countUsesOfVReg` per query rescans the
+/// whole function and makes the pass O(queries * insts) — a quadratic blowup on
+/// large functions. The tally mirrors `countUsesInInst` exactly, so
+/// `useCounts.get(v) orelse 0` equals `countUsesOfVReg(func, v)` for the
+/// function in its current (unmutated) state.
+pub const VRegUseCounts = std.AutoHashMap(ir.VReg, u32);
+
+pub fn buildVRegUseCounts(
+    func: *const ir.IrFunction,
+    allocator: std.mem.Allocator,
+) !VRegUseCounts {
+    var counts = VRegUseCounts.init(allocator);
+    errdefer counts.deinit();
+
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |inst| {
+            for (getUsedVRegs(inst).slice()) |u| try addVRegUse(&counts, u);
+            switch (inst.op) {
+                .ret_multi => |vregs| for (vregs) |v| try addVRegUse(&counts, v),
+                .call => |cl| for (cl.args) |a| try addVRegUse(&counts, a),
+                .call_indirect => |ci| {
+                    try addVRegUse(&counts, ci.elem_idx);
+                    for (ci.args) |a| try addVRegUse(&counts, a);
+                },
+                .call_ref => |cr| {
+                    try addVRegUse(&counts, cr.func_ref);
+                    for (cr.args) |a| try addVRegUse(&counts, a);
+                },
+                .phi => |edges| for (edges) |edge| try addVRegUse(&counts, edge.val),
+                .parallel_copy => |pairs| for (pairs) |p| try addVRegUse(&counts, p.src),
+                .throw => |th| for (th.args) |a| try addVRegUse(&counts, a),
+                else => {},
+            }
+        }
+    }
+
+    return counts;
+}
+
+fn addVRegUse(counts: *VRegUseCounts, vreg: ir.VReg) !void {
+    const gop = try counts.getOrPut(vreg);
+    gop.value_ptr.* = if (gop.found_existing) gop.value_ptr.* + 1 else 1;
 }
 
 fn countVRegSliceUses(vregs: []const ir.VReg, vreg: ir.VReg) u32 {
@@ -2662,13 +2830,26 @@ fn sameOp(a: ir.Inst, b: ir.Inst) bool {
 
 // ── Global Value Numbering (cross-block CSE) ────────────────────────────────
 
+const GvnForwardedLoad = struct { bid: ir.BlockId, index: usize };
+
+fn removeForwardedLoads(func: *ir.IrFunction, forwarded_loads: []const GvnForwardedLoad) void {
+    var i = forwarded_loads.len;
+    while (i > 0) {
+        i -= 1;
+        const loc = forwarded_loads[i];
+        _ = func.blocks.items[loc.bid].instructions.orderedRemove(loc.index);
+    }
+}
+
 /// Dominator-scoped GVN: deduplicate identical pure, non-trapping
 /// instructions across basic blocks using the dominator tree.
 ///
 /// Walks the dom tree in DFS pre-order with a scoped expression table.
 /// When an instruction in block B matches an entry from a dominator of B,
-/// all uses of B's instruction are rewritten to the dominating def via
-/// `replaceVReg`. `deadCodeElimination` removes the now-unused original.
+/// GVN records an alias from B's result to the dominating def. All aliases are
+/// applied with one function scan at the end of the pass so huge functions do
+/// not get rescanned once per duplicate. `deadCodeElimination` removes the
+/// now-unused original.
 ///
 /// Subsumes block-local `commonSubexprElimination`.
 pub fn globalValueNumbering(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
@@ -2676,6 +2857,8 @@ pub fn globalValueNumbering(func: *ir.IrFunction, allocator: std.mem.Allocator) 
 
     const Visitor = struct {
         table: std.ArrayList(GvnEntry),
+        aliases: VRegAliasMap,
+        forwarded_loads: std.ArrayList(GvnForwardedLoad),
         allocator: std.mem.Allocator,
 
         pub fn snapshot(self: *@This()) usize {
@@ -2686,9 +2869,33 @@ pub fn globalValueNumbering(func: *ir.IrFunction, allocator: std.mem.Allocator) 
             self.table.shrinkRetainingCapacity(snap_len);
         }
 
+        pub fn canonicalizeVReg(self: *@This(), vreg: ir.VReg) ir.VReg {
+            return canonicalVReg(&self.aliases, vreg);
+        }
+
+        fn recordAlias(self: *@This(), old: ir.VReg, new: ir.VReg) !void {
+            try putVRegAlias(&self.aliases, old, new);
+        }
+
+        pub fn onForwardedLoad(
+            self: *@This(),
+            _: *ir.IrFunction,
+            bid: ir.BlockId,
+            index: usize,
+            _: *ir.Inst,
+            maybe_dest: ?ir.VReg,
+            held: ir.VReg,
+            _: *LoadFrameStack,
+        ) !LoadForwardingDomWalkInstructionResult {
+            const dest = maybe_dest orelse return .unchanged;
+            try self.recordAlias(dest, held);
+            try self.forwarded_loads.append(self.allocator, .{ .bid = bid, .index = index });
+            return .unchanged;
+        }
+
         pub fn onInstruction(
             self: *@This(),
-            ir_func: *ir.IrFunction,
+            _: *ir.IrFunction,
             _: ir.BlockId,
             _: usize,
             inst: *ir.Inst,
@@ -2712,27 +2919,43 @@ pub fn globalValueNumbering(func: *ir.IrFunction, allocator: std.mem.Allocator) 
 
             if (inst.dest == null or hasSideEffect(inst.*) or !isPure(inst.*)) return .unchanged;
 
+            var canonical_inst = inst.*;
+            _ = replaceAliasesInInstCount(&canonical_inst, &self.aliases);
+
             var found: ?ir.VReg = null;
             for (self.table.items) |entry| {
-                if (entry.inst.type == inst.type and sameOp(entry.inst, inst.*)) {
+                if (entry.inst.type == canonical_inst.type and sameOp(entry.inst, canonical_inst)) {
                     found = entry.vreg;
                     break;
                 }
             }
 
             if (found) |earlier_vreg| {
-                const replacements = replaceVRegCount(ir_func, inst.dest.?, earlier_vreg);
-                return if (replacements > 0) .changed else .unchanged;
+                try self.recordAlias(inst.dest.?, earlier_vreg);
+                return .unchanged;
             }
 
-            try self.table.append(self.allocator, .{ .inst = inst.*, .vreg = inst.dest.? });
+            try self.table.append(self.allocator, .{ .inst = canonical_inst, .vreg = inst.dest.? });
             return .unchanged;
         }
     };
 
-    var visitor = Visitor{ .table = .empty, .allocator = allocator };
+    var visitor = Visitor{
+        .table = .empty,
+        .aliases = VRegAliasMap.init(allocator),
+        .forwarded_loads = .empty,
+        .allocator = allocator,
+    };
     defer visitor.table.deinit(allocator);
-    return try LoadForwardingDomWalk(Visitor).run(&visitor, func, allocator);
+    defer visitor.aliases.deinit();
+    defer visitor.forwarded_loads.deinit(allocator);
+
+    _ = try LoadForwardingDomWalk(Visitor).run(&visitor, func, allocator);
+    const replacements = replaceVRegsCount(func, &visitor.aliases);
+    if (replacements > 0) {
+        removeForwardedLoads(func, visitor.forwarded_loads.items);
+    }
+    return replacements > 0;
 }
 
 // ── Pass Manager ────────────────────────────────────────────────────────────
@@ -2796,7 +3019,45 @@ pub const RunOptions = struct {
     /// pass loop. Off by default; `wamrc` populates this from
     /// `WAMR_AOT_PASS_TIMING*` environment variables.
     pass_timing: PassTimingOptions = .{},
+    /// Optional stderr timing diagnostics for expensive CFG/dominator
+    /// recomputation inside analysis helpers. Off by default; `wamrc`
+    /// populates this from `WAMR_AOT_ANALYSIS_TIMING*` environment
+    /// variables.
+    analysis_timing: AnalysisTimingOptions = .{},
+    /// Compile-time guard for `tailDuplicateSmallJoins`. Defaults keep the
+    /// pass enabled for normal functions but skip/cap pathological CFGs.
+    tail_duplication: TailDuplicationOptions = .{},
 };
+
+pub const AnalysisTimingOptions = analysis.TimingOptions;
+
+pub const default_tail_dup_max_blocks: usize = 2048;
+pub const default_tail_dup_max_instructions: usize = 32 * 1024;
+pub const default_tail_dup_max_work: usize = 8 * 1024 * 1024;
+
+pub const TailDuplicationOptions = struct {
+    skip: bool = false,
+    max_blocks: usize = default_tail_dup_max_blocks,
+    max_instructions: usize = default_tail_dup_max_instructions,
+    max_work: usize = default_tail_dup_max_work,
+    log: bool = false,
+};
+
+threadlocal var tail_duplication_options: TailDuplicationOptions = .{};
+
+const TailDuplicationOptionsScope = struct {
+    previous: TailDuplicationOptions,
+
+    fn deinit(self: *TailDuplicationOptionsScope) void {
+        tail_duplication_options = self.previous;
+    }
+};
+
+fn pushTailDuplicationOptions(options: TailDuplicationOptions) TailDuplicationOptionsScope {
+    const previous = tail_duplication_options;
+    tail_duplication_options = options;
+    return .{ .previous = previous };
+}
 
 pub const PassTimingOptions = struct {
     enabled: bool = false,
@@ -2849,6 +3110,45 @@ pub fn passTimingOptionsFromEnv(env: *const std.process.Environ.Map) PassTimingO
     return out;
 }
 
+/// Parse env-gated analysis timing diagnostics. `WAMR_AOT_ANALYSIS_TIMING=1`
+/// enables logging for slow `buildSuccessors` / `computeDominators` calls.
+/// Optional knobs:
+///
+///   - `WAMR_AOT_ANALYSIS_TIMING_THRESHOLD_MS` (default: 100)
+///   - `WAMR_AOT_ANALYSIS_TIMING_MODULE` (component core/module index)
+///   - `WAMR_AOT_ANALYSIS_TIMING_FUNC` (local IR function index)
+pub fn analysisTimingOptionsFromEnv(env: *const std.process.Environ.Map) AnalysisTimingOptions {
+    const gate = env.get("WAMR_AOT_ANALYSIS_TIMING") orelse return .{};
+    if (!envFlagEnabled(gate)) return .{};
+
+    var out = AnalysisTimingOptions{ .enabled = true };
+    if (parseEnvU64For(env, "WAMR_AOT_ANALYSIS_TIMING_THRESHOLD_MS", "aot-analysis-timing")) |ms| {
+        const max_ms = std.math.maxInt(u64) / std.time.ns_per_ms;
+        out.threshold_ns = if (ms > max_ms) std.math.maxInt(u64) else ms * std.time.ns_per_ms;
+    }
+    if (parseEnvU32For(env, "WAMR_AOT_ANALYSIS_TIMING_MODULE", "aot-analysis-timing")) |m| out.module_filter = m;
+    if (parseEnvU32For(env, "WAMR_AOT_ANALYSIS_TIMING_FUNC", "aot-analysis-timing")) |f| out.func_filter = f;
+    return out;
+}
+
+/// Parse tail-duplication compile-time guard knobs. Set any max to `0` to
+/// disable that individual cap while validating the pass on large inputs.
+///
+///   - `WAMR_AOT_SKIP_TAIL_DUP=1` disables the pass globally.
+///   - `WAMR_AOT_TAIL_DUP_MAX_BLOCKS` (default: 2048)
+///   - `WAMR_AOT_TAIL_DUP_MAX_INSTS` (default: 32768)
+///   - `WAMR_AOT_TAIL_DUP_MAX_WORK` (default: 8388608)
+///   - `WAMR_AOT_TAIL_DUP_LOG=1` logs skip/cap decisions.
+pub fn tailDuplicationOptionsFromEnv(env: *const std.process.Environ.Map) TailDuplicationOptions {
+    var out = TailDuplicationOptions{};
+    if (env.get("WAMR_AOT_SKIP_TAIL_DUP")) |v| out.skip = envFlagEnabled(v);
+    if (parseEnvUsizeFor(env, "WAMR_AOT_TAIL_DUP_MAX_BLOCKS", "aot-tail-dup")) |n| out.max_blocks = n;
+    if (parseEnvUsizeFor(env, "WAMR_AOT_TAIL_DUP_MAX_INSTS", "aot-tail-dup")) |n| out.max_instructions = n;
+    if (parseEnvUsizeFor(env, "WAMR_AOT_TAIL_DUP_MAX_WORK", "aot-tail-dup")) |n| out.max_work = n;
+    if (env.get("WAMR_AOT_TAIL_DUP_LOG")) |v| out.log = envFlagEnabled(v);
+    return out;
+}
+
 fn envFlagEnabled(value: []const u8) bool {
     return value.len != 0 and
         !std.mem.eql(u8, value, "0") and
@@ -2858,17 +3158,33 @@ fn envFlagEnabled(value: []const u8) bool {
 }
 
 fn parseEnvU64(env: *const std.process.Environ.Map, name: []const u8) ?u64 {
+    return parseEnvU64For(env, name, "aot-pass-timing");
+}
+
+fn parseEnvU64For(env: *const std.process.Environ.Map, name: []const u8, comptime label: []const u8) ?u64 {
     const value = env.get(name) orelse return null;
     return std.fmt.parseInt(u64, value, 10) catch |err| {
-        std.debug.print("[aot-pass-timing] ignoring {s}={s}: {s}\n", .{ name, value, @errorName(err) });
+        std.debug.print("[" ++ label ++ "] ignoring {s}={s}: {s}\n", .{ name, value, @errorName(err) });
         return null;
     };
 }
 
 fn parseEnvU32(env: *const std.process.Environ.Map, name: []const u8) ?u32 {
+    return parseEnvU32For(env, name, "aot-pass-timing");
+}
+
+fn parseEnvU32For(env: *const std.process.Environ.Map, name: []const u8, comptime label: []const u8) ?u32 {
     const value = env.get(name) orelse return null;
     return std.fmt.parseInt(u32, value, 10) catch |err| {
-        std.debug.print("[aot-pass-timing] ignoring {s}={s}: {s}\n", .{ name, value, @errorName(err) });
+        std.debug.print("[" ++ label ++ "] ignoring {s}={s}: {s}\n", .{ name, value, @errorName(err) });
+        return null;
+    };
+}
+
+fn parseEnvUsizeFor(env: *const std.process.Environ.Map, name: []const u8, comptime label: []const u8) ?usize {
+    const value = env.get(name) orelse return null;
+    return std.fmt.parseInt(usize, value, 10) catch |err| {
+        std.debug.print("[" ++ label ++ "] ignoring {s}={s}: {s}\n", .{ name, value, @errorName(err) });
         return null;
     };
 }
@@ -3269,6 +3585,15 @@ pub fn passName(p: PassFn) []const u8 {
     return "<unknown>";
 }
 
+fn passMutatesCfg(p: PassFn) bool {
+    return p == &foldConstantBranches or
+        p == &foldBranchOnEqz or
+        p == &threadChainedConditionalBranches or
+        p == &tailDuplicateSmallJoins or
+        p == &hoistLoopInvariantCode or
+        p == &unrollSmallFixedLoops;
+}
+
 // ── Loop-invariant bounds-check hoisting ────────────────────────────────────
 
 /// Hoist loop-invariant bounds checks to the loop preheader.
@@ -3315,19 +3640,28 @@ pub fn passName(p: PassFn) []const u8 {
 pub fn hoistLoopBoundsChecks(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
     if (func.blocks.items.len == 0) return false;
 
-    var dom = try analysis.computeDominators(func, allocator);
-    defer dom.deinit();
+    const cfg_cache = analysis.currentCfgAnalysisCache();
+    var owned_dom: ?analysis.DomTree = null;
+    defer if (owned_dom) |*dom| dom.deinit();
+    const dom: *const analysis.DomTree = if (cfg_cache) |cache|
+        try cache.getDominators(func)
+    else blk: {
+        owned_dom = try analysis.computeDominators(func, allocator);
+        break :blk &owned_dom.?;
+    };
 
-    var lf = try analysis.computeLoops(func, &dom, allocator);
+    var lf = try analysis.computeLoopsCached(func, dom, allocator, cfg_cache);
     defer lf.deinit();
     if (lf.loops.len == 0) return false;
 
-    var predecessors = try analysis.buildPredecessors(func, allocator);
-    defer {
-        var pit = predecessors.iterator();
-        while (pit.next()) |entry| allocator.free(entry.value_ptr.*);
-        predecessors.deinit();
-    }
+    var owned_predecessors: ?std.AutoHashMap(ir.BlockId, []const ir.BlockId) = null;
+    defer if (owned_predecessors) |*preds| analysis.freeBlockIdMap(preds, allocator);
+    const predecessors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId) = if (cfg_cache) |cache|
+        try cache.getPredecessors(func)
+    else blk: {
+        owned_predecessors = try analysis.buildPredecessors(func, allocator);
+        break :blk &owned_predecessors.?;
+    };
 
     // Build def-block map: for each VReg, which block defines it?
     var def_block = std.AutoHashMap(ir.VReg, ir.BlockId).init(allocator);
@@ -3403,7 +3737,7 @@ pub fn hoistLoopBoundsChecks(func: *ir.IrFunction, allocator: std.mem.Allocator)
                 return d.dominates(a, b);
             }
         };
-        std.sort.insertion(ir.BlockId, must_exec.items, &dom, DomLess.lt);
+        std.sort.insertion(ir.BlockId, must_exec.items, dom, DomLess.lt);
 
         // ── Scan must-execute blocks for loop-invariant bases ──
         // Stop at the first fence op (call, memory_grow, etc.) in any
@@ -3554,19 +3888,25 @@ pub fn hoistLoopBoundsChecks(func: *ir.IrFunction, allocator: std.mem.Allocator)
 pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
     if (func.blocks.items.len == 0) return false;
 
-    var dom = try analysis.computeDominators(func, allocator);
-    defer dom.deinit();
+    const cfg_cache = analysis.currentCfgAnalysisCache();
+    var owned_dom: ?analysis.DomTree = null;
+    defer if (owned_dom) |*dom| dom.deinit();
+    const dom: *const analysis.DomTree = if (cfg_cache) |cache|
+        try cache.getDominators(func)
+    else blk: {
+        owned_dom = try analysis.computeDominators(func, allocator);
+        break :blk &owned_dom.?;
+    };
 
-    var lf = try analysis.computeLoops(func, &dom, allocator);
+    var lf = try analysis.computeLoopsCached(func, dom, allocator, cfg_cache);
     defer lf.deinit();
     if (lf.loops.len == 0) return false;
 
-    var predecessors = try analysis.buildPredecessors(func, allocator);
-    defer {
-        var pit = predecessors.iterator();
-        while (pit.next()) |entry| allocator.free(entry.value_ptr.*);
-        predecessors.deinit();
-    }
+    var predecessors = if (cfg_cache) |cache|
+        try analysis.cloneBlockIdMap(try cache.getPredecessors(func), allocator)
+    else
+        try analysis.buildPredecessors(func, allocator);
+    defer analysis.freeBlockIdMap(&predecessors, allocator);
 
     var def_block = std.AutoHashMap(ir.VReg, ir.BlockId).init(allocator);
     defer def_block.deinit();
@@ -3578,7 +3918,7 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
 
     var changed = false;
     for (lf.loops) |*loop| {
-        const ph = (try obtainLoopPreheader(func, loop, &predecessors, &dom, allocator)) orelse continue;
+        const ph = (try obtainLoopPreheader(func, loop, &predecessors, dom, allocator)) orelse continue;
 
         // One-shot scan of the loop body: which wasm-local / wasm-global
         // indices are written, and does the body contain any call or
@@ -4939,6 +5279,13 @@ pub fn foldBranchOnEqz(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool
         }
     }
 
+    // Tally uses once. Rewriting a br_if to use the inner value only ever
+    // zeroes the (single-use) eqz result it replaces and is sound regardless
+    // of use count, so the precomputed tally yields the same decisions as a
+    // per-candidate `countUsesOfVReg` scan without the O(br_ifs * insts) cost.
+    var use_counts = try buildVRegUseCounts(func, allocator);
+    defer use_counts.deinit();
+
     for (func.blocks.items) |*block| {
         if (block.instructions.items.len == 0) continue;
         const term = &block.instructions.items[block.instructions.items.len - 1];
@@ -4951,7 +5298,7 @@ pub fn foldBranchOnEqz(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool
                     .eqz => |v| v,
                     else => continue,
                 };
-                if (countUsesOfVReg(func, bi.cond) != 1) continue;
+                if ((use_counts.get(bi.cond) orelse 0) != 1) continue;
                 term.op = .{ .br_if = .{
                     .cond = inner,
                     .then_block = bi.else_block,
@@ -5212,6 +5559,14 @@ pub fn foldSignExtendingLoad(func: *ir.IrFunction, allocator: std.mem.Allocator)
     var rewrites = std.ArrayList(Rewrite).empty;
     defer rewrites.deinit(allocator);
 
+    // Tally uses once. Folding requires the load result to have exactly one
+    // use (rewriting the load to sign-extend would change the value seen by
+    // any other consumer), and candidates are collected from the unmutated
+    // function, so the precomputed tally matches a per-candidate
+    // `countUsesOfVReg` scan at far lower cost on large functions.
+    var use_counts = try buildVRegUseCounts(func, allocator);
+    defer use_counts.deinit();
+
     for (func.blocks.items, 0..) |block, bi| {
         for (block.instructions.items, 0..) |inst, ii| {
             const ext_dest = inst.dest orelse continue;
@@ -5239,7 +5594,7 @@ pub fn foldSignExtendingLoad(func: *ir.IrFunction, allocator: std.mem.Allocator)
             if (ld.size != want_size) continue;
             if (ld.sign_extend) continue;
             if (producer.type != ext_type) continue;
-            if (countUsesOfVReg(func, src) != 1) continue;
+            if ((use_counts.get(src) orelse 0) != 1) continue;
             const load_dest = producer.dest orelse continue;
             try rewrites.append(allocator, .{
                 .ext_blk = @intCast(bi),
@@ -5300,6 +5655,13 @@ pub fn foldSelectOnEqz(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool
         }
     }
 
+    // Tally uses once. Rewriting a select to use the inner value only zeroes
+    // the (single-use) eqz result and is sound regardless of use count, so the
+    // precomputed tally matches a per-candidate `countUsesOfVReg` scan without
+    // the O(selects * insts) blowup.
+    var use_counts = try buildVRegUseCounts(func, allocator);
+    defer use_counts.deinit();
+
     for (func.blocks.items) |*block| {
         for (block.instructions.items) |*inst| {
             const sel = switch (inst.op) {
@@ -5313,7 +5675,7 @@ pub fn foldSelectOnEqz(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool
                 .eqz => |v| v,
                 else => continue,
             };
-            if (countUsesOfVReg(func, sel.cond) != 1) continue;
+            if ((use_counts.get(sel.cond) orelse 0) != 1) continue;
             inst.op = .{ .select = .{
                 .cond = inner,
                 .if_true = sel.if_false,
@@ -6243,6 +6605,7 @@ pub fn scrubUnreachableBlocks(func: *ir.IrFunction, allocator: std.mem.Allocator
         try block.instructions.append(block.allocator, .{ .op = .{ .@"unreachable" = {} } });
         changed = true;
     }
+    if (analysis.currentCfgAnalysisCache()) |cache| cache.invalidate();
     return changed;
 }
 
@@ -6283,21 +6646,6 @@ pub fn promoteLocalsToSSA(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
                 .br, .br_if, .br_table, .ret, .ret_multi, .@"unreachable" => {
                     if (idx + 1 < block.instructions.items.len)
                         block.instructions.shrinkRetainingCapacity(idx + 1);
-                    break;
-                },
-                else => {},
-            }
-        }
-    }
-
-    // Strip dead code after the first terminator in each block.
-    for (func.blocks.items) |*block| {
-        for (block.instructions.items, 0..) |inst, idx| {
-            switch (inst.op) {
-                .br, .br_if, .br_table, .ret, .ret_multi, .@"unreachable" => {
-                    if (idx + 1 < block.instructions.items.len) {
-                        block.instructions.shrinkRetainingCapacity(idx + 1);
-                    }
                     break;
                 },
                 else => {},
@@ -6360,6 +6708,13 @@ pub fn promoteLocalsToSSA(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
     }
     for (has_phi) |*m| m.* = std.AutoHashMap(ir.BlockId, ir.VReg).init(allocator);
 
+    // Reverse index: phi-dest VReg -> the local it was placed for. Phi dests
+    // are freshly allocated and unique, so this lets the rename walk map a phi
+    // back to its local in O(1) instead of scanning all `nlocals` per phi
+    // (which was the dominant O(phis * locals) cost on large functions).
+    var phi_local = std.AutoHashMap(ir.VReg, usize).init(allocator);
+    defer phi_local.deinit();
+
     // Worklist for iterated DF.
     var worklist: std.ArrayList(ir.BlockId) = .empty;
     defer worklist.deinit(allocator);
@@ -6401,6 +6756,12 @@ pub fn promoteLocalsToSSA(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
                         .type = local_type,
                     });
                     try has_phi[local_idx].put(y, phi_dest);
+                    // Phi dests are freshly allocated and globally unique, so
+                    // each maps to exactly one local; assert it to catch any
+                    // VReg-uniqueness violation early.
+                    const gop = try phi_local.getOrPut(phi_dest);
+                    std.debug.assert(!gop.found_existing);
+                    gop.value_ptr.* = local_idx;
                     if (!in_worklist[y]) {
                         try worklist.append(allocator, y);
                         in_worklist[y] = true;
@@ -6581,13 +6942,8 @@ pub fn promoteLocalsToSSA(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
                 .phi => {
                     // Push phi dest onto the local's stack.
                     const dest = inst.dest orelse continue;
-                    for (0..nlocals) |local_idx| {
-                        if (has_phi[local_idx].get(bid)) |phi_vreg| {
-                            if (phi_vreg == dest) {
-                                try stacks[local_idx].append(allocator, dest);
-                                break;
-                            }
-                        }
+                    if (phi_local.get(dest)) |local_idx| {
+                        try stacks[local_idx].append(allocator, dest);
                     }
                 },
                 .local_set => |ls| {
@@ -6633,19 +6989,13 @@ pub fn promoteLocalsToSSA(func: *ir.IrFunction, allocator: std.mem.Allocator) !b
             for (succ_block.instructions.items) |*succ_inst| {
                 if (succ_inst.op != .phi) break; // phis are at top
                 const phi_dest = succ_inst.dest orelse continue;
-                // Find which local this phi belongs to.
-                for (0..nlocals) |local_idx| {
-                    if (has_phi[local_idx].get(succ)) |pv| {
-                        if (pv == phi_dest) {
-                            // Fill in this block's edge.
-                            for (@constCast(succ_inst.op.phi)) |*edge| {
-                                if (edge.block == bid) {
-                                    if (stacks[local_idx].items.len > 0) {
-                                        edge.val = stacks[local_idx].items[stacks[local_idx].items.len - 1];
-                                    }
-                                }
-                            }
-                            break;
+                // Find which local this phi belongs to (O(1) reverse lookup).
+                const local_idx = phi_local.get(phi_dest) orelse continue;
+                // Fill in this block's edge.
+                for (@constCast(succ_inst.op.phi)) |*edge| {
+                    if (edge.block == bid) {
+                        if (stacks[local_idx].items.len > 0) {
+                            edge.val = stacks[local_idx].items[stacks[local_idx].items.len - 1];
                         }
                     }
                 }
@@ -6944,7 +7294,29 @@ pub fn coalescePhiLocalsToParallelCopy(func: *ir.IrFunction, allocator: std.mem.
 /// emits them. The outer `runPasses` fixpoint loop (cap 8) bounds how
 /// many times this pass can re-run — in practice 1-2 invocations suffice.
 pub fn tailDuplicateSmallJoins(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    return tailDuplicateSmallJoinsWithOptions(func, allocator, tail_duplication_options);
+}
+
+fn tailDuplicateSmallJoinsWithOptions(
+    func: *ir.IrFunction,
+    allocator: std.mem.Allocator,
+    options: TailDuplicationOptions,
+) !bool {
     if (func.blocks.items.len < 2) return false;
+
+    const stats = collectPassTimingStats(func);
+    if (options.skip) {
+        logTailDupSkip(func, "env-skip", options, stats, null);
+        return false;
+    }
+    if (tailDupCapExceeded(options.max_blocks, stats.blocks)) {
+        logTailDupSkip(func, "max-blocks", options, stats, null);
+        return false;
+    }
+    if (tailDupCapExceeded(options.max_instructions, stats.instructions)) {
+        logTailDupSkip(func, "max-insts", options, stats, null);
+        return false;
+    }
 
     var predecessors = try analysis.buildPredecessors(func, allocator);
     defer {
@@ -6953,25 +7325,271 @@ pub fn tailDuplicateSmallJoins(func: *ir.IrFunction, allocator: std.mem.Allocato
         predecessors.deinit();
     }
 
+    const estimate = estimateTailDuplicationWork(func, &predecessors, stats);
+    if (estimate.candidate_joins == 0) return false;
+    if (tailDupCapExceeded(options.max_work, estimate.total)) {
+        logTailDupSkip(func, "max-work", options, stats, estimate);
+        return false;
+    }
+
     var changed = false;
 
     var b_id: ir.BlockId = 1;
     while (b_id < func.blocks.items.len) : (b_id += 1) {
         if (try tryAbsorbJoin(func, b_id, &predecessors, allocator)) {
             changed = true;
+            // The CFG changed, so any cached successors/predecessors/dominators
+            // a later pass might read are now stale. Invalidate before the
+            // incremental update below so an allocation failure there cannot
+            // leave a stale cache behind.
+            if (analysis.currentCfgAnalysisCache()) |cache| cache.invalidate();
 
-            // Predecessor map is now stale (preds of B disappeared; preds
-            // of B's successors gained the duplicated copies). Rebuild
-            // before considering further joins so the next iteration sees
-            // the current CFG.
-            var it = predecessors.iterator();
-            while (it.next()) |entry| allocator.free(entry.value_ptr.*);
-            predecessors.deinit();
-            predecessors = try analysis.buildPredecessors(func, allocator);
+            // Patch the predecessor map in place rather than rebuilding the
+            // entire map (an O(blocks+edges) operation, plus a full successor
+            // rebuild) after every absorption. The per-absorption rebuild made
+            // this pass O(joins * (blocks+edges)) and the dominant AOT
+            // compile-time cost on large functions.
+            try applyTailDupToPredecessors(func, b_id, &predecessors, allocator);
         }
     }
 
     return changed;
+}
+
+/// Incrementally update `predecessors` after `tryAbsorbJoin` duplicated join
+/// `b_id` into each of its predecessors, reproducing exactly what a fresh
+/// `analysis.buildPredecessors` would yield — without the O(blocks+edges)
+/// rebuild that previously ran after every absorption.
+///
+/// Absorbing join `B` (whose predecessors all end in a plain `br B`) rewrites
+/// each predecessor's terminator into a clone of `B`'s terminator. The only
+/// predecessor-set changes are therefore:
+///   - each distinct successor of `B` gains every former predecessor of `B`,
+///     and
+///   - `B` loses all of its predecessors.
+///
+/// `B` keeps its own (unchanged) outgoing edges and stays in `func.blocks`
+/// until a later `scrubUnreachableBlocks`, so it remains a predecessor of its
+/// successors — matching a fresh rebuild. Because the IR verifier guarantees a
+/// single terminator at the end of every block, each former predecessor's only
+/// out-edge was `br B`, so appending it to a successor's list never duplicates
+/// an existing entry.
+fn applyTailDupToPredecessors(
+    func: *const ir.IrFunction,
+    b_id: ir.BlockId,
+    predecessors: *std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+    allocator: std.mem.Allocator,
+) !void {
+    const b_slot = predecessors.getPtr(b_id) orelse return;
+    const cloned_preds = b_slot.*;
+    if (cloned_preds.len == 0) return;
+
+    const b = &func.blocks.items[b_id];
+    const term = b.instructions.items[b.instructions.items.len - 1];
+
+    // An absorbable join always ends in a single br / br_if / ret terminator,
+    // so it has at most two distinct successors to fix up.
+    var succ_buf: [2]ir.BlockId = undefined;
+    var succ_len: usize = 0;
+    switch (term.op) {
+        .br => |tgt| {
+            succ_buf[0] = tgt;
+            succ_len = 1;
+        },
+        .br_if => |bi| {
+            succ_buf[0] = bi.then_block;
+            succ_len = 1;
+            if (bi.else_block != bi.then_block) {
+                succ_buf[1] = bi.else_block;
+                succ_len = 2;
+            }
+        },
+        else => {}, // ret: no successors
+    }
+
+    // `B` is never its own successor (self-loop joins are rejected by
+    // `tryAbsorbJoin`), so none of these slots alias `b_slot`, and overwriting
+    // existing values never rehashes the map — `b_slot` stays valid.
+    for (succ_buf[0..succ_len]) |s_id| {
+        const slot = predecessors.getPtr(s_id) orelse continue;
+        const old = slot.*;
+        const updated = try allocator.alloc(ir.BlockId, old.len + cloned_preds.len);
+        @memcpy(updated[0..old.len], old);
+        @memcpy(updated[old.len..], cloned_preds);
+        allocator.free(old);
+        slot.* = updated;
+    }
+
+    allocator.free(cloned_preds);
+    b_slot.* = &.{};
+}
+
+const TailDupWorkEstimate = struct {
+    candidate_joins: usize = 0,
+    predecessor_edges: usize = 0,
+    external_use_scans: usize = 0,
+    cloned_instructions: usize = 0,
+    cfg_rebuild_work: usize = 0,
+    total: usize = 0,
+
+    fn addWork(self: *TailDupWorkEstimate, amount: usize) void {
+        self.total = saturatingAddUsize(self.total, amount);
+    }
+};
+
+fn tailDupCapExceeded(limit: usize, value: usize) bool {
+    return limit != 0 and value > limit;
+}
+
+fn saturatingAddUsize(a: usize, b: usize) usize {
+    const max = std.math.maxInt(usize);
+    return if (max - a < b) max else a + b;
+}
+
+fn saturatingMulUsize(a: usize, b: usize) usize {
+    if (a == 0 or b == 0) return 0;
+    const max = std.math.maxInt(usize);
+    return if (a > max / b) max else a * b;
+}
+
+fn logTailDupSkip(
+    func: *const ir.IrFunction,
+    reason: []const u8,
+    options: TailDuplicationOptions,
+    stats: PassTimingStats,
+    estimate: ?TailDupWorkEstimate,
+) void {
+    if (!options.log) return;
+    const func_name = func.name orelse "-";
+    if (estimate) |e| {
+        std.debug.print(
+            "[aot-tail-dup] skip reason={s} func_name={s} blocks={d} insts={d} max_blocks={d} max_insts={d} max_work={d} candidates={d} pred_edges={d} ext_scans={d} cloned_insts={d} rebuild_work={d} work={d}\n",
+            .{
+                reason,
+                func_name,
+                stats.blocks,
+                stats.instructions,
+                options.max_blocks,
+                options.max_instructions,
+                options.max_work,
+                e.candidate_joins,
+                e.predecessor_edges,
+                e.external_use_scans,
+                e.cloned_instructions,
+                e.cfg_rebuild_work,
+                e.total,
+            },
+        );
+    } else {
+        std.debug.print(
+            "[aot-tail-dup] skip reason={s} func_name={s} blocks={d} insts={d} max_blocks={d} max_insts={d} max_work={d}\n",
+            .{
+                reason,
+                func_name,
+                stats.blocks,
+                stats.instructions,
+                options.max_blocks,
+                options.max_instructions,
+                options.max_work,
+            },
+        );
+    }
+}
+
+fn estimateTailDuplicationWork(
+    func: *const ir.IrFunction,
+    predecessors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+    stats: PassTimingStats,
+) TailDupWorkEstimate {
+    var out = TailDupWorkEstimate{};
+
+    var b_id: ir.BlockId = 1;
+    while (b_id < func.blocks.items.len) : (b_id += 1) {
+        const candidate = estimateTailDupCandidate(func, b_id, predecessors) orelse continue;
+        out.candidate_joins = saturatingAddUsize(out.candidate_joins, 1);
+        out.predecessor_edges = saturatingAddUsize(out.predecessor_edges, candidate.pred_count);
+        out.external_use_scans = saturatingAddUsize(out.external_use_scans, candidate.def_count);
+        const cloned = saturatingMulUsize(candidate.pred_count, candidate.inst_count);
+        out.cloned_instructions = saturatingAddUsize(out.cloned_instructions, cloned);
+        const rebuild = saturatingAddUsize(stats.blocks, stats.instructions);
+        out.cfg_rebuild_work = saturatingAddUsize(out.cfg_rebuild_work, rebuild);
+
+        out.addWork(candidate.pred_count);
+        out.addWork(saturatingMulUsize(candidate.def_count, stats.instructions));
+        out.addWork(cloned);
+        out.addWork(rebuild);
+    }
+
+    return out;
+}
+
+const TailDupCandidateEstimate = struct {
+    pred_count: usize,
+    inst_count: usize,
+    def_count: usize,
+};
+
+fn estimateTailDupCandidate(
+    func: *const ir.IrFunction,
+    b_id: ir.BlockId,
+    predecessors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+) ?TailDupCandidateEstimate {
+    const b = &func.blocks.items[b_id];
+    if (b.instructions.items.len == 0) return null;
+
+    const term_idx = findTerminatorIndex(b);
+    if (term_idx == b.instructions.items.len) return null;
+    if (term_idx != b.instructions.items.len - 1) return null;
+
+    const body_len = term_idx;
+    if (body_len > 4) return null;
+
+    switch (b.instructions.items[term_idx].op) {
+        .br, .br_if, .ret => {},
+        else => return null,
+    }
+
+    var def_count: usize = 0;
+    for (b.instructions.items[0..body_len]) |inst| {
+        if (inst.dest != null) def_count += 1;
+        switch (inst.op) {
+            .phi,
+            .call,
+            .call_indirect,
+            .call_ref,
+            .call_result,
+            .br,
+            .br_if,
+            .br_table,
+            .ret,
+            .ret_multi,
+            .@"unreachable",
+            => return null,
+            else => {},
+        }
+    }
+    if (b.instructions.items[term_idx].dest != null) def_count += 1;
+
+    const preds = predecessors.get(b_id) orelse return null;
+    if (preds.len < 2) return null;
+
+    for (preds) |p| {
+        if (p == b_id) return null;
+        if (p >= func.blocks.items.len) return null;
+        const pb = &func.blocks.items[p];
+        if (pb.instructions.items.len == 0) return null;
+        const pterm = pb.instructions.items[pb.instructions.items.len - 1];
+        switch (pterm.op) {
+            .br => |tgt| if (tgt != b_id) return null,
+            else => return null,
+        }
+    }
+
+    return .{
+        .pred_count = preds.len,
+        .inst_count = b.instructions.items.len,
+        .def_count = def_count,
+    };
 }
 
 /// Attempt to tail-duplicate block `b_id` into each of its predecessors.
@@ -7151,6 +7769,10 @@ pub fn runPassesWithOptions(
     opts: RunOptions,
 ) !u32 {
     var total_changes: u32 = 0;
+    const previous_analysis_timing = analysis.setTimingOptions(opts.analysis_timing);
+    defer _ = analysis.setTimingOptions(previous_analysis_timing);
+    var tail_dup_scope = pushTailDuplicationOptions(opts.tail_duplication);
+    defer tail_dup_scope.deinit();
 
     // Local helper: run the verifier and stamp the pass name on the
     // surfaced failure record. A no-op when `verify_mode == .off`.
@@ -7171,11 +7793,19 @@ pub fn runPassesWithOptions(
         fn check(
             mode: verifier.VerifyMode,
             pass_label: []const u8,
+            module_idx: u32,
             func: *ir.IrFunction,
             func_idx: u32,
             alloc: std.mem.Allocator,
         ) verifier.VerifyError!void {
             if (mode == .off) return;
+            var timing_context = analysis.pushTimingContext(.{
+                .module_idx = module_idx,
+                .func_idx = func_idx,
+                .phase = "verify",
+                .pass_name = pass_label,
+            });
+            defer timing_context.deinit();
             try analysis.refreshBlockPredecessors(func, alloc);
             verifier.verifyFunction(func, func_idx, mode, alloc) catch |e| {
                 verifier.last_failure.pass_name = pass_label;
@@ -7226,7 +7856,15 @@ pub fn runPassesWithOptions(
         var inlined_count: u32 = 0;
         if (!opts.bisect.skipsInlineSmall(opts.module_idx)) {
             while (inline_iter < 4) : (inline_iter += 1) {
-                const iter_inlined = try inlineSmallFunctionsCount(module, allocator);
+                const iter_inlined = blk: {
+                    var timing_context = analysis.pushTimingContext(.{
+                        .module_idx = opts.module_idx,
+                        .phase = "pass",
+                        .pass_name = "inlineSmallFunctions",
+                    });
+                    defer timing_context.deinit();
+                    break :blk try inlineSmallFunctionsCount(module, allocator);
+                };
                 if (iter_inlined == 0) break;
                 inlined_count += iter_inlined;
                 total_changes += 1;
@@ -7237,7 +7875,7 @@ pub fn runPassesWithOptions(
                         // #761: suppress verifier on bisect-affected funcs.
                         const vm: verifier.VerifyMode =
                             if (opts.bisect.affectsFunction(opts.module_idx, fi32)) .off else opts.verify_mode;
-                        try Verify.check(vm, "inlineSmallFunctions", f, fi32, allocator);
+                        try Verify.check(vm, "inlineSmallFunctions", opts.module_idx, f, fi32, allocator);
                     }
                 }
 
@@ -7300,6 +7938,10 @@ pub fn runPassesWithOptions(
             // pass fixpoint, scrubUnreachableBlocks).
             const effective_verify_mode: verifier.VerifyMode =
                 if (opts.bisect.affectsFunction(opts.module_idx, func_idx)) .off else opts.verify_mode;
+            var cfg_cache = analysis.CfgAnalysisCache.init(allocator);
+            defer cfg_cache.deinit();
+            var cfg_cache_scope = analysis.pushCfgAnalysisCache(&cfg_cache);
+            defer cfg_cache_scope.deinit();
 
             // SSA promotion: only meaningful on the first outer round. On
             // later rounds the function is already past mem2reg and any new
@@ -7311,7 +7953,17 @@ pub fn runPassesWithOptions(
                 if (timing_for_func) {
                     printPassTimingStart(timing, "pass-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "promoteLocalsToSSA");
                 }
-                const promote_changed = try promoteLocalsToSSA(func, allocator);
+                const promote_changed = blk: {
+                    var timing_context = analysis.pushTimingContext(.{
+                        .module_idx = opts.module_idx,
+                        .func_idx = func_idx,
+                        .phase = "pass",
+                        .pass_name = "promoteLocalsToSSA",
+                    });
+                    defer timing_context.deinit();
+                    break :blk try promoteLocalsToSSA(func, allocator);
+                };
+                cfg_cache.invalidate();
                 if (timing_for_func) {
                     maybePrintPassTiming(
                         timing,
@@ -7336,7 +7988,7 @@ pub fn runPassesWithOptions(
                     if (timing_for_func) {
                         printPassTimingStart(timing, "verify-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "promoteLocalsToSSA");
                     }
-                    try Verify.check(effective_verify_mode, "promoteLocalsToSSA", func, func_idx, allocator);
+                    try Verify.check(effective_verify_mode, "promoteLocalsToSSA", opts.module_idx, func, func_idx, allocator);
                     if (timing_for_func) {
                         maybePrintPassTiming(
                             timing,
@@ -7370,7 +8022,16 @@ pub fn runPassesWithOptions(
                         if (timing_for_func) {
                             printPassTimingStart(timing, "pass-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "lowerPhisToLocals");
                         }
-                        const lower_changed = try lowerPhisToLocals(func, allocator);
+                        const lower_changed = blk: {
+                            var timing_context = analysis.pushTimingContext(.{
+                                .module_idx = opts.module_idx,
+                                .func_idx = func_idx,
+                                .phase = "pass",
+                                .pass_name = "lowerPhisToLocals",
+                            });
+                            defer timing_context.deinit();
+                            break :blk try lowerPhisToLocals(func, allocator);
+                        };
                         if (timing_for_func) {
                             maybePrintPassTiming(
                                 timing,
@@ -7395,7 +8056,7 @@ pub fn runPassesWithOptions(
                             if (timing_for_func) {
                                 printPassTimingStart(timing, "verify-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "lowerPhisToLocals");
                             }
-                            try Verify.check(effective_verify_mode, "lowerPhisToLocals", func, func_idx, allocator);
+                            try Verify.check(effective_verify_mode, "lowerPhisToLocals", opts.module_idx, func, func_idx, allocator);
                             if (timing_for_func) {
                                 maybePrintPassTiming(
                                     timing,
@@ -7452,7 +8113,18 @@ pub fn runPassesWithOptions(
                     if (timing_for_func) {
                         printPassTimingStart(timing, "pass-start", module, opts.module_idx, func, func_idx, outer_iter, iter, pass_idx, pass_label);
                     }
-                    const changed = try pass(func, allocator);
+                    const changed = blk: {
+                        var timing_context = analysis.pushTimingContext(.{
+                            .module_idx = opts.module_idx,
+                            .func_idx = func_idx,
+                            .phase = "pass",
+                            .pass_idx = pass_idx,
+                            .pass_name = pass_label,
+                        });
+                        defer timing_context.deinit();
+                        break :blk try pass(func, allocator);
+                    };
+                    if (passMutatesCfg(pass)) cfg_cache.invalidate();
                     if (timing_for_func) {
                         maybePrintPassTiming(
                             timing,
@@ -7480,7 +8152,7 @@ pub fn runPassesWithOptions(
                         if (timing_for_func) {
                             printPassTimingStart(timing, "verify-start", module, opts.module_idx, func, func_idx, outer_iter, iter, pass_idx, pass_label);
                         }
-                        try Verify.check(effective_verify_mode, pass_label, func, func_idx, allocator);
+                        try Verify.check(effective_verify_mode, pass_label, opts.module_idx, func, func_idx, allocator);
                         if (timing_for_func) {
                             maybePrintPassTiming(
                                 timing,
@@ -7526,7 +8198,17 @@ pub fn runPassesWithOptions(
             if (timing_for_func) {
                 printPassTimingStart(timing, "pass-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "scrubUnreachableBlocks");
             }
-            const scrub_changed = try scrubUnreachableBlocks(func, allocator);
+            const scrub_changed = blk: {
+                var timing_context = analysis.pushTimingContext(.{
+                    .module_idx = opts.module_idx,
+                    .func_idx = func_idx,
+                    .phase = "pass",
+                    .pass_name = "scrubUnreachableBlocks",
+                });
+                defer timing_context.deinit();
+                break :blk try scrubUnreachableBlocks(func, allocator);
+            };
+            cfg_cache.invalidate();
             if (timing_for_func) {
                 maybePrintPassTiming(
                     timing,
@@ -7551,7 +8233,7 @@ pub fn runPassesWithOptions(
                 if (timing_for_func) {
                     printPassTimingStart(timing, "verify-start", module, opts.module_idx, func, func_idx, outer_iter, 0, null, "scrubUnreachableBlocks");
                 }
-                try Verify.check(effective_verify_mode, "scrubUnreachableBlocks", func, func_idx, allocator);
+                try Verify.check(effective_verify_mode, "scrubUnreachableBlocks", opts.module_idx, func, func_idx, allocator);
                 if (timing_for_func) {
                     maybePrintPassTiming(
                         timing,
@@ -9101,6 +9783,34 @@ test "replaceVRegCount: reports only actual rewritten uses" {
 
     try std.testing.expectEqual(@as(u32, 1), replaceVRegCount(&func, v0, v1));
     try std.testing.expectEqual(@as(u32, 0), replaceVRegCount(&func, v0, v1));
+}
+
+test "replaceVRegsCount: batches multiple aliases in one function scan" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+    const block_id = try func.newBlock();
+    var block = &func.blocks.items[block_id];
+
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    const v3 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0 });
+    try block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = v1 });
+    try block.append(.{ .op = .{ .iconst_32 = 3 }, .dest = v2 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v2 } }, .dest = v3 });
+    try block.append(.{ .op = .{ .ret = v0 } });
+
+    var aliases = VRegAliasMap.init(allocator);
+    defer aliases.deinit();
+    try putVRegAlias(&aliases, v0, v1);
+    try putVRegAlias(&aliases, v2, v1);
+
+    try std.testing.expectEqual(@as(u32, 3), replaceVRegsCount(&func, &aliases));
+    try std.testing.expectEqual(ir.Inst.Op{ .add = .{ .lhs = v1, .rhs = v1 } }, block.instructions.items[3].op);
+    try std.testing.expectEqual(ir.Inst.Op{ .ret = v1 }, block.instructions.items[4].op);
+    try std.testing.expectEqual(@as(u32, 0), replaceVRegsCount(&func, &aliases));
 }
 
 // ── Block Reordering Tests ─────────────────────────────────────────────────
@@ -12571,6 +13281,60 @@ test "computeMagicU32: known divisors" {
     }
 }
 
+test "buildVRegUseCounts matches countUsesOfVReg across op kinds" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+
+    // getUsedVRegs path: binary op, eqz, select (cover br_if.cond too).
+    try func.getBlock(b0).append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = func.newVReg(), .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .eqz = v0 }, .dest = func.newVReg(), .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .select = .{ .cond = v2, .if_true = v0, .if_false = v1 } }, .dest = func.newVReg(), .type = .i32 });
+
+    // Variadic switch paths mirrored by buildVRegUseCounts/countUsesInInst.
+    const cl_args = try allocator.alloc(ir.VReg, 2);
+    cl_args[0] = v0;
+    cl_args[1] = v0;
+    try func.getBlock(b0).append(.{ .op = .{ .call = .{ .func_idx = 0, .args = cl_args } }, .dest = func.newVReg(), .type = .i32 });
+
+    const ci_args = try allocator.alloc(ir.VReg, 1);
+    ci_args[0] = v1;
+    try func.getBlock(b0).append(.{ .op = .{ .call_indirect = .{ .type_idx = 0, .elem_idx = v2, .args = ci_args } }, .dest = func.newVReg(), .type = .i32 });
+
+    const cr_args = try allocator.alloc(ir.VReg, 1);
+    cr_args[0] = v0;
+    try func.getBlock(b0).append(.{ .op = .{ .call_ref = .{ .type_idx = 0, .func_ref = v1, .args = cr_args } }, .dest = func.newVReg(), .type = .i32 });
+
+    const phi_edges = try allocator.alloc(ir.Inst.PhiEdge, 2);
+    phi_edges[0] = .{ .block = b0, .val = v0 };
+    phi_edges[1] = .{ .block = b0, .val = v2 };
+    try func.getBlock(b0).append(.{ .op = .{ .phi = phi_edges }, .dest = func.newVReg(), .type = .i32 });
+
+    const pc_pairs = try allocator.alloc(ir.Inst.ParallelCopy, 1);
+    pc_pairs[0] = .{ .dst = func.newVReg(), .src = v1, .ty = .i32 };
+    try func.getBlock(b0).append(.{ .op = .{ .parallel_copy = pc_pairs } });
+
+    const rm_vals = try allocator.alloc(ir.VReg, 2);
+    rm_vals[0] = v0;
+    rm_vals[1] = v1;
+    try func.getBlock(b0).append(.{ .op = .{ .ret_multi = rm_vals } });
+
+    var counts = try buildVRegUseCounts(&func, allocator);
+    defer counts.deinit();
+
+    // The precomputed tally must equal a per-vreg countUsesOfVReg scan for
+    // every vreg (defs included, which should report zero uses unless used).
+    var v: ir.VReg = 0;
+    while (v < func.next_vreg) : (v += 1) {
+        try std.testing.expectEqual(countUsesOfVReg(&func, v), counts.get(v) orelse 0);
+    }
+}
+
 test "foldBranchOnEqz: swaps targets and drops eqz use" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 1, 1, 0);
@@ -13995,6 +14759,91 @@ test "tailDuplicateSmallJoins: 4-block diamond — join inlined into both arms" 
     }
 }
 
+test "tailDuplicateSmallJoins: block cap skips eligible diamond without changes" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const cond = func.newVReg();
+    const v_join_add = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 10 }, .dest = v0 });
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 20 }, .dest = v1 });
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = cond });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = b1, .else_block = b2 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b3).append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v_join_add });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = v_join_add } });
+
+    const changed = try tailDuplicateSmallJoinsWithOptions(&func, allocator, .{
+        .max_blocks = 3,
+        .max_instructions = 0,
+        .max_work = 0,
+    });
+    try std.testing.expect(!changed);
+    try std.testing.expectEqual(ir.Inst.Op{ .br = b3 }, func.getBlock(b1).instructions.items[0].op);
+    try std.testing.expectEqual(ir.Inst.Op{ .br = b3 }, func.getBlock(b2).instructions.items[0].op);
+}
+
+test "tailDuplicateSmallJoins: work cap skips before mutating" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const cond = func.newVReg();
+    const v_join_add = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 10 }, .dest = v0 });
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 20 }, .dest = v1 });
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = cond });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = b1, .else_block = b2 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b3).append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v_join_add });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = v_join_add } });
+
+    const changed = try tailDuplicateSmallJoinsWithOptions(&func, allocator, .{
+        .max_blocks = 0,
+        .max_instructions = 0,
+        .max_work = 1,
+    });
+    try std.testing.expect(!changed);
+    try std.testing.expectEqual(ir.Inst.Op{ .br = b3 }, func.getBlock(b1).instructions.items[0].op);
+    try std.testing.expectEqual(ir.Inst.Op{ .br = b3 }, func.getBlock(b2).instructions.items[0].op);
+}
+
+test "tailDuplicationOptionsFromEnv parses skip caps and logging" {
+    const allocator = std.testing.allocator;
+    var env = std.process.Environ.Map.init(allocator);
+    defer env.deinit();
+
+    try env.put("WAMR_AOT_SKIP_TAIL_DUP", "1");
+    try env.put("WAMR_AOT_TAIL_DUP_MAX_BLOCKS", "123");
+    try env.put("WAMR_AOT_TAIL_DUP_MAX_INSTS", "456");
+    try env.put("WAMR_AOT_TAIL_DUP_MAX_WORK", "789");
+    try env.put("WAMR_AOT_TAIL_DUP_LOG", "yes");
+
+    const opts = tailDuplicationOptionsFromEnv(&env);
+    try std.testing.expect(opts.skip);
+    try std.testing.expect(opts.log);
+    try std.testing.expectEqual(@as(usize, 123), opts.max_blocks);
+    try std.testing.expectEqual(@as(usize, 456), opts.max_instructions);
+    try std.testing.expectEqual(@as(usize, 789), opts.max_work);
+}
+
 test "tailDuplicateSmallJoins: triple predecessor with br terminator — all three duplicated" {
     // b0,b1,b2 each unconditionally br to b3 (sub + br_if to b4 or b5).
     // After duplication, all three predecessors should each contain the
@@ -14264,6 +15113,7 @@ test "GVN: cross-block load forwarded from dominator (#541)" {
 
     const changed = try globalValueNumbering(&func, allocator);
     try std.testing.expect(changed);
+    try std.testing.expectEqual(@as(usize, 1), func.getBlock(tail).instructions.items.len);
     try std.testing.expectEqual(ir.Inst.Op{ .ret = v_dom }, func.getBlock(tail).instructions.items[0].op);
 }
 
@@ -14284,6 +15134,53 @@ test "GVN: unused duplicate does not report changed" {
     const changed = try globalValueNumbering(&func, allocator);
     try std.testing.expect(!changed);
     try std.testing.expectEqual(ir.Inst.Op{ .iconst_32 = 7 }, block.instructions.items[1].op);
+}
+
+test "GVN: batched aliases canonicalize later expressions" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    var block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v_add_a = func.newVReg();
+    const v_add_b = func.newVReg();
+
+    try block.append(.{ .op = .{ .iconst_32 = 7 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 7 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v1, .rhs = v1 } }, .dest = v_add_a, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v0 } }, .dest = v_add_b, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v_add_b } });
+
+    const changed = try globalValueNumbering(&func, allocator);
+    try std.testing.expect(changed);
+    try std.testing.expectEqual(ir.Inst.Op{ .add = .{ .lhs = v0, .rhs = v0 } }, block.instructions.items[2].op);
+    try std.testing.expectEqual(ir.Inst.Op{ .ret = v_add_a }, block.instructions.items[4].op);
+}
+
+test "GVN load: unused forwarded load alias does not report changed" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const entry = try func.newBlock();
+    const tail = try func.newBlock();
+    const v_base = func.newVReg();
+    const v_dom = func.newVReg();
+    const v_unused = func.newVReg();
+
+    try func.getBlock(entry).append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_dom, .type = .i32 });
+    try func.getBlock(entry).append(.{ .op = .{ .br = tail } });
+    try func.getBlock(tail).append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_unused, .type = .i32 });
+    try func.getBlock(tail).append(.{ .op = .{ .ret = v_dom } });
+
+    const changed = try globalValueNumbering(&func, allocator);
+    try std.testing.expect(!changed);
+    try std.testing.expectEqual(@as(usize, 2), func.getBlock(tail).instructions.items.len);
+    try std.testing.expect(func.getBlock(tail).instructions.items[0].op == .load);
+    try std.testing.expectEqual(ir.Inst.Op{ .ret = v_dom }, func.getBlock(tail).instructions.items[1].op);
 }
 
 test "CSE: diamond — add v0,v1 in both arms hoisted to dominator (#541)" {
@@ -14353,6 +15250,7 @@ test "GVN load: sibling-block store does NOT poison dominator-cached load (#541)
 
     const changed = try globalValueNumbering(&func, allocator);
     try std.testing.expect(changed);
+    try std.testing.expectEqual(@as(usize, 1), func.getBlock(right).instructions.items.len);
     try std.testing.expectEqual(ir.Inst.Op{ .ret = v_dom }, func.getBlock(right).instructions.items[0].op);
 }
 

--- a/src/compiler/ir/verifier.zig
+++ b/src/compiler/ir/verifier.zig
@@ -1685,6 +1685,36 @@ fn verifyLoadUseCleanPathsDfs(
                     );
                 }
             },
+            .v128_store => |st| {
+                if (alias_class.storeAliasesLoad(load_key, alias_class.storeRangeFromV128Store(st))) {
+                    return failLoadForwardingSoundness(
+                        func,
+                        func_index,
+                        load_vreg,
+                        inst.op,
+                        cur_block,
+                        @intCast(ii),
+                        path.items,
+                        use_block,
+                        can_reach_use,
+                    );
+                }
+            },
+            .v128_store_lane => |st| {
+                if (alias_class.storeAliasesLoad(load_key, alias_class.storeRangeFromV128StoreLane(st))) {
+                    return failLoadForwardingSoundness(
+                        func,
+                        func_index,
+                        load_vreg,
+                        inst.op,
+                        cur_block,
+                        @intCast(ii),
+                        path.items,
+                        use_block,
+                        can_reach_use,
+                    );
+                }
+            },
             else => {},
         }
         if (alias_class.opIsLoadBarrier(inst.op)) {

--- a/src/compiler/ir/verifier.zig
+++ b/src/compiler/ir/verifier.zig
@@ -785,8 +785,15 @@ fn checkSsaDominance(
     func_index: u32,
     allocator: std.mem.Allocator,
 ) VerifyError!void {
-    var dom = try analysis.computeDominators(func, allocator);
-    defer dom.deinit();
+    const cfg_cache = analysis.currentCfgAnalysisCache();
+    var owned_dom: ?analysis.DomTree = null;
+    defer if (owned_dom) |*dom| dom.deinit();
+    const dom: *const analysis.DomTree = if (cfg_cache) |cache|
+        try cache.getDominators(func)
+    else blk: {
+        owned_dom = try analysis.computeDominators(func, allocator);
+        break :blk &owned_dom.?;
+    };
 
     const nblocks = func.blocks.items.len;
     // For each VReg, record (block, inst_index) of its definition.
@@ -832,7 +839,7 @@ fn checkSsaDominance(
             var c = Ctx{
                 .param_count = param_count,
                 .def_loc = &def_loc,
-                .dom = &dom,
+                .dom = dom,
                 .cur_block = block.id,
                 .cur_idx = @intCast(ii),
                 .cur_op = inst.op,
@@ -1318,17 +1325,26 @@ fn checkLoopInfo(
     func_index: u32,
     allocator: std.mem.Allocator,
 ) VerifyError!void {
-    var dom = analysis.computeDominators(func, allocator) catch |e| switch (e) {
-        error.OutOfMemory => return error.OutOfMemory,
+    const cfg_cache = analysis.currentCfgAnalysisCache();
+    var owned_dom: ?analysis.DomTree = null;
+    defer if (owned_dom) |*dom| dom.deinit();
+    const dom: *const analysis.DomTree = if (cfg_cache) |cache|
+        cache.getDominators(func) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+        }
+    else blk: {
+        owned_dom = analysis.computeDominators(func, allocator) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+        break :blk &owned_dom.?;
     };
-    defer dom.deinit();
 
-    var forest = analysis.computeLoops(func, &dom, allocator) catch |e| switch (e) {
+    var forest = analysis.computeLoopsCached(func, dom, allocator, cfg_cache) catch |e| switch (e) {
         error.OutOfMemory => return error.OutOfMemory,
     };
     defer forest.deinit();
 
-    try verifyLoopForest(func_index, &dom, &forest);
+    try verifyLoopForest(func_index, dom, &forest);
 }
 
 /// Validate a loop forest against a dominator tree. Split out so tests
@@ -1395,11 +1411,20 @@ fn checkDomTreeStructure(
     func_index: u32,
     allocator: std.mem.Allocator,
 ) VerifyError!void {
-    var dom = analysis.computeDominators(func, allocator) catch |e| switch (e) {
-        error.OutOfMemory => return error.OutOfMemory,
+    const cfg_cache = analysis.currentCfgAnalysisCache();
+    var owned_dom: ?analysis.DomTree = null;
+    defer if (owned_dom) |*dom| dom.deinit();
+    const dom: *const analysis.DomTree = if (cfg_cache) |cache|
+        cache.getDominators(func) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+        }
+    else blk: {
+        owned_dom = analysis.computeDominators(func, allocator) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+        break :blk &owned_dom.?;
     };
-    defer dom.deinit();
-    try verifyDomTreeStructure(func, func_index, &dom);
+    try verifyDomTreeStructure(func, func_index, dom);
 
     // TODO: once any pass caches a `DomTree` on `IrFunction` across the
     // pipeline, also diff that cached tree against the freshly computed

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -301,6 +301,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
             },
             .verify_mode = verify_mode,
             .bisect = wamr.aot_bisect.global,
+            .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
         };
         const opt_changes = passes.runPassesWithOptions(&ir_module, passes.defaultPassesForTarget(target_arch), allocator, run_opts) catch |err| {
             // If the IR verifier tripped, surface its diagnostic before
@@ -901,6 +902,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
         .target_arch = target_arch,
         .optimize = optimize,
         .cache_dir = cache_dir,
+        .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
     }) catch |err| {
         std.debug.print("error: precompile failed: {s}\n", .{@errorName(err)});
         std.process.exit(1);
@@ -1018,6 +1020,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
             std.debug.print("wamrc: compiling {s} → {s}\n", .{ in_path, artifact_path });
             var result = wamr.component_aot_compile.precompileComponent(allocator, wasm_data, artifact_path, .{
                 .target_arch = target_arch,
+                .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
             }) catch |err| {
                 std.debug.print("error: precompile failed: {s}\n", .{@errorName(err)});
                 std.process.exit(1);
@@ -1031,6 +1034,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
             std.debug.print("wamrc: compiling {s} → {s}\n", .{ in_path, artifact_path });
             const cwasm = wamr.component_aot_compile.compileCoreWasm(allocator, wasm_data, .{
                 .target_arch = target_arch,
+                .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
             }) catch |err| {
                 std.debug.print("error: compile failed: {s}\n", .{@errorName(err)});
                 std.process.exit(1);

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -117,9 +117,8 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
     // Default to `.after_each_pass` in safe builds (Debug / ReleaseSafe)
     // and `.off` in release builds, matching the cost-vs-diagnostic
     // tradeoff documented in #624. The user can override with
-    // `--verify-ir[=…]` or `--no-verify-ir`.
-    var verify_mode: wamr.ir_verifier.VerifyMode =
-        if (std.debug.runtime_safety) .after_each_pass else .off;
+    // `WAMR_AOT_VERIFY_IR`, `--verify-ir[=…]`, or `--no-verify-ir`.
+    var verify_mode = verifyModeFromEnvOrDefault(init.environ_map);
 
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
@@ -161,10 +160,8 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
             dump_out_dir = a["--dump-ir-out=".len..];
         } else if (std.mem.eql(u8, a, "--verify-ir")) {
             verify_mode = .after_each_pass;
-        } else if (std.mem.eql(u8, a, "--verify-ir=after-each-pass")) {
-            verify_mode = .after_each_pass;
-        } else if (std.mem.eql(u8, a, "--verify-ir=paranoid")) {
-            verify_mode = .paranoid;
+        } else if (std.mem.startsWith(u8, a, "--verify-ir=")) {
+            verify_mode = parseVerifyModeOrDie("--verify-ir", a["--verify-ir=".len..]);
         } else if (std.mem.eql(u8, a, "--no-verify-ir")) {
             verify_mode = .off;
         } else if (std.mem.eql(u8, a, "--cache") and i + 1 < sub_args.len) {
@@ -302,6 +299,8 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
             .verify_mode = verify_mode,
             .bisect = wamr.aot_bisect.global,
             .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
+            .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
+            .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
         };
         const opt_changes = passes.runPassesWithOptions(&ir_module, passes.defaultPassesForTarget(target_arch), allocator, run_opts) catch |err| {
             // If the IR verifier tripped, surface its diagnostic before
@@ -833,6 +832,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
     };
     // #761 Phase 2: per-core codegen cache directory.
     var cache_dir: ?[]const u8 = null;
+    var verify_mode = verifyModeFromEnvOrDefault(init.environ_map);
 
     var i: usize = 0;
     while (i < sub_args.len) : (i += 1) {
@@ -846,6 +846,12 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
             output_manifest = sub_args[i];
         } else if (std.mem.eql(u8, a, "-O0")) {
             optimize = false;
+        } else if (std.mem.eql(u8, a, "--verify-ir")) {
+            verify_mode = .after_each_pass;
+        } else if (std.mem.startsWith(u8, a, "--verify-ir=")) {
+            verify_mode = parseVerifyModeOrDie("--verify-ir", a["--verify-ir=".len..]);
+        } else if (std.mem.eql(u8, a, "--no-verify-ir")) {
+            verify_mode = .off;
         } else if (std.mem.startsWith(u8, a, "--target=")) {
             const v = a["--target=".len..];
             if (std.mem.eql(u8, v, "x86_64") or std.mem.eql(u8, v, "x86-64")) {
@@ -903,6 +909,9 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
         .optimize = optimize,
         .cache_dir = cache_dir,
         .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
+        .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
+        .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
+        .verify_mode = verify_mode,
     }) catch |err| {
         std.debug.print("error: precompile failed: {s}\n", .{@errorName(err)});
         std.process.exit(1);
@@ -1021,6 +1030,9 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
             var result = wamr.component_aot_compile.precompileComponent(allocator, wasm_data, artifact_path, .{
                 .target_arch = target_arch,
                 .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
+                .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
+                .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
+                .verify_mode = verifyModeFromEnvOrDefault(init.environ_map),
             }) catch |err| {
                 std.debug.print("error: precompile failed: {s}\n", .{@errorName(err)});
                 std.process.exit(1);
@@ -1035,6 +1047,9 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
             const cwasm = wamr.component_aot_compile.compileCoreWasm(allocator, wasm_data, .{
                 .target_arch = target_arch,
                 .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
+                .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
+                .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
+                .verify_mode = verifyModeFromEnvOrDefault(init.environ_map),
             }) catch |err| {
                 std.debug.print("error: compile failed: {s}\n", .{@errorName(err)});
                 std.process.exit(1);
@@ -1162,6 +1177,47 @@ fn parseTargetArchOrDie(s: []const u8) TargetArch {
     if (std.mem.eql(u8, s, "x86_64") or std.mem.eql(u8, s, "x86-64")) return .x86_64;
     std.debug.print("error: unknown target '{s}' (supported: x86_64, aarch64)\n", .{s});
     std.process.exit(1);
+}
+
+fn defaultVerifyMode() wamr.ir_verifier.VerifyMode {
+    return if (std.debug.runtime_safety) .after_each_pass else .off;
+}
+
+fn parseVerifyMode(value: []const u8) ?wamr.ir_verifier.VerifyMode {
+    if (std.ascii.eqlIgnoreCase(value, "default")) return defaultVerifyMode();
+    if (std.ascii.eqlIgnoreCase(value, "off") or
+        std.mem.eql(u8, value, "0") or
+        std.ascii.eqlIgnoreCase(value, "false") or
+        std.ascii.eqlIgnoreCase(value, "no"))
+    {
+        return .off;
+    }
+    if (std.ascii.eqlIgnoreCase(value, "after-each-pass") or
+        std.ascii.eqlIgnoreCase(value, "after_each_pass") or
+        std.ascii.eqlIgnoreCase(value, "on") or
+        std.mem.eql(u8, value, "1") or
+        std.ascii.eqlIgnoreCase(value, "true") or
+        std.ascii.eqlIgnoreCase(value, "yes"))
+    {
+        return .after_each_pass;
+    }
+    if (std.ascii.eqlIgnoreCase(value, "paranoid")) return .paranoid;
+    return null;
+}
+
+fn parseVerifyModeOrDie(source: []const u8, value: []const u8) wamr.ir_verifier.VerifyMode {
+    return parseVerifyMode(value) orelse {
+        std.debug.print(
+            "error: invalid {s} value '{s}' (expected: off, after-each-pass, paranoid, default)\n",
+            .{ source, value },
+        );
+        std.process.exit(1);
+    };
+}
+
+fn verifyModeFromEnvOrDefault(env: *const std.process.Environ.Map) wamr.ir_verifier.VerifyMode {
+    const value = env.get("WAMR_AOT_VERIFY_IR") orelse return defaultVerifyMode();
+    return parseVerifyModeOrDie("WAMR_AOT_VERIFY_IR", value);
 }
 
 fn targetArchName(arch: TargetArch) []const u8 {
@@ -1402,11 +1458,13 @@ const compile_usage =
     \\  --verify-ir[=<mode>]          Run the IR invariant checker (#624)
     \\                                 after every pass that mutated the
     \\                                 function. Modes:
+    \\                                   off
     \\                                   after-each-pass (default with --verify-ir)
     \\                                   paranoid        (adds operand-width
     \\                                                    sanity check, #628)
     \\                                 Default: on for safety builds, off
-    \\                                 for release builds.
+    \\                                 for release builds; overridden by
+    \\                                 WAMR_AOT_VERIFY_IR when set.
     \\  --no-verify-ir                Disable the IR verifier (overrides
     \\                                 the safety-build default).
     \\  --cache <path>                #761 Phase 2 codegen cache sidecar.
@@ -1436,6 +1494,13 @@ const compile_component_usage =
     \\  -o <manifest.json>            Manifest path (default: <input>.cwasm.json)
     \\  --target=<x86_64|aarch64>     Target architecture (default: host)
     \\  -O0                           Disable IR optimizations (every core)
+    \\  --verify-ir[=<mode>]          Run the IR verifier after optimized IR
+    \\                                 passes. Modes: off, after-each-pass,
+    \\                                 paranoid, default. Default: on for
+    \\                                 safety builds, off for release builds;
+    \\                                 overridden by WAMR_AOT_VERIFY_IR when
+    \\                                 set.
+    \\  --no-verify-ir                Disable the IR verifier.
     \\  --cache-dir <dir>             #761 Phase 2 codegen cache root. Per
     \\                                 core: read/write `<dir>/core<N>.cache`
     \\                                 to reuse cached native code for any
@@ -1443,6 +1508,19 @@ const compile_component_usage =
     \\                                 Header-incompatible caches fall back
     \\                                 to full recompile of that core
     \\                                 (warn-only, never errors).
+    \\
+    \\Diagnostics env:
+    \\  WAMR_AOT_PASS_TIMING=1        Log slow pass and verifier phases
+    \\                                 (existing pass-timing diagnostics).
+    \\  WAMR_AOT_PASS_TIMING_THRESHOLD_MS=<ms>
+    \\                                 Pass/verifier threshold (default: 100).
+    \\  WAMR_AOT_ANALYSIS_TIMING=1    Log slow buildSuccessors /
+    \\                                 computeDominators calls.
+    \\  WAMR_AOT_ANALYSIS_TIMING_THRESHOLD_MS=<ms>
+    \\                                 Slow-call threshold (default: 100).
+    \\  WAMR_AOT_ANALYSIS_TIMING_MODULE=<N>
+    \\  WAMR_AOT_ANALYSIS_TIMING_FUNC=<N>
+    \\                                 Optional module/function filters.
     \\
 ;
 

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -67,9 +67,7 @@ fn logVerifierFailure(err: anyerror) void {
     std.log.err("aot-compile failed: {s}", .{written});
 }
 
-/// Options controlling `precompileComponent`. Today only the target
-/// arch is exposed; future options (opt level, dump-ir hooks, …) slot
-/// in here without breaking the API.
+/// Options controlling `precompileComponent` and per-core compilation.
 pub const PrecompileOptions = struct {
     target_arch: passes.TargetArch = switch (builtin.cpu.arch) {
         .aarch64 => .aarch64,
@@ -96,6 +94,15 @@ pub const PrecompileOptions = struct {
     /// Optional pass-loop timing/progress diagnostics, normally parsed by
     /// `wamrc` from `WAMR_AOT_PASS_TIMING*`.
     pass_timing: passes.PassTimingOptions = .{},
+    /// Optional analysis recomputation diagnostics, normally parsed by
+    /// `wamrc` from `WAMR_AOT_ANALYSIS_TIMING*`.
+    analysis_timing: passes.AnalysisTimingOptions = .{},
+    /// Tail-duplication compile-time guard/cap options.
+    tail_duplication: passes.TailDuplicationOptions = .{},
+    /// IR verifier mode for optimized builds. Defaults match the historical
+    /// component path: safe builds verify after each pass; release builds do
+    /// not verify unless explicitly requested.
+    verify_mode: verifier.VerifyMode = if (std.debug.runtime_safety) .after_each_pass else .off,
 };
 
 /// Optional cache I/O for `compileCoreWasm` (#761 Phase 2).
@@ -160,15 +167,17 @@ pub fn compileCoreWasmCached(
             passes.defaultPassesForTarget(opts.target_arch),
             allocator,
             .{
-                // Match single-module `wamrc compile`: run the IR verifier
-                // after every pass in safe builds. Components are heavy
+                // The default `opts.verify_mode` matches single-module
+                // `wamrc compile`: run the IR verifier after every pass in
+                // safe builds, and keep it off in release unless requested.
+                // Components are heavy
                 // (the StarlingMonkey-bundled wasms used by jco have
                 // ~12 k functions), but verifier-caught bugs like #754
                 // — operand-type-mismatch on `select` propagating
                 // through chained selects — are silent miscompiles
                 // that cost far more to debug at runtime than to catch
-                // here.  Release builds keep the previous off-by-default
-                // behaviour for compile-time perf.
+                // here, but `wamrc compile-component --verify-ir=off` can
+                // force it off for compile-time triage.
                 //
                 // Note: `-O0` (this branch's else arm) intentionally
                 // skips the verifier because the frontend emits
@@ -179,10 +188,7 @@ pub fn compileCoreWasmCached(
                 // checks trip benign `MultipleTerminators` errors.
                 // Users who want belt-and-suspenders verification on
                 // an `-O0` build should drop `-O0` instead.
-                .verify_mode = if (std.debug.runtime_safety)
-                    .after_each_pass
-                else
-                    .off,
+                .verify_mode = opts.verify_mode,
                 // #761 / #743: thread the global bisect spec through
                 // so `WAMR_AOT_SKIP_PASS=...:fn=<idx>` narrows the
                 // partial pipeline to one suspect function. The pass
@@ -193,6 +199,8 @@ pub fn compileCoreWasmCached(
                 // Per-core index honoured by `:mod=N` bisect filters.
                 .module_idx = opts.module_idx,
                 .pass_timing = opts.pass_timing,
+                .analysis_timing = opts.analysis_timing,
+                .tail_duplication = opts.tail_duplication,
             },
         ) catch |err| {
             logVerifierFailure(err);

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -93,6 +93,9 @@ pub const PrecompileOptions = struct {
     /// `wamrc compile` path leaves it at the default 0 (which still
     /// matches `:mod=0` filters, as intended).
     module_idx: u32 = 0,
+    /// Optional pass-loop timing/progress diagnostics, normally parsed by
+    /// `wamrc` from `WAMR_AOT_PASS_TIMING*`.
+    pass_timing: passes.PassTimingOptions = .{},
 };
 
 /// Optional cache I/O for `compileCoreWasm` (#761 Phase 2).
@@ -189,6 +192,7 @@ pub fn compileCoreWasmCached(
                 .bisect = aot_bisect.global,
                 // Per-core index honoured by `:mod=N` bisect filters.
                 .module_idx = opts.module_idx,
+                .pass_timing = opts.pass_timing,
             },
         ) catch |err| {
             logVerifierFailure(err);


### PR DESCRIPTION
Draft progress branch for WAMR #743 (optimized AOT compile of large
`jco`/StarlingMonkey-bundled components).

## Optimizer compile-time fixes (latest)

Profiling the optimized AOT compile of a 12,610-function component core
(`codegen-cli` core4) showed the IR optimizer was super-linear on a handful
of huge generated functions, so the **optimization phase never finished**
(timed out at `local_func=10,652/12,610` after ~20 min). Three independent
quadratic hotspots are now fixed:

| Pass | Quadratic cause | Fix | Worst single call |
|------|-----------------|-----|-------------------|
| `tailDuplicateSmallJoins` | full predecessor+successor rebuild after **every** absorption — O(joins·(blocks+edges)) | exact incremental predecessor update (`applyTailDupToPredecessors`) | **16,844 ms → 128 ms** |
| `foldBranchOnEqz` / `foldSignExtendingLoad` / `foldSelectOnEqz` | `countUsesOfVReg` full-function scan per candidate — O(candidates·insts) | one shared `buildVRegUseCounts` map, O(1) lookups | **3,522 ms → 72 ms** (82 s → sub-second on the largest fn) |
| `promoteLocalsToSSA` | SSA rename scanned all `nlocals` per phi (×2 sites) — O(phis·locals) | reverse `phi-dest → local` map; also removed a duplicate dead-code-strip loop | **72,348 ms → 4,400 ms** |

**Net effect:**
- Worst function (10,900 blocks / 874k insts after phi-lowering): **200 s → 58 s**.
- The optimization phase now **completes both module outer passes** over all
  12,610 functions (`Optimization: 153454 passes made changes`) — previously it
  could not finish even one pass within the timeout.
- All three transforms are **behavior-preserving** (rubber-duck reviewed; a new
  unit test asserts `buildVRegUseCounts == countUsesOfVReg` across all op kinds).

## Validation
- `zig fmt`, `zig build -Doptimize=ReleaseFast`, `zig build test --summary all`: all pass.

## Known remaining bottleneck (follow-up)
Past the now-fixed optimizer, **native codegen** (instruction-selection / register
allocation / emit) is the next long pole on these monster functions and did not
finish within a 60-min cap. Tracked separately.

Also includes the earlier #743 progress: load-forwarding alias-invalidation
fixes, `v128_store` invalidation coverage, epoch-split load-forwarding caches,
a CFG analysis cache, `--verify-ir=<mode>` support, pass/analysis timing
instrumentation, and tail-duplication guard knobs.
