### PR TITLE
aot: host trampolines on macOS aarch64 + fix wamrc run arg order

### DIFF
--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -1106,7 +1106,14 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
     }
 
     // Build the argv for `wamr run`. Layout:
-    //   wamr run <artifact> [forwarded args...]
+    //   wamr run [--precompiled-manifest <artifact>] [forwarded args...] <module>
+    //
+    // The forwarded args (e.g. `--env`, `--allow-net`, `--map-dir`) are
+    // `wamr run` *options* and must precede the module positional: `wamr
+    // run` stops option parsing at the first positional and treats every
+    // later token as a guest arg. Appending them after the module (as we
+    // did before) silently routed `--env` / `--allow-net` to the guest's
+    // argv instead of the WASI host config.
     const wamr_bin = findWamrBinary(allocator, io, init.environ_map) catch |err| {
         std.debug.print("error: could not locate `wamr` binary: {s}\n" ++
             "  Set WAMR_BIN, install `wamr` on PATH, or place it next to wamrc.\n", .{@errorName(err)});
@@ -1118,21 +1125,23 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
     defer child_argv.deinit(allocator);
     try child_argv.append(allocator, wamr_bin);
     try child_argv.append(allocator, "run");
-    // For components, `wamr run` takes the source `.wasm` and
-    // auto-discovers the sibling `<stem>.cwasm.json` (or honours
-    // `--precompiled-manifest` if the user picked a non-default
-    // location). For core wasm we hand it the freshly-written
-    // `.cwasm` directly.
+    // Options that `wamr run` parses before the module positional:
+    // the precompiled-manifest selector (components) plus every
+    // forwarded arg.
+    if (is_comp and output_path != null) {
+        try child_argv.append(allocator, "--precompiled-manifest");
+        try child_argv.append(allocator, artifact_path);
+    }
+    for (forward_args.items) |fa| try child_argv.append(allocator, fa);
+    // The module positional comes last. For components, `wamr run`
+    // takes the source `.wasm` and auto-discovers the sibling
+    // `<stem>.cwasm.json` (or honours `--precompiled-manifest`). For
+    // core wasm we hand it the freshly-written `.cwasm` directly.
     if (is_comp) {
-        if (output_path != null) {
-            try child_argv.append(allocator, "--precompiled-manifest");
-            try child_argv.append(allocator, artifact_path);
-        }
         try child_argv.append(allocator, in_path);
     } else {
         try child_argv.append(allocator, artifact_path);
     }
-    for (forward_args.items) |fa| try child_argv.append(allocator, fa);
 
     var child = std.process.spawn(io, .{
         .argv = child_argv.items,

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -533,6 +533,29 @@ pub fn icacheFlush(start: [*]u8, len: usize) void {
     }
 }
 
+/// Whether the platform allocates JIT/trampoline code via macOS's
+/// per-thread MAP_JIT write-protection (Apple Silicon). On such
+/// targets an RWX region cannot simply be `mmap`ed and written; the
+/// region is mapped `MAP_JIT` and each thread flips between
+/// write-enabled and execute-enabled with `jitWriteProtect`.
+pub const macos_jit = is_macos and builtin.cpu.arch == .aarch64;
+
+extern "c" fn pthread_jit_write_protect_np(enabled: c_int) void;
+
+/// Toggle the calling thread's view of MAP_JIT pages between
+/// executable (`enable = true`) and writable (`enable = false`).
+/// No-op on every target except macOS aarch64. Callers writing into a
+/// MAP_JIT region must wrap the write in
+/// `jitWriteProtect(false) … jitWriteProtect(true)` and then
+/// `icacheFlush` the modified range. The protection is per-thread, so
+/// the thread that later *executes* the code must be in the
+/// execute-enabled state (which `jitWriteProtect(true)` leaves it in).
+pub fn jitWriteProtect(enable: bool) void {
+    if (comptime macos_jit) {
+        pthread_jit_write_protect_np(if (enable) 1 else 0);
+    }
+}
+
 fn icacheFlushAarch64(start: [*]u8, len: usize) void {
     if (is_macos) {
         // macOS: use sys_icache_invalidate from libsystem.

--- a/src/runtime/aot/host_trampolines.zig
+++ b/src/runtime/aot/host_trampolines.zig
@@ -338,12 +338,16 @@ pub const TrampolinePool = struct {
     // `linkLibC` on every binary reachable from `TrampolinePool.init`
     // (broke `wamr.exe` Windows build under #662 Phase C, where the lazy
     // pool ctor became reachable from the CLI).
+    //
+    // macOS aarch64 (Apple Silicon) IS supported: it forbids a plain RWX
+    // `mmap`, but the region can be mapped `MAP_JIT` and written under
+    // per-thread `pthread_jit_write_protect_np` toggling (see
+    // `platform.jitWriteProtect`). Required so cross-instance / canon-lower
+    // thunks resolve on Apple Silicon instead of trap-stubbing and then
+    // segfaulting (the wasi:http component path).
     const supports_pool: bool = blk: {
         if (builtin.os.tag == .windows) break :blk false;
         if (builtin.cpu.arch != .x86_64 and builtin.cpu.arch != .aarch64) break :blk false;
-        // macOS aarch64 forbids RWX mmap without MAP_JIT + pthread_jit_write_protect_np;
-        // not worth wiring up for stdio-echo's needs. AOT layer falls back to interp.
-        if (builtin.os.tag == .macos and builtin.cpu.arch == .aarch64) break :blk false;
         break :blk true;
     };
 
@@ -362,15 +366,25 @@ pub const TrampolinePool = struct {
         errdefer allocator.free(slots);
 
         const map_len = std.mem.alignForward(usize, @as(usize, cap) * STUB_BYTES, page_size);
+        // macOS aarch64 needs MAP_JIT; the field only exists on darwin so
+        // build the flags via a comptime branch to stay portable.
+        const map_flags: std.posix.MAP = if (comptime platform.macos_jit)
+            .{ .TYPE = .PRIVATE, .ANONYMOUS = true, .JIT = true }
+        else
+            .{ .TYPE = .PRIVATE, .ANONYMOUS = true };
         const memory = try std.posix.mmap(
             null,
             map_len,
             .{ .READ = true, .WRITE = true, .EXEC = true },
-            .{ .TYPE = .PRIVATE, .ANONYMOUS = true },
+            map_flags,
             -1,
             0,
         );
+        // Under MAP_JIT the region starts execute-protected for this
+        // thread; flip it writable to zero-fill, then back to executable.
+        platform.jitWriteProtect(false);
         @memset(memory, 0);
+        platform.jitWriteProtect(true);
 
         return .{
             .memory = memory,
@@ -448,8 +462,7 @@ pub const TrampolinePool = struct {
         };
         self.slots[slot].lowered_sig.slot = slot;
         self.next_slot += 1;
-        writeStub(self.stubBytes(slot), slot);
-        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
+        self.installStub(slot);
         g_active_pool = self;
 
         return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
@@ -463,8 +476,7 @@ pub const TrampolinePool = struct {
             .canon_lower_idx = canon_lower_idx,
         };
         self.next_slot += 1;
-        writeStub(self.stubBytes(slot), slot);
-        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
+        self.installStub(slot);
         g_active_pool = self;
 
         return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
@@ -487,8 +499,7 @@ pub const TrampolinePool = struct {
         };
         self.slots[slot].lowered_sig.slot = slot;
         self.next_slot += 1;
-        writeStub(self.stubBytes(slot), slot);
-        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
+        self.installStub(slot);
         g_active_pool = self;
 
         return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
@@ -510,8 +521,7 @@ pub const TrampolinePool = struct {
         };
         self.slots[slot].lowered_sig.slot = slot;
         self.next_slot += 1;
-        writeStub(self.stubBytes(slot), slot);
-        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
+        self.installStub(slot);
         g_active_pool = self;
 
         return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
@@ -534,8 +544,7 @@ pub const TrampolinePool = struct {
         };
         self.slots[slot].lowered_sig.slot = slot;
         self.next_slot += 1;
-        writeStub(self.stubBytes(slot), slot);
-        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
+        self.installStub(slot);
         g_active_pool = self;
 
         return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
@@ -555,8 +564,7 @@ pub const TrampolinePool = struct {
             .dispatch_kind = .trap_stub,
         };
         self.next_slot += 1;
-        writeStub(self.stubBytes(slot), slot);
-        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
+        self.installStub(slot);
         g_active_pool = self;
 
         return @ptrFromInt(@intFromPtr(self.stubPtr(slot)));
@@ -581,6 +589,18 @@ pub const TrampolinePool = struct {
     fn stubBytes(self: *TrampolinePool, slot: u32) []u8 {
         const start = @as(usize, slot) * STUB_BYTES;
         return self.memory[start .. start + STUB_BYTES];
+    }
+
+    /// Write the arch-specific shim for `slot` into the pool's
+    /// executable memory and flush the icache. On macOS aarch64 the
+    /// MAP_JIT region is flipped writable for the write and back to
+    /// executable afterward (`platform.jitWriteProtect`); a no-op
+    /// elsewhere.
+    fn installStub(self: *TrampolinePool, slot: u32) void {
+        platform.jitWriteProtect(false);
+        writeStub(self.stubBytes(slot), slot);
+        platform.jitWriteProtect(true);
+        platform.icacheFlush(self.stubPtr(slot), STUB_BYTES);
     }
 };
 


### PR DESCRIPTION
## Problem

`wamrc run <component.wasm> -- --allow-net … --env …` could not execute a `wasi:http` component (an outbound-HTTP guest) on Apple Silicon. Two independent bugs:

1. **Segfault from missing host trampolines.** `TrampolinePool.supports_pool` was hardcoded `false` on macOS aarch64 (a plain RWX `mmap` is forbidden there). Every cross-instance / canon-lower thunk then failed with `UnsupportedPlatform`, each import fell back to a trap stub (which also failed to install), and the component segfaulted — the `[aot reject] … UnsupportedPlatform` storm followed by signal 11.

2. **Empty guest environment.** Even with trampolines working, the guest exited with `missing AZURE_SUBSCRIPTION_ID` — the `--env` / `--allow-net` flags never reached WASI.

## Fix

### 1. macOS aarch64 host-import trampolines (`platform.zig`, `host_trampolines.zig`)

Apple Silicon allows JIT code via `MAP_JIT` pages written under per-thread `pthread_jit_write_protect_np` toggling. The pool is now mapped `MAP_JIT`, and every stub write (the initial zero-fill and each `writeStub`) is wrapped in `platform.jitWriteProtect(false) … (true)` before the icache flush. New `platform.jitWriteProtect` / `platform.macos_jit` are no-ops on every other target, so x86_64 / Linux behaviour is unchanged. The 6 `writeStub + icacheFlush` call sites are consolidated into a single `installStub` helper.

### 2. `wamrc run` argument ordering (`compiler/main.zig`)

`wamrc run <module> -- <args>` forwarded `<args>` **after** the module positional in the spawned `wamr run` argv. But `wamr run` stops option parsing at the first positional (the module) and treats every later token as a guest arg — so `--env KEY=VALUE` / `--allow-net CIDR` silently became guest argv entries instead of WASI host config. The forwarded args (and the `--precompiled-manifest` selector) are now emitted **before** the module positional.

## Testing

- `zig build test`: **4384/4476 pass** (92 skipped, 0 failed) — unchanged from `main`.
- End-to-end on macOS aarch64: the [`azure-sdk-for-zig` `avs-wasi` example](https://github.com/cataggar/azure-sdk-for-zig/tree/examples/arm_avs_wasi) (a `wasi:http/outgoing-handler` component) now runs under:
  ```sh
  wamrc run avs.wasm -- --allow-net 0.0.0.0/0 --env AZURE_SUBSCRIPTION_ID=… --env AZURE_TOKEN=…
  ```
  listing Azure AVS private clouds over `wasi:http`. Previously: `[aot reject]` storm → segfault.
