### PR TITLE
compiler/ir: load forwarding must not cross aliasing effects on any CFG path (#743)

### DIFF
--- a/src/compiler/ir/forward_redundant_loads_dominator.zig
+++ b/src/compiler/ir/forward_redundant_loads_dominator.zig
@@ -474,3 +474,157 @@ test "FRLDominator (cell H): barrier in then-branch, store in else-branch, merge
     try testing.expect(m.instructions.items[0].op == .load);
     try testing.expectEqual(ir.Inst.Op{ .ret = v_merge }, m.instructions.items[1].op);
 }
+
+test "FRLDominator (#743): load in loop NOT forwarded across loop-body barrier" {
+    // The forwarded load lives at a loop block whose loop body contains a
+    // `call` barrier. The barrier is a dominator-tree DESCENDANT of the
+    // load, so #719 sibling-ordering can't catch it: the forward happens
+    // before the walk descends to the barrier. At run time the back-edge
+    // re-runs the call (which may modify the loaded location) before the
+    // loaded block is re-entered, so the dominating load's value is stale.
+    //
+    //   entry:  v_dom = load p[0]
+    //           br header
+    //   header: v_use = load p[0]    ; must NOT be forwarded
+    //           br_if cond, body, exit
+    //   body:   call f               ; barrier in loop body
+    //           br header            ; back-edge
+    //   exit:   ret v_use
+    const allocator = testing.allocator;
+    const meta = FrlTestFuncMeta{};
+    var func = makeFrlTestFunc(allocator, meta);
+    defer func.deinit();
+
+    const entry = try func.newBlock();
+    const header = try func.newBlock();
+    const body = try func.newBlock();
+    const exit = try func.newBlock();
+
+    const v_base = func.newVReg();
+    const cond = func.newVReg();
+    const v_dom = func.newVReg();
+    const v_use = func.newVReg();
+    const v_call = func.newVReg();
+
+    {
+        const blk = &func.blocks.items[entry];
+        try blk.append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_dom, .type = .i32 });
+        try terminateBr(blk, header);
+    }
+    {
+        const blk = &func.blocks.items[header];
+        try blk.append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_use, .type = .i32 });
+        try terminateBrIf(blk, cond, body, exit);
+    }
+    {
+        const blk = &func.blocks.items[body];
+        try blk.append(.{ .op = .{ .call = .{ .func_idx = 0 } }, .dest = v_call, .type = .i32 });
+        try terminateBr(blk, header);
+    }
+    {
+        const blk = &func.blocks.items[exit];
+        try blk.append(.{ .op = .{ .ret = v_use }, .type = .i32 });
+    }
+
+    _ = try forwardRedundantLoadsDominator(&func, allocator);
+    // The header's load must survive (load + br_if).
+    const h = &func.blocks.items[header];
+    try testing.expectEqual(@as(usize, 2), h.instructions.items.len);
+    try testing.expect(h.instructions.items[0].op == .load);
+}
+
+test "FRLDominator (#743): load in barrier-free loop IS still forwarded" {
+    // No-regression guard: the same shape but with a barrier-free loop body
+    // leaves `p[0]` unmodified across iterations, so forwarding the header
+    // load from the dominating entry load stays sound and must still happen.
+    const allocator = testing.allocator;
+    const meta = FrlTestFuncMeta{};
+    var func = makeFrlTestFunc(allocator, meta);
+    defer func.deinit();
+
+    const entry = try func.newBlock();
+    const header = try func.newBlock();
+    const body = try func.newBlock();
+    const exit = try func.newBlock();
+
+    const v_base = func.newVReg();
+    const cond = func.newVReg();
+    const v_dom = func.newVReg();
+    const v_use = func.newVReg();
+
+    {
+        const blk = &func.blocks.items[entry];
+        try blk.append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_dom, .type = .i32 });
+        try terminateBr(blk, header);
+    }
+    {
+        const blk = &func.blocks.items[header];
+        try blk.append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_use, .type = .i32 });
+        try terminateBrIf(blk, cond, body, exit);
+    }
+    {
+        const blk = &func.blocks.items[body];
+        try terminateBr(blk, header);
+    }
+    {
+        const blk = &func.blocks.items[exit];
+        try blk.append(.{ .op = .{ .ret = v_use }, .type = .i32 });
+    }
+
+    _ = try forwardRedundantLoadsDominator(&func, allocator);
+    // The header's load is redundant with the entry load (loop never writes
+    // p[0]) → forwarded away, leaving only the br_if terminator.
+    const h = &func.blocks.items[header];
+    try testing.expectEqual(@as(usize, 1), h.instructions.items.len);
+    try testing.expect(h.instructions.items[0].op == .br_if);
+}
+
+test "FRLDominator (#743): load NOT forwarded when the use block itself stores in a loop" {
+    // The effecting block IS the use block: `header` loads p[0], later stores
+    // p[0], and loops back to itself. The store runs after the load within one
+    // iteration (harmless that pass) but before the load re-executes on the
+    // next iteration, so the dominating entry value is stale. This exercises
+    // the `B == d` corner the corridor walk must not skip.
+    const allocator = testing.allocator;
+    const meta = FrlTestFuncMeta{};
+    var func = makeFrlTestFunc(allocator, meta);
+    defer func.deinit();
+
+    const entry = try func.newBlock();
+    const header = try func.newBlock();
+    const exit = try func.newBlock();
+
+    const v_base = func.newVReg();
+    const cond = func.newVReg();
+    const v_dom = func.newVReg();
+    const v_use = func.newVReg();
+    const v_one = func.newVReg();
+    const v_new = func.newVReg();
+
+    {
+        const blk = &func.blocks.items[entry];
+        try blk.append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_dom, .type = .i32 });
+        try terminateBr(blk, header);
+    }
+    {
+        const blk = &func.blocks.items[header];
+        try blk.append(.{ .op = .{ .load = .{ .base = v_base, .offset = 0, .size = 4 } }, .dest = v_use, .type = .i32 });
+        try blk.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_one, .type = .i32 });
+        try blk.append(.{ .op = .{ .add = .{ .lhs = v_use, .rhs = v_one } }, .dest = v_new, .type = .i32 });
+        try blk.append(.{ .op = .{ .store = .{ .base = v_base, .offset = 0, .size = 4, .val = v_new } }, .type = .i32 });
+        try terminateBrIf(blk, cond, header, exit);
+    }
+    {
+        const blk = &func.blocks.items[exit];
+        try blk.append(.{ .op = .{ .ret = v_use }, .type = .i32 });
+    }
+
+    _ = try forwardRedundantLoadsDominator(&func, allocator);
+    // header's load must survive.
+    const h = &func.blocks.items[header];
+    var has_load = false;
+    for (h.instructions.items) |inst| {
+        if (inst.op == .load) has_load = true;
+    }
+    try testing.expect(has_load);
+}

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -224,6 +224,89 @@ pub const LoadForwardingDomWalkInstructionResult = enum {
     removed,
 };
 
