### PR TITLE
ci(release): sign via release Environment OIDC subject (#830)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,15 @@ jobs:
   build:
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    # Windows targets sign via Azure Trusted Signing over OIDC. Run those
+    # jobs in the `release` GitHub Environment so their OIDC subject is the
+    # tag-independent `repo:cataggar/wamr:environment:release`, matched by a
+    # single federated identity credential — subject-based FICs can't
+    # wildcard `refs/tags/v*`, so a per-tag FIC would otherwise be needed
+    # before every release (cataggar/wamr#830). Non-Windows jobs get no
+    # environment (empty string) so a future environment protection rule
+    # can't gate the whole matrix.
+    environment: ${{ endsWith(matrix.target, '-windows') && 'release' || '' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The release workflow's Windows jobs sign binaries via Azure Trusted Signing over **OIDC federated identity**. The credential is **subject-based**, and subject-based FICs **cannot wildcard** `refs/tags/v*`. So every release tag needed its own `repo:cataggar/wamr:ref:refs/tags/<tag>` FIC created by hand *before* the tag push, or `azure/login` failed:

```
AADSTS700213: No matching federated identity record found for presented assertion
subject 'repo:cataggar/wamr:ref:refs/tags/v3.0.0-dev.11'
```

This recurred on `v3.0.0-dev.11` ([run 27187272249](https://github.com/cataggar/wamr/actions/runs/27187272249)), reopening #830.

## Fix

Run the Windows build/sign jobs in a **`release` GitHub Environment**, so their OIDC subject becomes the tag-independent `repo:cataggar/wamr:environment:release` — matched by a **single** environment-based FIC that covers every future tag. This mirrors how [`cataggar/ghr`](https://github.com/cataggar/ghr) already authenticates (`repo:cataggar/ghr:environment:release`).

```yaml
environment: ${{ endsWith(matrix.target, '-windows') && 'release' || '' }}
```

The `environment:` is gated to `-windows` targets (empty string elsewhere) so a future environment protection rule can't inadvertently gate the whole 9-target build matrix.

## One-time setup performed alongside this PR (shared app `0a7bdf71-…`)

- Created the **`release`** GitHub Environment on `cataggar/wamr`.
- Created FIC **`wamr-environment-release`** → subject `repo:cataggar/wamr:environment:release`.

## dev.11 unblock (independent of this PR)

`v3.0.0-dev.11` was tagged on the pre-environment workflow, so it can't use the environment subject. A per-tag FIC (`wamr-tag-v3-0-0-dev-11`) was created and the failed run re-run to publish it.

## Follow-up after merge

The per-tag FICs (`wamr-tag-v3-0-0-dev-10`, `wamr-tag-v3-0-0-dev-11`) can be deleted — `dev.12`+ authenticates through the environment FIC with no manual step. Updates #830.
