### PR TITLE
fix(aarch64): guard phi coalescing against lost-copy, enable #540 (#820)

### DIFF
--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -9667,10 +9667,75 @@ test "compile: phi-resolution end-to-end produces no per-arm frame round-trip" {
     //   b0:  v_init = iconst 0; br b1
     //   b1:  v_i = phi (b0, v_init) (b1, v_next); v_next = v_i + 1;
     //        br_if cond → b1 else b2
-    //   b2:  ret v_i
-    // The phi-resolution should NOT emit `str ... [fp, ...]` and
-    // matching `ldr` purely for the phi bridge: instead a register MOV
-    // (or, when the coalescer wins, no instruction at all).
+    //   b2:  ret v_next
+    // The counter `v_i` is read only inside the loop (its post-loop result
+    // is observed via `v_next`, not `v_i`), so it is safe to coalesce and the
+    // phi-resolution should NOT emit `str ... [fp, ...]` and matching `ldr`
+    // purely for the phi bridge: instead a register MOV (or, when the
+    // coalescer wins, no instruction at all). A phi whose result is live
+    // across the loop exit takes the memory path instead (see the #820
+    // lost-copy tests above).
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v_init = func.newVReg();
+    const v_i = func.newVReg();
+    const v_one = func.newVReg();
+    const v_next = func.newVReg();
+    const v_cond = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v_init, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    const edges = try allocator.alloc(ir.Inst.PhiEdge, 2);
+    edges[0] = .{ .block = b0, .val = v_init };
+    edges[1] = .{ .block = b1, .val = v_next };
+    try func.getBlock(b1).append(.{ .op = .{ .phi = edges }, .dest = v_i, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_one, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v_i, .rhs = v_one } }, .dest = v_next, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 10 }, .dest = v_cond, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_cond, .then_block = b1, .else_block = b2 } } });
+
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_next } });
+
+    try func.getBlock(b1).addPredecessor(b0);
+    try func.getBlock(b1).addPredecessor(b1);
+    try func.getBlock(b2).addPredecessor(b1);
+
+    _ = try @import("../../ir/passes.zig").lowerPhisToLocals(&func, allocator);
+    _ = try @import("../../ir/passes.zig").coalescePhiLocalsToParallelCopy(&func, allocator);
+
+    const code = try compileFunction(&func, allocator);
+    defer allocator.free(code);
+    try std.testing.expect(code.len > 0);
+}
+
+// Count `parallel_copy` ops across all blocks of `func`.
+fn countParallelCopies(func: *const ir.IrFunction) u32 {
+    var n: u32 = 0;
+    for (func.blocks.items) |*block| {
+        for (block.instructions.items) |inst| {
+            if (inst.op == .parallel_copy) n += 1;
+        }
+    }
+    return n;
+}
+
+test "coalescePhiLocalsToParallelCopy: rejects loop phi live across loop exit (#820)" {
+    // Lost-copy hazard: a loop-counter phi whose value is read AFTER the
+    // loop. Coalescing would route the back-edge increment through the phi
+    // register, clobbering the value the post-loop use still needs (this is
+    // what hung CoreMark `core_list_mergesort`). The pass must leave it on
+    // the memory path.
+    //   b0:  v_init = 0; br b1
+    //   b1:  v_i = phi(b0:v_init, b1:v_next); v_next = v_i + 1;
+    //        br_if cond → b1 else b2
+    //   b2:  ret v_i           ← v_i live across the loop exit
     const allocator = std.testing.allocator;
     var func = ir.IrFunction.init(allocator, 0, 1, 0);
     defer func.deinit();
@@ -9704,11 +9769,59 @@ test "compile: phi-resolution end-to-end produces no per-arm frame round-trip" {
     try func.getBlock(b2).addPredecessor(b1);
 
     _ = try @import("../../ir/passes.zig").lowerPhisToLocals(&func, allocator);
-    _ = try @import("../../ir/passes.zig").coalescePhiLocalsToParallelCopy(&func, allocator);
+    const changed = try @import("../../ir/passes.zig").coalescePhiLocalsToParallelCopy(&func, allocator);
 
-    const code = try compileFunction(&func, allocator);
-    defer allocator.free(code);
-    try std.testing.expect(code.len > 0);
+    // The single phi is the lost-copy case → rejected → nothing coalesced.
+    try std.testing.expect(!changed);
+    try std.testing.expectEqual(@as(u32, 0), countParallelCopies(&func));
+}
+
+test "coalescePhiLocalsToParallelCopy: coalesces loop phi used only inside the loop" {
+    // The safe counterpart of the #820 test: the loop-counter phi is read
+    // only inside the loop body (never after the exit), so coalescing it is
+    // safe and must still happen.
+    //   b0:  v_init = 0; br b1
+    //   b1:  v_i = phi(b0:v_init, b1:v_next); v_next = v_i + 1;
+    //        br_if cond=v_i → b1 else b2
+    //   b2:  ret v_ret        ← does NOT use v_i
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const b0 = try func.newBlock();
+    const b1 = try func.newBlock();
+    const b2 = try func.newBlock();
+
+    const v_init = func.newVReg();
+    const v_i = func.newVReg();
+    const v_one = func.newVReg();
+    const v_next = func.newVReg();
+    const v_ret = func.newVReg();
+
+    try func.getBlock(b0).append(.{ .op = .{ .iconst_32 = 0 }, .dest = v_init, .type = .i32 });
+    try func.getBlock(b0).append(.{ .op = .{ .br = b1 } });
+
+    const edges = try allocator.alloc(ir.Inst.PhiEdge, 2);
+    edges[0] = .{ .block = b0, .val = v_init };
+    edges[1] = .{ .block = b1, .val = v_next };
+    try func.getBlock(b1).append(.{ .op = .{ .phi = edges }, .dest = v_i, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .iconst_32 = 1 }, .dest = v_one, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .add = .{ .lhs = v_i, .rhs = v_one } }, .dest = v_next, .type = .i32 });
+    try func.getBlock(b1).append(.{ .op = .{ .br_if = .{ .cond = v_i, .then_block = b1, .else_block = b2 } } });
+
+    try func.getBlock(b2).append(.{ .op = .{ .iconst_32 = 42 }, .dest = v_ret, .type = .i32 });
+    try func.getBlock(b2).append(.{ .op = .{ .ret = v_ret } });
+
+    try func.getBlock(b1).addPredecessor(b0);
+    try func.getBlock(b1).addPredecessor(b1);
+    try func.getBlock(b2).addPredecessor(b1);
+
+    _ = try @import("../../ir/passes.zig").lowerPhisToLocals(&func, allocator);
+    const changed = try @import("../../ir/passes.zig").coalescePhiLocalsToParallelCopy(&func, allocator);
+
+    // In-loop-only phi → safe → coalesced into parallel_copy(s).
+    try std.testing.expect(changed);
+    try std.testing.expect(countParallelCopies(&func) > 0);
 }
 
 test "compileFunction: iconst_32 + ret" {

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -7497,6 +7497,93 @@ fn findTerminatorIndex(block: *const ir.BasicBlock) usize {
     return block.instructions.items.len;
 }
 
+/// Lost-copy hazard check for `coalescePhiLocalsToParallelCopy` (#820).
+///
+/// Coalescing replaces the join's `local_get → dest` with `parallel_copy
+/// dest ← src` at each predecessor terminator. For a back-edge predecessor
+/// (the loop latch) this copy writes `dest` at the end of the loop body. In
+/// the original (memory-slot) form the join *reloads* `dest` on every header
+/// visit, so a use of `dest` reached after the loop sees the value that was
+/// loaded on the exit iteration — independent of the latch store. After
+/// coalescing there is no reload: the latch copy's value persists past the
+/// loop. If `dest` is read outside the loop the read observes the wrong
+/// (incremented / next-iteration) value — the classic lost-copy problem
+/// (CoreMark `core_list_mergesort` hung this way: a loop-counter phi's
+/// `br_if cond=v533` read the clobbered value and never terminated).
+///
+/// We bail when `dest` has any use outside the natural loop(s) of the
+/// back-edge(s) into `join_block`. Simple in-loop counters (all uses inside
+/// the loop body) stay eligible; values live across the loop exit do not.
+fn synthCoalesceLostCopyUnsafe(
+    func: *const ir.IrFunction,
+    dom: *const analysis.DomTree,
+    preds: *const std.AutoHashMap(ir.BlockId, []const ir.BlockId),
+    join_block: ir.BlockId,
+    dest: ir.VReg,
+    allocator: std.mem.Allocator,
+) !bool {
+    const nblocks = func.blocks.items.len;
+
+    // Back-edge predecessors of the join are CFG preds dominated by the
+    // join (the join is on every path to them ⇒ they close a loop).
+    const join_preds = preds.get(join_block) orelse return false;
+    var has_back_edge = false;
+    for (join_preds) |p| {
+        if (dom.dominates(join_block, p)) {
+            has_back_edge = true;
+            break;
+        }
+    }
+    // No loop back-edge into the join ⇒ every copy is on a forward edge and
+    // defines `dest` once per path; no clobber is possible.
+    if (!has_back_edge) return false;
+
+    // Natural loop L = {join} ∪ {blocks reachable backward from a back-edge
+    // predecessor without crossing the join}. Uses of `dest` outside L are
+    // live across the loop exit and would observe a clobbered value.
+    var in_loop = try allocator.alloc(bool, nblocks);
+    defer allocator.free(in_loop);
+    @memset(in_loop, false);
+    in_loop[join_block] = true;
+
+    var worklist: std.ArrayListUnmanaged(ir.BlockId) = .empty;
+    defer worklist.deinit(allocator);
+    for (join_preds) |p| {
+        if (!dom.dominates(join_block, p)) continue;
+        if (!in_loop[p]) {
+            in_loop[p] = true;
+            try worklist.append(allocator, p);
+        }
+    }
+    while (worklist.pop()) |n| {
+        const np = preds.get(n) orelse continue;
+        for (np) |q| {
+            if (!in_loop[q]) {
+                in_loop[q] = true;
+                try worklist.append(allocator, q);
+            }
+        }
+    }
+
+    // Any use of `dest` in a block outside the natural loop is unsafe.
+    const Probe = struct {
+        target: ir.VReg,
+        found: *bool,
+        fn check(self: @This(), v: ir.VReg) void {
+            if (v == self.target) self.found.* = true;
+        }
+    };
+    for (func.blocks.items, 0..) |*block, bid| {
+        if (in_loop[bid]) continue;
+        for (block.instructions.items) |inst| {
+            var used = false;
+            verifier.forEachOperand(inst, Probe{ .target = dest, .found = &used }, Probe.check);
+            if (used) return true;
+        }
+    }
+    return false;
+}
+
 /// Phi-resolution: route through register MOV instead of frame round-trip
 /// (#540 / #386 follow-up). Coalesces the (`local_set` in each predecessor
 /// + `local_get` at the join) pair that `lowerPhisToLocals` emits per
@@ -7569,6 +7656,34 @@ pub fn coalescePhiLocalsToParallelCopy(func: *ir.IrFunction, allocator: std.mem.
             slot.dest = dest;
             slot.ty = inst.type;
             slot.eligible = true;
+        }
+    }
+
+    // #820 lost-copy guard: drop any synth whose phi-destination is read
+    // outside the loop whose latch would receive a back-edge parallel_copy.
+    // Coalescing such a synth makes the latch copy clobber a value the
+    // out-of-loop use still needs (CoreMark mergesort infinite loop).
+    var have_eligible = false;
+    for (info) |it| {
+        if (it.eligible) {
+            have_eligible = true;
+            break;
+        }
+    }
+    if (have_eligible) {
+        var dom = try analysis.computeDominators(func, allocator);
+        defer dom.deinit();
+        var preds = try analysis.buildPredecessors(func, allocator);
+        defer {
+            var pit = preds.iterator();
+            while (pit.next()) |entry| allocator.free(entry.value_ptr.*);
+            preds.deinit();
+        }
+        for (info) |*it| {
+            if (!it.eligible) continue;
+            if (try synthCoalesceLostCopyUnsafe(func, &dom, &preds, it.join_block, it.dest, allocator)) {
+                it.eligible = false;
+            }
         }
     }
 

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -354,23 +354,12 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
 
     // #540: Route phi-resolution through register MOV instead of frame
     // round-trip on aarch64. The IR op `parallel_copy`, codegen emitter