+/// #743: returns true when forwarding a load value defined in block `a` to a
+/// use in block `d` is UNSOUND — i.e. some block carrying an aliasing memory
+/// effect (a `call`/atomic/bulk-mem barrier or any `store`) lies strictly
+/// between `a` and `d` on some CFG path, **including paths that traverse loop
+/// back-edges**. The dominator-tree DFS that drives load forwarding only
+/// invalidates barriers it encounters on the descent, so a barrier in a
+/// sibling/merge subtree or a loop body is otherwise missed.
+///
+/// `fwd_stamp` / `bwd_stamp` are reusable per-block generation markers (length
+/// == block count) and `gen` is a value not previously used in either array;
+/// `queue` is reusable scratch. The check runs in O(corridor) per call —
+/// only the blocks that both descend from `a` and reach `d` are visited.
+fn loadForwardCrossesEffect(
+    a: ir.BlockId,
+    d: ir.BlockId,
+    successors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+    predecessors: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+    effect: []const bool,
+    fwd_stamp: []u32,
+    bwd_stamp: []u32,
+    gen: u32,
+    queue: *std.ArrayList(ir.BlockId),
+    allocator: std.mem.Allocator,
+) !bool {
+    if (a == d) return false;
+    if (a >= bwd_stamp.len or d >= bwd_stamp.len) return false;
+
+    // Backward BFS from `d`: mark every block that can reach `d`.
+    queue.clearRetainingCapacity();
+    bwd_stamp[d] = gen;
+    try queue.append(allocator, d);
+    var head: usize = 0;
+    while (head < queue.items.len) : (head += 1) {
+        const x = queue.items[head];
+        if (predecessors.get(x)) |preds| {
+            for (preds) |p| {
+                if (p < bwd_stamp.len and bwd_stamp[p] != gen) {
+                    bwd_stamp[p] = gen;
+                    try queue.append(allocator, p);
+                }
+            }
+        }
+    }
+    // `a` dominates `d`, so it reaches `d`; bail defensively otherwise.
+    if (bwd_stamp[a] != gen) return false;
+
+    // The use block `d` may carry an aliasing effect (a store/barrier) that
+    // runs AFTER the forwarded load within `d`. On a single pass that is
+    // harmless (the load is read first), but when `d` lies on a loop — i.e.
+    // `d` can reach itself — that effect runs before `d`'s load re-executes
+    // on the next iteration, so the dominating value is stale. Detect this by
+    // checking whether any successor of `d` can still reach `d`.
+    if (d < effect.len and effect[d]) {
+        if (successors.get(d)) |succs| {
+            for (succs) |s| {
+                if (s < bwd_stamp.len and bwd_stamp[s] == gen) return true;
+            }
+        }
+    }
+
+    // Forward BFS from `a`, restricted to the corridor of blocks that reach
+    // `d`. Any effecting block strictly inside the corridor (≠ a, ≠ d) makes
+    // the forward unsound.
+    queue.clearRetainingCapacity();
+    fwd_stamp[a] = gen;
+    try queue.append(allocator, a);
+    head = 0;
+    while (head < queue.items.len) : (head += 1) {
+        const x = queue.items[head];
+        if (successors.get(x)) |succs| {
+            for (succs) |s| {
+                if (s >= fwd_stamp.len) continue;
+                if (bwd_stamp[s] != gen) continue; // not on an a→d path
+                if (fwd_stamp[s] == gen) continue; // already visited
+                fwd_stamp[s] = gen;
+                if (s != d and effect[s]) return true;
+                try queue.append(allocator, s);
+            }
+        }
+    }
+    return false;
+}
+
 /// Generic driver for load-forwarding dominator DFS passes.
 /// The driver owns dominator computation, `BarrierOrderedDomChildren`, the
 /// DFS stack, `LoadFrameStack` push/pop, load/store/barrier dispatch, and the
