### PR TITLE
perf(regalloc): enriched per-function spill-cost metric (#808 Lever 1)

### DIFF
--- a/src/compiler/codegen/timing.zig
+++ b/src/compiler/codegen/timing.zig
@@ -15,6 +15,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const passes = @import("../ir/passes.zig");
+const regalloc = @import("../ir/regalloc.zig");
 
 pub const Options = passes.CodegenTimingOptions;
 
@@ -121,6 +122,38 @@ pub fn printFunc(r: FuncReport) void {
             r.hash_ns / ns_per_ms, msFrac(r.hash_ns),         r.total_ns / ns_per_ms, msFrac(r.total_ns),        r.setup_ns / ns_per_ms,
             msFrac(r.setup_ns),    r.liveness_ns / ns_per_ms, msFrac(r.liveness_ns),  r.regalloc_ns / ns_per_ms, msFrac(r.regalloc_ns),
             emit_ns / ns_per_ms,   msFrac(emit_ns),
+        },
+    );
+}
+
+pub const SpillMetricOptions = passes.SpillMetricOptions;
+
+/// Per-function spill-cost diagnostic line (#808 Lever 1). `spill_count`
+/// is the raw `AllocResult.spill_count` (total 8-byte slots); the rest come
+/// from `regalloc.computeSpillMetric`. Printed only when the caller's
+/// `SpillMetricOptions.shouldLog` is satisfied; the backends gate the
+/// (cheap) metric computation on the same predicate so the disabled path
+/// pays nothing.
+pub const SpillReport = struct {
+    module_idx: u32,
+    func_idx: u32,
+    func_name: []const u8,
+    insts: usize,
+    clobbers: u32,
+    spill_count: u32,
+    metric: regalloc.SpillMetric,
+};
+
+pub fn printSpill(r: SpillReport) void {
+    const m = r.metric;
+    std.debug.print(
+        "[aot-spill-metric] local_func={d} mod={d} name={s} insts={d} clobbers={d} " ++
+            "slots={d} spilled_vregs={d} scalar={d} v128={d} slots_scalar={d} slots_v128={d} " ++
+            "spill_ld={d} spill_st={d} remat={d} callee_saved={d}\n",
+        .{
+            r.func_idx,          r.module_idx,             r.func_name,         r.insts,          r.clobbers,
+            r.spill_count,       m.spilled_vregs,          m.spilled_vregs_scalar, m.spilled_vregs_v128, m.slots_scalar,
+            m.slots_v128,        m.spill_loads,            m.spill_stores,      m.remat_vregs,    m.callee_saved_used,
         },
     );
 }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -1616,6 +1616,9 @@ pub fn compileModuleCached(
 /// parsing so per-function / per-sub-phase costs can be attributed.
 pub const CompileOptions = struct {
     codegen_timing: passes.CodegenTimingOptions = .{},
+    /// #808 Lever 1: per-function spill-cost diagnostics. Off unless
+    /// `WAMR_AOT_SPILL_METRIC` is set.
+    spill_metric: passes.SpillMetricOptions = .{},
     /// Component core/module index, used only to match the
     /// `WAMR_AOT_CODEGEN_TIMING_MODULE` filter. Single-module
     /// `wamrc compile` leaves it at 0.
@@ -1726,6 +1729,11 @@ pub fn compileModuleCachedWithOptions(
                 ir_module.global_offsets orelse &.{},
                 allocator,
                 if (func_timer) |*ft| ft else null,
+                if (options.spill_metric.enabled) SpillMetricCtx{
+                    .opts = options.spill_metric,
+                    .module_idx = options.module_idx,
+                    .func_idx = @intCast(fi),
+                } else null,
             );
             if (ct_live) {
                 compile_ns = codegen_timing.nowNs() -| compile_t0;
@@ -2157,18 +2165,29 @@ fn compileFunctionRAWithGlobalOffsets(
     global_offsets: []const u32,
     allocator: std.mem.Allocator,
 ) !FuncCompileResult {
-    return compileFunctionRAWithGlobalOffsetsTimed(func, import_count, global_offsets, allocator, null);
+    return compileFunctionRAWithGlobalOffsetsTimed(func, import_count, global_offsets, allocator, null, null);
 }
+
+/// #808 Lever 1 context: identifies the function for the spill-metric line
+/// and carries the (already enabled) options. `null` disables the metric.
+const SpillMetricCtx = struct {
+    opts: passes.SpillMetricOptions,
+    module_idx: u32,
+    func_idx: u32,
+};
 
 /// #778: same as `compileFunctionRAWithGlobalOffsets`, but records the
 /// contiguous setup / liveness / regalloc spans into `timer` when codegen
 /// timing is live. `timer == null` is the normal (untimed) path.
+/// `spill_ctx` (≠ null) additionally requests the #808 Lever 1 per-function
+/// spill-cost diagnostic.
 fn compileFunctionRAWithGlobalOffsetsTimed(
     func: *const ir.IrFunction,
     import_count: u32,
     global_offsets: []const u32,
     allocator: std.mem.Allocator,
     timer: ?*codegen_timing.FuncTimer,
+    spill_ctx: ?SpillMetricCtx,
 ) !FuncCompileResult {
     if (functionUsesV128(func)) return error.UnsupportedV128;
 
@@ -2319,6 +2338,33 @@ fn compileFunctionRAWithGlobalOffsetsTimed(
     );
     defer alloc_result.deinit();
     if (timer) |t| t.end(.regalloc);
+
+    // #808 Lever 1: per-function spill-cost diagnostic. The metric walk is
+    // gated on the (already enabled) module filter so the disabled path
+    // pays nothing; `printSpill` is further gated by `shouldLog`.
+    if (spill_ctx) |sc| {
+        if (sc.opts.moduleMatches(sc.module_idx)) {
+            const metric = try regalloc.computeSpillMetric(
+                allocator,
+                func,
+                x86_64_reg_set(func.local_count),
+                live_ranges,
+                &alloc_result,
+            );
+            if (sc.opts.shouldLog(sc.module_idx, sc.func_idx, metric.spilled_vregs)) {
+                codegen_timing.printSpill(.{
+                    .module_idx = sc.module_idx,
+                    .func_idx = sc.func_idx,
+                    .func_name = func.name orelse "<anon>",
+                    .insts = countInstructions(func),
+                    .clobbers = @intCast(clobber_points.items.len),
+                    .spill_count = alloc_result.spill_count,
+                    .metric = metric,
+                });
+            }
+        }
+    }
+
     // Everything below (used-register scans + emit loop + branch/table/
     // call patch resolution + toOwnedSlice) is attributed to the derived
     // `emit` bucket (total − setup − liveness − regalloc).

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -3365,6 +3365,50 @@ pub fn codegenTimingOptionsFromEnv(env: *const std.process.Environ.Map) CodegenT
     return out;
 }
 
+/// Stderr per-function spill-cost diagnostics for the native-codegen phase
+/// (#808 Lever 1). Off by default; `wamrc` populates it from
+/// `WAMR_AOT_SPILL_METRIC*`. The codegen backends compute the metric via
+/// `regalloc.computeSpillMetric` and print it through
+/// `src/compiler/codegen/timing.zig`.
+pub const SpillMetricOptions = struct {
+    enabled: bool = false,
+    /// Only emit a line for functions with at least this many spilled
+    /// vregs (default 1 — skip the spill-free majority).
+    min_spilled_vregs: u32 = 1,
+    module_filter: ?u32 = null,
+    func_filter: ?u32 = null,
+
+    pub fn moduleMatches(self: SpillMetricOptions, module_idx: u32) bool {
+        return self.module_filter == null or self.module_filter.? == module_idx;
+    }
+
+    /// Whether to emit a line for a function given its module index, local
+    /// function index, and spilled-vreg count.
+    pub fn shouldLog(self: SpillMetricOptions, module_idx: u32, func_idx: u32, spilled_vregs: u32) bool {
+        if (!self.enabled or !self.moduleMatches(module_idx)) return false;
+        if (self.func_filter) |f| return f == func_idx;
+        return spilled_vregs >= self.min_spilled_vregs;
+    }
+};
+
+/// Parse env-gated spill-metric diagnostics. `WAMR_AOT_SPILL_METRIC=1`
+/// enables logging; `0`, `false`, `no`, `off`, or an empty value keep it
+/// disabled. Optional knobs:
+///
+///   - `WAMR_AOT_SPILL_METRIC_MIN_SPILLS` (default: 1)
+///   - `WAMR_AOT_SPILL_METRIC_MODULE` (component core/module index)
+///   - `WAMR_AOT_SPILL_METRIC_FUNC` (local IR function index)
+pub fn spillMetricOptionsFromEnv(env: *const std.process.Environ.Map) SpillMetricOptions {
+    const gate = env.get("WAMR_AOT_SPILL_METRIC") orelse return .{};
+    if (!envFlagEnabled(gate)) return .{};
+
+    var out = SpillMetricOptions{ .enabled = true };
+    if (parseEnvU32(env, "WAMR_AOT_SPILL_METRIC_MIN_SPILLS")) |n| out.min_spilled_vregs = n;
+    if (parseEnvU32(env, "WAMR_AOT_SPILL_METRIC_MODULE")) |m| out.module_filter = m;
+    if (parseEnvU32(env, "WAMR_AOT_SPILL_METRIC_FUNC")) |f| out.func_filter = f;
+    return out;
+}
+
 fn envFlagEnabled(value: []const u8) bool {
     return value.len != 0 and
         !std.mem.eql(u8, value, "0") and
@@ -15448,6 +15492,51 @@ test "codegenTimingOptionsFromEnv: parses gate, threshold, cadence, and filters"
     // Module filter matching.
     try std.testing.expect(opts.moduleMatches(4));
     try std.testing.expect(!opts.moduleMatches(0));
+}
+
+test "spillMetricOptionsFromEnv: disabled unless gate set" {
+    const allocator = std.testing.allocator;
+    var env = std.process.Environ.Map.init(allocator);
+    defer env.deinit();
+
+    try env.put("WAMR_AOT_SPILL_METRIC_MIN_SPILLS", "5");
+    try std.testing.expect(!spillMetricOptionsFromEnv(&env).enabled);
+
+    try env.put("WAMR_AOT_SPILL_METRIC", "off");
+    try std.testing.expect(!spillMetricOptionsFromEnv(&env).enabled);
+}
+
+test "spillMetricOptionsFromEnv: parses gate, threshold, and filters" {
+    const allocator = std.testing.allocator;
+    var env = std.process.Environ.Map.init(allocator);
+    defer env.deinit();
+
+    try env.put("WAMR_AOT_SPILL_METRIC", "1");
+    try env.put("WAMR_AOT_SPILL_METRIC_MIN_SPILLS", "32");
+    try env.put("WAMR_AOT_SPILL_METRIC_MODULE", "4");
+    try env.put("WAMR_AOT_SPILL_METRIC_FUNC", "11396");
+
+    const opts = spillMetricOptionsFromEnv(&env);
+    try std.testing.expect(opts.enabled);
+    try std.testing.expectEqual(@as(u32, 32), opts.min_spilled_vregs);
+    try std.testing.expectEqual(@as(?u32, 4), opts.module_filter);
+    try std.testing.expectEqual(@as(?u32, 11396), opts.func_filter);
+
+    // A func filter logs that exact function regardless of spill count, and
+    // suppresses all others; module filter still gates.
+    try std.testing.expect(opts.shouldLog(4, 11396, 0));
+    try std.testing.expect(!opts.shouldLog(4, 11397, 9999));
+    try std.testing.expect(!opts.shouldLog(0, 11396, 9999));
+}
+
+test "SpillMetricOptions.shouldLog: min-spill threshold without a func filter" {
+    const opts = SpillMetricOptions{ .enabled = true, .min_spilled_vregs = 10 };
+    try std.testing.expect(opts.shouldLog(0, 3, 10));
+    try std.testing.expect(opts.shouldLog(0, 3, 11));
+    try std.testing.expect(!opts.shouldLog(0, 3, 9));
+    // Disabled options never log.
+    const off = SpillMetricOptions{ .enabled = false, .min_spilled_vregs = 1 };
+    try std.testing.expect(!off.shouldLog(0, 0, 1000));
 }
 
 test "tailDuplicateSmallJoins: triple predecessor with br terminator — all three duplicated" {

--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -502,6 +502,131 @@ pub fn classifyRematCandidates(
     return map;
 }
 
+/// Enriched per-function spill cost, derived purely from a finished
+/// `AllocResult` plus the function's IR and live ranges (#808 Lever 1).
+///
+/// `AllocResult.spill_count` alone reports only the number of 8-byte spill
+/// *slots* — that conflates a slot-reuse win (which cuts frame size but not
+/// memory traffic) with a real reduction in load/store work. This metric
+/// separates the two so the #798 profile can be correlated against actual
+/// codegen traffic, not just slot accounting:
+///   - distinct spilled vregs (scalar vs v128),
+///   - 8-byte slots consumed by each class,
+///   - emitted spill *reloads* (one per IR use of a spilled vreg) and
+///     *stores* (one per IR def of a spilled vreg) — the real traffic,
+///   - rematerialised vregs (#542), which avoid both slot and traffic,
+///   - distinct callee-saved registers used (each a prologue push +
+///     epilogue pop — the only register save/restore traffic in WAMR's
+///     clobber-aware model, since values live across a call are forced
+///     onto callee-saved regs rather than push/pop'd around the call).
+pub const SpillMetric = struct {
+    /// Distinct vregs assigned to a stack slot.
+    spilled_vregs: u32 = 0,
+    spilled_vregs_scalar: u32 = 0,
+    spilled_vregs_v128: u32 = 0,
+    /// 8-byte slots consumed by scalar / v128 spills (v128 = 2 each). The
+    /// sum can be below `AllocResult.spill_count` because inter-class
+    /// alignment padding is attributed to neither bucket.
+    slots_scalar: u32 = 0,
+    slots_v128: u32 = 0,
+    /// Emitted spill reloads: one per IR operand reference to a spilled
+    /// vreg (codegen reloads from the slot at each use site).
+    spill_loads: u32 = 0,
+    /// Emitted spill stores: one per IR def of a spilled vreg.
+    spill_stores: u32 = 0,
+    /// Vregs rematerialised (#542) instead of spilled — no slot, no
+    /// reload (the def is re-emitted at each use instead).
+    remat_vregs: u32 = 0,
+    /// Distinct callee-saved physical registers used by the allocation.
+    /// Excludes ABI-pinned regs (vmctx / memory_base) that are not in the
+    /// allocatable pool.
+    callee_saved_used: u32 = 0,
+};
+
+const SpillUseCounter = struct {
+    spilled: *const std.AutoHashMap(ir.VReg, void),
+    count: u32 = 0,
+
+    fn visit(self: *SpillUseCounter, v: ir.VReg) anyerror!void {
+        if (self.spilled.contains(v)) self.count += 1;
+    }
+};
+
+/// Compute the #808 Lever 1 spill metric for one function. Pure: mutates
+/// nothing, allocates only scratch freed before returning. `ranges` is the
+/// same slice passed to `allocateFromRanges*` (used to classify each
+/// spilled vreg's type); `alloc_result` is its output.
+pub fn computeSpillMetric(
+    allocator: std.mem.Allocator,
+    func: *const ir.IrFunction,
+    reg_set: RegSet,
+    ranges: []const analysis.LiveRange,
+    alloc_result: *const AllocResult,
+) !SpillMetric {
+    var metric: SpillMetric = .{ .remat_vregs = alloc_result.remat.count() };
+
+    // vreg → type, sourced from the live ranges that drove allocation.
+    var type_of = std.AutoHashMap(ir.VReg, ir.IrType).init(allocator);
+    defer type_of.deinit();
+    for (ranges) |r| try type_of.put(r.vreg, r.type);
+
+    // Distinct spilled vregs + per-class slot accounting.
+    var spilled = std.AutoHashMap(ir.VReg, void).init(allocator);
+    defer spilled.deinit();
+    {
+        var it = alloc_result.assignments.iterator();
+        while (it.next()) |e| {
+            if (e.value_ptr.* != .stack) continue;
+            try spilled.put(e.key_ptr.*, {});
+            metric.spilled_vregs += 1;
+            const ty = type_of.get(e.key_ptr.*) orelse ir.IrType.i64;
+            if (ty == .v128) {
+                metric.spilled_vregs_v128 += 1;
+                metric.slots_v128 += ty.spillSlots64();
+            } else {
+                metric.spilled_vregs_scalar += 1;
+                metric.slots_scalar += ty.spillSlots64();
+            }
+        }
+    }
+
+    // Emitted spill traffic: one store per def of a spilled vreg, one
+    // reload per operand reference to a spilled vreg.
+    var uc = SpillUseCounter{ .spilled = &spilled };
+    for (func.blocks.items) |block| {
+        for (block.instructions.items) |inst| {
+            if (inst.dest) |d| {
+                if (spilled.contains(d)) metric.spill_stores += 1;
+            }
+            try range_split.forEachUseInst(inst, &uc, SpillUseCounter.visit);
+        }
+    }
+    metric.spill_loads = uc.count;
+
+    // Distinct callee-saved physical registers used (prologue/epilogue
+    // save/restore traffic). Physreg values fit in u8 and are < 64 on
+    // every target, so a u64 bitmask keyed by physreg value suffices.
+    var callee_saved_set: u64 = 0;
+    for (reg_set.callee_saved_indices) |idx| {
+        const phys = reg_set.alloc_regs[idx];
+        if (phys < 64) callee_saved_set |= (@as(u64, 1) << @intCast(phys));
+    }
+    var callee_used: u64 = 0;
+    {
+        var it = alloc_result.assignments.iterator();
+        while (it.next()) |e| {
+            if (e.value_ptr.* != .reg) continue;
+            const phys = e.value_ptr.reg;
+            if (phys < 64 and (callee_saved_set & (@as(u64, 1) << @intCast(phys))) != 0) {
+                callee_used |= (@as(u64, 1) << @intCast(phys));
+            }
+        }
+    }
+    metric.callee_saved_used = @popCount(callee_used);
+
+    return metric;
+}
+
 /// Variant of `allocate` that takes pre-computed live ranges. Used by
 /// aarch64 to inject FMA-fusion awareness: the codegen's MADD/MSUB pre-pass
 /// reads a fused mul's sources at the following add instruction, so those
@@ -1226,6 +1351,92 @@ test "measurePhiSpillDelta: null without phis; SSA never spills more than naive"
         // SSA intervals are a subset under the call-clobber model too.
         try std.testing.expect(d.ssa_spills_xcall <= d.naive_spills_xcall);
     }
+}
+
+test "computeSpillMetric: counts spilled vregs, slots, traffic, and callee-saved use" {
+    const allocator = std.testing.allocator;
+    const reg_set: RegSet = .{
+        .alloc_regs = &.{ 10, 11, 12 },
+        .callee_saved_indices = &.{2}, // physreg 12 is callee-saved
+        .caller_saved_indices = &.{ 0, 1 }, // physregs 10, 11 are caller-saved
+        .spill_base = 0,
+        .spill_stride = 8,
+    };
+
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const block = func.getBlock(b0);
+
+    const v0 = func.newVReg(); // spilled scalar: 1 def + 2 uses
+    const v1 = func.newVReg(); // caller-saved reg
+    const v2 = func.newVReg(); // spilled v128: 1 def + 1 use
+    const v3 = func.newVReg(); // callee-saved reg
+    const v4 = func.newVReg();
+    const v5 = func.newVReg();
+
+    try block.append(.{ .op = .{ .iconst_32 = 1 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v1 } }, .dest = v3, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = v0, .rhs = v3 } }, .dest = v4, .type = .i32 });
+    try block.append(.{ .op = .{ .v128_const = 0 }, .dest = v2, .type = .v128 });
+    try block.append(.{ .op = .{ .v128_not = v2 }, .dest = v5, .type = .v128 });
+    try block.append(.{ .op = .{ .ret = v4 }, .type = .void });
+
+    // Ranges only supply per-vreg types for the scalar/v128 split.
+    const ranges = [_]analysis.LiveRange{
+        .{ .vreg = v0, .start = 0, .end = 4, .type = .i32 },
+        .{ .vreg = v2, .start = 4, .end = 5, .type = .v128 },
+    };
+
+    // Hand-built allocation: deterministic placement independent of the
+    // linear-scan decisions, so the metric's accounting is isolated.
+    var result: AllocResult = .{
+        .assignments = std.AutoHashMap(ir.VReg, Allocation).init(allocator),
+        .spill_count = 3,
+        .remat = std.AutoHashMap(ir.VReg, RematDef).init(allocator),
+    };
+    defer result.deinit();
+    try result.assignments.put(v0, .{ .stack = 0 });
+    try result.assignments.put(v1, .{ .reg = 10 });
+    try result.assignments.put(v2, .{ .stack = 8 });
+    try result.assignments.put(v3, .{ .reg = 12 }); // callee-saved
+    try result.assignments.put(v4, .{ .reg = 11 });
+    try result.assignments.put(v5, .{ .reg = 11 });
+
+    const m = try computeSpillMetric(allocator, &func, reg_set, &ranges, &result);
+    try std.testing.expectEqual(@as(u32, 2), m.spilled_vregs);
+    try std.testing.expectEqual(@as(u32, 1), m.spilled_vregs_scalar);
+    try std.testing.expectEqual(@as(u32, 1), m.spilled_vregs_v128);
+    try std.testing.expectEqual(@as(u32, 1), m.slots_scalar);
+    try std.testing.expectEqual(@as(u32, 2), m.slots_v128);
+    try std.testing.expectEqual(@as(u32, 3), m.spill_loads); // v0 ×2 + v2 ×1
+    try std.testing.expectEqual(@as(u32, 2), m.spill_stores); // v0 + v2 defs
+    try std.testing.expectEqual(@as(u32, 0), m.remat_vregs);
+    try std.testing.expectEqual(@as(u32, 1), m.callee_saved_used); // physreg 12
+}
+
+test "computeSpillMetric: no spills yields an all-zero metric" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 0, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    const block = func.getBlock(b0);
+    const v0 = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 7 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v0 }, .type = .void });
+
+    const ranges = [_]analysis.LiveRange{
+        .{ .vreg = v0, .start = 0, .end = 1, .type = .i32 },
+    };
+    var result = try allocateFromRanges(allocator, test_reg_set, &.{}, &ranges);
+    defer result.deinit();
+
+    const m = try computeSpillMetric(allocator, &func, test_reg_set, &ranges, &result);
+    try std.testing.expectEqual(@as(u32, 0), m.spilled_vregs);
+    try std.testing.expectEqual(@as(u32, 0), m.spill_loads);
+    try std.testing.expectEqual(@as(u32, 0), m.spill_stores);
+    try std.testing.expectEqual(@as(u32, 0), m.callee_saved_used);
 }
 
 test "allocate: no spills with few live values" {

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -426,6 +426,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
     const compiled: codegen_cache.CompileResultCached = switch (target_arch) {
         .x86_64 => x86_64_compile.compileModuleCachedWithOptions(&ir_module, reuse_ptr, allocator, .{
             .codegen_timing = codegen_timing,
+            .spill_metric = passes.spillMetricOptionsFromEnv(init.environ_map),
         }) catch |err| {
             std.debug.print("Error compiling to x86-64: {}\n", .{err});
             std.process.exit(1);
@@ -944,6 +945,7 @@ fn runCompileComponent(init: std.process.Init, allocator: std.mem.Allocator, sub
         .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
         .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
         .codegen_timing = passes.codegenTimingOptionsFromEnv(init.environ_map),
+        .spill_metric = passes.spillMetricOptionsFromEnv(init.environ_map),
         .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
         .verify_mode = verify_mode,
     }) catch |err| {
@@ -1066,6 +1068,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
                 .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
                 .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
                 .codegen_timing = passes.codegenTimingOptionsFromEnv(init.environ_map),
+                .spill_metric = passes.spillMetricOptionsFromEnv(init.environ_map),
                 .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
                 .verify_mode = verifyModeFromEnvOrDefault(init.environ_map),
             }) catch |err| {
@@ -1084,6 +1087,7 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
                 .pass_timing = passes.passTimingOptionsFromEnv(init.environ_map),
                 .analysis_timing = passes.analysisTimingOptionsFromEnv(init.environ_map),
                 .codegen_timing = passes.codegenTimingOptionsFromEnv(init.environ_map),
+                .spill_metric = passes.spillMetricOptionsFromEnv(init.environ_map),
                 .tail_duplication = passes.tailDuplicationOptionsFromEnv(init.environ_map),
                 .verify_mode = verifyModeFromEnvOrDefault(init.environ_map),
             }) catch |err| {

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -100,6 +100,9 @@ pub const PrecompileOptions = struct {
     /// Optional native-codegen timing diagnostics (#778), normally parsed
     /// by `wamrc` from `WAMR_AOT_CODEGEN_TIMING*`.
     codegen_timing: passes.CodegenTimingOptions = .{},
+    /// Optional per-function spill-cost diagnostics (#808 Lever 1),
+    /// normally parsed by `wamrc` from `WAMR_AOT_SPILL_METRIC*`.
+    spill_metric: passes.SpillMetricOptions = .{},
     /// Tail-duplication compile-time guard/cap options.
     tail_duplication: passes.TailDuplicationOptions = .{},
     /// IR verifier mode for optimized builds. Defaults match the historical
@@ -242,6 +245,7 @@ pub fn compileCoreWasmCached(
             return error.CoreCompileFailed,
         .x86_64 => x86_64_compile.compileModuleCachedWithOptions(&ir_module, cache_ctx.reuse, allocator, .{
             .codegen_timing = opts.codegen_timing,
+            .spill_metric = opts.spill_metric,
             .module_idx = opts.module_idx,
         }) catch
             return error.CoreCompileFailed,


### PR DESCRIPTION
Implements **Lever 1** of #808 (child of #798 Lever 4): an enriched
per-function spill-cost metric to rank the worst-spilling functions and
correlate against the #798 Tier-0 profile.

## Why
`AllocResult.spill_count` reports only the number of 8-byte spill **slots**,
which conflates a slot-reuse win (smaller frame, same memory traffic) with a
real reduction in load/store work. #808's design review calls this a
false-progress trap: a later slot-reuse lever (Lever 3) would shrink slots
without cutting traffic. The metric must distinguish **slots** from **traffic**.

## What
- **`regalloc.computeSpillMetric`** — a pure analysis over a finished
  `AllocResult` + the function IR + its live ranges. Reports:
  - distinct spilled vregs (scalar vs v128),
  - 8-byte slots per class,
  - emitted spill **reloads** (one per IR use of a spilled vreg) and **stores**
    (one per def) — the real traffic,
  - rematerialised vregs (#542),
  - distinct callee-saved registers used (prologue/epilogue save/restore — the
    only register save/restore traffic in WAMR's clobber-aware model, since
    values live across a call are forced onto callee-saved regs rather than
    push/pop'd around the call).
- Env-gated diagnostic mirroring #778 codegen timing:
  `passes.SpillMetricOptions` + `spillMetricOptionsFromEnv`
  (`WAMR_AOT_SPILL_METRIC`, `_MIN_SPILLS`, `_MODULE`, `_FUNC`),
  `timing.printSpill`. Threaded into the **x86_64** production codegen and all
  three `wamrc` compile entry points. Disabled path is a no-op.

x86_64 is the #798 acceptance target (`range_split.zig` is aarch64-only;
aarch64/zig1 is only an iteration proxy). aarch64 wiring can be a fast follow-up.

## Output
\`\`\`
[aot-spill-metric] local_func=43 mod=0 name=<anon> insts=4269 clobbers=83 \
  slots=318 spilled_vregs=318 scalar=318 v128=0 slots_scalar=318 slots_v128=0 \
  spill_ld=2284 spill_st=318 remat=0 callee_saved=3
\`\`\`

## Verification
- `zig build test` green.
- New unit tests: `computeSpillMetric` accounting (scalar+v128, slots, ld/st
  traffic, callee-saved) and `spillMetricOptionsFromEnv` / `shouldLog` gating.
- Smoke-tested on CoreMark (`--target x86_64`): `local_func=43` ranks worst
  (318 spilled vregs / 2284 reloads). Note x86_64 bails on v128 functions, so
  the v128 buckets are 0 there by construction; they exist for aarch64 reuse.

## Next (per #808, gated on the #798 Tier-0 profile)
Lever 4 (next-use spill selection, split-around-calls, remat-across-calls) is
the primary regalloc lever; general `range_split` generalization (Lever 2) and
spill-slot reuse (Lever 3) come last. Do not start splitter work until the
profile confirms regalloc/spills are a material share of the 21s.