### PR TITLE
compiler: make core4 optimized AOT compile finish (codegen liveness + optimizer scoping) (#778)

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -11,6 +11,8 @@ const schedule = @import("schedule.zig");
 const coalesce_post = @import("coalesce_post.zig");
 const range_split = @import("../../ir/range_split.zig");
 const codegen_cache = @import("../../codegen_cache.zig");
+const passes = @import("../../ir/passes.zig");
+const codegen_timing = @import("../timing.zig");
 
 /// Compile-time debug flag: when true, print per-function range-split
 /// stats to stderr. Flip via `zig build -Drange-split-debug=true` after
@@ -556,6 +558,13 @@ pub const CompileOptions = struct {
     /// follow-up. Disabling this option also disables the scan on the
     /// `coalesce_post.zig` unit tests via build.zig's test step.
     enable_post_emit_coalesce: bool = true,
+    /// #778: native-codegen timing diagnostics. aarch64 reports per-function
+    /// totals + a module summary (no x86_64-style setup/liveness/regalloc
+    /// sub-phase breakdown — the #778 bottleneck is the x86_64 host path).
+    codegen_timing: passes.CodegenTimingOptions = .{},
+    /// Component core/module index, used only to match the
+    /// `WAMR_AOT_CODEGEN_TIMING_MODULE` filter.
+    module_idx: u32 = 0,
 };
 
 /// Context threaded through per-function compilation for cross-function
@@ -8371,11 +8380,31 @@ pub fn compileModuleCachedWithOptions(
 
     var stats: codegen_cache.CacheStats = .{};
 
+    // #778: codegen timing (coarse — per-function totals + module summary).
+    const ct = options.codegen_timing;
+    const ct_live = ct.enabled and ct.moduleMatches(options.module_idx);
+    const module_start_ns: u64 = if (ct_live) codegen_timing.nowNs() else 0;
+    var mod_hash_ns: u64 = 0;
+    var mod_compile_ns: u64 = 0;
+    var mod_compiled: usize = 0;
+    var mod_reused: usize = 0;
+    codegen_timing.printModuleBegin(ct, options.module_idx, func_count);
+
     for (ir_module.functions.items, 0..) |func, fi| {
         const func_base: u32 = @intCast(all_code.items.len);
         try offsets.append(allocator, func_base);
 
-        const ir_sha = codegen_cache.hashFunction(&func);
+        var hash_ns: u64 = 0;
+        const ir_sha = blk: {
+            if (ct_live) {
+                const t0 = codegen_timing.nowNs();
+                const sha = codegen_cache.hashFunction(&func);
+                hash_ns = codegen_timing.nowNs() -| t0;
+                mod_hash_ns += hash_ns;
+                break :blk sha;
+            }
+            break :blk codegen_cache.hashFunction(&func);
+        };
 
         var reused = false;
         var hit_code: []const u8 = undefined;
@@ -8392,6 +8421,7 @@ pub fn compileModuleCachedWithOptions(
 
         var cache_code_owned: []u8 = undefined;
         var cache_patches_owned: []codegen_cache.FuncCallPatch = undefined;
+        var compile_ns: u64 = 0;
 
         if (reused) {
             cache_code_owned = try allocator.dupe(u8, hit_code);
@@ -8405,6 +8435,7 @@ pub fn compileModuleCachedWithOptions(
                 });
             }
             stats.reused += 1;
+            mod_reused += 1;
         } else {
             var func_patches: std.ArrayListUnmanaged(CallPatch) = .empty;
             defer func_patches.deinit(allocator);
@@ -8419,6 +8450,7 @@ pub fn compileModuleCachedWithOptions(
                 .options = options,
                 .allocator = allocator,
             };
+            const compile_t0: u64 = if (ct_live) codegen_timing.nowNs() else 0;
             const func_code = compileFunctionImpl(&func, ctx, allocator) catch |err| {
                 std.debug.print("Error compiling function {d} ({d} blocks, {d} vregs): {}\n", .{
                     fi,
@@ -8428,6 +8460,10 @@ pub fn compileModuleCachedWithOptions(
                 });
                 return err;
             };
+            if (ct_live) {
+                compile_ns = codegen_timing.nowNs() -| compile_t0;
+                mod_compile_ns += compile_ns;
+            }
 
             const new_patches = try allocator.alloc(codegen_cache.FuncCallPatch, func_patches.items.len);
             errdefer allocator.free(new_patches);
@@ -8448,6 +8484,21 @@ pub fn compileModuleCachedWithOptions(
             }
             try all_code.appendSlice(allocator, func_code);
             stats.recompiled += 1;
+            mod_compiled += 1;
+        }
+
+        if (ct_live and codegen_timing.shouldLogFunc(ct, options.module_idx, @intCast(fi), compile_ns)) {
+            // aarch64: sub-phase fields left 0 (no breakdown); emit_ms
+            // therefore equals total_ms in the line.
+            codegen_timing.printFunc(.{
+                .module_idx = options.module_idx,
+                .func_idx = @intCast(fi),
+                .blocks = func.blocks.items.len,
+                .insts = aarch64CountInstructions(&func),
+                .reused = reused,
+                .hash_ns = hash_ns,
+                .total_ns = compile_ns,
+            });
         }
 
         cache_funcs[fi] = .{
@@ -8460,6 +8511,7 @@ pub fn compileModuleCachedWithOptions(
 
     // Resolve BL patches — identical logic to
     // `compileModuleWithOptions` above.
+    const patch_t0: u64 = if (ct_live) codegen_timing.nowNs() else 0;
     for (global_call_patches.items) |p| {
         if (p.target_func_idx >= offsets.items.len) return error.BadFuncIndex;
         const target_off: i64 = @intCast(offsets.items[p.target_func_idx]);
@@ -8475,6 +8527,19 @@ pub fn compileModuleCachedWithOptions(
         const new_word: u32 = (existing & 0xFC000000) | imm26;
         std.mem.writeInt(u32, bytes, new_word, .little);
     }
+    if (ct_live) {
+        const now = codegen_timing.nowNs();
+        codegen_timing.printModuleSummary(ct, .{
+            .module_idx = options.module_idx,
+            .funcs = func_count,
+            .compiled = mod_compiled,
+            .reused = mod_reused,
+            .hash_ns = mod_hash_ns,
+            .compile_ns = mod_compile_ns,
+            .global_patch_ns = now -| patch_t0,
+            .total_ns = now -| module_start_ns,
+        });
+    }
 
     return .{
         .code = try all_code.toOwnedSlice(allocator),
@@ -8482,6 +8547,14 @@ pub fn compileModuleCachedWithOptions(
         .cache_functions = cache_funcs,
         .stats = stats,
     };
+}
+
+/// Sum of instructions across all blocks — reported in #778 codegen
+/// timing lines.
+fn aarch64CountInstructions(func: *const ir.IrFunction) usize {
+    var n: usize = 0;
+    for (func.blocks.items) |block| n += block.instructions.items.len;
+    return n;
 }
 
 // ── Register-Allocator Preparation ─────────────────────────────────────────

--- a/src/compiler/codegen/timing.zig
+++ b/src/compiler/codegen/timing.zig
@@ -1,0 +1,162 @@
+//! Shared native-codegen timing instrumentation (issue #778).
+//!
+//! Mirrors the optimizer's `WAMR_AOT_PASS_TIMING*` diagnostics for the
+//! native-codegen phase so a super-linear per-function cost (instruction
+//! selection / register allocation / emit) can be attributed without a
+//! profiler. Off unless the codegen timing options are enabled, which the
+//! `wamrc` driver parses from `WAMR_AOT_CODEGEN_TIMING*` via
+//! `passes.codegenTimingOptionsFromEnv`. Disabled is a hard no-op: the
+//! per-function backends only construct a `FuncTimer` when logging is live.
+//!
+//! Output is single-threaded stderr (`std.debug.print`); codegen runs one
+//! function at a time per module today, so per-phase wall-clock is
+//! meaningful and the lines do not interleave.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const passes = @import("../ir/passes.zig");
+
+pub const Options = passes.CodegenTimingOptions;
+
+const ns_per_ms: u64 = std.time.ns_per_ms;
+const ns_per_us: u64 = std.time.ns_per_us;
+
+/// Monotonic nanosecond clock. Mirrors `passes.passTimingNowNs` — this Zig
+/// build has no `std.time.Timer`, so timing uses `clock_gettime(MONOTONIC)`
+/// directly. Returns 0 if the platform clock is unavailable.
+pub fn nowNs() u64 {
+    return switch (comptime builtin.os.tag) {
+        .linux => blk: {
+            const linux = std.os.linux;
+            var ts: linux.timespec = undefined;
+            const rc = linux.clock_gettime(.MONOTONIC, &ts);
+            if (rc != 0) break :blk 0;
+            break :blk @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+        },
+        .macos, .ios, .tvos, .watchos, .visionos => blk: {
+            var ts: std.c.timespec = undefined;
+            if (std.c.clock_gettime(.MONOTONIC, &ts) != 0) break :blk 0;
+            break :blk @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+        },
+        .windows => blk: {
+            const ntdll = std.os.windows.ntdll;
+            var counter: std.os.windows.LARGE_INTEGER = undefined;
+            var freq: std.os.windows.LARGE_INTEGER = undefined;
+            _ = ntdll.RtlQueryPerformanceCounter(&counter);
+            _ = ntdll.RtlQueryPerformanceFrequency(&freq);
+            const ticks: u128 = @intCast(counter);
+            const hz: u128 = @intCast(freq);
+            break :blk @as(u64, @truncate(ticks * std.time.ns_per_s / hz));
+        },
+        else => 0,
+    };
+}
+
+/// Per-function sub-phase stopwatch threaded into the x86-64 per-function
+/// compile. Records the contiguous `setup` / `liveness` / `regalloc`
+/// spans; the caller derives `emit` (everything else, including the emit
+/// loop and patch finalisation) as `total - setup - liveness - regalloc`
+/// so the four buckets always partition the function's compile time.
+pub const Phase = enum { setup, liveness, regalloc };
+
+pub const FuncTimer = struct {
+    span_start: u64 = 0,
+    setup_ns: u64 = 0,
+    liveness_ns: u64 = 0,
+    regalloc_ns: u64 = 0,
+
+    pub fn start() FuncTimer {
+        return .{};
+    }
+
+    pub fn begin(self: *FuncTimer) void {
+        self.span_start = nowNs();
+    }
+
+    pub fn end(self: *FuncTimer, phase: Phase) void {
+        const dt = nowNs() -| self.span_start;
+        switch (phase) {
+            .setup => self.setup_ns += dt,
+            .liveness => self.liveness_ns += dt,
+            .regalloc => self.regalloc_ns += dt,
+        }
+    }
+};
+
+/// Decide whether a per-function line should be emitted. Gated at the
+/// function level (not per sub-phase) so a slow function always prints its
+/// full breakdown: matched `func_filter`, the every-N cadence, or the
+/// total exceeding the threshold all qualify.
+pub fn shouldLogFunc(opts: Options, module_idx: u32, func_idx: u32, total_ns: u64) bool {
+    if (!opts.enabled or !opts.moduleMatches(module_idx)) return false;
+    if (opts.func_filter) |f| {
+        if (f == func_idx) return true;
+    }
+    if (opts.every_n_functions != 0 and func_idx % opts.every_n_functions == 0) return true;
+    return total_ns >= opts.threshold_ns;
+}
+
+pub const FuncReport = struct {
+    module_idx: u32,
+    func_idx: u32,
+    blocks: usize,
+    insts: usize,
+    reused: bool,
+    hash_ns: u64,
+    /// Per-function compile call wall-clock (0 for cache reuse hits).
+    total_ns: u64,
+    setup_ns: u64 = 0,
+    liveness_ns: u64 = 0,
+    regalloc_ns: u64 = 0,
+};
+
+pub fn printFunc(r: FuncReport) void {
+    const emit_ns = r.total_ns -| r.setup_ns -| r.liveness_ns -| r.regalloc_ns;
+    std.debug.print(
+        "[aot-codegen-timing] local_func={d} mod={d} blocks={d} insts={d} reused={} " ++
+            "hash_ms={d}.{d:0>3} total_ms={d}.{d:0>3} setup_ms={d}.{d:0>3} " ++
+            "liveness_ms={d}.{d:0>3} regalloc_ms={d}.{d:0>3} emit_ms={d}.{d:0>3}\n",
+        .{
+            r.func_idx,            r.module_idx,              r.blocks,               r.insts,                   r.reused,
+            r.hash_ns / ns_per_ms, msFrac(r.hash_ns),         r.total_ns / ns_per_ms, msFrac(r.total_ns),        r.setup_ns / ns_per_ms,
+            msFrac(r.setup_ns),    r.liveness_ns / ns_per_ms, msFrac(r.liveness_ns),  r.regalloc_ns / ns_per_ms, msFrac(r.regalloc_ns),
+            emit_ns / ns_per_ms,   msFrac(emit_ns),
+        },
+    );
+}
+
+pub fn printModuleBegin(opts: Options, module_idx: u32, funcs: usize) void {
+    if (!opts.enabled or !opts.moduleMatches(module_idx)) return;
+    std.debug.print(
+        "[aot-codegen-timing] begin mod={d} funcs={d} threshold_ms={d} every_n_funcs={d}\n",
+        .{ module_idx, funcs, opts.threshold_ns / ns_per_ms, opts.every_n_functions },
+    );
+}
+
+pub const ModuleReport = struct {
+    module_idx: u32,
+    funcs: usize,
+    compiled: usize,
+    reused: usize,
+    hash_ns: u64,
+    compile_ns: u64,
+    global_patch_ns: u64,
+    total_ns: u64,
+};
+
+pub fn printModuleSummary(opts: Options, r: ModuleReport) void {
+    if (!opts.enabled or !opts.moduleMatches(r.module_idx)) return;
+    std.debug.print(
+        "[aot-codegen-timing] module-summary mod={d} funcs={d} compiled={d} reused={d} " ++
+            "hash_ms={d}.{d:0>3} compile_ms={d}.{d:0>3} global_patch_ms={d}.{d:0>3} total_ms={d}.{d:0>3}\n",
+        .{
+            r.module_idx,                  r.funcs,                   r.compiled,               r.reused,
+            r.hash_ns / ns_per_ms,         msFrac(r.hash_ns),         r.compile_ns / ns_per_ms, msFrac(r.compile_ns),
+            r.global_patch_ns / ns_per_ms, msFrac(r.global_patch_ns), r.total_ns / ns_per_ms,   msFrac(r.total_ns),
+        },
+    );
+}
+
+fn msFrac(ns: u64) u64 {
+    return (ns % ns_per_ms) / ns_per_us;
+}

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -11,6 +11,7 @@ const ir = @import("../../ir/ir.zig");
 const passes = @import("../../ir/passes.zig");
 const emit = @import("emit.zig");
 const codegen_cache = @import("../../codegen_cache.zig");
+const codegen_timing = @import("../timing.zig");
 
 // ── Comptime codegen-trace knobs ────────────────────────────────────────
 //
@@ -1599,6 +1600,26 @@ pub fn compileModuleCached(
     reuse: ?*const codegen_cache.Cache,
     allocator: std.mem.Allocator,
 ) !codegen_cache.CompileResultCached {
+    return compileModuleCachedWithOptions(ir_module, reuse, allocator, .{});
+}
+
+/// x86-64 codegen options. Currently only carries the issue-#778 codegen
+/// timing knobs; threaded through from `wamrc`'s `WAMR_AOT_CODEGEN_TIMING*`
+/// parsing so per-function / per-sub-phase costs can be attributed.
+pub const CompileOptions = struct {
+    codegen_timing: passes.CodegenTimingOptions = .{},
+    /// Component core/module index, used only to match the
+    /// `WAMR_AOT_CODEGEN_TIMING_MODULE` filter. Single-module
+    /// `wamrc compile` leaves it at 0.
+    module_idx: u32 = 0,
+};
+
+pub fn compileModuleCachedWithOptions(
+    ir_module: *const ir.IrModule,
+    reuse: ?*const codegen_cache.Cache,
+    allocator: std.mem.Allocator,
+    options: CompileOptions,
+) !codegen_cache.CompileResultCached {
     var all_code: std.ArrayList(u8) = .empty;
     errdefer all_code.deinit(allocator);
     var offsets: std.ArrayList(u32) = .empty;
@@ -1619,11 +1640,33 @@ pub fn compileModuleCached(
 
     var stats: codegen_cache.CacheStats = .{};
 
+    // #778: codegen timing. Off unless WAMR_AOT_CODEGEN_TIMING is set.
+    // Timing work is gated on `ct_live` so the disabled path pays nothing
+    // beyond the cheap option checks.
+    const ct = options.codegen_timing;
+    const ct_live = ct.enabled and ct.moduleMatches(options.module_idx);
+    const module_start_ns: u64 = if (ct_live) codegen_timing.nowNs() else 0;
+    var mod_hash_ns: u64 = 0;
+    var mod_compile_ns: u64 = 0;
+    var mod_compiled: usize = 0;
+    var mod_reused: usize = 0;
+    codegen_timing.printModuleBegin(ct, options.module_idx, func_count);
+
     for (ir_module.functions.items, 0..) |func, fi| {
         const func_start: u32 = @intCast(all_code.items.len);
         try offsets.append(allocator, func_start);
 
-        const ir_sha = codegen_cache.hashFunction(&func);
+        var hash_ns: u64 = 0;
+        const ir_sha = blk: {
+            if (ct_live) {
+                const t0 = codegen_timing.nowNs();
+                const sha = codegen_cache.hashFunction(&func);
+                hash_ns = codegen_timing.nowNs() -| t0;
+                mod_hash_ns += hash_ns;
+                break :blk sha;
+            }
+            break :blk codegen_cache.hashFunction(&func);
+        };
 
         // Cache lookup: by function position AND ir_sha256. Position
         // alone is unsafe because two same-shape modules could share
@@ -1648,6 +1691,9 @@ pub fn compileModuleCached(
         var cache_code_owned: []u8 = undefined;
         var cache_patches_owned: []codegen_cache.FuncCallPatch = undefined;
 
+        var compile_ns: u64 = 0;
+        var func_timer: ?codegen_timing.FuncTimer = null;
+
         if (reused) {
             // Dup so the new cache owns its own memory independent of
             // the `reuse` lifetime.
@@ -1662,13 +1708,21 @@ pub fn compileModuleCached(
                 });
             }
             stats.reused += 1;
+            mod_reused += 1;
         } else {
-            const result = try compileFunctionRAWithGlobalOffsets(
+            if (ct_live) func_timer = codegen_timing.FuncTimer.start();
+            const compile_t0: u64 = if (ct_live) codegen_timing.nowNs() else 0;
+            const result = try compileFunctionRAWithGlobalOffsetsTimed(
                 &func,
                 ir_module.import_count,
                 ir_module.global_offsets orelse &.{},
                 allocator,
+                if (func_timer) |*ft| ft else null,
             );
+            if (ct_live) {
+                compile_ns = codegen_timing.nowNs() -| compile_t0;
+                mod_compile_ns += compile_ns;
+            }
             // `result.code` and `result.call_patches` are owned here.
             // Convert internal CallPatch → public FuncCallPatch and
             // hand both to the cache slot.
@@ -1691,6 +1745,24 @@ pub fn compileModuleCached(
                 });
             }
             stats.recompiled += 1;
+            mod_compiled += 1;
+        }
+
+        if (ct_live) {
+            if (codegen_timing.shouldLogFunc(ct, options.module_idx, @intCast(fi), compile_ns)) {
+                codegen_timing.printFunc(.{
+                    .module_idx = options.module_idx,
+                    .func_idx = @intCast(fi),
+                    .blocks = func.blocks.items.len,
+                    .insts = countInstructions(&func),
+                    .reused = reused,
+                    .hash_ns = hash_ns,
+                    .total_ns = compile_ns,
+                    .setup_ns = if (func_timer) |ft| ft.setup_ns else 0,
+                    .liveness_ns = if (func_timer) |ft| ft.liveness_ns else 0,
+                    .regalloc_ns = if (func_timer) |ft| ft.regalloc_ns else 0,
+                });
+            }
         }
 
         cache_funcs[fi] = .{
@@ -1704,12 +1776,26 @@ pub fn compileModuleCached(
     // Inter-function PC-relative E8 patches — identical logic to
     // `compileModule` above so reused and fresh code share the same
     // resolution pass.
+    const patch_t0: u64 = if (ct_live) codegen_timing.nowNs() else 0;
     for (global_call_patches.items) |patch| {
         if (patch.target_func_idx < offsets.items.len) {
             const target_off = offsets.items[patch.target_func_idx];
             const rel: i32 = @intCast(@as(i64, @intCast(target_off)) - @as(i64, @intCast(patch.patch_offset + 4)));
             std.mem.writeInt(i32, all_code.items[patch.patch_offset..][0..4], rel, .little);
         }
+    }
+    if (ct_live) {
+        const now = codegen_timing.nowNs();
+        codegen_timing.printModuleSummary(ct, .{
+            .module_idx = options.module_idx,
+            .funcs = func_count,
+            .compiled = mod_compiled,
+            .reused = mod_reused,
+            .hash_ns = mod_hash_ns,
+            .compile_ns = mod_compile_ns,
+            .global_patch_ns = now -| patch_t0,
+            .total_ns = now -| module_start_ns,
+        });
     }
 
     return .{
@@ -1718,6 +1804,14 @@ pub fn compileModuleCached(
         .cache_functions = cache_funcs,
         .stats = stats,
     };
+}
+
+/// Sum of instructions across all blocks — reported in codegen timing
+/// lines so monster functions are easy to spot (#778).
+fn countInstructions(func: *const ir.IrFunction) usize {
+    var n: usize = 0;
+    for (func.blocks.items) |block| n += block.instructions.items.len;
+    return n;
 }
 
 pub const CompileResultCached = codegen_cache.CompileResultCached;
@@ -2055,7 +2149,23 @@ fn compileFunctionRAWithGlobalOffsets(
     global_offsets: []const u32,
     allocator: std.mem.Allocator,
 ) !FuncCompileResult {
+    return compileFunctionRAWithGlobalOffsetsTimed(func, import_count, global_offsets, allocator, null);
+}
+
+/// #778: same as `compileFunctionRAWithGlobalOffsets`, but records the
+/// contiguous setup / liveness / regalloc spans into `timer` when codegen
+/// timing is live. `timer == null` is the normal (untimed) path.
+fn compileFunctionRAWithGlobalOffsetsTimed(
+    func: *const ir.IrFunction,
+    import_count: u32,
+    global_offsets: []const u32,
+    allocator: std.mem.Allocator,
+    timer: ?*codegen_timing.FuncTimer,
+) !FuncCompileResult {
     if (functionUsesV128(func)) return error.UnsupportedV128;
+
+    // Setup span: block ordering + const-fold table + clobber/hint walk.
+    if (timer) |t| t.begin();
 
     // Compute block emission order ONCE, before anything that uses global
     // instruction numbering. Clobber points, live ranges, and code emission
@@ -2186,8 +2296,12 @@ fn compileFunctionRAWithGlobalOffsets(
     }
 
     // Compute live ranges using the SAME block_order, then allocate registers.
+    if (timer) |t| t.end(.setup);
+    if (timer) |t| t.begin();
     const live_ranges = try analysis.computeLiveRangesWithOrder(func, block_order, allocator);
     defer allocator.free(live_ranges);
+    if (timer) |t| t.end(.liveness);
+    if (timer) |t| t.begin();
     var alloc_result = try regalloc.allocateFromRangesWithHints(
         allocator,
         x86_64_reg_set(func.local_count),
@@ -2196,7 +2310,10 @@ fn compileFunctionRAWithGlobalOffsets(
         hint_points.items,
     );
     defer alloc_result.deinit();
-
+    if (timer) |t| t.end(.regalloc);
+    // Everything below (used-register scans + emit loop + branch/table/
+    // call patch resolution + toOwnedSlice) is attributed to the derived
+    // `emit` bucket (total − setup − liveness − regalloc).
     // Compute which caller-saved registers are actually used by this function.
     // Only these need to be saved/restored around call sites.
     var used_caller_saved: [caller_saved_alloc.len]bool = .{false} ** caller_saved_alloc.len;
@@ -5204,6 +5321,67 @@ test "compileModuleCached: no reuse produces same bytes as compileModule" {
     try std.testing.expectEqual(@as(u32, 0), cached.stats.reused);
     try std.testing.expectEqual(@as(u32, 2), cached.stats.recompiled);
     try std.testing.expectEqual(@as(usize, 2), cached.cache_functions.len);
+}
+
+test "compileModuleCachedWithOptions: codegen timing is non-invasive (byte-identical)" {
+    // #778: enabling WAMR_AOT_CODEGEN_TIMING must not perturb the emitted
+    // code. Compile the same module untimed and with timing enabled
+    // (threshold 0 → every function takes the logging branch) and require
+    // byte-identical code + offsets.
+    const allocator = std.testing.allocator;
+    var m_plain = try buildTwoFnAddModule(allocator);
+    defer m_plain.deinit();
+    var m_timed = try buildTwoFnAddModule(allocator);
+    defer m_timed.deinit();
+
+    const plain = try compileModuleCached(&m_plain, null, allocator);
+    defer allocator.free(plain.code);
+    defer allocator.free(plain.offsets);
+    defer freeCachedFuncs(allocator, plain.cache_functions);
+
+    const timed = try compileModuleCachedWithOptions(&m_timed, null, allocator, .{
+        .codegen_timing = .{ .enabled = true, .threshold_ns = 0 },
+    });
+    defer allocator.free(timed.code);
+    defer allocator.free(timed.offsets);
+    defer freeCachedFuncs(allocator, timed.cache_functions);
+
+    try std.testing.expectEqualSlices(u8, plain.code, timed.code);
+    try std.testing.expectEqualSlices(u32, plain.offsets, timed.offsets);
+    try std.testing.expectEqual(plain.stats.recompiled, timed.stats.recompiled);
+}
+
+test "codegen timing: shouldLogFunc gating and FuncTimer partition" {
+    const opts: passes.CodegenTimingOptions = .{
+        .enabled = true,
+        .threshold_ns = 100 * std.time.ns_per_ms,
+        .every_n_functions = 8,
+        .module_filter = 2,
+        .func_filter = 5,
+    };
+    // Disabled options never log.
+    try std.testing.expect(!codegen_timing.shouldLogFunc(.{}, 2, 5, std.math.maxInt(u64)));
+    // Wrong module is filtered out regardless of cost.
+    try std.testing.expect(!codegen_timing.shouldLogFunc(opts, 0, 5, std.math.maxInt(u64)));
+    // Matching func_filter logs even under threshold.
+    try std.testing.expect(codegen_timing.shouldLogFunc(opts, 2, 5, 0));
+    // every-N cadence logs (func 16 is a multiple of 8) under threshold.
+    try std.testing.expect(codegen_timing.shouldLogFunc(opts, 2, 16, 0));
+    // Otherwise gated on the threshold.
+    try std.testing.expect(!codegen_timing.shouldLogFunc(opts, 2, 3, 1));
+    try std.testing.expect(codegen_timing.shouldLogFunc(opts, 2, 3, 100 * std.time.ns_per_ms));
+
+    // FuncTimer accumulates the three named spans independently.
+    var ft = codegen_timing.FuncTimer.start();
+    try std.testing.expectEqual(@as(u64, 0), ft.setup_ns);
+    ft.begin();
+    ft.end(.setup);
+    // Recording `setup` must not touch the other two accumulators.
+    try std.testing.expectEqual(@as(u64, 0), ft.liveness_ns);
+    try std.testing.expectEqual(@as(u64, 0), ft.regalloc_ns);
+    ft.begin();
+    ft.end(.liveness);
+    try std.testing.expectEqual(@as(u64, 0), ft.regalloc_ns);
 }
 
 test "compileModuleCached: warm cache reuses every function (byte-identical)" {

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -331,12 +331,125 @@ pub fn computeLiveness(
         });
     }
 
-    // Fixed-point iteration
+    // Predecessors drive the worklist: when a block's live_in grows, its
+    // predecessors' live_out may grow, so they must be revisited.
+    var predecessors = try buildPredecessorsFromSuccessors(func, allocator, &successors);
+    defer {
+        var it = predecessors.iterator();
+        while (it.next()) |entry| allocator.free(entry.value_ptr.*);
+        predecessors.deinit();
+    }
+
+    // Worklist solver for the backward liveness dataflow. Converges to the
+    // same least fixpoint as a round-robin iterate-until-stable sweep, but
+    // only re-visits blocks whose successors changed instead of rescanning
+    // every block each round (issue #778: liveness dominated codegen on
+    // functions with thousands of blocks). `computeLivenessRoundRobin` is
+    // the reference implementation a differential test pins this to.
+    const nblocks = func.blocks.items.len;
+    var in_queue = try allocator.alloc(bool, nblocks);
+    defer allocator.free(in_queue);
+    @memset(in_queue, false);
+
+    var worklist: std.ArrayList(ir.BlockId) = .empty;
+    defer worklist.deinit(allocator);
+    // Seed every block, low index first; LIFO pop then visits high index
+    // first, matching the old reverse-index sweep's first pass.
+    for (0..nblocks) |seed| {
+        const bid: ir.BlockId = @intCast(seed);
+        try worklist.append(allocator, bid);
+        in_queue[bid] = true;
+    }
+
+    while (worklist.pop()) |bid| {
+        in_queue[bid] = false;
+        const block = &func.blocks.items[bid];
+        const bl = liveness.getPtr(bid).?;
+
+        // live_out ∪= live_in[succ]  (monotone accumulate)
+        if (successors.get(bid)) |succs| {
+            for (succs) |succ_id| {
+                if (liveness.getPtr(succ_id)) |succ_bl| {
+                    var sit = succ_bl.live_in.iterator();
+                    while (sit.next()) |entry| {
+                        _ = try bl.live_out.getOrPut(entry.key_ptr.*);
+                    }
+                }
+            }
+        }
+
+        // live_in = use[B] ∪ (live_out[B] - def[B]) — recomputed by the same
+        // backward instruction walk the reference uses, so the per-block
+        // transfer function (and therefore the fixpoint) is identical.
+        var live = std.AutoHashMap(ir.VReg, void).init(allocator);
+        defer live.deinit();
+        var lit = bl.live_out.iterator();
+        while (lit.next()) |entry| try live.put(entry.key_ptr.*, {});
+
+        var inst_idx: usize = block.instructions.items.len;
+        while (inst_idx > 0) {
+            inst_idx -= 1;
+            const inst = block.instructions.items[inst_idx];
+            if (inst.dest) |dest| _ = live.remove(dest);
+            if (inst.op == .parallel_copy) {
+                for (inst.op.parallel_copy) |p| _ = live.remove(p.dst);
+            }
+            addInstUses(&live, inst);
+        }
+
+        // Merge into live_in; if it grew, revisit predecessors so their
+        // live_out picks up the new entries.
+        var grew = false;
+        var wit = live.iterator();
+        while (wit.next()) |entry| {
+            const result = try bl.live_in.getOrPut(entry.key_ptr.*);
+            if (!result.found_existing) {
+                result.value_ptr.* = {};
+                grew = true;
+            }
+        }
+        if (grew) {
+            if (predecessors.get(bid)) |preds| {
+                for (preds) |p| {
+                    if (!in_queue[p]) {
+                        in_queue[p] = true;
+                        try worklist.append(allocator, p);
+                    }
+                }
+            }
+        }
+    }
+
+    return liveness;
+}
+
+/// Reference round-robin liveness solver retained as the differential
+/// oracle for `computeLiveness` (the worklist version). Both compute the
+/// same least fixpoint of the backward liveness dataflow; this one simply
+/// sweeps every block in reverse index order until a full pass makes no
+/// change. Used by tests only — do not call from codegen.
+fn computeLivenessRoundRobin(
+    func: *const ir.IrFunction,
+    allocator: std.mem.Allocator,
+) !std.AutoHashMap(ir.BlockId, BlockLiveness) {
+    const successors = try buildSuccessors(func, allocator);
+    defer {
+        var it = successors.iterator();
+        while (it.next()) |entry| allocator.free(entry.value_ptr.*);
+        @constCast(&successors).deinit();
+    }
+
+    var liveness = std.AutoHashMap(ir.BlockId, BlockLiveness).init(allocator);
+    for (0..func.blocks.items.len) |idx| {
+        try liveness.put(@intCast(idx), .{
+            .live_in = std.AutoHashMap(ir.VReg, void).init(allocator),
+            .live_out = std.AutoHashMap(ir.VReg, void).init(allocator),
+        });
+    }
+
     var changed = true;
     while (changed) {
         changed = false;
-
-        // Process blocks in reverse order
         var block_idx: usize = func.blocks.items.len;
         while (block_idx > 0) {
             block_idx -= 1;
@@ -344,7 +457,6 @@ pub fn computeLiveness(
             const block = &func.blocks.items[block_idx];
             const bl = liveness.getPtr(bid).?;
 
-            // live_out = ∪ live_in[succ]
             if (successors.get(bid)) |succs| {
                 for (succs) |succ_id| {
                     if (liveness.getPtr(succ_id)) |succ_bl| {
@@ -360,29 +472,22 @@ pub fn computeLiveness(
                 }
             }
 
-            // live_in = use[B] ∪ (live_out[B] - def[B])
-            // Start with live_out, remove defs, add uses (backward through instructions)
             var live = std.AutoHashMap(ir.VReg, void).init(allocator);
             defer live.deinit();
-            // Copy live_out into working set
             var lit = bl.live_out.iterator();
             while (lit.next()) |entry| try live.put(entry.key_ptr.*, {});
 
-            // Walk instructions backward
             var inst_idx: usize = block.instructions.items.len;
             while (inst_idx > 0) {
                 inst_idx -= 1;
                 const inst = block.instructions.items[inst_idx];
-                // Remove def
                 if (inst.dest) |dest| _ = live.remove(dest);
                 if (inst.op == .parallel_copy) {
                     for (inst.op.parallel_copy) |p| _ = live.remove(p.dst);
                 }
-                // Add uses
                 addInstUses(&live, inst);
             }
 
-            // Update live_in if changed
             var wit = live.iterator();
             while (wit.next()) |entry| {
                 const result = try bl.live_in.getOrPut(entry.key_ptr.*);
@@ -2337,6 +2442,152 @@ test "computeLiveness: cross-block value is live" {
 
     // Block 0 should have nothing live_in (entry block)
     try std.testing.expectEqual(@as(u32, 0), liveness.get(b0).?.live_in.count());
+}
+
+fn expectLivenessEqual(
+    reference: *std.AutoHashMap(ir.BlockId, BlockLiveness),
+    actual: *std.AutoHashMap(ir.BlockId, BlockLiveness),
+) !void {
+    try std.testing.expectEqual(reference.count(), actual.count());
+    var it = reference.iterator();
+    while (it.next()) |entry| {
+        const bid = entry.key_ptr.*;
+        const ref_bl = entry.value_ptr.*;
+        const act_bl = actual.get(bid) orelse return error.MissingBlock;
+        try std.testing.expectEqual(ref_bl.live_in.count(), act_bl.live_in.count());
+        try std.testing.expectEqual(ref_bl.live_out.count(), act_bl.live_out.count());
+        var iit = ref_bl.live_in.iterator();
+        while (iit.next()) |e| try std.testing.expect(act_bl.live_in.contains(e.key_ptr.*));
+        var oit = ref_bl.live_out.iterator();
+        while (oit.next()) |e| try std.testing.expect(act_bl.live_out.contains(e.key_ptr.*));
+    }
+}
+
+fn freeLiveness(liveness: *std.AutoHashMap(ir.BlockId, BlockLiveness)) void {
+    var it = liveness.iterator();
+    while (it.next()) |entry| {
+        entry.value_ptr.live_in.deinit();
+        entry.value_ptr.live_out.deinit();
+    }
+    liveness.deinit();
+}
+
+test "computeLiveness: worklist matches round-robin reference across CFG shapes" {
+    const allocator = std.testing.allocator;
+
+    // Each builder constructs a distinct CFG that stresses backward
+    // liveness propagation: a diamond merge, a natural loop with a value
+    // live across the backedge, a nested loop, and a long chain. The
+    // worklist solver must agree with the reference round-robin solver on
+    // live_in / live_out for every block.
+    const builders = [_]*const fn (std.mem.Allocator) anyerror!ir.IrFunction{
+        &buildDiamondLivenessFunc,
+        &buildLoopLivenessFunc,
+        &buildNestedLoopLivenessFunc,
+        &buildChainLivenessFunc,
+    };
+
+    for (builders) |build| {
+        var func = try build(allocator);
+        defer func.deinit();
+
+        var reference = try computeLivenessRoundRobin(&func, allocator);
+        defer freeLiveness(&reference);
+        var actual = try computeLiveness(&func, allocator);
+        defer freeLiveness(&actual);
+
+        try expectLivenessEqual(&reference, &actual);
+    }
+}
+
+fn buildDiamondLivenessFunc(allocator: std.mem.Allocator) !ir.IrFunction {
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    errdefer func.deinit();
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const a = func.newVReg();
+    const c = func.newVReg();
+    const cond = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = a });
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 2 }, .dest = c });
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 0 }, .dest = cond });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = b1, .else_block = b2 } } });
+    const t1 = func.newVReg();
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = a, .rhs = c } }, .dest = t1 });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b3 } });
+    const t2 = func.newVReg();
+    try func.getBlock(b2).append(.{ .op = .{ .sub = .{ .lhs = a, .rhs = c } }, .dest = t2 });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = a } });
+    return func;
+}
+
+fn buildLoopLivenessFunc(allocator: std.mem.Allocator) !ir.IrFunction {
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    errdefer func.deinit();
+    const entry = try func.newBlock();
+    const header = try func.newBlock();
+    const body = try func.newBlock();
+    const exit = try func.newBlock();
+    const acc = func.newVReg();
+    const cond = func.newVReg();
+    // acc defined in entry, used in body and exit (live across the loop).
+    try func.getBlock(entry).append(.{ .op = .{ .iconst_32 = 10 }, .dest = acc });
+    try func.getBlock(entry).append(.{ .op = .{ .br = header } });
+    try func.getBlock(header).append(.{ .op = .{ .iconst_32 = 1 }, .dest = cond });
+    try func.getBlock(header).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = body, .else_block = exit } } });
+    const t = func.newVReg();
+    try func.getBlock(body).append(.{ .op = .{ .add = .{ .lhs = acc, .rhs = acc } }, .dest = t });
+    try func.getBlock(body).append(.{ .op = .{ .br = header } }); // backedge
+    try func.getBlock(exit).append(.{ .op = .{ .ret = acc } });
+    return func;
+}
+
+fn buildNestedLoopLivenessFunc(allocator: std.mem.Allocator) !ir.IrFunction {
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    errdefer func.deinit();
+    const entry = try func.newBlock();
+    const outer = try func.newBlock();
+    const inner = try func.newBlock();
+    const inner_body = try func.newBlock();
+    const outer_tail = try func.newBlock();
+    const exit = try func.newBlock();
+    const base = func.newVReg();
+    const c1 = func.newVReg();
+    const c2 = func.newVReg();
+    try func.getBlock(entry).append(.{ .op = .{ .iconst_32 = 7 }, .dest = base });
+    try func.getBlock(entry).append(.{ .op = .{ .br = outer } });
+    try func.getBlock(outer).append(.{ .op = .{ .iconst_32 = 1 }, .dest = c1 });
+    try func.getBlock(outer).append(.{ .op = .{ .br_if = .{ .cond = c1, .then_block = inner, .else_block = exit } } });
+    try func.getBlock(inner).append(.{ .op = .{ .iconst_32 = 1 }, .dest = c2 });
+    try func.getBlock(inner).append(.{ .op = .{ .br_if = .{ .cond = c2, .then_block = inner_body, .else_block = outer_tail } } });
+    const t = func.newVReg();
+    try func.getBlock(inner_body).append(.{ .op = .{ .add = .{ .lhs = base, .rhs = base } }, .dest = t });
+    try func.getBlock(inner_body).append(.{ .op = .{ .br = inner } }); // inner backedge
+    try func.getBlock(outer_tail).append(.{ .op = .{ .br = outer } }); // outer backedge
+    try func.getBlock(exit).append(.{ .op = .{ .ret = base } });
+    return func;
+}
+
+fn buildChainLivenessFunc(allocator: std.mem.Allocator) !ir.IrFunction {
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    errdefer func.deinit();
+    const v = func.newVReg();
+    var prev = try func.newBlock();
+    try func.getBlock(prev).append(.{ .op = .{ .iconst_32 = 3 }, .dest = v });
+    // Long chain so the value is live across many blocks — the case where
+    // reverse-index round-robin needs several sweeps but the worklist
+    // converges directly. Both must agree.
+    var i: u32 = 0;
+    while (i < 12) : (i += 1) {
+        const next = try func.newBlock();
+        try func.getBlock(prev).append(.{ .op = .{ .br = next } });
+        prev = next;
+    }
+    try func.getBlock(prev).append(.{ .op = .{ .ret = v } });
+    return func;
 }
 
 test "buildSuccessors: loop backedge" {

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -258,6 +258,48 @@ pub fn cloneBlockIdMap(
     return result;
 }
 
+fn consumeCachedSuccessor(cached: []const ir.BlockId, index: *usize, target: ir.BlockId) bool {
+    if (index.* >= cached.len or cached[index.*] != target) return false;
+    index.* += 1;
+    return true;
+}
+
+fn cachedBlockSuccessorsMatch(block: *const ir.BasicBlock, cached: []const ir.BlockId) bool {
+    var index: usize = 0;
+    for (block.instructions.items) |inst| {
+        switch (inst.op) {
+            .br => |target| {
+                if (!consumeCachedSuccessor(cached, &index, target)) return false;
+            },
+            .br_if => |bi| {
+                if (!consumeCachedSuccessor(cached, &index, bi.then_block)) return false;
+                if (!consumeCachedSuccessor(cached, &index, bi.else_block)) return false;
+            },
+            .br_table => |bt| {
+                for (bt.targets) |target| {
+                    if (!consumeCachedSuccessor(cached, &index, target)) return false;
+                }
+                if (!consumeCachedSuccessor(cached, &index, bt.default)) return false;
+            },
+            else => {},
+        }
+    }
+    return index == cached.len;
+}
+
+fn cachedSuccessorsStillMatch(
+    func: *const ir.IrFunction,
+    successors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+) bool {
+    if (@as(usize, @intCast(successors.count())) != func.blocks.items.len) return false;
+    for (0..func.blocks.items.len) |idx| {
+        const bid: ir.BlockId = @intCast(idx);
+        const cached = successors.get(bid) orelse return false;
+        if (!cachedBlockSuccessorsMatch(&func.blocks.items[idx], cached)) return false;
+    }
+    return true;
+}
+
 // ── Liveness analysis ───────────────────────────────────────────────────
 
 /// Per-block liveness sets.
@@ -1334,6 +1376,8 @@ pub fn cloneDomTree(source: *const DomTree, allocator: std.mem.Allocator) !DomTr
 
 pub const CfgAnalysisCache = struct {
     allocator: std.mem.Allocator,
+    cached_func: ?*const ir.IrFunction = null,
+    dirty: bool = false,
     successors: ?std.AutoHashMap(ir.BlockId, []const ir.BlockId) = null,
     predecessors: ?std.AutoHashMap(ir.BlockId, []const ir.BlockId) = null,
     dominators: ?DomTree = null,
@@ -1343,10 +1387,10 @@ pub const CfgAnalysisCache = struct {
     }
 
     pub fn deinit(self: *CfgAnalysisCache) void {
-        self.invalidate();
+        self.clear();
     }
 
-    pub fn invalidate(self: *CfgAnalysisCache) void {
+    fn clear(self: *CfgAnalysisCache) void {
         if (self.dominators) |*dom| {
             dom.deinit();
             self.dominators = null;
@@ -1359,14 +1403,45 @@ pub const CfgAnalysisCache = struct {
             freeBlockIdMap(succs, self.allocator);
             self.successors = null;
         }
+        self.cached_func = null;
+        self.dirty = false;
+    }
+
+    /// Mark cached CFG analyses as potentially stale. The next lookup compares
+    /// the cached successor lists to the current function and reuses the
+    /// analyses only when the block set and branch edges are unchanged.
+    pub fn invalidate(self: *CfgAnalysisCache) void {
+        if (self.successors != null or self.predecessors != null or self.dominators != null) {
+            self.dirty = true;
+        }
+    }
+
+    fn ensureFresh(self: *CfgAnalysisCache, func: *const ir.IrFunction) void {
+        if (self.cached_func) |cached| {
+            if (cached != func) {
+                self.clear();
+                return;
+            }
+        }
+        if (!self.dirty) return;
+        if (self.successors) |*succs| {
+            if (cachedSuccessorsStillMatch(func, succs)) {
+                self.dirty = false;
+                return;
+            }
+        }
+        self.clear();
     }
 
     pub fn getSuccessors(
         self: *CfgAnalysisCache,
         func: *const ir.IrFunction,
     ) !*const std.AutoHashMap(ir.BlockId, []const ir.BlockId) {
+        self.ensureFresh(func);
         if (self.successors == null) {
             self.successors = try buildSuccessorsFresh(func, self.allocator);
+            self.cached_func = func;
+            self.dirty = false;
         }
         return &self.successors.?;
     }
@@ -1375,6 +1450,7 @@ pub const CfgAnalysisCache = struct {
         self: *CfgAnalysisCache,
         func: *const ir.IrFunction,
     ) !*const std.AutoHashMap(ir.BlockId, []const ir.BlockId) {
+        self.ensureFresh(func);
         if (self.predecessors == null) {
             const successors = try self.getSuccessors(func);
             self.predecessors = try buildPredecessorsFromSuccessors(func, self.allocator, successors);
@@ -1386,6 +1462,7 @@ pub const CfgAnalysisCache = struct {
         self: *CfgAnalysisCache,
         func: *const ir.IrFunction,
     ) !*const DomTree {
+        self.ensureFresh(func);
         if (self.dominators == null) {
             const timing = beginTiming(.compute_dominators);
             defer timing.finish(func);
@@ -2320,6 +2397,15 @@ test "buildPredecessors: diamond" {
     try std.testing.expectEqual(@as(usize, 2), preds.get(b3).?.len);
 }
 
+fn expectDomTreeEqual(expected: *const DomTree, actual: *const DomTree) !void {
+    try std.testing.expectEqual(expected.idom.len, actual.idom.len);
+    for (expected.idom, actual.idom) |e, a| try std.testing.expectEqual(e, a);
+    try std.testing.expectEqual(expected.post_num.len, actual.post_num.len);
+    for (expected.post_num, actual.post_num) |e, a| try std.testing.expectEqual(e, a);
+    try std.testing.expectEqual(expected.post_order.len, actual.post_order.len);
+    for (expected.post_order, actual.post_order) |e, a| try std.testing.expectEqual(e, a);
+}
+
 test "CfgAnalysisCache: predecessor cache deduplicates repeated br_table targets" {
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 0, 0);
@@ -2340,6 +2426,45 @@ test "CfgAnalysisCache: predecessor cache deduplicates repeated br_table targets
     const preds = try cache.getPredecessors(&func);
     try std.testing.expectEqual(@as(usize, 1), preds.get(b1).?.len);
     try std.testing.expectEqual(b0, preds.get(b1).?[0]);
+}
+
+test "CfgAnalysisCache: invalidate keeps dominators after non-CFG edit" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+    const b3 = try func.newBlock();
+    const cond = func.newVReg();
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = cond });
+    try func.getBlock(b0).append(.{ .op = .{ .br_if = .{ .cond = cond, .then_block = b1, .else_block = b2 } } });
+    try func.getBlock(b1).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b2).append(.{ .op = .{ .br = b3 } });
+    try func.getBlock(b3).append(.{ .op = .{ .ret = null } });
+
+    var cache = CfgAnalysisCache.init(allocator);
+    defer cache.deinit();
+
+    const dom_before = try cache.getDominators(&func);
+    const idom_ptr = dom_before.idom.ptr;
+    const post_num_ptr = dom_before.post_num.ptr;
+    const post_order_ptr = dom_before.post_order.ptr;
+
+    func.getBlock(b0).instructions.items[0].op = .{ .iconst_32 = 7 };
+    cache.invalidate();
+    try std.testing.expect(cache.dirty);
+
+    const dom_after = try cache.getDominators(&func);
+    try std.testing.expect(!cache.dirty);
+    try std.testing.expect(idom_ptr == dom_after.idom.ptr);
+    try std.testing.expect(post_num_ptr == dom_after.post_num.ptr);
+    try std.testing.expect(post_order_ptr == dom_after.post_order.ptr);
+
+    var fresh = try computeDominators(&func, allocator);
+    defer fresh.deinit();
+    try expectDomTreeEqual(&fresh, dom_after);
 }
 
 test "CfgAnalysisCache: invalidate refreshes dominators after branch retarget" {
@@ -2366,9 +2491,15 @@ test "CfgAnalysisCache: invalidate refreshes dominators after branch retarget" {
 
     func.getBlock(b0).instructions.items[1].op.br_if.else_block = b1;
     cache.invalidate();
+    try std.testing.expect(cache.dirty);
 
     const dom_after = try cache.getDominators(&func);
+    try std.testing.expect(!cache.dirty);
     try std.testing.expectEqual(@as(?ir.BlockId, b1), dom_after.idom[b3]);
+
+    var fresh = try computeDominators(&func, allocator);
+    defer fresh.deinit();
+    try expectDomTreeEqual(&fresh, dom_after);
 }
 
 test "computeDominators: linear chain" {

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -3149,6 +3149,46 @@ pub fn tailDuplicationOptionsFromEnv(env: *const std.process.Environ.Map) TailDu
     return out;
 }
 
+/// Stderr timing/progress diagnostics for the native-codegen phase
+/// (instruction selection / register allocation / emit). Mirrors
+/// `PassTimingOptions`; the codegen backends consume it via
+/// `src/compiler/codegen/timing.zig`. Off by default; `wamrc` populates
+/// it from `WAMR_AOT_CODEGEN_TIMING*` environment variables (issue #778).
+pub const CodegenTimingOptions = struct {
+    enabled: bool = false,
+    threshold_ns: u64 = 100 * std.time.ns_per_ms,
+    every_n_functions: u32 = 0,
+    module_filter: ?u32 = null,
+    func_filter: ?u32 = null,
+
+    pub fn moduleMatches(self: CodegenTimingOptions, module_idx: u32) bool {
+        return self.module_filter == null or self.module_filter.? == module_idx;
+    }
+};
+
+/// Parse env-gated codegen timing diagnostics. `WAMR_AOT_CODEGEN_TIMING=1`
+/// enables logging; `0`, `false`, `no`, `off`, or an empty value keep it
+/// disabled. Optional knobs (mirror `WAMR_AOT_PASS_TIMING*`):
+///
+///   - `WAMR_AOT_CODEGEN_TIMING_THRESHOLD_MS` (default: 100)
+///   - `WAMR_AOT_CODEGEN_TIMING_EVERY_N_FUNCS` (function progress cadence)
+///   - `WAMR_AOT_CODEGEN_TIMING_MODULE` (component core/module index)
+///   - `WAMR_AOT_CODEGEN_TIMING_FUNC` (local IR function index)
+pub fn codegenTimingOptionsFromEnv(env: *const std.process.Environ.Map) CodegenTimingOptions {
+    const gate = env.get("WAMR_AOT_CODEGEN_TIMING") orelse return .{};
+    if (!envFlagEnabled(gate)) return .{};
+
+    var out = CodegenTimingOptions{ .enabled = true };
+    if (parseEnvU64(env, "WAMR_AOT_CODEGEN_TIMING_THRESHOLD_MS")) |ms| {
+        const max_ms = std.math.maxInt(u64) / std.time.ns_per_ms;
+        out.threshold_ns = if (ms > max_ms) std.math.maxInt(u64) else ms * std.time.ns_per_ms;
+    }
+    if (parseEnvU32(env, "WAMR_AOT_CODEGEN_TIMING_EVERY_N_FUNCS")) |n| out.every_n_functions = n;
+    if (parseEnvU32(env, "WAMR_AOT_CODEGEN_TIMING_MODULE")) |m| out.module_filter = m;
+    if (parseEnvU32(env, "WAMR_AOT_CODEGEN_TIMING_FUNC")) |f| out.func_filter = f;
+    return out;
+}
+
 fn envFlagEnabled(value: []const u8) bool {
     return value.len != 0 and
         !std.mem.eql(u8, value, "0") and
@@ -14842,6 +14882,43 @@ test "tailDuplicationOptionsFromEnv parses skip caps and logging" {
     try std.testing.expectEqual(@as(usize, 123), opts.max_blocks);
     try std.testing.expectEqual(@as(usize, 456), opts.max_instructions);
     try std.testing.expectEqual(@as(usize, 789), opts.max_work);
+}
+
+test "codegenTimingOptionsFromEnv: disabled unless gate set" {
+    const allocator = std.testing.allocator;
+    var env = std.process.Environ.Map.init(allocator);
+    defer env.deinit();
+
+    // No gate → disabled, even with knobs present.
+    try env.put("WAMR_AOT_CODEGEN_TIMING_THRESHOLD_MS", "5");
+    try std.testing.expect(!codegenTimingOptionsFromEnv(&env).enabled);
+
+    // Falsey gate values keep it disabled.
+    try env.put("WAMR_AOT_CODEGEN_TIMING", "off");
+    try std.testing.expect(!codegenTimingOptionsFromEnv(&env).enabled);
+}
+
+test "codegenTimingOptionsFromEnv: parses gate, threshold, cadence, and filters" {
+    const allocator = std.testing.allocator;
+    var env = std.process.Environ.Map.init(allocator);
+    defer env.deinit();
+
+    try env.put("WAMR_AOT_CODEGEN_TIMING", "1");
+    try env.put("WAMR_AOT_CODEGEN_TIMING_THRESHOLD_MS", "250");
+    try env.put("WAMR_AOT_CODEGEN_TIMING_EVERY_N_FUNCS", "64");
+    try env.put("WAMR_AOT_CODEGEN_TIMING_MODULE", "4");
+    try env.put("WAMR_AOT_CODEGEN_TIMING_FUNC", "11396");
+
+    const opts = codegenTimingOptionsFromEnv(&env);
+    try std.testing.expect(opts.enabled);
+    try std.testing.expectEqual(@as(u64, 250 * std.time.ns_per_ms), opts.threshold_ns);
+    try std.testing.expectEqual(@as(u32, 64), opts.every_n_functions);
+    try std.testing.expectEqual(@as(?u32, 4), opts.module_filter);
+    try std.testing.expectEqual(@as(?u32, 11396), opts.func_filter);
+
+    // Module filter matching.
+    try std.testing.expect(opts.moduleMatches(4));
+    try std.testing.expect(!opts.moduleMatches(0));
 }
 
 test "tailDuplicateSmallJoins: triple predecessor with br terminator — all three duplicated" {

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -6332,14 +6332,19 @@ fn shiftBlockIdsInInst(inst: *ir.Inst, offset: ir.BlockId) void {
 /// result, its (single) `ret` value is translated through local renames
 /// (to cover the `local.get; ret` identity case) and the call's dest is
 /// rewritten to it.
-fn inlineSmallFunctionsCount(module: *ir.IrModule, allocator: std.mem.Allocator) !u32 {
+fn inlineSmallFunctionsCount(
+    module: *ir.IrModule,
+    allocator: std.mem.Allocator,
+    inlined_callers: ?*std.DynamicBitSet,
+) !u32 {
+    if (inlined_callers) |dirty| std.debug.assert(dirty.capacity() == module.functions.items.len);
+
     var eligible = try allocator.alloc(bool, module.functions.items.len);
     defer allocator.free(eligible);
     for (module.functions.items, 0..) |*f, i| eligible[i] = isInlinable(f, inline_small_max_insts, inline_small_max_blocks);
 
-    var caller_changed = try allocator.alloc(bool, module.functions.items.len);
-    defer allocator.free(caller_changed);
-    @memset(caller_changed, false);
+    var caller_changed = try std.DynamicBitSet.initEmpty(allocator, module.functions.items.len);
+    defer caller_changed.deinit();
 
     var inlined_count: u32 = 0;
     for (module.functions.items, 0..) |*caller, caller_idx| {
@@ -6569,7 +6574,8 @@ fn inlineSmallFunctionsCount(module: *ir.IrModule, allocator: std.mem.Allocator)
             // can no longer free its args slice; release it here.
             if (call_args.len > 0) caller.allocator.free(call_args);
 
-            caller_changed[caller_idx] = true;
+            caller_changed.set(caller_idx);
+            if (inlined_callers) |dirty| dirty.set(caller_idx);
             inlined_count += 1;
         }
     }
@@ -6582,13 +6588,13 @@ fn inlineSmallFunctionsCount(module: *ir.IrModule, allocator: std.mem.Allocator)
     // touched so the IR verifier (check 6, `MissingPredecessor` /
     // `StalePredecessor`) sees a consistent view. See issue #630.
     for (module.functions.items, 0..) |*f, i| {
-        if (caller_changed[i]) try analysis.refreshBlockPredecessors(f, allocator);
+        if (caller_changed.isSet(i)) try analysis.refreshBlockPredecessors(f, allocator);
     }
     return inlined_count;
 }
 
 pub fn inlineSmallFunctions(module: *ir.IrModule, allocator: std.mem.Allocator) !bool {
-    return (try inlineSmallFunctionsCount(module, allocator)) != 0;
+    return (try inlineSmallFunctionsCount(module, allocator, null)) != 0;
 }
 
 // ── SSA Promotion (mem2reg) ─────────────────────────────────────────────
@@ -7808,6 +7814,16 @@ pub fn runPassesWithOptions(
     allocator: std.mem.Allocator,
     opts: RunOptions,
 ) !u32 {
+    return runPassesWithOptionsScoped(module, passes, allocator, opts, true);
+}
+
+fn runPassesWithOptionsScoped(
+    module: *ir.IrModule,
+    passes: []const PassFn,
+    allocator: std.mem.Allocator,
+    opts: RunOptions,
+    scope_outer_after_inlining: bool,
+) !u32 {
     var total_changes: u32 = 0;
     const previous_analysis_timing = analysis.setTimingOptions(opts.analysis_timing);
     defer _ = analysis.setTimingOptions(previous_analysis_timing);
@@ -7888,8 +7904,13 @@ pub fn runPassesWithOptions(
             },
         );
     }
+    var inlined_callers = try std.DynamicBitSet.initEmpty(allocator, module.functions.items.len);
+    defer inlined_callers.deinit();
+
     var outer_iter: u32 = 0;
     while (outer_iter < outer_max) : (outer_iter += 1) {
+        inlined_callers.setRangeValue(.{ .start = 0, .end = module.functions.items.len }, false);
+
         // Module-level: inline small leaf callees. Iterate to fixpoint so
         // callers of callers also benefit within a single outer round.
         var inline_iter: u32 = 0;
@@ -7903,7 +7924,7 @@ pub fn runPassesWithOptions(
                         .pass_name = "inlineSmallFunctions",
                     });
                     defer timing_context.deinit();
-                    break :blk try inlineSmallFunctionsCount(module, allocator);
+                    break :blk try inlineSmallFunctionsCount(module, allocator, &inlined_callers);
                 };
                 if (iter_inlined == 0) break;
                 inlined_count += iter_inlined;
@@ -7947,6 +7968,13 @@ pub fn runPassesWithOptions(
 
         for (module.functions.items, 0..) |*func, func_idx_usize| {
             const func_idx: u32 = @intCast(func_idx_usize);
+            if (scope_outer_after_inlining and outer_iter >= 1 and !inlined_callers.isSet(func_idx_usize)) {
+                // The outer >0 per-function round exists only to clean up IR
+                // exposed by inlining in this same outer round. Inlining mutates
+                // caller bodies only; callees used as inline sources and unrelated
+                // functions have no new per-function opportunities to settle.
+                continue;
+            }
             const timing_for_func = timing.functionMatches(opts.module_idx, func_idx);
             const function_start_ns = if (timing_for_func) passTimingNowNs() else 0;
             const function_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};
@@ -12451,6 +12479,120 @@ test "runPasses: non-matching mod filter preserves second inlining round" {
             try std.testing.expect(inst.op != .call);
         }
     }
+}
+
+fn outerScopeBuildDelayedInlineModule(allocator: std.mem.Allocator) !ir.IrModule {
+    var module = ir.IrModule.init(allocator);
+    errdefer module.deinit();
+
+    // f0 starts too large (and with two returns) to inline. The first
+    // per-function round folds its constant branch and scrubs the now-dead
+    // large block, making f0 eligible for the second outer inlining round.
+    try module.functions.append(allocator, ir.IrFunction.init(allocator, 0, 1, 0));
+    {
+        const f = &module.functions.items[0];
+        const entry = try f.newBlock();
+        const dead = try f.newBlock();
+        const done = try f.newBlock();
+
+        const v_cond = f.newVReg();
+        try f.getBlock(entry).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v_cond, .type = .i32 });
+        try f.getBlock(entry).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = dead, .else_block = done } } });
+
+        var i: u32 = 0;
+        while (i < inline_small_max_insts) : (i += 1) {
+            const v_pad = f.newVReg();
+            try f.getBlock(dead).append(.{ .op = .{ .iconst_32 = @intCast(i) }, .dest = v_pad, .type = .i32 });
+        }
+        const v_dead = f.newVReg();
+        try f.getBlock(dead).append(.{ .op = .{ .iconst_32 = 99 }, .dest = v_dead, .type = .i32 });
+        try f.getBlock(dead).append(.{ .op = .{ .ret = v_dead } });
+
+        const v_ret = f.newVReg();
+        try f.getBlock(done).append(.{ .op = .{ .iconst_32 = 7 }, .dest = v_ret, .type = .i32 });
+        try f.getBlock(done).append(.{ .op = .{ .ret = v_ret } });
+    }
+
+    // f1 is the only caller changed by the second outer round.
+    try module.functions.append(allocator, ir.IrFunction.init(allocator, 0, 1, 0));
+    {
+        const f = &module.functions.items[1];
+        const entry = try f.newBlock();
+        const v_call = f.newVReg();
+        try f.getBlock(entry).append(.{ .op = .{ .call = .{ .func_idx = 0 } }, .dest = v_call, .type = .i32 });
+        try f.getBlock(entry).append(.{ .op = .{ .ret = v_call } });
+    }
+
+    // f2 is independent and should not be revisited in outer_iter == 1.
+    try module.functions.append(allocator, ir.IrFunction.init(allocator, 0, 1, 0));
+    {
+        const f = &module.functions.items[2];
+        const entry = try f.newBlock();
+        const v_ret = f.newVReg();
+        try f.getBlock(entry).append(.{ .op = .{ .iconst_32 = 11 }, .dest = v_ret, .type = .i32 });
+        try f.getBlock(entry).append(.{ .op = .{ .ret = v_ret } });
+    }
+
+    return module;
+}
+
+fn outerScopeFunctionHasCall(func: *const ir.IrFunction) bool {
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |inst| {
+            if (inst.op == .call) return true;
+        }
+    }
+    return false;
+}
+
+fn outerScopeExpectSameIr(expected: *const ir.IrModule, actual: *const ir.IrModule) !void {
+    try std.testing.expectEqual(expected.functions.items.len, actual.functions.items.len);
+    for (expected.functions.items, actual.functions.items) |expected_func, actual_func| {
+        try std.testing.expectEqual(expected_func.param_count, actual_func.param_count);
+        try std.testing.expectEqual(expected_func.result_count, actual_func.result_count);
+        try std.testing.expectEqual(expected_func.local_count, actual_func.local_count);
+        try std.testing.expectEqual(expected_func.next_vreg, actual_func.next_vreg);
+        try std.testing.expectEqual(expected_func.blocks.items.len, actual_func.blocks.items.len);
+        for (expected_func.blocks.items, actual_func.blocks.items) |expected_block, actual_block| {
+            try std.testing.expectEqual(expected_block.id, actual_block.id);
+            try std.testing.expectEqual(expected_block.instructions.items.len, actual_block.instructions.items.len);
+            for (expected_block.instructions.items, actual_block.instructions.items) |expected_inst, actual_inst| {
+                try std.testing.expectEqualDeep(expected_inst, actual_inst);
+            }
+        }
+    }
+}
+
+const OuterScopeDumpStats = struct {
+    outer1_fold_constant_branches: [3]u32 = .{ 0, 0, 0 },
+
+    fn callback(ctx: *anyopaque, info: DumpInfo) anyerror!void {
+        const stats: *OuterScopeDumpStats = @ptrCast(@alignCast(ctx));
+        if (info.outer_iter == 1 and std.mem.eql(u8, info.pass_name, "foldConstantBranches")) {
+            stats.outer1_fold_constant_branches[@intCast(info.func_index)] += 1;
+        }
+    }
+};
+
+test "runPasses: second outer round only revisits callers changed by inlining" {
+    const allocator = std.testing.allocator;
+    var scoped = try outerScopeBuildDelayedInlineModule(allocator);
+    defer scoped.deinit();
+    var full = try outerScopeBuildDelayedInlineModule(allocator);
+    defer full.deinit();
+
+    const test_passes = [_]PassFn{&foldConstantBranches};
+    var stats = OuterScopeDumpStats{};
+    _ = try runPassesWithOptionsScoped(&scoped, &test_passes, allocator, .{
+        .dump_hook = .{ .ctx = &stats, .callback = OuterScopeDumpStats.callback },
+    }, true);
+    _ = try runPassesWithOptionsScoped(&full, &test_passes, allocator, .{}, false);
+
+    try outerScopeExpectSameIr(&full, &scoped);
+    try std.testing.expect(!outerScopeFunctionHasCall(&scoped.functions.items[1]));
+    try std.testing.expectEqual(@as(u32, 0), stats.outer1_fold_constant_branches[0]);
+    try std.testing.expect(stats.outer1_fold_constant_branches[1] > 0);
+    try std.testing.expectEqual(@as(u32, 0), stats.outer1_fold_constant_branches[2]);
 }
 
 test "foldConstantBranches: zero cond picks else block" {

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -402,14 +402,18 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
     }
     const reuse_ptr: ?*const codegen_cache.Cache = if (loaded_cache) |*c| c else null;
 
