### PR TITLE
compiler/ir: real lowered-form baseline corrects the SSA spill measurement (#392)

### DIFF
--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -17,6 +17,7 @@ const std = @import("std");
 const ir = @import("ir.zig");
 const analysis = @import("analysis.zig");
 const range_split = @import("range_split.zig");
+const passes = @import("passes.zig");
 
 /// Physical register identifier. Widest architecture we target is aarch64
 /// with 0..30 (v0..v31 is separate). `u8` leaves headroom.
@@ -374,6 +375,14 @@ pub const PhiSpillDelta = struct {
     /// pressure real codegen sees.
     ssa_spills_xcall: u32,
     naive_spills_xcall: u32,
+    /// Spill slots of the **actual status-quo lowering**: phis lowered to
+    /// `local_set`(at each predecessor)/`local_get`(at the join) exactly as
+    /// `lowerPhisToLocals` does in production, then allocated. This is the
+    /// honest baseline — `lowerPhisToLocals` already ends each arm at its
+    /// predecessor, so it is *not* the naive in-block model. (Excludes #540
+    /// parallel-copy coalescing / FMA / hints, so it is an approximation.)
+    lowered_spills: u32,
+    lowered_spills_xcall: u32,
 };
 
 /// Clobber points at every call in `func`, in the same global instruction
@@ -441,6 +450,19 @@ pub fn measurePhiSpillDelta(
     var naive_x = try allocate(func, allocator, measure_reg_set, clobbers);
     defer naive_x.deinit();
 
+    // Honest status-quo baseline: lower phis exactly as production does, then
+    // allocate. `lowerPhisToLocals` ends each arm at its predecessor's
+    // `local_set`, so this is SSA-like for arms (not the naive in-block model).
+    var clone = try func.clone(allocator);
+    defer clone.deinit();
+    _ = try passes.lowerPhisToLocals(&clone, allocator);
+    const clone_clobbers = try buildCallClobbers(&clone, measure_reg_set, allocator);
+    defer allocator.free(clone_clobbers);
+    var lowered = try allocate(&clone, allocator, measure_reg_set, &.{});
+    defer lowered.deinit();
+    var lowered_x = try allocate(&clone, allocator, measure_reg_set, clone_clobbers);
+    defer lowered_x.deinit();
+
     return .{
         .phis = phis,
         .calls = @intCast(clobbers.len),
@@ -448,6 +470,8 @@ pub fn measurePhiSpillDelta(
         .naive_spills = naive.spill_count,
         .ssa_spills_xcall = ssa_x.spill_count,
         .naive_spills_xcall = naive_x.spill_count,
+        .lowered_spills = lowered.spill_count,
+        .lowered_spills_xcall = lowered_x.spill_count,
     };
 }
 

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -37,8 +37,8 @@ const Subcommand = enum { compile, compile_component, run, verify, version, help
 fn ssaSpillMeasure(func: *const ir.IrFunction, allocator: std.mem.Allocator) void {
     const delta = (regalloc.measurePhiSpillDelta(func, allocator) catch return) orelse return;
     std.debug.print(
-        "[ssa-spill-measure] fn={s} phis={d} calls={d} ssa_spills={d} naive_spills={d} ssa_xcall={d} naive_xcall={d}\n",
-        .{ func.name orelse "<anon>", delta.phis, delta.calls, delta.ssa_spills, delta.naive_spills, delta.ssa_spills_xcall, delta.naive_spills_xcall },
+        "[ssa-spill-measure] fn={s} phis={d} calls={d} ssa_xcall={d} lowered_xcall={d} naive_xcall={d} ssa={d} lowered={d} naive={d}\n",
+        .{ func.name orelse "<anon>", delta.phis, delta.calls, delta.ssa_spills_xcall, delta.lowered_spills_xcall, delta.naive_spills_xcall, delta.ssa_spills, delta.lowered_spills, delta.naive_spills },
     );
 }
 


### PR DESCRIPTION
**Important course-correction for #392.** Per the plan to *confirm the win survives* before the Step 3b-ii codegen rewrite, I added the **real production baseline** to the measurement — and it shows the SSA win is essentially nil.

## The bug in the earlier measurement
The "naive" baseline in #805/#806 ran `allocate` on **phi-form** IR, which treats phi arms as in-block uses at the join and over-extends every arm across the join. **Production never does that.** `lowerPhisToLocals` inserts `local_set <synth>, arm` at each predecessor's terminator (passes.zig:7346), ending each arm's range *at its predecessor* — already SSA-like — and #540 resolves those via reg→reg `parallel_copy`.

## Fix
`measurePhiSpillDelta` now also lowers a clone via the real `lowerPhisToLocals` and allocates it, reporting `lowered_spills*` — the honest status-quo baseline.

## Re-measured on CoreMark (37 phi functions, call-clobber model)
| | SSA | **lowered (real)** | naive (strawman) |
|---|---:|---:|---:|
| call-clobber | 391 | **394** | 1521 |
| no-clobber | 241 | **245** | 1577 |

**SSA eliminates only 3 spills (0.8%) over the actual production lowering.**

## Conclusion
The existing `lowerPhisToLocals` + #540 parallel-copy pipeline already achieves SSA-like phi-arm intervals and reg→reg resolution, so SSA-aware allocation buys ~1%. The large, risky **Step 3b-ii is not justified** — I recommend **parking #392 here**. Steps 1–3a (`computeSsaLiveRanges`, `allocateSsa`, `resolvePhiEdges`) remain valid, tested infrastructure should the calculus ever change.

Full suite green: **87/87 steps, 4411/4423 passed**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>