### PR TITLE
fix(aot): apply #540 phi-residency in the in-process AOT harness (#808)

### DIFF
--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -7584,6 +7584,23 @@ fn synthCoalesceLostCopyUnsafe(
     return false;
 }
 
+/// #540: Route phi-resolution through a register MOV instead of a frame
+/// round-trip on aarch64 by applying `coalescePhiLocalsToParallelCopy` to
+/// every function in the module. Shared by the standalone `wamrc` driver
+/// (`main.zig`) and the in-process AOT harness (`aot_harness.compileToAot`)
+/// so the two codegen paths never drift (#808). No-op unless
+/// `target == .aarch64`; x86_64 keeps the frameStore/frameLoad lowering.
+pub fn applyPostOptCodegenLowering(
+    module: *ir.IrModule,
+    target: TargetArch,
+    allocator: std.mem.Allocator,
+) !void {
+    if (target != .aarch64) return;
+    for (module.functions.items) |*f| {
+        _ = try coalescePhiLocalsToParallelCopy(f, allocator);
+    }
+}
+
 /// Phi-resolution: route through register MOV instead of frame round-trip
 /// (#540 / #386 follow-up). Coalesces the (`local_set` in each predecessor
 /// + `local_get` at the join) pair that `lowerPhisToLocals` emits per

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -358,15 +358,13 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
     // live-range fix (#818), and lowering pass
     // `coalescePhiLocalsToParallelCopy` (with the #820 lost-copy guard) are
     // all implemented and unit-tested. x86_64 is out of scope and keeps the
-    // existing frameStore/frameLoad lowering.
-    if (target_arch == .aarch64) {
-        for (ir_module.functions.items) |*f| {
-            _ = passes.coalescePhiLocalsToParallelCopy(f, allocator) catch |err| {
-                std.debug.print("Error lowering phi parallel-copies: {}\n", .{err});
-                std.process.exit(1);
-            };
-        }
-    }
+    // existing frameStore/frameLoad lowering. Shared with the in-process AOT
+    // harness via `passes.applyPostOptCodegenLowering` so the two paths
+    // can't drift (#808).
+    passes.applyPostOptCodegenLowering(&ir_module, target_arch, allocator) catch |err| {
+        std.debug.print("Error lowering phi parallel-copies: {}\n", .{err});
+        std.process.exit(1);
+    };
 
     if (dumper.matchesPass("final")) {
         for (ir_module.functions.items, 0..) |*f, fi| {

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -1030,19 +1030,26 @@ fn compileToAot(
     var ir_module = try frontend.lowerModule(module, a);
     defer ir_module.deinit();
 
+    const target: passes.TargetArch = switch (builtin.cpu.arch) {
+        .aarch64 => .aarch64,
+        else => .x86_64,
+    };
+
     // Opt-in IR verifier (#624). Fuzz / differential harness callers can
     // toggle this via `InitOptions.verify_ir`; default `false` to avoid
     // regressing pre-existing differential tests whose IR shapes have not
     // yet been audited against the invariants.
     _ = try passes.runPassesWithOptions(
         &ir_module,
-        passes.defaultPassesForTarget(switch (builtin.cpu.arch) {
-            .aarch64 => .aarch64,
-            else => .x86_64,
-        }),
+        passes.defaultPassesForTarget(target),
         a,
         .{ .verify_mode = if (verify_ir) .after_each_pass else .off },
     );
+
+    // #540: apply the same aarch64 phi-residency lowering the standalone
+    // `wamrc` driver does (`main.zig`), so this in-process harness compiles
+    // production codegen rather than the pre-#540 frame round-trip (#808).
+    try passes.applyPostOptCodegenLowering(&ir_module, target, a);
 
     const code: []const u8, const offsets: []const u32 = switch (builtin.cpu.arch) {
         .aarch64 => blk: {


### PR DESCRIPTION
## Problem

While re-planning #808 I A/B-measured #540 (now enabled on aarch64 via #820) and confirmed it delivers **+19.5% on CoreMark** (wamrc+wamr: ~11,250 it/s ON vs ~9,400 OFF, CRCs valid).

But the **in-process AOT harness `aot_harness.compileToAot`** — used by `coremark-profile`, `coremark-aot-runner`, and the fuzz/diff/spec tests — ran the IR passes + aarch64 codegen but **never applied #540** (`coalescePhiLocalsToParallelCopy`). Only the standalone `wamrc` driver (`main.zig`) did. So the harness compiled the **pre-#540** frame round-trip and under-reported aarch64 production by ~19.5%:

| harness | before | after |
|---|---:|---:|
| `coremark-profile` / `coremark-aot-runner` | 9378 it/s | **11,250 it/s** |

This made `coremark-profile` misleading for #808/#393 lever selection (it showed the pre-#540 hot distribution).

## Fix

Extract the lowering into a shared `passes.applyPostOptCodegenLowering(module, target, allocator)` (no-op off aarch64) and call it from **both** `main.zig` and `compileToAot`, so the two codegen paths can no longer drift.

## Verification (aarch64)

- `coremark-profile` / `coremark-aot-runner`: 9378 → **11,250 it/s**, CRCs valid (`crcfinal=0x4983`).
- Post-#540 hot distribution now visible to the profiler: `matrix_test` 21.2% → 15.8%; `core_bench_list` (42%) and `core_state_transition` (30%) now dominate.
- `zig build test` green — identical to clean-baseline run.

Refs #808.