@@ -261,6 +344,70 @@ pub fn LoadForwardingDomWalk(comptime Visitor: type) type {
             defer dom_children.deinit();
 
             if (dom.idom[0] == null) return false;
+
+            // #743: per-forward load-availability soundness check. The
+            // dominator-tree DFS below only invalidates a barrier (`call` /
+            // atomic / bulk-mem) or aliasing `store` when it is *encountered
+            // on the descent*. A barrier reachable through a sibling/merge
+            // subtree — or through a loop back-edge — is therefore missed,
+            // and a load whose value was recorded above it can be unsoundly
+            // forwarded (the forward is applied before the barrier is
+            // visited). The frame heuristic (clearAll + the #719 barrier
+            // ordering) only prunes the easy cases; this exact check closes
+            // the gap by verifying, at each forward, that no effecting block
+            // lies on any CFG path between the value's defining block and the
+            // use block (loop back-edges included).
+            var successors = try analysis.buildSuccessors(func, allocator);
+            defer analysis.freeBlockIdMap(&successors, allocator);
+            var predecessors = try analysis.buildPredecessors(func, allocator);
+            defer analysis.freeBlockIdMap(&predecessors, allocator);
+
+            const nblk = func.blocks.items.len;
+            const effect_blocks = try allocator.alloc(bool, nblk);
+            defer allocator.free(effect_blocks);
+            for (func.blocks.items, 0..) |bb, bi| {
+                var has = false;
+                for (bb.instructions.items) |inst| {
+                    switch (inst.op) {
+                        .store, .v128_store, .v128_store_lane => has = true,
+                        else => if (opIsLoadBarrier(inst.op)) {
+                            has = true;
+                        },
+                    }
+                    if (has) break;
+                }
+                effect_blocks[bi] = has;
+            }
+
+            // vreg -> defining block, so a forwarded value's source block is
+            // known at the use site.
+            const invalid_block: ir.BlockId = std.math.maxInt(ir.BlockId);
+            const def_block = try allocator.alloc(ir.BlockId, func.next_vreg);
+            defer allocator.free(def_block);
+            @memset(def_block, invalid_block);
+            for (func.blocks.items, 0..) |bb, bi| {
+                for (bb.instructions.items) |inst| {
+                    if (inst.dest) |dst| {
+                        if (dst < def_block.len and def_block[dst] == invalid_block) def_block[dst] = @intCast(bi);
+                    }
+                    if (inst.op == .parallel_copy) {
+                        for (inst.op.parallel_copy) |p| {
+                            if (p.dst < def_block.len and def_block[p.dst] == invalid_block) def_block[p.dst] = @intCast(bi);
+                        }
+                    }
+                }
+            }
+
+            // Reusable BFS scratch for `loadForwardCrossesEffect`.
+            const fwd_stamp = try allocator.alloc(u32, nblk);
+            defer allocator.free(fwd_stamp);
+            @memset(fwd_stamp, 0);
+            const bwd_stamp = try allocator.alloc(u32, nblk);
+            defer allocator.free(bwd_stamp);
+            @memset(bwd_stamp, 0);
+            var bfs_queue: std.ArrayList(ir.BlockId) = .empty;
+            defer bfs_queue.deinit(allocator);
+            var fwd_gen: u32 = 0;
 
             var load_frames = LoadFrameStack.init(allocator);
             defer load_frames.deinit();
@@ -301,7 +448,30 @@ pub fn LoadForwardingDomWalk(comptime Visitor: type) type {
                                     key_ld.base = visitor.canonicalizeVReg(key_ld.base);
                                 }
                                 const key: LoadKey = .{ .mem = alias_class.memKeyFromLoad(key_ld) };
-                                if (load_frames.lookup(key)) |held| {
+                                const held_opt = load_frames.lookup(key);
+                                // #743: only forward when no aliasing memory
+                                // effect lies on any CFG path between the
+                                // value's defining block and this use.
+                                const can_forward = blk: {
+                                    const held = held_opt orelse break :blk false;
+                                    const a_block = if (held < def_block.len) def_block[held] else invalid_block;
+                                    if (a_block == invalid_block) break :blk false;
+                                    fwd_gen += 1;
+                                    break :blk !(try loadForwardCrossesEffect(
+                                        a_block,
+                                        bid,
+                                        &successors,
+                                        &predecessors,
+                                        effect_blocks,
+                                        fwd_stamp,
+                                        bwd_stamp,
+                                        fwd_gen,
+                                        &bfs_queue,
+                                        allocator,
+                                    ));
+                                };
+                                if (can_forward) {
+                                    const held = held_opt.?;
                                     if (comptime @hasDecl(Visitor, "onForwardedLoad")) {
                                         switch (try visitor.onForwardedLoad(func, bid, i, inst, inst.dest, held, &load_frames)) {
                                             .unchanged => {},
@@ -3959,7 +4129,6 @@ pub fn hoistLoopInvariantCode(func: *ir.IrFunction, allocator: std.mem.Allocator
     var changed = false;
     for (lf.loops) |*loop| {
         const ph = (try obtainLoopPreheader(func, loop, &predecessors, dom, allocator)) orelse continue;
-
         // One-shot scan of the loop body: which wasm-local / wasm-global
         // indices are written, and does the body contain any call or
         // memory-mutating op?


### PR DESCRIPTION
## Summary

Fixes the #743 hang and a follow-on miscompile by closing a soundness gap in the **dominator-scoped load forwarder** shared by `globalValueNumbering`, `commonSubexprElimination`, and `forwardRedundantLoadsDominator` (`LoadForwardingDomWalk` in `src/compiler/ir/passes.zig`).

## The bug

The forwarder only invalidated an aliasing barrier (`call`/atomic/bulk-mem) or `store` when its dom-tree DFS **encountered it on the descent**. Effects reachable only through a sibling/merge subtree or a **loop back-edge** are missed, so a value loaded before a loop (or before a merge) could be forwarded into a block whose load actually observes a *later* store/call — yielding a stale value. The #719 sibling-ordering heuristic only handles the simple diamond cases.

Two real manifestations in the keyvault end-to-end run (`tcgc.compile`):

1. **Infinite `resource.drop` loop** — core-4 `func7463`: a `[v6+468]` loop branch-flag load forwarded to a dominating load across the loop body's `call`s, so the guest's loop condition never updated.
2. **Wrong `SubtleCrypto.digest`** — core-4 `fn2178`: after `hoistLoopInvariantCode` synthesized a preheader (correctly) and reshaped the CFG, a `[v25+8]` load inside a loop block was forwarded past **that same block's own store** to `[v25+8]`. Here the effecting block *is* the use block, reachable from itself via the back-edge.

## The fix

An exact per-forward CFG-reachability check (`loadForwardCrossesEffect`). Before forwarding a load whose value is defined in block `a` to a use in block `d`, refuse if any block carrying an aliasing effect lies on some `a`→`d` path — **including paths through loop back-edges and the use block's own post-load effect**. Two stamped BFS over the cached CFG, O(corridor) per forward. Conservative-safe: it only ever declines a forward, so it cannot introduce a miscompile.

## Validation

- Full pipeline keyvault e2e now prints `got 58187 bytes back from tcgc.compile` (matches the wasmtime oracle); previously hung, then mis-digested.
- `zig build test`: 79/79 steps, 3684/3691 tests pass (7 skipped) — no regressions.
- CoreMark AOT: `Correct operation validated` (CRCs match); fix is correctness-only and perf-neutral (declines only genuinely-unsound forwards).
- New regression tests in `forward_redundant_loads_dominator.zig`: load not forwarded across a loop-body barrier, across the use block's own loop store (the `B == d` corner), and a no-regression guard that a barrier-free loop load is still forwarded.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>