### PR TITLE
skill: add aot-perf-profile (Azure Linux perf + JIT de-anonymization)

### DIFF
--- a/.github/skills/aot-perf-profile/SKILL.md
+++ b/.github/skills/aot-perf-profile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aot-perf-profile
-description: Profile a precompiled WAMR AOT run on an Azure Linux x86_64 VM and attribute cycles per wasm function and per instruction class. Installs `perf` (kernel-tools), records the precompiled load+execute run, then de-anonymizes the `[JIT]` mapping that perf cannot symbolize by mapping sample IPs to `local_func` indices via the `.cwasm` function section, and classifies the hot function's instruction mix (spill reloads / frame stores / bounds checks / call_indirect dispatch / memory). Use for #798-style runtime-gap investigations to decide whether spills, bounds-checks, or dispatch dominate before committing to codegen levers.
+description: Profile a precompiled WAMR AOT run (a component like keyvault/#798, or a core module like CoreMark/#393) on an Azure Linux x86_64 VM and attribute cycles per wasm function and per instruction class. Installs `perf` (kernel-tools), records the precompiled load+execute run, then de-anonymizes the `[JIT]` mapping that perf cannot symbolize by mapping sample IPs to `local_func` indices via the `.cwasm` function section, and classifies the hot function's instruction mix (spill reloads / frame stores / reg-reg moves / bounds checks / call_indirect or br_table dispatch / memory). Use for runtime-gap investigations to decide whether spills, zero-extension/move overhead, bounds-checks, or dispatch dominate before committing to codegen levers.
 ---
 
 # AOT perf profiling + JIT de-anonymization
@@ -100,6 +100,26 @@ awk '/\[aot-spill-metric\]/{for(i=1;i<=NF;i++){n=index($i,"=");
 Note the per-core `<stem>.<N>.cwasm` files written next to the manifest —
 the biggest one is the hot core's text and you need it in Step 5.
 
+### Core wasm modules (e.g. CoreMark, #393)
+
+For a **single core module** (not a component) — CoreMark, a microbench,
+any `.wasm` core — use `wamrc compile` instead of `compile-component`,
+and run it with `wamr run <m>.cwasm` directly (the CLI runs `.cwasm`
+core modules). Everything else (Steps 4–6) is identical; pass that one
+`.cwasm` to `aot_jit_attr.py` — its function indices are module-local.
+
+```sh
+./zig-out/bin/wamrc compile tests/benchmarks/coremark/coremark_wasi.wasm \
+  -o /work/cm/coremark.cwasm
+perf record -g --call-graph=dwarf -F 999 -o /work/cm/cm.perf -- \
+  ./zig-out/bin/wamr run /work/cm/coremark.cwasm
+python3 .github/skills/aot-perf-profile/aot_jit_attr.py \
+  --perf /work/cm/cm.perf --cwasm /work/cm/coremark.cwasm --func 10
+```
+
+(Spill ranking from Step 3 still works on a core module: `wamrc compile`
+honours `WAMR_AOT_SPILL_METRIC=1`; there's just one module, `mod=0`.)
+
 ## Step 4 — `perf record` the precompiled run (runtime, the gate)
 
 Profile **load+execute only** (precompiled — no compile in the loop). The
@@ -177,6 +197,23 @@ fn's `spill_ld` only 1.8% → supply is not the constraint.) Revert after.
 Lesson: the biggest *compile-time* spiller was never executed; the hot
 function was the **#3** spiller. Always confirm the runtime-hot function
 with Step 5 before optimizing the compile-time "monster".
+
+## Worked example (#393 CoreMark, captured 2026-06)
+
+Same tooling on the core module `coremark_wasi.wasm` (`wamr run`, 16.5 s):
+
+| metric | value |
+|---|---|
+| `[JIT]` | 99.9% of cycles |
+| hot fns | `local_func` 10 / 3 / 7 ≈ **30% / 28% / 28%** (list / matrix / state) |
+| hot-fn mix | **reg-reg mov 15–18%** each, ALU 5–7%, **spill traffic only 3–4%** |
+| dominant instrs | wasm i32 zero-extends (`mov esi,esi`, `mov edx,edx`, …) + a `br_table` (`add r10,r11; jmp r10`) |
+
+Lesson: CoreMark is **not** spill-bound (confirms #393/#524 — its hot
+loops aren't register-pressure-bound); the cost is **redundant i32
+zero-extension `mov eXX,eXX`** + branch/dispatch — a different lever
+(zero-ext elimination / coalescing) than keyvault's spills. The skill
+distinguishes the two workload classes directly.
 
 ## Anti-patterns
 

--- a/.github/skills/aot-perf-profile/SKILL.md
+++ b/.github/skills/aot-perf-profile/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: aot-perf-profile
+description: Profile a precompiled WAMR AOT run on an Azure Linux x86_64 VM and attribute cycles per wasm function and per instruction class. Installs `perf` (kernel-tools), records the precompiled load+execute run, then de-anonymizes the `[JIT]` mapping that perf cannot symbolize by mapping sample IPs to `local_func` indices via the `.cwasm` function section, and classifies the hot function's instruction mix (spill reloads / frame stores / bounds checks / call_indirect dispatch / memory). Use for #798-style runtime-gap investigations to decide whether spills, bounds-checks, or dispatch dominate before committing to codegen levers.
+---
+
+# AOT perf profiling + JIT de-anonymization
+
+Attribute where a **precompiled** WAMR AOT run spends its cycles, broken
+down per wasm `local_func` and per instruction class. Built for the #798
+"close the WAMR↔Wasmtime AOT runtime gap" work (the keyvault/TCGC /
+SpiderMonkey workload), but applies to any precompiled component run.
+
+The hard part this skill solves: WAMR maps generated AOT code as an
+**anonymous RX mmap**, so `perf` lumps ~98% of the run into one
+unsymbolized `[JIT]` bucket. This skill recovers per-function and
+per-instruction attribution from the `.cwasm` layout.
+
+## When to use
+
+- You have a precompiled WAMR run that is slower than a reference
+  (wasmtime/native) and need to know **what** is slow — spills vs.
+  bounds-checks vs. dispatch vs. memcpy — before picking a codegen lever
+  (#798 Tier 0; gates #808).
+- You want a per-function runtime ranking to confirm which function is
+  actually hot (it is often **not** the biggest compile-time function —
+  see the worked example below).
+- You're validating that a codegen/regalloc change moved the hot path.
+
+Do **not** use this skill for:
+
+- AOT *correctness* bugs (wrong output / traps) — use `aot-diff-debug`
+  then `aot-pass-bisect`.
+- Compile-time cost — that's `WAMR_AOT_CODEGEN_TIMING` / pass-timing, not
+  a runtime `perf record`.
+
+## Environment
+
+This VM is **Microsoft Azure Linux 3 (`azurelinux`, `azl3`)**, x86_64.
+Package manager is `tdnf` (and `dnf`). `perf` is **not** preinstalled and
+ships in the **`kernel-tools`** package, which must match the running
+kernel.
+
+## Step 1 — install `perf` (Azure Linux)
+
+```sh
+uname -m          # expect x86_64
+uname -r          # e.g. 6.6.139.1-1.azl3 — note this exact version
+sudo tdnf install -y kernel-tools     # installs the matching perf
+perf --version    # should print perf version == uname -r
+```
+
+`tdnf` resolves `kernel-tools` to the version matching the running
+kernel; if it picks an older build, the mismatch usually still records
+fine, but prefer the exact match. Confirm sampling is allowed:
+
+```sh
+cat /proc/sys/kernel/perf_event_paranoid   # 0 (or -1) = full user+kernel
+cat /proc/sys/kernel/kptr_restrict         # 0 = kernel symbols visible
+# If paranoid > 1:  sudo sysctl kernel.perf_event_paranoid=0
+```
+
+## Step 2 — build wamr/wamrc (ReleaseFast, isolated cache)
+
+The bench/perf convention is **ReleaseFast** (a Debug host inflates
+host-side symbols; the generated AOT code is identical either way). Per
+#374, isolate the Zig cache per worktree.
+
+```sh
+cd <wamr>
+unset ZIG_LOCAL_CACHE_DIR
+export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
+zig build -Doptimize=ReleaseFast
+./zig-out/bin/wamr version    # expect: optimize ReleaseFast
+```
+
+## Step 3 — precompile with the spill metric (compile-time ranking)
+
+Precompile the component once with the #809/#810 spill metric on. This
+ranks functions by **emitted reloads** (`spill_ld` = real traffic) and is
+the compile-time half of the picture.
+
+```sh
+WAMR_AOT_SPILL_METRIC=1 WAMR_AOT_SPILL_METRIC_MIN_SPILLS=1 \
+WAMR_AOT_CODEGEN_TIMING=1 WAMR_AOT_CODEGEN_TIMING_THRESHOLD_MS=0 \
+  ./zig-out/bin/wamrc compile-component \
+  -o /work/perf/comp.cwasm.json <component>.wasm 2> spill.log
+```
+
+Rank spillers (the `spill_ld` field is `=`-delimited token 12, but it is
+followed by more text, so sort with awk, not `sort -t= -k12`):
+
+```sh
+awk '/\[aot-spill-metric\]/{for(i=1;i<=NF;i++){n=index($i,"=");
+  if(n>0)f[substr($i,1,n-1)]=substr($i,n+1)}
+  printf "%d\tmod=%s lfunc=%s insts=%s spilled_vregs=%s spill_st=%s\n",
+  f["spill_ld"],f["mod"],f["local_func"],f["insts"],f["spilled_vregs"],f["spill_st"]}' \
+  spill.log | sort -k1,1 -nr | head -15
+```
+
+Note the per-core `<stem>.<N>.cwasm` files written next to the manifest —
+the biggest one is the hot core's text and you need it in Step 5.
+
+## Step 4 — `perf record` the precompiled run (runtime, the gate)
+
+Profile **load+execute only** (precompiled — no compile in the loop). The
+`wamr` CLI uses `--map-dir HOST::GUEST` preopens and auto-discovers a
+sibling `<input>.cwasm.json`, or takes `--precompiled-manifest <path>`.
+For the keyvault repro, the azure-sdk-for-zig `run.sh` is wasmtime-only;
+this skill ships `run_wamr_keyvault.sh` that mirrors its WASI preopens
+against the `wamr` binary (paths overridable via env).
+
+```sh
+SKILL=.github/skills/aot-perf-profile
+perf record -g --call-graph=dwarf -F 999 -o wamr.perf -- \
+  env WAMR_BIN=$PWD/zig-out/bin/wamr MANIFEST=/work/perf/comp.cwasm.json \
+      OUT=/work/perf/out $SKILL/run_wamr_keyvault.sh
+# ...or for any component:
+perf record -g --call-graph=dwarf -F 999 -o wamr.perf -- <wamr run cmd>
+perf report -i wamr.perf --stdio --sort=dso | head   # sanity: ~98% [JIT]
+```
+
+Expect ~98% in `[JIT]` (generated code) and <2% in the `wamr`
+host/libc/kernel. That alone tells you **host helpers (memcpy / trap_oob
+/ dispatch trampolines) are immaterial** — the cost is in generated code.
+
+## Step 5 — de-anonymize `[JIT]` (per-function + instruction mix)
+
+`perf` cannot symbolize the anonymous JIT region, and **DWARF cannot
+unwind it** (the generated code has no CFI), so `perf script` callchains
+are mostly empty — do **not** rely on them. Use the per-address **self**
+sample counts from `perf report` instead. The helper script does all of
+this: it parses `func_offsets[]` from the `.cwasm` function section,
+finds the text mmap base in the perf data (by matching the core's text
+size), buckets IPs per `local_func`, and classifies one function's
+instruction mix.
+
+```sh
+SKILL=.github/skills/aot-perf-profile
+# Per-function runtime ranking (which function is actually hot):
+python3 $SKILL/aot_jit_attr.py --perf wamr.perf --cwasm comp.4.cwasm
+
+# Add --func <N> to classify the hot function's instruction mix:
+python3 $SKILL/aot_jit_attr.py --perf wamr.perf --cwasm comp.4.cwasm --func 6145
+```
+
+It prints: total samples, % of run in this core, top functions by
+self-samples, and for `--func` the class breakdown (spill reloads /
+frame stores / reg-reg mov / ALU / bounds-check / linear-mem / dispatch /
+call) plus the 20 hottest instructions. Cross-validate: the static
+frame-load count for the hot fn should ≈ its `spill_ld` from Step 3.
+
+If size-matching picks the wrong mapping (multiple equal-size cores),
+pass `--base 0x...` explicitly; get candidate bases from
+`perf script -i wamr.perf --show-mmap-events | grep '//anon' | grep -E 'r[w-]xp'`.
+
+## Step 6 (optional) — register-supply sensitivity sweep
+
+To decide whether the hot function is **register-supply-bound** vs.
+**spill-quality-bound** without writing real codegen: temporarily add
+GPRs to `x86_64_alloc_regs` / `x86_64_callee_saved_indices` in
+`src/compiler/codegen/x86_64/compile.zig`, rebuild wamrc, re-run Step 3,
+and diff the hot fn's `spill_ld`. **The metric is computed from the
+allocation, so it is valid even though the emitted code is wrong** — just
+do not *run* that build. (Worked example: 8→13 GPRs cut the keyvault hot
+fn's `spill_ld` only 1.8% → supply is not the constraint.) Revert after.
+
+## Worked example (#798 keyvault, captured 2026-06)
+
+| metric | value |
+|---|---|
+| run | 21.4 s, `[JIT]` = 98.2% of cycles |
+| hot fn | `mod4 local_func=6145` = **75%** of run (SpiderMonkey interp loop) |
+| hot-fn mix | spill reloads 34.6%, frame stores 17.4% → **stack traffic ~52%** |
+| bounds-check | 2.4% · dispatch ~0.3% · linear-mem 1.5% |
+| compile-time #1 spiller | `local_func=11396` (`spill_ld`=514,965) — **runtime-COLD (0 samples)** |
+
+Lesson: the biggest *compile-time* spiller was never executed; the hot
+function was the **#3** spiller. Always confirm the runtime-hot function
+with Step 5 before optimizing the compile-time "monster".
+
+## Anti-patterns
+
+| Anti-pattern | Why it misleads | Do instead |
+|---|---|---|
+| Reading `perf report` symbols and stopping at `98% [JIT]` | It is one anonymous bucket; tells you nothing per-function | Run Step 5 to map IPs → `local_func` |
+| Using `perf script -F ip` callchains | DWARF can't unwind the no-CFI JIT → ~empty stacks | Use per-address **self** counts (`perf report -g none -n`) |
+| Optimizing the largest compile-time function | It may be runtime-cold | Rank by **runtime** self-samples (Step 5) first |
+| `sort -t= -k12` on the spill log | `spill_ld`'s field has trailing text → lexical sort | Parse with awk (Step 3) |
+| Debug build for the runtime profile | Inflates host symbols, not representative | Build ReleaseFast (Step 2) |
+| Installing a random `perf` | Azure Linux ships it in `kernel-tools` keyed to the kernel | `sudo tdnf install kernel-tools` (Step 1) |
+
+## References
+
+- Issue #798 — the runtime-gap tracker + lever list this profiles for.
+- Issue #808 / PRs #809, #810 — the `WAMR_AOT_SPILL_METRIC*` diagnostic
+  (`src/compiler/codegen/timing.zig:printSpill`,
+  `src/compiler/ir/passes.zig:spillMetricOptionsFromEnv`).
+- `src/runtime/aot/loader.zig:parseFunctionSection` — the `.cwasm`
+  function section (`type=3`: count then `(offset:u32, type_idx:u32)`)
+  that `aot_jit_attr.py` parses for `func_offsets[]`. Text section is
+  `type=2`; magic `\0aot` (`0x746f6100`), version 7.
+- `src/runtime/aot/runtime.zig` — the `local_func[N]+0x..` trap
+  symbolizer that uses the same `func_offsets`; r15 mmap'd RX at
+  `runtime.zig` `mprotect`.
+- `src/compiler/codegen/x86_64/compile.zig` — `x86_64_alloc_regs`
+  (8 allocatable GPRs; `rbx`=vmctx #465, `r15`=memory_base #466) for the
+  Step 6 sweep.
+
+## Companion skills
+
+- `aot-diff-debug` / `aot-pass-bisect` — for AOT *correctness* bugs.
+- `nvme-worktree` — isolate the build on `/work` NVMe for Step 2.

--- a/.github/skills/aot-perf-profile/aot_jit_attr.py
+++ b/.github/skills/aot-perf-profile/aot_jit_attr.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""De-anonymize a WAMR AOT `perf` profile and attribute cycles per function
+and per instruction class.
+
+WAMR maps generated AOT code as an anonymous RX mmap, so `perf` collapses
+~98% of a precompiled run into one unsymbolized `[JIT]` bucket. This tool
+maps sample IPs back to wasm `local_func` indices using the `.cwasm`
+function section (`func_offsets[]`) plus the text mmap base recorded in the
+perf data, then (optionally) classifies the hot instructions of one
+function (spill reloads / frame stores / bounds checks / dispatch / ...).
+
+Usage:
+  aot_jit_attr.py --perf wamr.perf --cwasm core4.cwasm            # per-function top
+  aot_jit_attr.py --perf wamr.perf --cwasm core4.cwasm --func 6145  # + instr mix
+
+Requires: perf, objdump, python3. x86_64 only for --func classification.
+"""
+import argparse, bisect, json, re, struct, subprocess, sys, tempfile, os
+
+AOT_MAGIC = 0x746F6100  # "\0aot"
+AOT_VERSION = 7
+SEC_TEXT = 2
+SEC_FUNCTION = 3
+
+
+def parse_cwasm(path):
+    """Return (func_offsets:list[int], text_size:int, text_fileoff:int)."""
+    f = open(path, "rb").read()
+    magic, ver = struct.unpack_from("<II", f, 0)
+    if magic != AOT_MAGIC:
+        sys.exit(f"{path}: bad magic {magic:#x} (not a .cwasm)")
+    if ver != AOT_VERSION:
+        print(f"warning: {path} aot_version={ver}, expected {AOT_VERSION}", file=sys.stderr)
+    pos = 8
+    offs = text_size = text_fileoff = None
+    while pos + 8 <= len(f):
+        st, sz = struct.unpack_from("<II", f, pos)
+        pos += 8
+        if st == SEC_TEXT:
+            text_fileoff, text_size = pos, sz
+        elif st == SEC_FUNCTION:
+            cnt, = struct.unpack_from("<I", f, pos)
+            arr = struct.unpack_from("<%dI" % (cnt * 2), f, pos + 4)
+            offs = list(arr[0::2])  # interleaved (offset, type_idx)
+        pos += sz
+    if offs is None or text_size is None:
+        sys.exit(f"{path}: missing function/text section")
+    return offs, text_size, text_fileoff, f
+
+
+def jit_exec_mmaps(perf):
+    """[(base,size)] of anonymous executable mappings, largest first."""
+    out = subprocess.run(
+        ["perf", "script", "-i", perf, "--show-mmap-events"],
+        capture_output=True, text=True).stdout
+    maps = []
+    pat = re.compile(r"\[(0x[0-9a-f]+)\((0x[0-9a-f]+)\).*?\]: r[w-]xp //anon")
+    for line in out.splitlines():
+        m = pat.search(line)
+        if m:
+            maps.append((int(m.group(1), 16), int(m.group(2), 16)))
+    return sorted(set(maps), key=lambda x: -x[1])
+
+
+def addr_counts(perf):
+    """{ip:self_sample_count} for [JIT] addresses; also total self samples."""
+    out = subprocess.run(
+        ["perf", "report", "-i", perf, "--stdio", "-g", "none", "-n",
+         "--sort=dso,symbol", "--percent-limit", "0"],
+        capture_output=True, text=True).stdout
+    row = re.compile(r"^\s*[\d.]+%\s+[\d.]+%\s+(\d+)\s+(.*)$")
+    cnt, total = {}, 0
+    for line in out.splitlines():
+        m = row.match(line)
+        if not m:
+            continue
+        c = int(m.group(1)); total += c
+        rest = m.group(2)
+        if "[JIT]" in rest:
+            sm = re.search(r"\[[.]\]\s+(0x[0-9a-fA-F]+)", rest)
+            if sm:
+                cnt[int(sm.group(1), 16)] = cnt.get(int(sm.group(1), 16), 0) + c
+    return cnt, total
+
+
+def classify(t):
+    mn = t.split()[0] if t else ""
+    frame = ("[rbp-" in t) or ("[rbp+" in t) or ("[rsp" in t)
+    is_mov = mn in ("mov", "movzx", "movsx", "movsxd", "movsd", "movss",
+                    "movdqu", "movdqa", "movaps", "movups", "movq", "movd")
+    if frame and is_mov:
+        dest = t[len(mn):].strip().split(",")[0]
+        return "spill_store" if (("[rbp-" in dest) or ("[rbp+" in dest) or ("[rsp" in dest)) else "spill_load"
+    if mn == "cmp" and re.search(r"\[(rbx|r10|r11)\+0x8\]", t):
+        return "bounds_cmp"
+    if mn in ("ja", "jae", "jb", "jbe"):
+        return "bounds_branch"
+    if mn == "call":
+        return "call"
+    if mn == "jmp":
+        return "dispatch_jmp" if re.search(r"jmp\s+r(ax|10|11)", t) else "jmp"
+    if mn in ("je", "jne", "jl", "jle", "jg", "jge", "js", "jns", "jp", "jnp", "jo", "jno"):
+        return "cond_branch"
+    if is_mov and "[" in t and not frame and "rip" not in t:
+        return "mem_access"
+    if is_mov:
+        return "regmov"
+    if mn in ("add", "sub", "and", "or", "xor", "shl", "shr", "sar", "imul",
+              "mul", "inc", "dec", "neg", "not", "test", "lea", "sete", "setne",
+              "seta", "cdqe", "cqo"):
+        return "alu"
+    return "other"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--perf", required=True)
+    ap.add_argument("--cwasm", required=True, help="the core .cwasm that owns the hot code")
+    ap.add_argument("--func", type=int, default=None, help="classify this local_func's instr mix")
+    ap.add_argument("--top", type=int, default=20)
+    ap.add_argument("--base", default=None, help="override text mmap base (hex)")
+    a = ap.parse_args()
+
+    offs, tsize, tfileoff, fbytes = parse_cwasm(a.cwasm)
+    cnt, total = addr_counts(a.perf)
+    if total == 0:
+        sys.exit("no samples in perf data")
+
+    if a.base:
+        base = int(a.base, 16)
+    else:
+        # pick the anon exec mapping whose size matches this core's text (page-rounded)
+        maps = jit_exec_mmaps(a.perf)
+        base = None
+        for b, s in maps:
+            if abs(s - tsize) <= 0x2000:
+                base = b; break
+        if base is None and maps:
+            base = maps[0][0]
+            print(f"warning: no mmap size match for text_size={tsize}; using largest "
+                  f"anon exec base {base:#x} (size {maps[0][1]})", file=sys.stderr)
+        if base is None:
+            sys.exit("could not find an anonymous executable mapping in perf data")
+    end = base + tsize
+    print(f"core text base={base:#x} size={tsize} ({tsize/1048576:.1f} MB), "
+          f"func_count={len(offs)}, total self samples={total}")
+
+    perfunc, in_core = {}, 0
+    for ip, c in cnt.items():
+        if base <= ip < end:
+            in_core += c
+            fi = bisect.bisect_right(offs, ip - base) - 1
+            perfunc[fi] = perfunc.get(fi, 0) + c
+    print(f"samples in this core: {in_core} ({100*in_core/total:.1f}% of run)\n")
+    print(f"=== top {a.top} functions by self samples ===")
+    for fi, c in sorted(perfunc.items(), key=lambda x: -x[1])[:a.top]:
+        fend = offs[fi + 1] if fi + 1 < len(offs) else tsize
+        print(f"  local_func={fi:<6} samples={c:<6} ({100*c/total:.2f}% of run)  "
+              f"code_bytes={fend-offs[fi]}")
+
+    if a.func is None:
+        return
+    fi = a.func
+    if fi < 0 or fi >= len(offs):
+        sys.exit(f"--func {fi} out of range (0..{len(offs)-1})")
+    s = offs[fi]; e = offs[fi + 1] if fi + 1 < len(offs) else tsize
+    fnbase = base + s
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tf:
+        tf.write(fbytes[tfileoff + s:tfileoff + e]); tmp = tf.name
+    try:
+        asm = subprocess.run(
+            ["objdump", "-D", "-b", "binary", "-m", "i386:x86-64", "-M", "intel",
+             "--adjust-vma=0x%x" % fnbase, tmp], capture_output=True, text=True).stdout
+    finally:
+        os.remove(tmp)
+    ipat = re.compile(r"^\s*([0-9a-f]+):\s+(?:[0-9a-f]{2} )+\s*(.*)$")
+    fn_total = 0
+    byclass = {}
+    hot = []
+    for line in asm.splitlines():
+        m = ipat.match(line)
+        if not m:
+            continue
+        addr = int(m.group(1), 16); txt = m.group(2).strip()
+        c = cnt.get(addr, 0)
+        fn_total += c
+        cl = classify(txt)
+        byclass[cl] = byclass.get(cl, 0) + c
+        if c:
+            hot.append((c, addr, txt))
+    print(f"\n=== local_func={fi} instruction-class mix "
+          f"(self={fn_total}, {100*fn_total/total:.1f}% of run) ===")
+    groups = {
+        "spill_load (reloads)": ["spill_load"],
+        "frame stores": ["spill_store"],
+        "reg-reg mov": ["regmov"],
+        "ALU": ["alu"],
+        "bounds-check": ["bounds_cmp", "bounds_branch"],
+        "linear-mem access": ["mem_access"],
+        "dispatch (computed-goto)": ["dispatch_jmp"],
+        "call": ["call"],
+        "other branches": ["cond_branch", "jmp"],
+        "other": ["other"],
+    }
+    for g, ks in sorted(groups.items(), key=lambda kv: -sum(byclass.get(k, 0) for k in kv[1])):
+        v = sum(byclass.get(k, 0) for k in ks)
+        print(f"  {g:<28} {v:>7}  ({100*v/total:.1f}% of run)")
+    sp = byclass.get("spill_load", 0) + byclass.get("spill_store", 0)
+    print(f"  >> stack/spill traffic = {100*sp/total:.1f}% of total run; "
+          f"reloads alone = {100*byclass.get('spill_load',0)/total:.1f}%")
+    print(f"\n=== top 20 hottest instructions in local_func={fi} ===")
+    for c, addr, txt in sorted(hot, reverse=True)[:20]:
+        print(f"  {c:>5} ({100*c/total:.2f}%)  {addr:x}: {txt}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/aot-perf-profile/run_wamr_keyvault.sh
+++ b/.github/skills/aot-perf-profile/run_wamr_keyvault.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Example WAMR runner for the #798 keyvault/Secrets TCGC codegen workload.
+#
+# The azure-sdk-for-zig `codegen/cli/scripts/run.sh` is wasmtime-only; this
+# mirrors its WASI preopens but drives the wamr AOT binary, so the run is
+# load+execute only (precompiled). Paths are overridable via env vars so the
+# script works across checkouts. Use under `perf record` (Step 4 of SKILL.md).
+#
+#   WAMR_BIN=<wamr>  MANIFEST=<comp.cwasm.json>  OUT=<dir>  ./run_wamr_keyvault.sh
+set -euo pipefail
+
+WAMR_BIN="${WAMR_BIN:?set WAMR_BIN to the ReleaseFast wamr binary}"
+ASZ="${ASZ:-$HOME/azure-sdk-for-zig}"
+WASM="${WASM:-$ASZ/codegen/cli/zig-out/bin/codegen-cli.composed.wasm}"
+PREOPENS="${PREOPENS:-$ASZ/codegen/tcgc-component/dist/stdlib-preopens.txt}"
+SPEC="${SPEC:-$HOME/azure-rest-api-specs/specification/keyvault/data-plane/Secrets}"
+OUT="${OUT:-/tmp/keyvault-out}"
+MANIFEST="${MANIFEST:-}"   # optional --precompiled-manifest (else sibling auto-probe)
+
+mkdir -p "$OUT"
+SPEC="$(cd "$SPEC" && pwd)"; OUT="$(cd "$OUT" && pwd)"
+
+args=( run )
+[ -n "$MANIFEST" ] && args+=( --precompiled-manifest "$MANIFEST" )
+args+=( --map-dir "$SPEC::/spec" --map-dir "$OUT::/out" )
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    host="${line%%=*}"; virt="${line#*=}"
+    args+=( --map-dir "$host::$virt" )
+done < "$PREOPENS"
+args+=( "$WASM" /spec /out --package-name keyvault-secrets )
+
+exec "$WAMR_BIN" "${args[@]}"


### PR DESCRIPTION
Captures the #798 Tier-0 profiling workflow as a reusable project skill (sibling of `aot-diff-debug` / `aot-pass-bisect`).

## What it does
Profiles a **precompiled** WAMR AOT run and attributes cycles **per wasm `local_func`** and **per instruction class** (spill reloads / frame stores / bounds-checks / `call_indirect` dispatch / memory). The hard part it solves: WAMR maps generated code as an anonymous RX mmap, so `perf` collapses ~98% of a run into one unsymbolized `[JIT]` bucket, and DWARF can't unwind the no-CFI JIT. The skill recovers attribution from the `.cwasm` `func_offsets[]` + the text mmap base in the perf data.

## Files
- `SKILL.md` — end-to-end process: install `perf` on **Azure Linux** (`sudo tdnf install kernel-tools`, match `uname -r`), build ReleaseFast, spill-metric precompile + ranking, `perf record --call-graph=dwarf`, JIT de-anonymization, a register-supply sensitivity sweep, the #798 worked example, and an anti-patterns table.
- `aot_jit_attr.py` — parses the `.cwasm` function section, maps sample IPs → functions, classifies the hot function's instruction mix.
- `run_wamr_keyvault.sh` — sanitized, env-overridable keyvault runner (the azure-sdk `run.sh` is wasmtime-only).

## Validation
Both tools reproduce the captured #798 numbers exactly (`local_func=6145` = 75.25% of run; stack/spill traffic ~52%; bounds-checks 2.4%) and the runner smoke-tests to `got 58188 bytes` / exit 0.

Refs #798, #808.