### PR TITLE
compiler/ir: measure SSA vs legacy allocator spill pressure (#392 step 3b-i)

### DIFF
--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -3197,6 +3197,12 @@ pub const RunOptions = struct {
     /// Compile-time guard for `tailDuplicateSmallJoins`. Defaults keep the
     /// pass enabled for normal functions but skip/cap pathological CFGs.
     tail_duplication: TailDuplicationOptions = .{},
+    /// Optional diagnostic invoked once per function while it is still in
+    /// **phi form**, just before `lowerPhisToLocals`. Used to measure
+    /// SSA-aware vs legacy allocator spill pressure (#392 step 3b-i). Wired
+    /// by `wamrc` from `WAMR_SSA_REGALLOC_MEASURE`; null in normal builds so
+    /// release codegen pays nothing.
+    phi_spill_measure: ?*const fn (*const ir.IrFunction, std.mem.Allocator) void = null,
 };
 
 pub const AnalysisTimingOptions = analysis.TimingOptions;
@@ -8317,6 +8323,7 @@ fn runPassesWithOptionsScoped(
                             .outer_iter = outer_iter,
                         });
                     }
+                    if (opts.phi_spill_measure) |measure| measure(func, allocator);
                     if (!opts.bisect.skipsPhisToLocals(opts.module_idx, func_idx)) {
                         const lower_start_ns = if (timing_for_func) passTimingNowNs() else 0;
                         const lower_start_stats = if (timing_for_func) collectPassTimingStats(func) else PassTimingStats{};

--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -348,6 +348,59 @@ fn allocationEql(a: Allocation, b: Allocation) bool {
     };
 }
 
+/// Representative aarch64 integer register file used purely to *measure*
+/// the spill impact of SSA-aware allocation (#392 step 3b-i): 23 allocatable
+/// GPRs (x0–x14 + x21–x28), no clobber points. The exact register numbers
+/// are irrelevant to the spill *count*; only the pool size and interval
+/// overlap matter, so this isolates the effect of phi interval handling.
+const measure_reg_set: RegSet = .{
+    .alloc_regs = &.{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 21, 22, 23, 24, 25, 26, 27, 28 },
+    .callee_saved_indices = &.{ 15, 16, 17, 18, 19, 20, 21, 22 },
+    .caller_saved_indices = &.{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 },
+    .spill_base = 0,
+    .spill_stride = 8,
+};
+
+pub const PhiSpillDelta = struct {
+    /// Number of phi instructions in the function.
+    phis: u32,
+    /// Spill slots used when allocating over SSA live ranges.
+    ssa_spills: u32,
+    /// Spill slots used when allocating over the legacy (naive in-block
+    /// phi) live ranges — the status-quo interval model.
+    naive_spills: u32,
+};
+
+/// Measure how SSA-aware allocation changes spill pressure versus the
+/// status-quo interval model, on a function still in **phi form**
+/// (#392 step 3b-i). Returns `null` for functions with no phis (nothing to
+/// compare). Both allocations use the same representative register file and
+/// empty clobbers, so the only variable is phi interval handling:
+///   - `ssa_spills`   = `allocateSsa`  (phi-arm ranges end at the predecessor)
+///   - `naive_spills` = `allocate`     (phi arms treated as join-block uses)
+///
+/// Pure measurement — it mutates nothing and is intended to be called from an
+/// env-gated diagnostic hook before `lowerPhisToLocals`.
+pub fn measurePhiSpillDelta(
+    func: *const ir.IrFunction,
+    allocator: std.mem.Allocator,
+) !?PhiSpillDelta {
+    var phis: u32 = 0;
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |inst| {
+            if (inst.op == .phi) phis += 1;
+        }
+    }
+    if (phis == 0) return null;
+
+    var ssa = try allocateSsa(func, allocator, measure_reg_set, &.{});
+    defer ssa.deinit();
+    var naive = try allocate(func, allocator, measure_reg_set, &.{});
+    defer naive.deinit();
+
+    return .{ .phis = phis, .ssa_spills = ssa.spill_count, .naive_spills = naive.spill_count };
+}
+
 /// Classify every vreg in `func` whose def is a "cheap" pure op
 /// (currently only `iconst_32` / `iconst_64`) into a map of
 /// rematerialisation values. Callers pass this to
@@ -1070,6 +1123,32 @@ test "resolvePhiEdges: flags a critical edge (predecessor with multiple successo
             try std.testing.expectEqual(@as(ir.BlockId, 1), e.pred);
             try std.testing.expect(!e.needs_split);
         }
+    }
+}
+
+test "measurePhiSpillDelta: null without phis; SSA never spills more than naive" {
+    const allocator = std.testing.allocator;
+
+    // A phi-free function yields no measurement.
+    {
+        var func = ir.IrFunction.init(allocator, 0, 0, 0);
+        defer func.deinit();
+        const b0 = try func.newBlock();
+        const v0 = func.newVReg();
+        try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0, .type = .i32 });
+        try func.getBlock(b0).append(.{ .op = .{ .ret = v0 }, .type = .void });
+        try std.testing.expect((try measurePhiSpillDelta(&func, allocator)) == null);
+    }
+
+    // The arm diamond has one phi; SSA intervals are a subset of the naive
+    // ones, so SSA can never spill more.
+    {
+        var func = ir.IrFunction.init(allocator, 0, 0, 0);
+        defer func.deinit();
+        _ = try buildArmDiamond(&func, allocator);
+        const d = (try measurePhiSpillDelta(&func, allocator)).?;
+        try std.testing.expectEqual(@as(u32, 1), d.phis);
+        try std.testing.expect(d.ssa_spills <= d.naive_spills);
     }
 }
 

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -12,6 +12,7 @@ const aarch64_compile = wamr.aarch64_compile;
 const passes = wamr.passes;
 const ir_print = wamr.ir_print;
 const ir = wamr.ir;
