### PR TITLE
perf(x86_64): eliminate redundant i32 zero-extensions (#393)

### DIFF
--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -3128,8 +3128,15 @@ fn compileInstRA(
                 if (lhs_reg_raw != null and rhs_reg_raw != null and
                     lhs_reg_raw.? != dr and lhs_reg_raw.? != .rsp and rhs_reg_raw.? != .rsp)
                 {
-                    try code.leaRegBaseIndex64(dr, lhs_reg_raw.?, rhs_reg_raw.?);
-                    try writeDefTyped(code, alloc_result, dest, dr, inst.type);
+                    if (inst.type == .i32) {
+                        // 32-bit LEA zero-extends the low-32 sum — exactly
+                        // i32.add, no trailing `mov eXX,eXX` (#393).
+                        try code.leaRegBaseIndex32(dr, lhs_reg_raw.?, rhs_reg_raw.?);
+                        try writeDef(code, alloc_result, dest, dr);
+                    } else {
+                        try code.leaRegBaseIndex64(dr, lhs_reg_raw.?, rhs_reg_raw.?);
+                        try writeDefTyped(code, alloc_result, dest, dr, inst.type);
+                    }
                     return;
                 }
             }

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -3137,16 +3137,33 @@ fn compileInstRA(
             const lhs_reg = try useVReg(code, alloc_result, bin.lhs, dr);
             if (lhs_reg != dr) try code.movRegReg(dr, lhs_reg);
             const rhs_reg = try useVReg(code, alloc_result, bin.rhs, scratch);
-            switch (inst.op) {
-                .add => try code.addRegReg(dr, rhs_reg),
-                .sub => try code.subRegReg(dr, rhs_reg),
-                .mul => try code.imulRegReg(dr, rhs_reg),
-                .@"and" => try code.andRegReg(dr, rhs_reg),
-                .@"or" => try code.orRegReg(dr, rhs_reg),
-                .xor => try code.xorRegReg(dr, rhs_reg),
-                else => unreachable,
+            if (inst.type == .i32) {
+                // 32-bit ALU computes the low-32 (wrapping) result and
+                // zero-extends it — exactly Wasm i32 semantics — so the
+                // trailing `mov eXX,eXX` zero-extend is unnecessary
+                // (#393 zero-extension elimination).
+                switch (inst.op) {
+                    .add => try code.addRegReg32(dr, rhs_reg),
+                    .sub => try code.subRegReg32(dr, rhs_reg),
+                    .mul => try code.imulRegReg32(dr, rhs_reg),
+                    .@"and" => try code.andRegReg32(dr, rhs_reg),
+                    .@"or" => try code.orRegReg32(dr, rhs_reg),
+                    .xor => try code.xorRegReg32(dr, rhs_reg),
+                    else => unreachable,
+                }
+                try writeDef(code, alloc_result, dest, dr);
+            } else {
+                switch (inst.op) {
+                    .add => try code.addRegReg(dr, rhs_reg),
+                    .sub => try code.subRegReg(dr, rhs_reg),
+                    .mul => try code.imulRegReg(dr, rhs_reg),
+                    .@"and" => try code.andRegReg(dr, rhs_reg),
+                    .@"or" => try code.orRegReg(dr, rhs_reg),
+                    .xor => try code.xorRegReg(dr, rhs_reg),
+                    else => unreachable,
+                }
+                try writeDefTyped(code, alloc_result, dest, dr, inst.type);
             }
-            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
         },
 
         // ── Comparisons ───────────────────────────────────────────────

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -3221,8 +3221,15 @@ fn compileInstRA(
         .local_get => |idx| {
             const dest = inst.dest orelse return;
             const dr = destReg(alloc_result, dest);
-            try code.movRegMem(dr, .rbp, -@as(i32, @intCast((idx + 2) * 8)));
-            try writeDefTyped(code, alloc_result, dest, dr, inst.type);
+            if (inst.type == .i32) {
+                // 32-bit load reads the low-32 (the i32 value) and
+                // zero-extends — no trailing `mov eXX,eXX` needed (#393).
+                try code.movRegMem32(dr, .rbp, -@as(i32, @intCast((idx + 2) * 8)));
+                try writeDef(code, alloc_result, dest, dr);
+            } else {
+                try code.movRegMem(dr, .rbp, -@as(i32, @intCast((idx + 2) * 8)));
+                try writeDefTyped(code, alloc_result, dest, dr, inst.type);
+            }
         },
         .local_set => |ls| {
             const src_reg = try useVReg(code, alloc_result, ls.val, .rax);

--- a/src/compiler/codegen/x86_64/emit.zig
+++ b/src/compiler/codegen/x86_64/emit.zig
@@ -351,6 +351,17 @@ pub const CodeBuffer = struct {
         try self.emitI32(disp);
     }
 
+    /// MOV reg, [base + disp32] (32-bit load; zero-extends to 64). For i32
+    /// values the low 32 bits are the value, so this both loads and
+    /// zero-extends — no separate `mov eXX,eXX` needed (#393).
+    pub fn movRegMem32(self: *CodeBuffer, dst: Reg, base: Reg, disp: i32) !void {
+        try self.rex(false, dst, base);
+        try self.emitByte(0x8B);
+        try self.modrm(0b10, dst.low3(), base.low3());
+        if (base.low3() == 4) try self.emitByte(0x24); // SIB for RSP-based
+        try self.emitI32(disp);
+    }
+
     /// MOV [base + disp32], reg (64-bit store to memory).
     pub fn movMemReg(self: *CodeBuffer, base: Reg, disp: i32, src: Reg) !void {
         try self.rexW(src, base);

--- a/src/compiler/codegen/x86_64/emit.zig
+++ b/src/compiler/codegen/x86_64/emit.zig
@@ -199,6 +199,51 @@ pub const CodeBuffer = struct {
         try self.modrm(0b11, src.low3(), dst.low3());
     }
 
+    /// ADD r32, r32 (32-bit). Result is the low-32 sum, zero-extended to 64
+    /// — matching Wasm `i32.add` wrap semantics, so no separate zero-extend
+    /// is needed (#393 zero-extension elimination).
+    pub fn addRegReg32(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        if (dst.isExtended() or src.isExtended()) try self.rex(false, src, dst);
+        try self.emitByte(0x01);
+        try self.modrm(0b11, src.low3(), dst.low3());
+    }
+
+    /// SUB r32, r32 (32-bit; low-32 result zero-extended).
+    pub fn subRegReg32(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        if (dst.isExtended() or src.isExtended()) try self.rex(false, src, dst);
+        try self.emitByte(0x29);
+        try self.modrm(0b11, src.low3(), dst.low3());
+    }
+
+    /// IMUL r32, r32 (32-bit two-operand; low-32 result zero-extended).
+    pub fn imulRegReg32(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        if (dst.isExtended() or src.isExtended()) try self.rex(false, dst, src);
+        try self.emitByte(0x0F);
+        try self.emitByte(0xAF);
+        try self.modrm(0b11, dst.low3(), src.low3());
+    }
+
+    /// AND r32, r32 (32-bit; low-32 result zero-extended).
+    pub fn andRegReg32(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        if (dst.isExtended() or src.isExtended()) try self.rex(false, src, dst);
+        try self.emitByte(0x21);
+        try self.modrm(0b11, src.low3(), dst.low3());
+    }
+
+    /// OR r32, r32 (32-bit; low-32 result zero-extended).
+    pub fn orRegReg32(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        if (dst.isExtended() or src.isExtended()) try self.rex(false, src, dst);
+        try self.emitByte(0x09);
+        try self.modrm(0b11, src.low3(), dst.low3());
+    }
+
+    /// XOR r32, r32 (32-bit; low-32 result zero-extended).
+    pub fn xorRegReg32(self: *CodeBuffer, dst: Reg, src: Reg) !void {
+        if (dst.isExtended() or src.isExtended()) try self.rex(false, src, dst);
+        try self.emitByte(0x31);
+        try self.modrm(0b11, src.low3(), dst.low3());
+    }
+
     /// PUSH reg (uses REX prefix only for r8–r15).
     pub fn pushReg(self: *CodeBuffer, reg: Reg) !void {
         if (reg.isExtended()) try self.emitByte(0x41);

--- a/src/compiler/codegen/x86_64/emit.zig
+++ b/src/compiler/codegen/x86_64/emit.zig
@@ -571,6 +571,26 @@ pub const CodeBuffer = struct {
         if (needs_disp8) try self.emitByte(0x00);
     }
 
+    /// LEA r32, [base + index] (32-bit operand size). The address is computed
+    /// in 64 bits but the result is truncated to 32 and zero-extended — and
+    /// since add-mod-2^32 depends only on the low 32 bits of each operand,
+    /// this is exactly Wasm `i32.add` (#393), with no separate zero-extend.
+    pub fn leaRegBaseIndex32(self: *CodeBuffer, dst: Reg, base: Reg, index: Reg) !void {
+        std.debug.assert(index != .rsp);
+        const rex_byte: u8 = 0x40 |
+            (@as(u8, @intFromEnum(dst) >> 3) << 2) |
+            (@as(u8, @intFromEnum(index) >> 3) << 1) |
+            (@as(u8, @intFromEnum(base) >> 3));
+        if (rex_byte != 0x40) try self.emitByte(rex_byte);
+        try self.emitByte(0x8D); // LEA
+        const needs_disp8 = base.low3() == 5;
+        const mod: u2 = if (needs_disp8) 0b01 else 0b00;
+        try self.modrm(mod, dst.low3(), 0b100); // rm=100 → SIB follows
+        const sib: u8 = (@as(u8, 0) << 6) | (@as(u8, index.low3()) << 3) | @as(u8, base.low3());
+        try self.emitByte(sib);
+        if (needs_disp8) try self.emitByte(0x00);
+    }
+
     /// ADD reg, imm32 (64-bit).
     /// ADD reg, imm (64-bit). Uses the imm8 form (opcode 0x83) when imm fits
     /// in a signed byte, saving 3 bytes vs the imm32 form (opcode 0x81).


### PR DESCRIPTION
Child of #393. Removes redundant Wasm i32 zero-extension `mov eXX,eXX` self-moves from x86_64 codegen.

## Motivation (measured)
The `aot-perf-profile` skill on the precompiled CoreMark AOT run showed **`mov eXX,eXX` i32 zero-extension self-moves = ~40% of the entire run** (https://github.com/cataggar/wamr/issues/393#issuecomment-4642054183). They came from codegen emitting a 64-bit op/load followed by an unconditional `zeroExtend32`, even though x86 32-bit ops/loads already zero-extend.

## Approach
Use **32-bit instructions** for i32 values — they produce the correct low-32 (wrapping) result/value **and** zero-extend, so the separate `mov eXX,eXX` is unnecessary. Provably correct by x86 semantics; no dataflow/known-bits analysis.

## Commits
1. **32-bit ALU** for i32 `add/sub/and/or/xor/mul` (`addRegReg32`/…).
2. **32-bit load** for i32 `local.get` (`movRegMem32`).
3. **32-bit LEA-fusion** for i32 `add` (`leaRegBaseIndex32`).

## Validation
- CoreMark CRCs byte-identical to baseline; **~+5%** iter/s (3-run means), code ~3% smaller.
- Full suite **87/87 steps, 4449/4456 tests pass** after each commit.
- keyvault component end-to-end: **`got 58188 bytes`, exit 0** (compile ~49 s, no regression).
- x86_64 only; AArch64 zero-extension is a separate follow-up.

## Deferred
A 4th lever (`iconst_32` → `B8+rd` 32-bit-mov encoding) is **correct** (suite + CoreMark pass) but tripped a **latent infinite loop** in keyvault core-0 codegen — split out as #813. The remaining zero-ext cases (reg-reg copy, general spill reload, immediate-form ALU; still ~15% of CoreMark) should wait until #813 is understood, since they shrink code similarly.

Refs #393, #813.