### PR TITLE
wamrc: free per-entry element-segment func_indices (#789)

### DIFF
--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -582,9 +582,18 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         });
     }
 
-    // Build element segment entries
+    // Build element segment entries. Each entry owns a freshly-allocated
+    // `func_indices` slice (borrowed by `emit_aot.emit` for the duration of
+    // this function), so the defer must free those per-entry slices too —
+    // mirroring `func_type_entries` below. Freeing only the list backing
+    // leaked one block per active element segment (#789).
     var elem_entries: std.ArrayList(emit_aot.ElemEntry) = .empty;
-    defer elem_entries.deinit(allocator);
+    defer {
+        for (elem_entries.items) |ee| {
+            if (ee.func_indices.len > 0) allocator.free(ee.func_indices);
+        }
+        elem_entries.deinit(allocator);
+    }
     for (module.elements) |seg| {
         if (seg.is_declarative) continue;
         const offset: u32 = if (seg.is_passive) 0 else blk: {


### PR DESCRIPTION
Closes #789.

### Problem

`wamrc compile` leaks one heap block per non-declarative **element segment**.
`runCompile` (`src/compiler/main.zig`) allocates a fresh `u32` slice for each
segment's function-index table and stores it in `emit_aot.ElemEntry.func_indices`,
but the `elem_entries` `defer` only freed the `ArrayList` backing store — never the
per-entry slices. The adjacent `func_type_entries` list frees its per-entry
`params`/`results` correctly, so this was an asymmetry rather than a deliberate
borrow.

Any module that builds an indirect-call table (essentially every non-trivial
program) trips Zig's `DebugAllocator` leak detector at process exit:

```
error(DebugAllocator): memory address 0x… leaked:
src/compiler/main.zig:600:44: in runCompile (main.zig)
        const indices = try allocator.alloc(u32, seg.func_indices.len);
```

`wamrc`'s root allocator is `init.gpa`, which Zig's `lib/std/start.zig` wires to
`std.heap.DebugAllocator(.{})` in Debug **and ReleaseSafe** builds (running
`deinit()` at exit; "leaks do not affect return code", hence exit 0). The trace is
empty in ReleaseSafe because that config uses 0 stack-trace frames; a Debug build
(6 frames) localized it to `main.zig:600`.

### Fix

Give `elem_entries` the same per-entry-free `defer` already used by
`func_type_entries`. Behavior-preserving — only adds `free` calls after
`emit_aot.emit` has consumed the slices.

### Validation

- `wamrc compile codegen-cli.wasm` (3.7 MB, previously 1 leaked block) and
  `tcgc-core.wasm` (33 MB, 1 leaked block) → **0** leaked blocks now.
- Small/table-less modules (`stdio-echo.wasm`, `noop.wasm`) were never affected
  and remain clean.
- Full suite: `79/79 steps, 3667/3674 tests passed (7 skipped, 0 failures)`.

### Context

Found while validating the fix for #786 (frontend `UnboundVRegUse`) by compiling
core 4 of `codegen-cli` with the IR verifier on; the leak line appears on both the
verify and `--no-verify-ir` paths, unrelated to the verifier.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>