+const regalloc = wamr.regalloc;
 const codegen_cache = wamr.codegen_cache;
 
 const TargetArch = passes.TargetArch;
@@ -28,6 +29,18 @@ comptime {
 }
 
 const Subcommand = enum { compile, compile_component, run, verify, version, help };
+
+/// #392 step 3b-i diagnostic: log SSA-aware vs legacy (naive in-block phi)
+/// allocator spill counts for one phi-form function. Wired into the pass
+/// pipeline only when `WAMR_SSA_REGALLOC_MEASURE` is set. Errors and
+/// phi-free functions are silently skipped.
+fn ssaSpillMeasure(func: *const ir.IrFunction, allocator: std.mem.Allocator) void {
+    const delta = (regalloc.measurePhiSpillDelta(func, allocator) catch return) orelse return;
+    std.debug.print(
+        "[ssa-spill-measure] fn={s} phis={d} ssa_spills={d} naive_spills={d}\n",
+        .{ func.name orelse "<anon>", delta.phis, delta.ssa_spills, delta.naive_spills },
+    );
+}
 
 fn parseSubcommand(s: []const u8) ?Subcommand {
     if (std.mem.eql(u8, s, "compile")) return .compile;
@@ -291,6 +304,12 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
 
     // 4. Optimize IR (unless -O0)
     if (optimize) {
+        // #392 step 3b-i: when WAMR_SSA_REGALLOC_MEASURE is set, log, per phi
+        // function, the spill count of SSA-aware allocation vs the legacy
+        // (naive in-block phi) interval model. Diagnostic only — no codegen
+        // change.
+        const ssa_spill_measure: ?*const fn (*const ir.IrFunction, std.mem.Allocator) void =
+            if (init.environ_map.get("WAMR_SSA_REGALLOC_MEASURE") != null) &ssaSpillMeasure else null;
         const run_opts: passes.RunOptions = .{
             .dump_hook = if (dumper.pass_names.len == 0) null else .{
                 .ctx = @ptrCast(&dumper),
@@ -301,6 +320,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
             .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
             .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
             .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
+            .phi_spill_measure = ssa_spill_measure,
         };
         const opt_changes = passes.runPassesWithOptions(&ir_module, passes.defaultPassesForTarget(target_arch), allocator, run_opts) catch |err| {
             // If the IR verifier tripped, surface its diagnostic before

--- a/src/root.zig
+++ b/src/root.zig
@@ -89,6 +89,9 @@ pub const aarch64_peephole = @import("compiler/codegen/aarch64/peephole.zig");
 /// AOT compiler optimization passes.
 pub const passes = @import("compiler/ir/passes.zig");
 
+/// Linear-scan register allocator (and SSA-aware variants, #392).
+pub const regalloc = @import("compiler/ir/regalloc.zig");
+
 /// AOT codegen bisection knobs — env-var parsing + process-global
 /// `PassBisectSpec` consumed by `runPassesWithOptions` (#761 / #743).
 pub const aot_bisect = @import("compiler/aot_bisect.zig");


### PR DESCRIPTION
Before committing to the risky codegen integration (Step 3b-ii), this validates #392's core hypothesis — that SSA-aware allocation reduces spills — with **real CoreMark data**.

## What
- `regalloc.measurePhiSpillDelta(func)`: for a function still in **phi form**, runs `allocateSsa` (SSA ranges) and `allocate` (legacy naive in-block phi ranges) over the **same** representative aarch64 register file with empty clobbers, so the only variable is phi interval handling. Returns both spill counts (null if no phis).
- A `phi_spill_measure` hook on `passes.RunOptions`, invoked once per function just before `lowerPhisToLocals`; `wamrc` wires it from `WAMR_SSA_REGALLOC_MEASURE`.
- **Diagnostic only** — no codegen change; nothing runs in normal builds (flag-gated, default off).

## Result (CoreMark, `coremark_wasi.wasm`)
| | phi functions | total phis | total spills |
|---|---:|---:|---:|
| naive (status quo intervals) | 37 | 1878 | **1577** |
| SSA-aware (`allocateSsa`) | 37 | 1878 | **241** |

**1336 spills eliminated — 84.7% reduction.** The naive model over-extends each phi arm across the join into every predecessor, inflating false register pressure; SSA intervals end arms at their predecessor's terminator.

> Caveat: this isolates the phi-interval effect (empty clobbers, representative 23-GPR file), so emitted-code gains will be smaller — but a reduction this large is a strong green light for the integration.

## Tests
`measurePhiSpillDelta` returns null without phis and never reports SSA spilling more than naive. Full suite green: **87/87 steps, 4120/4132 passed**.

## Next
**Step 3b-ii**: keep phis through to aarch64 codegen, run `allocateSsa`, split critical edges, and emit `resolvePhiEdges`'s parallel-copies in place of `lowerPhisToLocals` — behind a `CompileOption` flag (default off), then benchmark CoreMark/SIMD before flipping the default.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>