+    const codegen_timing = passes.codegenTimingOptionsFromEnv(init.environ_map);
     const compiled: codegen_cache.CompileResultCached = switch (target_arch) {
-        .x86_64 => x86_64_compile.compileModuleCached(&ir_module, reuse_ptr, allocator) catch |err| {
+        .x86_64 => x86_64_compile.compileModuleCachedWithOptions(&ir_module, reuse_ptr, allocator, .{
+            .codegen_timing = codegen_timing,
+        }) catch |err| {
             std.debug.print("Error compiling to x86-64: {}\n", .{err});
             std.process.exit(1);
         },
         .aarch64 => aarch64_compile.compileModuleCachedWithOptions(&ir_module, reuse_ptr, allocator, .{
             .enable_scheduler = enable_aarch64_scheduler,
             .enable_xreg_alloc = enable_aarch64_xreg_alloc,
+            .codegen_timing = codegen_timing,
         }) catch |err| {
             std.debug.print("Error compiling to AArch64: {}\n", .{err});
             std.process.exit(1);
@@ -910,6 +914,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
         .cache_dir = cache_dir,
         .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
         .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
+        .codegen_timing = passes.codegenTimingOptionsFromEnv(init.environ_map),
         .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
         .verify_mode = verify_mode,
     }) catch |err| {
@@ -1031,6 +1036,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
                 .target_arch = target_arch,
                 .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
                 .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
+                .codegen_timing = passes.codegenTimingOptionsFromEnv(init.environ_map),
                 .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
                 .verify_mode = verifyModeFromEnvOrDefault(init.environ_map),
             }) catch |err| {
@@ -1048,6 +1054,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
                 .target_arch = target_arch,
                 .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
                 .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
+                .codegen_timing = passes.codegenTimingOptionsFromEnv(init.environ_map),
                 .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
                 .verify_mode = verifyModeFromEnvOrDefault(init.environ_map),
             }) catch |err| {
@@ -1520,6 +1527,16 @@ const compile_component_usage =
     \\                                 Slow-call threshold (default: 100).
     \\  WAMR_AOT_ANALYSIS_TIMING_MODULE=<N>
     \\  WAMR_AOT_ANALYSIS_TIMING_FUNC=<N>
+    \\                                 Optional module/function filters.
+    \\  WAMR_AOT_CODEGEN_TIMING=1     Log native-codegen cost per function
+    \\                                 (x86_64: setup/liveness/regalloc/emit
+    \\                                 sub-phases + hash; module summary).
+    \\  WAMR_AOT_CODEGEN_TIMING_THRESHOLD_MS=<ms>
+    \\                                 Per-function threshold (default: 100).
+    \\  WAMR_AOT_CODEGEN_TIMING_EVERY_N_FUNCS=<N>
+    \\                                 Also log every Nth function.
+    \\  WAMR_AOT_CODEGEN_TIMING_MODULE=<N>
+    \\  WAMR_AOT_CODEGEN_TIMING_FUNC=<N>
     \\                                 Optional module/function filters.
     \\
 ;

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -97,6 +97,9 @@ pub const PrecompileOptions = struct {
     /// Optional analysis recomputation diagnostics, normally parsed by
     /// `wamrc` from `WAMR_AOT_ANALYSIS_TIMING*`.
     analysis_timing: passes.AnalysisTimingOptions = .{},
+    /// Optional native-codegen timing diagnostics (#778), normally parsed
+    /// by `wamrc` from `WAMR_AOT_CODEGEN_TIMING*`.
+    codegen_timing: passes.CodegenTimingOptions = .{},
     /// Tail-duplication compile-time guard/cap options.
     tail_duplication: passes.TailDuplicationOptions = .{},
     /// IR verifier mode for optimized builds. Defaults match the historical
@@ -232,9 +235,15 @@ pub fn compileCoreWasmCached(
     const module_epoch = codegen_cache.hashModuleEpoch(epoch_inputs);
 
     const compiled: codegen_cache.CompileResultCached = switch (opts.target_arch) {
-        .aarch64 => aarch64_compile.compileModuleCached(&ir_module, cache_ctx.reuse, allocator) catch
+        .aarch64 => aarch64_compile.compileModuleCachedWithOptions(&ir_module, cache_ctx.reuse, allocator, .{
+            .codegen_timing = opts.codegen_timing,
+            .module_idx = opts.module_idx,
+        }) catch
             return error.CoreCompileFailed,
-        .x86_64 => x86_64_compile.compileModuleCached(&ir_module, cache_ctx.reuse, allocator) catch
+        .x86_64 => x86_64_compile.compileModuleCachedWithOptions(&ir_module, cache_ctx.reuse, allocator, .{
+            .codegen_timing = opts.codegen_timing,
+            .module_idx = opts.module_idx,
+        }) catch
             return error.CoreCompileFailed,
     };
     const code = compiled.code;


### PR DESCRIPTION
Closes #778.

Makes the optimized AOT compile of the 12,610-function `codegen-cli` core4
component core actually finish and emit a `.cwasm` in a practical time.
Before: optimization ran ~2,300 s then native codegen hit the 3,600 s cap with
**no output**. After: the full compile finishes in **~60 s** and emits a valid
86.5 MB `.cwasm`.

### What changed
1. **Codegen timing instrumentation** (`WAMR_AOT_CODEGEN_TIMING*`) — mirrors
   `WAMR_AOT_PASS_TIMING*` for the native-codegen phase: per-function
   setup/liveness/regalloc/emit partition + `hashFunction` time + a module
   summary. Disabled by default (hard no-op). This **disproved the issue's
   regalloc hypothesis**: register allocation is <50 ms even on the monster
   functions — the hotspot is **liveness**.
2. **Worklist liveness solver** — `computeLiveness` was a round-robin
   iterate-until-stable sweep over blocks in reverse index order, rescanning
   every block each round. Replaced with a predecessor-driven worklist that
   only revisits a block when a successor's `live_in` grew. Converges to the
   identical least fixpoint (same transfer function, same monotone lattice), so
   it is behavior-preserving by construction. The old solver is kept verbatim as
   `computeLivenessRoundRobin` and pinned by a differential test.
3. **Scope the optimizer's 2nd outer pass** — `runPassesWithOptions` re-ran the
   full per-function pipeline over all 12,610 functions on the 2nd outer round.
   Now it only revisits functions that inlining actually changed in that round;
   untouched functions are provably already at fixpoint.
4. **CFG analysis cache reuse** — `invalidate()` is now lazy: the next lookup
   compares cached successor lists to the current function and reuses
   successors/predecessors/dominators when the CFG is unchanged, instead of
   recomputing every inner fixpoint iteration.

### Results (ReleaseFast, x86_64)
- core4 optimized compile: **3,600 s cap / no output → ~60 s** + valid `.cwasm`.
- Codegen total 44.6 s → 33.5 s (liveness worklist); worst-function liveness up
  to **4.2×** faster (local_func=10760: 6.16 s → 1.46 s).
- **Strongest validation:** recompiling core4 with the worklist liveness yields a
  **byte-identical** `.cwasm` (sha `2ec5678c…`) vs the round-robin baseline.

### Tests
- Full suite green (`zig build test --summary all`): 79/79 steps,
  3,653/3,660 passed, 7 skipped, 0 failures.
- New: `codegenTimingOptionsFromEnv` parsing, a non-invasive byte-identical
  codegen-timing test, `shouldLogFunc`/`FuncTimer` gating, a scoped-vs-unscoped
  deep-IR-equality test, CFG-cache reuse/recompute tests, and a worklist-vs-
  round-robin differential liveness test across diamond/loop/nested-loop/chain
  CFGs.

### Not in scope (follow-ups)
Emit is now the largest single codegen cost on high-block functions
(local_func=11396 emit ≈6.6 s) — filed separately. aarch64 reports per-function
totals + module summary only (no sub-phase breakdown).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
