### PR TITLE
perf(regalloc): wire the spill-cost metric into aarch64 codegen (#808 Lever 1)

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -562,6 +562,10 @@ pub const CompileOptions = struct {
     /// totals + a module summary (no x86_64-style setup/liveness/regalloc
     /// sub-phase breakdown — the #778 bottleneck is the x86_64 host path).
     codegen_timing: passes.CodegenTimingOptions = .{},
+    /// #808 Lever 1: per-function spill-cost diagnostics. Off unless
+    /// `WAMR_AOT_SPILL_METRIC` is set. Combines the scalar (X) and v128 (V)
+    /// allocations into one per-function report.
+    spill_metric: passes.SpillMetricOptions = .{},
     /// Component core/module index, used only to match the
     /// `WAMR_AOT_CODEGEN_TIMING_MODULE` filter.
     module_idx: u32 = 0,
@@ -652,6 +656,10 @@ const FuncCompileCtx = struct {
     /// coalesce / post-emit-coalesce spans into it. Null is the normal
     /// (untimed) path — a hard no-op.
     codegen_timer: ?*codegen_timing.Aarch64FuncTimer = null,
+    /// #808 Lever 1: local function index, used to label the spill-metric
+    /// line and to match the `WAMR_AOT_SPILL_METRIC_FUNC` filter. Defaults
+    /// to 0 on the single-function `compileFunctionWithOptions` entry.
+    func_idx: u32 = 0,
     allocator: std.mem.Allocator,
 };
 
@@ -1626,6 +1634,48 @@ pub fn compileFunctionImpl(
             v128_live_ranges.items,
         );
         if (tmr) |t| t.end(.regalloc);
+    }
+
+    // #808 Lever 1: per-function spill-cost diagnostic. Combines the scalar
+    // (X-reg) and v128 (V-reg) allocations — disjoint vreg sets, distinct
+    // register files — into one report. Gated so the disabled path pays
+    // nothing; `printSpill` is further gated by `shouldLog`.
+    if (ctx.options.spill_metric.enabled and
+        ctx.options.spill_metric.moduleMatches(ctx.options.module_idx))
+    {
+        var metric: regalloc.SpillMetric = .{};
+        var total_slots: u32 = 0;
+        if (alloc_result_storage) |*ar| {
+            metric = metric.add(try regalloc.computeSpillMetric(
+                allocator,
+                func,
+                aarch64RegSetForSpillBase(spill_base),
+                scalar_live_ranges.items,
+                ar,
+            ));
+            total_slots += ar.spill_count;
+        }
+        if (v128_alloc_result_storage) |*ar| {
+            metric = metric.add(try regalloc.computeSpillMetric(
+                allocator,
+                func,
+                aarch64VRegSetForSpillBase(v128_spill_base),
+                v128_live_ranges.items,
+                ar,
+            ));
+            total_slots += ar.spill_count;
+        }
+        if (ctx.options.spill_metric.shouldLog(ctx.options.module_idx, ctx.func_idx, metric.spilled_vregs)) {
+            codegen_timing.printSpill(.{
+                .module_idx = ctx.options.module_idx,
+                .func_idx = ctx.func_idx,
+                .func_name = func.name orelse "<anon>",
+                .insts = aarch64CountInstructions(func),
+                .clobbers = @intCast(clobbers.items.len),
+                .spill_count = total_slots,
+                .metric = metric,
+            });
+        }
     }
 
     // Finalize frame layout now that we know how many spill slots the
@@ -8330,6 +8380,7 @@ pub fn compileModuleWithOptions(
             .func_types = ir_module.func_types.items,
             .func_type_indices = ir_module.func_type_indices.items,
             .options = options,
+            .func_idx = @intCast(func_idx),
             .allocator = allocator,
         };
         const func_code = compileFunctionImpl(&func, ctx, allocator) catch |err| {
@@ -8498,6 +8549,7 @@ pub fn compileModuleCachedWithOptions(
                 .func_type_indices = ir_module.func_type_indices.items,
                 .options = options,
                 .codegen_timer = if (func_timer) |*t| t else null,
+                .func_idx = @intCast(fi),
                 .allocator = allocator,
             };
             const compile_t0: u64 = if (ct_live) codegen_timing.nowNs() else 0;

--- a/src/compiler/ir/regalloc.zig
+++ b/src/compiler/ir/regalloc.zig
@@ -541,6 +541,24 @@ pub const SpillMetric = struct {
     /// Excludes ABI-pinned regs (vmctx / memory_base) that are not in the
     /// allocatable pool.
     callee_saved_used: u32 = 0,
+
+    /// Sum two metrics field-wise. Used on aarch64 to combine the separate
+    /// scalar (X-reg) and v128 (V-reg) allocations into one report; their
+    /// vreg sets are disjoint and their register files distinct, so the
+    /// per-field sums are exact.
+    pub fn add(self: SpillMetric, other: SpillMetric) SpillMetric {
+        return .{
+            .spilled_vregs = self.spilled_vregs + other.spilled_vregs,
+            .spilled_vregs_scalar = self.spilled_vregs_scalar + other.spilled_vregs_scalar,
+            .spilled_vregs_v128 = self.spilled_vregs_v128 + other.spilled_vregs_v128,
+            .slots_scalar = self.slots_scalar + other.slots_scalar,
+            .slots_v128 = self.slots_v128 + other.slots_v128,
+            .spill_loads = self.spill_loads + other.spill_loads,
+            .spill_stores = self.spill_stores + other.spill_stores,
+            .remat_vregs = self.remat_vregs + other.remat_vregs,
+            .callee_saved_used = self.callee_saved_used + other.callee_saved_used,
+        };
+    }
 };
 
 const SpillUseCounter = struct {
@@ -1414,6 +1432,41 @@ test "computeSpillMetric: counts spilled vregs, slots, traffic, and callee-saved
     try std.testing.expectEqual(@as(u32, 2), m.spill_stores); // v0 + v2 defs
     try std.testing.expectEqual(@as(u32, 0), m.remat_vregs);
     try std.testing.expectEqual(@as(u32, 1), m.callee_saved_used); // physreg 12
+}
+
+test "SpillMetric.add: merges scalar and v128 sub-metrics field-wise" {
+    const a = SpillMetric{
+        .spilled_vregs = 3,
+        .spilled_vregs_scalar = 3,
+        .slots_scalar = 3,
+        .spill_loads = 9,
+        .spill_stores = 3,
+        .remat_vregs = 1,
+        .callee_saved_used = 4,
+    };
+    const b = SpillMetric{
+        .spilled_vregs = 2,
+        .spilled_vregs_v128 = 2,
+        .slots_v128 = 4,
+        .spill_loads = 5,
+        .spill_stores = 2,
+        .callee_saved_used = 1,
+    };
+    const m = a.add(b);
+    try std.testing.expectEqual(@as(u32, 5), m.spilled_vregs);
+    try std.testing.expectEqual(@as(u32, 3), m.spilled_vregs_scalar);
+    try std.testing.expectEqual(@as(u32, 2), m.spilled_vregs_v128);
+    try std.testing.expectEqual(@as(u32, 3), m.slots_scalar);
+    try std.testing.expectEqual(@as(u32, 4), m.slots_v128);
+    try std.testing.expectEqual(@as(u32, 14), m.spill_loads);
+    try std.testing.expectEqual(@as(u32, 5), m.spill_stores);
+    try std.testing.expectEqual(@as(u32, 1), m.remat_vregs);
+    try std.testing.expectEqual(@as(u32, 5), m.callee_saved_used);
+    // Adding a zero metric is the identity.
+    const m2 = m.add(.{});
+    try std.testing.expectEqual(m.spilled_vregs, m2.spilled_vregs);
+    try std.testing.expectEqual(m.spill_loads, m2.spill_loads);
+    try std.testing.expectEqual(m.callee_saved_used, m2.callee_saved_used);
 }
 
 test "computeSpillMetric: no spills yields an all-zero metric" {

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -435,6 +435,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
             .enable_scheduler = enable_aarch64_scheduler,
             .enable_xreg_alloc = enable_aarch64_xreg_alloc,
             .codegen_timing = codegen_timing,
+            .spill_metric = passes.spillMetricOptionsFromEnv(init.environ_map),
         }) catch |err| {
             std.debug.print("Error compiling to AArch64: {}\n", .{err});
             std.process.exit(1);

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -240,6 +240,7 @@ pub fn compileCoreWasmCached(
     const compiled: codegen_cache.CompileResultCached = switch (opts.target_arch) {
         .aarch64 => aarch64_compile.compileModuleCachedWithOptions(&ir_module, cache_ctx.reuse, allocator, .{
             .codegen_timing = opts.codegen_timing,
+            .spill_metric = opts.spill_metric,
             .module_idx = opts.module_idx,
         }) catch
             return error.CoreCompileFailed,


### PR DESCRIPTION
Follow-up to #809. That PR added `regalloc.computeSpillMetric` and the
`WAMR_AOT_SPILL_METRIC*` diagnostic but only wired it into the **x86_64**
backend. #808's iteration proxy is **zig1.wasm on the AArch64 self-hosted
runner**, so the metric is most useful when it can also rank functions on the
aarch64 codegen.

## What
- aarch64 allocates scalar (X-reg) and v128 (V-reg) live ranges into two
  separate `AllocResult`s. Compute the metric for each and merge field-wise via
  a new `SpillMetric.add` (disjoint vreg sets, distinct register files → exact
  sums). The combine runs inside `compileFunctionImpl` where both allocations
  are still live.
- `FuncCompileCtx` gains a `func_idx` so the line can be labelled and the
  `WAMR_AOT_SPILL_METRIC_FUNC` filter resolved. Set in both aarch64 module
  loops (cached + non-cached).
- Threaded through the aarch64 `wamrc` / component compile entry points.
  Disabled path is a no-op.

## Verification
- `zig build test` green on the aarch64 host (exercises the modified backend).
- New unit test for `SpillMetric.add`.
- Smoke-tested on CoreMark (native aarch64): worst spiller `local_func=43`
  reports **239 spilled vregs / 1985 reloads** — fewer than x86_64's 318 / 2284,
  as expected from aarch64's larger register file, with `callee_saved=8`
  (x19..x28).

```
[aot-spill-metric] local_func=43 mod=0 name=<anon> insts=4360 clobbers=83 \
  slots=239 spilled_vregs=239 scalar=239 v128=0 ... spill_ld=1985 spill_st=239 \
  remat=0 callee_saved=8
```

v128 buckets (0 on the no-SIMD CoreMark) are covered by the `computeSpillMetric`
unit test; no SIMD wasm fixture is available in-tree to exercise them e2e.