### PR TITLE
compiler/ir: foldInverseCompareEqz must carry the compare's operand width (#743)

### DIFF
--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -5778,6 +5778,7 @@ pub fn foldInverseCompareEqz(func: *ir.IrFunction, allocator: std.mem.Allocator)
         blk: ir.BlockId,
         ii: u32,
         new_op: ir.Inst.Op,
+        new_type: ir.IrType,
     };
     var rewrites = std.ArrayList(Rewrite).empty;
     defer rewrites.deinit(allocator);
@@ -5805,17 +5806,27 @@ pub fn foldInverseCompareEqz(func: *ir.IrFunction, allocator: std.mem.Allocator)
                 else => null,
             };
             if (new_op) |op| {
+                // The eqz being rewritten has `.type == .i32` (its operand is
+                // the i32 0/1 result of the comparison). The synthesized
+                // inverse comparison instead operates on the *producer's*
+                // operands, so it must carry the producer's operand-width
+                // `.type` (e.g. `.i64` for an `i64` relop). Keeping the eqz's
+                // `.type` made codegen emit a 32-bit compare on 64-bit
+                // operands — a miscompile on every `eqz(<i64 relop>)` (#743).
                 try rewrites.append(allocator, .{
                     .blk = @intCast(bi),
                     .ii = @intCast(ii),
                     .new_op = op,
+                    .new_type = producer.type,
                 });
             }
         }
     }
 
     for (rewrites.items) |r| {
-        func.blocks.items[r.blk].instructions.items[r.ii].op = r.new_op;
+        const target = &func.blocks.items[r.blk].instructions.items[r.ii];
+        target.op = r.new_op;
+        target.type = r.new_type;
         changed = true;
     }
     return changed;
@@ -13987,6 +13998,44 @@ test "foldInverseCompareEqz: eqz(eq) becomes ne" {
     }
     // dest preserved.
     try std.testing.expectEqual(@as(?ir.VReg, v_neg), block.instructions.items[3].dest);
+}
+
+test "foldInverseCompareEqz: carries i64 operand width into rewritten compare (#743)" {
+    // Regression for #743. `i64.eq` yields an i32 0/1 but records its
+    // *operand* width (`.i64`) in `Inst.type`; the following `i32.eqz` has
+    // `.type == .i32`. When the pass rewrites the eqz in place to the inverse
+    // comparison (`ne`) it must adopt the producer's i64 operand width — not
+    // keep the eqz's i32 type — or codegen emits a 32-bit compare on 64-bit
+    // operands, silently comparing only the low halves.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 2, 2, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    var block = &func.blocks.items[b0];
+
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v_cmp = func.newVReg();
+    const v_neg = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_64 = 0x1_0000_0000 }, .dest = v0, .type = .i64 });
+    try block.append(.{ .op = .{ .iconst_64 = 0 }, .dest = v1, .type = .i64 });
+    try block.append(.{ .op = .{ .eq = .{ .lhs = v0, .rhs = v1 } }, .dest = v_cmp, .type = .i64 });
+    try block.append(.{ .op = .{ .eqz = v_cmp }, .dest = v_neg, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v_neg } });
+
+    try std.testing.expect(try foldInverseCompareEqz(&func, allocator));
+
+    const rewritten = block.instructions.items[3];
+    switch (rewritten.op) {
+        .ne => |b| {
+            try std.testing.expectEqual(v0, b.lhs);
+            try std.testing.expectEqual(v1, b.rhs);
+        },
+        else => try std.testing.expect(false),
+    }
+    // The crux: the rewritten compare must carry the i64 operand width.
+    try std.testing.expectEqual(ir.IrType.i64, rewritten.type);
+    try std.testing.expectEqual(@as(?ir.VReg, v_neg), rewritten.dest);
 }
 
 test "foldInverseCompareEqz: all 10 mappings" {


### PR DESCRIPTION
Part of #743 (one of several optimizer miscompiles in core 4 — see below).

### Bug

`foldInverseCompareEqz` folds `eqz(<int relop>(a, b))` into the inverse comparison
on `(a, b)`, rewriting the `eqz` instruction in place and preserving its dest
vreg. It copied only the new `.op`, leaving `.type` at the eqz's `.i32`.

Integer relational ops record their **operand width** in `Inst.type` (an `i64`
compare has `.type == .i64`); the `eqz` of a compare result is always `.i32` (its
operand is the i32 0/1 the compare produced). So for an `i64` producer the
synthesized inverse compare was left tagged `.i32`, and codegen emitted a **32-bit
compare of 64-bit operands** — silently comparing only the low halves. Every
`eqz(<i64 relop>)` (e.g. `i64.eq` + `i32.eqz` ≡ `i64.ne`) miscompiled.

The sibling eqz-folders `foldBranchOnEqz` / `foldSelectOnEqz` are unaffected — they
reuse the eqz's operand and swap branches/arms rather than synthesizing a new
typed compare.

### Fix

Carry the producer's operand-width `.type` onto the rewritten instruction. i32
cases are unchanged (both already `.i32`).

### How it was found

Differential bisection of the #743 keyvault→`tcgc.compile` end-to-end repro
(`wamrc compile-component` + `WAMR=1 run.sh`), which after #786 no longer traps
(OOB gone) but hangs. Using the `-O0` / `WAMR_AOT_PASSES_LIMIT` / `WAMR_AOT_SKIP_PASS`
knobs (`:mod=4`) to bisect core 4's pipeline:

| core-4 pipeline | result |
|---|---|
| `-O0` (no IR opt) | ✅ completes |
| `PASSES_LIMIT=7` (passes 0–6) | ✅ completes |
| `PASSES_LIMIT=8` (adds pass 7 = `foldInverseCompareEqz`) | ❌ tcgc `CompileFailed` |

…which isolated this pass. **This fix alone does not yet make #743 pass** — with
it applied, the bisection advances to **pass 15 = `globalValueNumbering`** (hang)
and at least one more pass in [16, 25]. Those are separate, independent
miscompiles and are tracked on #743. This PR lands the one confirmed, minimal,
isolated fix.

### Validation

- New unit test: `eqz(i64.eq)` folds to `ne` with `.type == .i64`.
- Full suite: `79/79 steps, 3672/3679 tests passed (7 skipped, 0 failures)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>