-    // (general parallel-copy sequentializer, #817), and lowering pass
-    // `coalescePhiLocalsToParallelCopy` are all implemented and unit-tested.
-    //
-    // Still gated OFF pending #818: the loop-carried live-range fix below
-    // (computeLiveRangesScheduled / computeLiveRangesImpl start pull-back) is
-    // necessary but NOT sufficient. Enabling #540 still miscompiles
-    // `core_bench_list` (inlined `core_list_mergesort`) on aarch64 — a
-    // register-pressure-dependent codegen bug that is independent of the
-    // range collapse (the post-allocation interval set is provably
-    // conflict-free) and of the #817 resolver (fuzz-verified). Coalescing a
-    // single loop-counter phi reserves a register across the merge loop and
-    // the resulting reallocation trips a latent instruction-level miscompile
-    // (the #109 scratch-clobber class); adding a `volatile` to mergesort
-    // makes it vanish. Tracked separately with a minimal reproducer.
-    // x86_64 is out of scope and keeps the existing frameStore/frameLoad
-    // lowering anyway.
-    if (false and target_arch == .aarch64) {
+    // (general parallel-copy sequentializer, #817), the loop-carried
+    // live-range fix (#818), and lowering pass
+    // `coalescePhiLocalsToParallelCopy` (with the #820 lost-copy guard) are
+    // all implemented and unit-tested. x86_64 is out of scope and keeps the
+    // existing frameStore/frameLoad lowering.
+    if (target_arch == .aarch64) {
         for (ir_module.functions.items) |*f| {
             _ = passes.coalescePhiLocalsToParallelCopy(f, allocator) catch |err| {
                 std.debug.print("Error lowering phi parallel-copies: {}\n", .{err});


### PR DESCRIPTION
Closes #820.

## Summary

Fixes the residual #820 miscompile that kept #540 (aarch64 phi→register `parallel_copy`) gated off, and enables #540.

`coalescePhiLocalsToParallelCopy` rewrites a phi (lowered to a synth local: `local_set` in each predecessor + `local_get` at the join) into a `parallel_copy dest <- src` at each predecessor terminator. For a loop-header phi this places the back-edge increment copy at the latch. In the original memory-slot form the join **reloads** the value on every header visit, so a use of the phi result reached *after* the loop is insulated from the latch store. Coalescing removes that reload, so the latch copy's value persists past the loop and an out-of-loop use observes the wrong (incremented) value — the classic **lost-copy / SSA-destruction** problem.

This hung CoreMark `core_list_mergesort` (inlined into `core_bench_list`): the merge's loop-counter phi was read by a `br_if` after the loop, so the branch saw the incremented counter, `nmerges` never reached 1, `insize` doubled to `0x80000000`, and the program looped forever.

## Fix

`synthCoalesceLostCopyUnsafe` drops any synth whose phi destination has a use **outside the natural loop** of the back-edge(s) into the join. Simple in-loop counters and forward/diamond phis (no back-edge) stay eligible — coalescing still fires for the common cases. With the hazard ruled out, the #540 gate is flipped on for aarch64 in `main.zig`.

## Validation

- Reproducer: `crclist=9218` (matches gate-off **and** wasmtime)
- `wamrc verify` reproducer: **OK vs wasmtime oracle**
- CoreMark CRCs identical to wasmtime (`crcfinal 0x65c5`, "Correct operation validated")
- Full suite: **4462/4474 passed** (12 skipped), incl. 2 new regression tests:
  - `coalescePhiLocalsToParallelCopy: rejects loop phi live across loop exit (#820)`
  - `coalescePhiLocalsToParallelCopy: coalesces loop phi used only inside the loop`

No regression possible below the gate-off baseline: unsafe phis fall back to the exact pre-#540 frame path; safe phis use register moves.

Builds on #818 (#821).