### PR TITLE
feat(cli): add `wamr serve` / `wamrc serve`, align on --addr, drop --listen (#845)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ termination** ([#609](https://github.com/cataggar/wamr/issues/609)) is
 live:
 
 ```console
-$ wamr run --listen=<addr> --tls-cert=<cert.pem> --tls-key=<key.pem> app.wasm
-$ wamr run --listen=<addr> --tls-pem=<combined.pem> app.wasm   # cert + key in one file
+$ wamr serve --addr <addr> --tls-cert=<cert.pem> --tls-key=<key.pem> app.wasm
+$ wamr serve --addr <addr> --tls-pem=<combined.pem> app.wasm   # cert + key in one file
 ```
 
 The cert chain (`std.crypto.Certificate.Bundle`) and PEM-encoded private

--- a/build.zig
+++ b/build.zig
@@ -1359,7 +1359,7 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile, aot_br
     installAndValidate(b, examples_step, http_component, "zig-http.wasm");
 
     // End-to-end serve smoke: a small driver (tests/component-http-smoke/
-    // driver.zig) spawns `wamr run --listen=127.0.0.1:<port>` against the
+    // driver.zig) spawns `wamr serve --addr=127.0.0.1:<port>` against the
     // built component, then hits `/` and `/missing` over TCP and asserts
     // the expected `200 "Hello, world!\n"` / `404` shapes. Mirrors the
     // wasi-sock driver pattern (#437).
@@ -1416,7 +1416,7 @@ fn addComponentExamples(b: *std.Build, wamr_exe: *std.Build.Step.Compile, aot_br
     });
     installAndValidate(b, examples_step, petstore_component, "zig-http-petstore.wasm");
 
-    // End-to-end serve smoke: the driver spawns `wamr run --listen=…`
+    // End-to-end serve smoke: the driver spawns `wamr serve --addr=…`
     // against the built component, then exercises the petstore routes
     // (GET/POST/DELETE on /pets, /pets/{id}, /pets/{id}/toys) over TCP.
     // Wamr-only, same rationale as the zig-http smoke above.

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ on machines that do not have the external toolchain installed.
 | Step                    | What it does                                                     |
 |-------------------------|------------------------------------------------------------------|
 | `zig build examples`     | Build, encode, and validate every component below.               |
-| `zig build examples-run` | Run the runnable examples through `./zig-out/bin/wamr` — `zig-hello` greeting + exit code, the two composed calculator commands, and the `zig-http` curl-equivalent smoke (spin up `wamr run --listen=…`, send two requests, assert `200 "Hello, world!\n"` / `404`). |
+| `zig build examples-run` | Run the runnable examples through `./zig-out/bin/wamr` — `zig-hello` greeting + exit code, the two composed calculator commands, and the `zig-http` curl-equivalent smoke (spin up `wamr serve --addr …`, send two requests, assert `200 "Hello, world!\n"` / `404`). |
 
 Outputs land under `zig-out/examples/`:
 

--- a/examples/zig-http-petstore/README.md
+++ b/examples/zig-http-petstore/README.md
@@ -48,11 +48,10 @@ instance). Toys are static read-only seed data.
 
 ### wamr
 
-Keyvalue is in-memory by default (persists for the server process); add
-`--keyvalue-store=<file>` to persist to a JSON file across restarts.
+Keyvalue is in-memory (persists for the server-process lifetime).
 
 ```console
-$ ./zig-out/bin/wamr run --listen=127.0.0.1:8080 \
+$ ./zig-out/bin/wamrc serve --addr 127.0.0.1:8080 \
         zig-out/examples/zig-http-petstore.wasm &
 
 $ curl -s http://127.0.0.1:8080/pets

--- a/examples/zig-http-petstore/src/main.zig
+++ b/examples/zig-http-petstore/src/main.zig
@@ -19,9 +19,9 @@
 //! This makes the example behave identically under wamr's serial serve
 //! loop and under `wasmtime serve`.
 //!
-//! Run under wamr (in-memory store, or `--keyvalue-store=<file>` to persist):
+//! Run under wamr (in-memory keyvalue store for the server lifetime):
 //!
-//!   wamr run --listen=127.0.0.1:8080 zig-http-petstore.wasm
+//!   wamrc serve --addr 127.0.0.1:8080 zig-http-petstore.wasm
 //!   curl -i http://127.0.0.1:8080/pets
 //!
 //! Run under wasmtime:

--- a/examples/zig-http/README.md
+++ b/examples/zig-http/README.md
@@ -22,7 +22,7 @@ Produces `zig-out/examples/zig-http.wasm`.
 
 ```sh
 # wamr
-wamrc run zig-out/examples/zig-http.wasm -- --listen=127.0.0.1:8080
+wamrc serve zig-out/examples/zig-http.wasm   # 127.0.0.1:8080
 
 # wasmtime
 wasmtime serve zig-out/examples/zig-http.wasm

--- a/examples/zig-http/src/main.zig
+++ b/examples/zig-http/src/main.zig
@@ -6,7 +6,7 @@
 //!
 //! Runs end-to-end through wamr:
 //!
-//!   wamr run --listen=127.0.0.1:8080 zig-http.wasm
+//!   wamrc serve --addr 127.0.0.1:8080 zig-http.wasm
 //!   curl -i http://127.0.0.1:8080/
 //!
 //! The canonical-ABI plumbing (host imports, ret-area decoding, the

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -28,7 +28,7 @@ comptime {
     _ = @import("verify_args.zig");
 }
 
-const Subcommand = enum { compile, compile_component, run, verify, version, help };
+const Subcommand = enum { compile, compile_component, run, serve, verify, version, help };
 
 /// #392 step 3b-i diagnostic: log SSA-aware vs legacy (naive in-block phi)
 /// allocator spill counts for one phi-form function. Wired into the pass
@@ -46,6 +46,7 @@ fn parseSubcommand(s: []const u8) ?Subcommand {
     if (std.mem.eql(u8, s, "compile")) return .compile;
     if (std.mem.eql(u8, s, "compile-component")) return .compile_component;
     if (std.mem.eql(u8, s, "run")) return .run;
+    if (std.mem.eql(u8, s, "serve")) return .serve;
     if (std.mem.eql(u8, s, "verify")) return .verify;
     if (std.mem.eql(u8, s, "version")) return .version;
     if (std.mem.eql(u8, s, "help")) return .help;
@@ -82,6 +83,7 @@ pub fn main(init: std.process.Init) !void {
         .compile => try runCompile(init, allocator, args[2..]),
         .compile_component => try runCompileComponent(init, allocator, args[2..]),
         .run => try runRun(init, allocator, args[2..]),
+        .serve => try runServe(init, allocator, args[2..]),
         .verify => try runVerify(init, allocator, args[2..]),
     }
 }
@@ -978,8 +980,8 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
     // After we encounter `--` or the first non-option positional, every
     // remaining token is forwarded verbatim to `wamr run`. We split the
     // input on `--` so users can disambiguate `wamrc run -O0 foo.wasm`
-    // (still our flag) from `wamrc run foo.wasm -- --listen ...`
-    // (`--listen` belongs to `wamr`).
+    // (still our flag) from `wamrc run foo.wasm -- --env K=V ...`
+    // (`--env` belongs to `wamr`).
     var forward_args: std.ArrayList([]const u8) = .empty;
     defer forward_args.deinit(allocator);
 
@@ -1022,6 +1024,24 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
         std.process.exit(1);
     };
 
+    try compileAndSpawn(init, allocator, "run", in_path, output_path, force, target_arch, forward_args.items);
+}
+
+/// Shared tail for `wamrc run` / `wamrc serve` (#845): compile the input
+/// if its artifact is missing or stale, then spawn `wamr <verb>` with
+/// stdio inherited and propagate the exit code. `forward_args` are passed
+/// verbatim to `wamr <verb>` *before* the module positional (they are
+/// `wamr`-side options, which stop at the first positional).
+fn compileAndSpawn(
+    init: std.process.Init,
+    allocator: std.mem.Allocator,
+    verb: []const u8,
+    in_path: []const u8,
+    output_path: ?[]const u8,
+    force: bool,
+    target_arch: TargetArch,
+    forward_args: []const []const u8,
+) !void {
     const io = init.io;
     const cwd = std.Io.Dir.cwd();
     const wasm_data = cwd.readFileAlloc(io, in_path, allocator, @enumFromInt(256 * 1024 * 1024)) catch |err| {
@@ -1108,15 +1128,15 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
         if (debug_log) std.debug.print("wamrc: reusing {s} (up to date)\n", .{artifact_path});
     }
 
-    // Build the argv for `wamr run`. Layout:
-    //   wamr run [--precompiled-manifest <artifact>] [forwarded args...] <module>
+    // Build the argv for `wamr <verb>`. Layout:
+    //   wamr <verb> [--precompiled-manifest <artifact>] [forwarded args...] <module>
     //
-    // The forwarded args (e.g. `--env`, `--allow-net`, `--map-dir`) are
-    // `wamr run` *options* and must precede the module positional: `wamr
-    // run` stops option parsing at the first positional and treats every
-    // later token as a guest arg. Appending them after the module (as we
-    // did before) silently routed `--env` / `--allow-net` to the guest's
-    // argv instead of the WASI host config.
+    // The forwarded args (e.g. `--env`/`--allow-net` for run, `--addr`/
+    // `--tls-*` for serve) are `wamr <verb>` *options* and must precede
+    // the module positional: `wamr <verb>` stops option parsing at the
+    // first positional and treats every later token as a guest arg.
+    // Appending them after the module (as we did before) silently routed
+    // `--env` / `--allow-net` to the guest's argv instead of host config.
     const wamr_bin = findWamrBinary(allocator, io, init.environ_map) catch |err| {
         std.debug.print("error: could not locate `wamr` binary: {s}\n" ++
             "  Set WAMR_BIN, install `wamr` on PATH, or place it next to wamrc.\n", .{@errorName(err)});
@@ -1127,16 +1147,16 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
     var child_argv: std.ArrayList([]const u8) = .empty;
     defer child_argv.deinit(allocator);
     try child_argv.append(allocator, wamr_bin);
-    try child_argv.append(allocator, "run");
-    // Options that `wamr run` parses before the module positional:
+    try child_argv.append(allocator, verb);
+    // Options that `wamr <verb>` parses before the module positional:
     // the precompiled-manifest selector (components) plus every
     // forwarded arg.
     if (is_comp and output_path != null) {
         try child_argv.append(allocator, "--precompiled-manifest");
         try child_argv.append(allocator, artifact_path);
     }
-    for (forward_args.items) |fa| try child_argv.append(allocator, fa);
-    // The module positional comes last. For components, `wamr run`
+    for (forward_args) |fa| try child_argv.append(allocator, fa);
+    // The module positional comes last. For components, `wamr <verb>`
     // takes the source `.wasm` and auto-discovers the sibling
     // `<stem>.cwasm.json` (or honours `--precompiled-manifest`). For
     // core wasm we hand it the freshly-written `.cwasm` directly.
@@ -1176,6 +1196,96 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []cons
             std.process.exit(1);
         },
     }
+}
+
+/// `wamrc serve <component.wasm> [options]` (#845): mirror `wamrc run`,
+/// but precompile-if-stale and then spawn `wamr serve` (the proxy world)
+/// instead of `wamr run`. `--addr` and the `--tls-*` flags are forwarded
+/// verbatim to `wamr serve`, so the wasmtime muscle memory
+/// `wamrc serve --addr 127.0.0.1:8080 app.wasm` works.
+fn runServe(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
+    if (sub_args.len == 1 and std.mem.eql(u8, sub_args[0], "help")) {
+        writeStdout(init.io, serve_usage);
+        return;
+    }
+
+    var input_path: ?[]const u8 = null;
+    var output_path: ?[]const u8 = null;
+    var force = false;
+    var target_arch: TargetArch = switch (builtin.cpu.arch) {
+        .aarch64 => .aarch64,
+        else => .x86_64,
+    };
+
+    // Everything after `--`, or any positional after the input, is
+    // forwarded to `wamr serve`. We also explicitly recognise the
+    // `wamr serve`-side value-taking flags *before* the input so
+    // `wamrc serve --addr <v> app.wasm` (space form) parses correctly
+    // and forwards both the flag and its value instead of mistaking the
+    // value for the input positional.
+    var forward_args: std.ArrayList([]const u8) = .empty;
+    defer forward_args.deinit(allocator);
+
+    const forwardable_value_flags = [_][]const u8{ "--addr", "--tls-cert", "--tls-key", "--tls-pem", "--env", "--log-level" };
+
+    var i: usize = 0;
+    var saw_dashdash = false;
+    while (i < sub_args.len) : (i += 1) {
+        const a = sub_args[i];
+        if (saw_dashdash) {
+            try forward_args.append(allocator, a);
+            continue;
+        }
+        if (std.mem.eql(u8, a, "--")) {
+            saw_dashdash = true;
+            continue;
+        }
+        if (std.mem.eql(u8, a, "-o") and i + 1 < sub_args.len) {
+            i += 1;
+            output_path = sub_args[i];
+        } else if (std.mem.eql(u8, a, "--force")) {
+            force = true;
+        } else if (std.mem.eql(u8, a, "--target") and i + 1 < sub_args.len) {
+            i += 1;
+            target_arch = parseTargetArchOrDie(sub_args[i]);
+        } else if (std.mem.startsWith(u8, a, "--target=")) {
+            target_arch = parseTargetArchOrDie(a["--target=".len..]);
+        } else fwd: {
+            // Forward `wamr serve` options. `--flag=value` forms forward
+            // as a single token; `--flag value` forms consume + forward
+            // the following value token too.
+            for (forwardable_value_flags) |flag| {
+                if (std.mem.eql(u8, a, flag)) {
+                    try forward_args.append(allocator, a);
+                    if (i + 1 < sub_args.len) {
+                        i += 1;
+                        try forward_args.append(allocator, sub_args[i]);
+                    }
+                    break :fwd;
+                }
+                if (std.mem.startsWith(u8, a, flag) and a.len > flag.len and a[flag.len] == '=') {
+                    try forward_args.append(allocator, a);
+                    break :fwd;
+                }
+            }
+            if (a.len > 0 and a[0] == '-' and input_path == null) {
+                // Any other leading-dash option before the input is
+                // forwarded verbatim (e.g. `--env=K=V`, `--log-level=info`).
+                try forward_args.append(allocator, a);
+            } else if (input_path == null) {
+                input_path = a;
+            } else {
+                try forward_args.append(allocator, a);
+            }
+        }
+    }
+
+    const in_path = input_path orelse {
+        std.debug.print("error: missing input component — usage: wamrc serve <component.wasm> [options]\n", .{});
+        std.process.exit(1);
+    };
+
+    try compileAndSpawn(init, allocator, "serve", in_path, output_path, force, target_arch, forward_args.items);
 }
 
 fn runVerify(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
@@ -1466,6 +1576,7 @@ const top_usage =
     \\  compile             Compile a .wasm module to a .cwasm AOT binary
     \\  compile-component   Precompile every embedded core of a component
     \\  run                 Compile (if needed) and execute via the wamr runtime
+    \\  serve               Compile (if needed) and serve a wasi:http component
     \\  verify              Differential-test wamr-AOT vs wasmtime on a wasm
     \\  version             Print version and exit
     \\  help                Print this help
@@ -1628,6 +1739,37 @@ const run_usage =
     \\                                 for components)
     \\  --force                       Recompile even if the artifact is fresh
     \\  --target=<x86_64|aarch64>     Target architecture (default: host)
+    \\
+;
+
+const serve_usage =
+    \\Usage: wamrc serve [options] <component.wasm> [-- <wamr serve args...>]
+    \\
+    \\Mirror `wamrc run`, but precompile-if-stale and then spawn
+    \\`wamr serve <component.wasm>` (the wasi:http proxy world) instead of
+    \\`wamr run`. Aligned with `wasmtime serve`. The freshness / artifact
+    \\rules are identical to `wamrc run`.
+    \\
+    \\`--addr` and the `--tls-cert` / `--tls-key` / `--tls-pem` flags are
+    \\forwarded verbatim to `wamr serve`, so the wasmtime muscle memory
+    \\works:
+    \\
+    \\  wamrc serve app.wasm                       # 127.0.0.1:8080
+    \\  wamrc serve --addr 0.0.0.0:8080 app.wasm
+    \\
+    \\Anything after `--` (or any other positional / option after the
+    \\input) is also forwarded to `wamr serve`. The `wamr` binary is
+    \\located via $WAMR_BIN, then a sibling of wamrc, then PATH.
+    \\
+    \\Options:
+    \\  -o <file>                     Override the manifest path
+    \\                                 (a `.cwasm.json` for components)
+    \\  --force                       Recompile even if the artifact is fresh
+    \\  --target=<x86_64|aarch64>     Target architecture (default: host)
+    \\  --addr <ip:port>              Forwarded to `wamr serve` (default
+    \\                                 127.0.0.1:8080)
+    \\  --tls-cert / --tls-key / --tls-pem PATH
+    \\                                Forwarded to `wamr serve` for HTTPS
     \\
 ;
 
@@ -1850,6 +1992,9 @@ pub fn matchGlob(pattern: []const u8, name: []const u8) bool {
 
 test "subcommand parsing" {
     try std.testing.expectEqual(@as(?Subcommand, .compile), parseSubcommand("compile"));
+    try std.testing.expectEqual(@as(?Subcommand, .run), parseSubcommand("run"));
+    try std.testing.expectEqual(@as(?Subcommand, .serve), parseSubcommand("serve"));
+    try std.testing.expectEqual(@as(?Subcommand, .verify), parseSubcommand("verify"));
     try std.testing.expectEqual(@as(?Subcommand, .version), parseSubcommand("version"));
     try std.testing.expectEqual(@as(?Subcommand, .help), parseSubcommand("help"));
     try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand("--help"));

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,7 +15,7 @@ pub const MapDir = struct {
     guest_name: []const u8,
 };
 
-const Subcommand = enum { run, version, help };
+const Subcommand = enum { run, serve, version, help };
 
 /// Set by `WAMR_TRACE_CLI_ADAPTER=1|verbose` at startup (#715). Each
 /// `WasiCliAdapter` constructed during `runRun` / `runComponent`
@@ -27,6 +27,7 @@ var wasi_cli_adapter_trace_verbose: bool = false;
 
 fn parseSubcommand(s: []const u8) ?Subcommand {
     if (std.mem.eql(u8, s, "run")) return .run;
+    if (std.mem.eql(u8, s, "serve")) return .serve;
     if (std.mem.eql(u8, s, "version")) return .version;
     if (std.mem.eql(u8, s, "help")) return .help;
     return null;
@@ -126,6 +127,7 @@ pub fn main(init: std.process.Init) !u8 {
         .version => try runVersion(init.io, args[2..]),
         .help => runHelp(init.io, args[2..]),
         .run => try runRun(init, allocator, args[2..]),
+        .serve => try runServe(init, allocator, args[2..]),
     };
 }
 
@@ -175,20 +177,6 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     // next to the component file. Missing/stale bundle is fatal — the
     // `wamr` CLI no longer embeds the AOT compiler.
     var precompiled_manifest: ?[]const u8 = null;
-    var listen_address: ?std.Io.net.IpAddress = null;
-    // `--tls-cert=<path>` + `--tls-key=<path>` (or the combined
-    // `--tls-pem=<path>`) (#583 follow-up to #595, completed in #609):
-    // when both cert and key (or just the combined PEM) are provided
-    // alongside `--listen`, the HTTP service terminates TLS on each
-    // accepted connection (HTTPS), then serves HTTP/1.1 over the
-    // decrypted stream. Server-side TLS (TLS 1.3, RSA + ECDSA certs) is
-    // provided by the `cataggar/tls.zig` dependency — Zig 0.16 std ships
-    // only `std.crypto.tls.Client`. The cert + key are loaded + validated
-    // at startup so a missing file / malformed PEM / key-cert mismatch
-    // surfaces before `bind`. Null when not provided.
-    var tls_cert_path: ?[]const u8 = null;
-    var tls_key_path: ?[]const u8 = null;
-    var tls_pem_path: ?[]const u8 = null;
     // `--log-level=<name>` (#583 B5). Sets the host-side
     // `wasi:logging/logging.log` severity filter. The CLI flag wins
     // over the `WAMR_LOG_LEVEL` env var, which is consulted at the
@@ -208,79 +196,8 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                 // so existing invocations keep working; warn once on
                 // stderr so out-of-tree callers can adapt.
                 std.debug.print("warning: --stack-size is ignored under the AOT-only CLI (issue #644)\n", .{});
-            } else if (std.mem.eql(u8, arg, "--listen") or std.mem.startsWith(u8, arg, "--listen=")) {
-                if (listen_address != null) {
-                    std.debug.print("error: --listen specified more than once; only one listening socket preopen is supported\n", .{});
-                    return 2;
-                }
-                if (std.mem.eql(u8, arg, "--listen")) {
-                    // Bare `--listen` -> 127.0.0.1:0 (kernel-assigned ephemeral
-                    // port). The actual bound address is printed to stdout
-                    // after bind so test drivers can scrape it.
-                    listen_address = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch unreachable;
-                } else {
-                    const spec = arg["--listen=".len..];
-                    listen_address = parseListenAddress(spec) catch {
-                        std.debug.print("error: invalid --listen address '{s}'\n", .{spec});
-                        return 2;
-                    };
-                }
             } else if (std.mem.startsWith(u8, arg, "--heap-size=")) {
                 // Reserved for future WASI heap allocation
-            } else if (std.mem.eql(u8, arg, "--tls-cert") or std.mem.startsWith(u8, arg, "--tls-cert=")) {
-                if (tls_cert_path != null) {
-                    std.debug.print("error: --tls-cert specified more than once\n", .{});
-                    return 2;
-                }
-                const spec = if (std.mem.eql(u8, arg, "--tls-cert")) blk: {
-                    i += 1;
-                    if (i >= run_args.len) {
-                        std.debug.print("error: --tls-cert requires a path to a PEM file\n", .{});
-                        return 2;
-                    }
-                    break :blk run_args[i];
-                } else arg["--tls-cert=".len..];
-                if (spec.len == 0) {
-                    std.debug.print("error: --tls-cert path is empty\n", .{});
-                    return 2;
-                }
-                tls_cert_path = spec;
-            } else if (std.mem.eql(u8, arg, "--tls-key") or std.mem.startsWith(u8, arg, "--tls-key=")) {
-                if (tls_key_path != null) {
-                    std.debug.print("error: --tls-key specified more than once\n", .{});
-                    return 2;
-                }
-                const spec = if (std.mem.eql(u8, arg, "--tls-key")) blk: {
-                    i += 1;
-                    if (i >= run_args.len) {
-                        std.debug.print("error: --tls-key requires a path to a PEM file\n", .{});
-                        return 2;
-                    }
-                    break :blk run_args[i];
-                } else arg["--tls-key=".len..];
-                if (spec.len == 0) {
-                    std.debug.print("error: --tls-key path is empty\n", .{});
-                    return 2;
-                }
-                tls_key_path = spec;
-            } else if (std.mem.eql(u8, arg, "--tls-pem") or std.mem.startsWith(u8, arg, "--tls-pem=")) {
-                if (tls_pem_path != null) {
-                    std.debug.print("error: --tls-pem specified more than once\n", .{});
-                    return 2;
-                }
-                const spec = if (std.mem.eql(u8, arg, "--tls-pem")) blk: {
-                    i += 1;
-                    if (i >= run_args.len) {
-                        std.debug.print("error: --tls-pem requires a path to a combined PEM file\n", .{});
-                        return 2;
-                    }
-                    break :blk run_args[i];
-                } else arg["--tls-pem=".len..];
-                if (spec.len == 0) {
-                    std.debug.print("error: --tls-pem path is empty\n", .{});
-                    return 2;
-                }
-                tls_pem_path = spec;
             } else if (std.mem.eql(u8, arg, "--env") or std.mem.startsWith(u8, arg, "--env=")) {
                 const spec = if (std.mem.eql(u8, arg, "--env")) blk: {
                     i += 1;
@@ -415,28 +332,6 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
         return 2;
     };
 
-    // ── TLS flag validation (#583 follow-up / #609) ──────────────────────
-    // Disallowed combinations:
-    //   * `--tls-cert` without `--tls-key` (or vice versa) — the pair is
-    //     load-bearing together.
-    //   * `--tls-pem` combined with either `--tls-cert` or `--tls-key` —
-    //     pick one of the two input shapes.
-    //   * Any of the TLS flags without `--listen` — TLS termination only
-    //     makes sense on the HTTP service path.
-    if (tls_pem_path != null and (tls_cert_path != null or tls_key_path != null)) {
-        std.debug.print("error: --tls-pem is mutually exclusive with --tls-cert / --tls-key\n", .{});
-        return 2;
-    }
-    if ((tls_cert_path == null) != (tls_key_path == null)) {
-        std.debug.print("error: --tls-cert and --tls-key must be specified together\n", .{});
-        return 2;
-    }
-    const tls_requested = tls_cert_path != null or tls_pem_path != null;
-    if (tls_requested and listen_address == null) {
-        std.debug.print("error: --tls-cert / --tls-key / --tls-pem require --listen\n", .{});
-        return 2;
-    }
-
     const io = init.io;
     const cwd = std.Io.Dir.cwd();
     const wasm_data = cwd.readFileAlloc(io, path, allocator, @enumFromInt(256 * 1024 * 1024)) catch |err| {
@@ -450,10 +345,6 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     // embedded compiler was removed. The `.cwasm` path now flows
     // through this code via `wamrc compile` (or `wamrc run`).
     if (wasm_data.len >= 4 and std.mem.readInt(u32, wasm_data[0..4], .little) == wamr.types.aot_magic) {
-        if (listen_address != null) {
-            std.debug.print("Error: --listen is not supported for AOT core modules (use a component)\n", .{});
-            return 2;
-        }
         return runAot(
             init.io,
             allocator,
@@ -515,112 +406,18 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                 std.debug.print("Error: --config-store '{s}': {}\n", .{ config_store_path orelse "", err });
                 return 2;
             };
-            // #644 / #680: resolve the AOT precompiled-cores manifest.
-            // The `wamr` CLI is AOT-only and the runtime no longer
-            // embeds the compiler — every component core must be
-            // available as a precompiled `.cwasm`, or instantiation
-            // fails hard with `error.AotImportUnresolvable` (the interp
-            // fallback is disabled at the CLI surface; library callers
-            // still get the legacy silent demotion by leaving
-            // `Options.aot_only` unset).
-            //
-            //  * `--precompiled-manifest <path>` (explicit): any error
-            //    opening / validating the manifest is fatal so the user
-            //    knows the AOT path isn't being taken.
-            //  * sibling `<input>.cwasm.json` (auto-detect):
-            //    used when present and valid.
-            //  * neither found → hard error. The `wamr` binary no
-            //    longer embeds the AOT compiler (issue #680); users
-            //    must run `wamrc compile-component <component.wasm>`
-            //    or `wamrc run <component.wasm>` first.
-            //
-            // The `LoadedManifest`'s lifetime must outlive
-            // `runComponent` / `runHttpComponent` because the mmapped
-            // `.cwasm` buffers it owns are borrowed by the
-            // `PrecompiledCore` slice handed to the instance loader.
+            // #644 / #680: resolve the AOT precompiled-cores manifest
+            // (shared with `wamr serve`). The `LoadedManifest`'s lifetime
+            // must outlive `runComponent` because the mmapped `.cwasm`
+            // buffers it owns are borrowed by the `PrecompiledCore` slice
+            // handed to the instance loader.
             var loaded_manifest: ?wamr.component_aot.LoadedManifest = null;
             defer if (loaded_manifest) |*lm| lm.deinit();
-
-            if (precompiled_manifest) |mp| {
-                loaded_manifest = wamr.component_aot.loadManifest(allocator, mp, wasm_data) catch |err| {
-                    std.debug.print("Error: --precompiled-manifest '{s}': {s}\n", .{ mp, loadManifestErrorMessage(err) });
-                    return 2;
-                };
-                const n = loaded_manifest.?.precompiledCores().len;
-                if (wamr.component_core_backend.debugAotEnabled())
-                    std.debug.print("wamr: loaded AOT manifest from {s} ({d} core{s} precompiled)\n", .{ mp, n, if (n == 1) @as([]const u8, "") else "s" });
-            } else {
-                // Auto-probe `<input>.cwasm.json`. Without an embedded
-                // compiler the absence of a sibling manifest is fatal —
-                // direct the user at `wamrc`.
-                const sibling = wamr.component_aot.defaultManifestPathFor(allocator, path) catch return 1;
-                defer allocator.free(sibling);
-                const io_probe = init.io;
-                const cwd_probe = std.Io.Dir.cwd();
-                const exists = blk: {
-                    var f = cwd_probe.openFile(io_probe, sibling, .{}) catch break :blk false;
-                    f.close(io_probe);
-                    break :blk true;
-                };
-                if (!exists) {
-                    std.debug.print(
-                        "Error: no AOT manifest found for '{s}'. The `wamr` runtime no longer embeds the compiler (#680).\n" ++
-                            "  Run `wamrc compile-component {s}` to produce '{s}', or\n" ++
-                            "  run `wamrc run {s} [-- args...]` to compile and execute in one step.\n",
-                        .{ path, path, sibling, path },
-                    );
-                    return 2;
-                }
-                loaded_manifest = wamr.component_aot.loadManifest(allocator, sibling, wasm_data) catch |err| {
-                    std.debug.print(
-                        "Error: AOT manifest at '{s}' is stale or invalid: {s}.\n" ++
-                            "  Rebuild it with `wamrc compile-component {s}` or run `wamrc run {s}`.\n",
-                        .{ sibling, loadManifestErrorMessage(err), path, path },
-                    );
-                    return 2;
-                };
-                const n = loaded_manifest.?.precompiledCores().len;
-                if (wamr.component_core_backend.debugAotEnabled())
-                    std.debug.print("wamr: loaded AOT manifest from {s} ({d} core{s} precompiled)\n", .{ sibling, n, if (n == 1) @as([]const u8, "") else "s" });
-            }
+            const manifest_rc = loadComponentManifestOrPrint(init, allocator, "run", path, wasm_data, precompiled_manifest, &loaded_manifest);
+            if (manifest_rc != 0) return manifest_rc;
             const precompiled_cores: []const wamr.component_core_backend.PrecompiledCore =
                 loaded_manifest.?.precompiledCores();
 
-            // #644: AOT-only policy. `wamr run` requires a precompiled
-            // bundle for every component — there is no interp fallback
-            // at the CLI surface and no in-process compiler. An empty
-            // bundle means the component had no core modules (an
-            // empty / malformed input that survived parsing).
-            if (precompiled_cores.len == 0) {
-                std.debug.print(
-                    "Error: component has no AOT-compiled cores and `wamr run` is AOT-only.\n" ++
-                        "  See issue #644.\n",
-                    .{},
-                );
-                return 2;
-            }
-
-            if (listen_address) |addr| {
-                // Load + parse the TLS cert + key at startup, so a
-                // missing file / malformed PEM surfaces before `bind`
-                // (matches the documented startup-validation rule for
-                // every other host-config flag).
-                var tls_config: ?wamr.wasi_cli_adapter.HttpsTlsConfig = null;
-                if (tls_pem_path) |p| {
-                    tls_config = wamr.wasi_cli_adapter.HttpsTlsConfig.loadFromCombinedPath(allocator, p) catch |err| {
-                        std.debug.print("Error: --tls-pem '{s}': {s}\n", .{ p, tlsLoadErrorMessage(err) });
-                        return 2;
-                    };
-                } else if (tls_cert_path) |cp| {
-                    const kp = tls_key_path.?;
-                    tls_config = wamr.wasi_cli_adapter.HttpsTlsConfig.loadFromPaths(allocator, cp, kp) catch |err| {
-                        std.debug.print("Error: --tls-cert '{s}' / --tls-key '{s}': {s}\n", .{ cp, kp, tlsLoadErrorMessage(err) });
-                        return 2;
-                    };
-                }
-                defer if (tls_config) |*c| c.deinit();
-                return runHttpComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, addr, effective_log_level, if (tls_config) |*c| c else null, precompiled_cores);
-            }
             return runComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, map_dirs.items, allow_net.items, effective_log_level, cfg_entries, keyvalue_store_path, precompiled_cores);
         }
     }
@@ -629,10 +426,6 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     // compiler (#680) — users must precompile with `wamrc compile`
     // (or use `wamrc run` for one-shot test execution).
     _ = aot_supported;
-    if (listen_address != null) {
-        std.debug.print("Error: --listen is not supported for plain core wasm modules (use a component)\n", .{});
-        return 2;
-    }
     std.debug.print(
         "Error: '{s}' is a plain core wasm module and the `wamr` runtime is AOT-only (#644)\n" ++
             "       without an embedded compiler (#680).\n" ++
@@ -643,6 +436,270 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
     return 2;
 }
 
+/// `wamr serve <component.wasm> [options]` (#845): serve a
+/// `wasi:http/incoming-handler` component as a long-lived HTTP server.
+/// Mirrors `wasmtime serve`:
+///   * `--addr <ip:port>` bind address (default `127.0.0.1:8080`).
+///   * `--addr 127.0.0.1:0` binds a kernel-assigned ephemeral port and
+///     prints the resolved address to stdout (for test drivers).
+///   * `--tls-cert` / `--tls-key` / `--tls-pem` terminate HTTPS.
+/// AOT-only like `run`: the component needs a `wamrc compile-component`
+/// manifest (explicit `--precompiled-manifest` or sibling
+/// `<input>.cwasm.json`).
+fn runServe(init: std.process.Init, allocator: std.mem.Allocator, serve_args: []const []const u8) !u8 {
+    if (serve_args.len == 1 and std.mem.eql(u8, serve_args[0], "help")) {
+        writeStdout(init.io, serve_usage);
+        return 0;
+    }
+    var wasm_path: ?[]const u8 = null;
+    var wasm_args: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer wasm_args.deinit(allocator);
+    var env_flags: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer env_flags.deinit(allocator);
+    var addr: ?std.Io.net.IpAddress = null;
+    var tls_cert_path: ?[]const u8 = null;
+    var tls_key_path: ?[]const u8 = null;
+    var tls_pem_path: ?[]const u8 = null;
+    var log_level: ?wamr.wasi_cli_adapter.WasiLogLevel = null;
+    var precompiled_manifest: ?[]const u8 = null;
+    var past_options = false;
+
+    var i: usize = 0;
+    while (i < serve_args.len) : (i += 1) {
+        const arg = serve_args[i];
+        if (!past_options and arg.len > 0 and arg[0] == '-') {
+            if (std.mem.eql(u8, arg, "--addr") or std.mem.startsWith(u8, arg, "--addr=")) {
+                if (addr != null) {
+                    std.debug.print("error: --addr specified more than once\n", .{});
+                    return 2;
+                }
+                const spec = if (std.mem.eql(u8, arg, "--addr")) blk: {
+                    i += 1;
+                    if (i >= serve_args.len) {
+                        std.debug.print("error: --addr requires an <ip:port> value\n", .{});
+                        return 2;
+                    }
+                    break :blk serve_args[i];
+                } else arg["--addr=".len..];
+                addr = parseAddr(spec) catch {
+                    std.debug.print("error: invalid --addr address '{s}'\n", .{spec});
+                    return 2;
+                };
+            } else if (std.mem.eql(u8, arg, "--tls-cert") or std.mem.startsWith(u8, arg, "--tls-cert=")) {
+                if (tls_cert_path != null) {
+                    std.debug.print("error: --tls-cert specified more than once\n", .{});
+                    return 2;
+                }
+                const spec = if (std.mem.eql(u8, arg, "--tls-cert")) blk: {
+                    i += 1;
+                    if (i >= serve_args.len) {
+                        std.debug.print("error: --tls-cert requires a path to a PEM file\n", .{});
+                        return 2;
+                    }
+                    break :blk serve_args[i];
+                } else arg["--tls-cert=".len..];
+                if (spec.len == 0) {
+                    std.debug.print("error: --tls-cert path is empty\n", .{});
+                    return 2;
+                }
+                tls_cert_path = spec;
+            } else if (std.mem.eql(u8, arg, "--tls-key") or std.mem.startsWith(u8, arg, "--tls-key=")) {
+                if (tls_key_path != null) {
+                    std.debug.print("error: --tls-key specified more than once\n", .{});
+                    return 2;
+                }
+                const spec = if (std.mem.eql(u8, arg, "--tls-key")) blk: {
+                    i += 1;
+                    if (i >= serve_args.len) {
+                        std.debug.print("error: --tls-key requires a path to a PEM file\n", .{});
+                        return 2;
+                    }
+                    break :blk serve_args[i];
+                } else arg["--tls-key=".len..];
+                if (spec.len == 0) {
+                    std.debug.print("error: --tls-key path is empty\n", .{});
+                    return 2;
+                }
+                tls_key_path = spec;
+            } else if (std.mem.eql(u8, arg, "--tls-pem") or std.mem.startsWith(u8, arg, "--tls-pem=")) {
+                if (tls_pem_path != null) {
+                    std.debug.print("error: --tls-pem specified more than once\n", .{});
+                    return 2;
+                }
+                const spec = if (std.mem.eql(u8, arg, "--tls-pem")) blk: {
+                    i += 1;
+                    if (i >= serve_args.len) {
+                        std.debug.print("error: --tls-pem requires a path to a combined PEM file\n", .{});
+                        return 2;
+                    }
+                    break :blk serve_args[i];
+                } else arg["--tls-pem=".len..];
+                if (spec.len == 0) {
+                    std.debug.print("error: --tls-pem path is empty\n", .{});
+                    return 2;
+                }
+                tls_pem_path = spec;
+            } else if (std.mem.eql(u8, arg, "--env") or std.mem.startsWith(u8, arg, "--env=")) {
+                const spec = if (std.mem.eql(u8, arg, "--env")) blk: {
+                    i += 1;
+                    if (i >= serve_args.len) {
+                        std.debug.print("error: --env requires KEY=VALUE\n", .{});
+                        return 2;
+                    }
+                    break :blk serve_args[i];
+                } else arg["--env=".len..];
+                if (std.mem.indexOfScalar(u8, spec, '=') == null) {
+                    std.debug.print("error: --env value '{s}' is missing '='\n", .{spec});
+                    return 2;
+                }
+                try env_flags.append(allocator, spec);
+            } else if (std.mem.eql(u8, arg, "--log-level") or std.mem.startsWith(u8, arg, "--log-level=")) {
+                const spec = if (std.mem.eql(u8, arg, "--log-level")) blk: {
+                    i += 1;
+                    if (i >= serve_args.len) {
+                        std.debug.print("error: --log-level requires <trace|debug|info|warn|error|critical>\n", .{});
+                        return 2;
+                    }
+                    break :blk serve_args[i];
+                } else arg["--log-level=".len..];
+                log_level = wamr.wasi_cli_adapter.WasiLogLevel.fromString(spec) orelse {
+                    std.debug.print(
+                        "error: --log-level value '{s}' is not one of trace|debug|info|warn|error|critical\n",
+                        .{spec},
+                    );
+                    return 2;
+                };
+            } else if (std.mem.eql(u8, arg, "--precompiled-manifest") or std.mem.startsWith(u8, arg, "--precompiled-manifest=")) {
+                if (precompiled_manifest != null) {
+                    std.debug.print("error: --precompiled-manifest specified more than once\n", .{});
+                    return 2;
+                }
+                const spec = if (std.mem.eql(u8, arg, "--precompiled-manifest")) blk: {
+                    i += 1;
+                    if (i >= serve_args.len) {
+                        std.debug.print("error: --precompiled-manifest requires a path to a wamrc compile-component manifest\n", .{});
+                        return 2;
+                    }
+                    break :blk serve_args[i];
+                } else arg["--precompiled-manifest=".len..];
+                if (spec.len == 0) {
+                    std.debug.print("error: --precompiled-manifest path is empty\n", .{});
+                    return 2;
+                }
+                precompiled_manifest = spec;
+            } else if (std.mem.eql(u8, arg, "--trace-aot-wasi")) {
+                wamr.aot_host_bridge.trace_enabled = true;
+            } else if (std.mem.eql(u8, arg, "--")) {
+                past_options = true;
+            } else {
+                std.debug.print("error: unknown option '{s}' — try `wamr serve help`\n", .{arg});
+                return 2;
+            }
+        } else if (wasm_path == null) {
+            wasm_path = arg;
+            past_options = true;
+        } else {
+            try wasm_args.append(allocator, arg);
+        }
+    }
+
+    const path = wasm_path orelse {
+        std.debug.print("error: missing component file — usage: wamr serve [options] <component.wasm>\n", .{});
+        return 2;
+    };
+
+    // TLS flag validation (#609): cert/key are load-bearing together;
+    // the combined PEM is mutually exclusive with the split pair.
+    if (tls_pem_path != null and (tls_cert_path != null or tls_key_path != null)) {
+        std.debug.print("error: --tls-pem is mutually exclusive with --tls-cert / --tls-key\n", .{});
+        return 2;
+    }
+    if ((tls_cert_path == null) != (tls_key_path == null)) {
+        std.debug.print("error: --tls-cert and --tls-key must be specified together\n", .{});
+        return 2;
+    }
+
+    const io = init.io;
+    const cwd = std.Io.Dir.cwd();
+    const wasm_data = cwd.readFileAlloc(io, path, allocator, @enumFromInt(256 * 1024 * 1024)) catch |err| {
+        wamr.utils.read_file.dieReadFileError(path, err);
+    };
+    defer allocator.free(wasm_data);
+
+    // `serve` is component-only. Reject AOT core images and plain core
+    // wasm with a pointer at `run` (matches the proxy-vs-command split).
+    if (wasm_data.len >= 4 and std.mem.readInt(u32, wasm_data[0..4], .little) == wamr.types.aot_magic) {
+        std.debug.print("Error: `wamr serve` requires a wasi:http/incoming-handler component, not an AOT core module (use `wamr run`).\n", .{});
+        return 2;
+    }
+    const is_component = wasm_data.len >= 8 and
+        std.mem.readInt(u32, wasm_data[0..4], .little) == wamr.types.wasm_magic and
+        std.mem.readInt(u32, wasm_data[4..8], .little) == wamr.types.component_version;
+    if (!is_component) {
+        std.debug.print("Error: `wamr serve` requires a wasi:http/incoming-handler component (got a non-component wasm). See `wamr serve help`.\n", .{});
+        return 2;
+    }
+
+    // For components: prefer explicit --env entries; otherwise inherit
+    // the host environment. EnvVar slices borrow from environ_map (which
+    // lives for the entire process).
+    var env_list: std.ArrayListUnmanaged(wamr.wasi_cli_adapter.EnvVar) = .empty;
+    defer env_list.deinit(allocator);
+    if (env_flags.items.len > 0) {
+        for (env_flags.items) |kv| {
+            const eq = std.mem.indexOfScalar(u8, kv, '=').?;
+            env_list.append(allocator, .{ .name = kv[0..eq], .value = kv[eq + 1 ..] }) catch {};
+        }
+    } else {
+        var it = init.environ_map.array_hash_map.iterator();
+        while (it.next()) |kv| {
+            env_list.append(allocator, .{ .name = kv.key_ptr.*, .value = kv.value_ptr.* }) catch {};
+        }
+    }
+
+    // `--log-level` wins over `WAMR_LOG_LEVEL` (consulted only when the
+    // flag is absent). (#583 B5)
+    const effective_log_level: ?wamr.wasi_cli_adapter.WasiLogLevel = log_level orelse blk: {
+        const raw = init.environ_map.get("WAMR_LOG_LEVEL") orelse break :blk null;
+        if (raw.len == 0) break :blk null;
+        const parsed = wamr.wasi_cli_adapter.WasiLogLevel.fromString(raw) orelse {
+            std.debug.print(
+                "warning: WAMR_LOG_LEVEL='{s}' is not one of trace|debug|info|warn|error|critical; ignoring\n",
+                .{raw},
+            );
+            break :blk null;
+        };
+        break :blk parsed;
+    };
+
+    var loaded_manifest: ?wamr.component_aot.LoadedManifest = null;
+    defer if (loaded_manifest) |*lm| lm.deinit();
+    const manifest_rc = loadComponentManifestOrPrint(init, allocator, "serve", path, wasm_data, precompiled_manifest, &loaded_manifest);
+    if (manifest_rc != 0) return manifest_rc;
+    const precompiled_cores = loaded_manifest.?.precompiledCores();
+
+    // Load + parse the TLS cert + key at startup, so a missing file /
+    // malformed PEM surfaces before `bind`.
+    var tls_config: ?wamr.wasi_cli_adapter.HttpsTlsConfig = null;
+    if (tls_pem_path) |p| {
+        tls_config = wamr.wasi_cli_adapter.HttpsTlsConfig.loadFromCombinedPath(allocator, p) catch |err| {
+            std.debug.print("Error: --tls-pem '{s}': {s}\n", .{ p, tlsLoadErrorMessage(err) });
+            return 2;
+        };
+    } else if (tls_cert_path) |cp| {
+        const kp = tls_key_path.?;
+        tls_config = wamr.wasi_cli_adapter.HttpsTlsConfig.loadFromPaths(allocator, cp, kp) catch |err| {
+            std.debug.print("Error: --tls-cert '{s}' / --tls-key '{s}': {s}\n", .{ cp, kp, tlsLoadErrorMessage(err) });
+            return 2;
+        };
+    }
+    defer if (tls_config) |*c| c.deinit();
+
+    // Default to wasmtime's `127.0.0.1:8080` when `--addr` is omitted.
+    const bind_addr = addr orelse (std.Io.net.IpAddress.parse("127.0.0.1", 8080) catch unreachable);
+    return runHttpComponent(wasm_data, allocator, path, wasm_args.items, env_list.items, bind_addr, effective_log_level, if (tls_config) |*c| c else null, precompiled_cores);
+}
+
 fn parseMapDir(spec: []const u8) !MapDir {
     const sep = std.mem.indexOf(u8, spec, "::") orelse return error.MissingSeparator;
     const host = spec[0..sep];
@@ -651,7 +708,10 @@ fn parseMapDir(spec: []const u8) !MapDir {
     return .{ .host_path = host, .guest_name = guest };
 }
 
-fn parseListenAddress(spec: []const u8) !std.Io.net.IpAddress {
+/// Parse a `--addr <ip:port>` bind spec into an `IpAddress`. Matches
+/// `wasmtime serve --addr`: an IP literal + port (no hostname
+/// resolution). IPv6 is bracketed, e.g. `[::1]:8080`.
+fn parseAddr(spec: []const u8) !std.Io.net.IpAddress {
     if (spec.len == 0) return error.InvalidAddress;
 
     var host: []const u8 = undefined;
@@ -679,6 +739,93 @@ fn parseListenAddress(spec: []const u8) !std.Io.net.IpAddress {
     if (host.len == 0 or port_text.len == 0) return error.InvalidAddress;
     const port = try std.fmt.parseInt(u16, port_text, 10);
     return std.Io.net.IpAddress.parse(host, port);
+}
+
+/// Resolve the AOT precompiled-cores manifest for a component, shared by
+/// `wamr run` and `wamr serve` (#644 / #680 / #845).
+///
+/// The `wamr` CLI is AOT-only and the runtime no longer embeds the
+/// compiler, so every component core must be available as a precompiled
+/// `.cwasm` or instantiation fails hard. Resolution order:
+///
+///   * `--precompiled-manifest <path>` (explicit): any error opening /
+///     validating the manifest is fatal so the user knows the AOT path
+///     isn't being taken.
+///   * sibling `<input>.cwasm.json` (auto-detect): used when present and
+///     valid.
+///   * neither found → hard error directing the user at `wamrc`.
+///
+/// On success returns 0 and sets `out_manifest`. On failure prints a
+/// diagnostic and returns a non-zero exit code; `out_manifest` may still
+/// be set (the caller's `defer …deinit()` handles cleanup either way).
+/// `verb` is the invoking subcommand ("run" / "serve") and only flavours
+/// the error text.
+fn loadComponentManifestOrPrint(
+    init: std.process.Init,
+    allocator: std.mem.Allocator,
+    verb: []const u8,
+    path: []const u8,
+    wasm_data: []const u8,
+    precompiled_manifest: ?[]const u8,
+    out_manifest: *?wamr.component_aot.LoadedManifest,
+) u8 {
+    if (precompiled_manifest) |mp| {
+        out_manifest.* = wamr.component_aot.loadManifest(allocator, mp, wasm_data) catch |err| {
+            std.debug.print("Error: --precompiled-manifest '{s}': {s}\n", .{ mp, loadManifestErrorMessage(err) });
+            return 2;
+        };
+        const n = out_manifest.*.?.precompiledCores().len;
+        if (wamr.component_core_backend.debugAotEnabled())
+            std.debug.print("wamr: loaded AOT manifest from {s} ({d} core{s} precompiled)\n", .{ mp, n, if (n == 1) @as([]const u8, "") else "s" });
+    } else {
+        // Auto-probe `<input>.cwasm.json`. Without an embedded compiler
+        // the absence of a sibling manifest is fatal — direct the user
+        // at `wamrc`.
+        const sibling = wamr.component_aot.defaultManifestPathFor(allocator, path) catch return 1;
+        defer allocator.free(sibling);
+        const io_probe = init.io;
+        const cwd_probe = std.Io.Dir.cwd();
+        const exists = blk: {
+            var f = cwd_probe.openFile(io_probe, sibling, .{}) catch break :blk false;
+            f.close(io_probe);
+            break :blk true;
+        };
+        if (!exists) {
+            std.debug.print(
+                "Error: no AOT manifest found for '{s}'. The `wamr` runtime no longer embeds the compiler (#680).\n" ++
+                    "  Run `wamrc compile-component {s}` to produce '{s}', or\n" ++
+                    "  run `wamrc {s} {s}` to compile and serve/execute in one step.\n",
+                .{ path, path, sibling, verb, path },
+            );
+            return 2;
+        }
+        out_manifest.* = wamr.component_aot.loadManifest(allocator, sibling, wasm_data) catch |err| {
+            std.debug.print(
+                "Error: AOT manifest at '{s}' is stale or invalid: {s}.\n" ++
+                    "  Rebuild it with `wamrc compile-component {s}` or run `wamrc {s} {s}`.\n",
+                .{ sibling, loadManifestErrorMessage(err), path, verb, path },
+            );
+            return 2;
+        };
+        const n = out_manifest.*.?.precompiledCores().len;
+        if (wamr.component_core_backend.debugAotEnabled())
+            std.debug.print("wamr: loaded AOT manifest from {s} ({d} core{s} precompiled)\n", .{ sibling, n, if (n == 1) @as([]const u8, "") else "s" });
+    }
+
+    // #644: AOT-only policy. `wamr run`/`serve` require a precompiled
+    // bundle for every component — there is no interp fallback at the CLI
+    // surface and no in-process compiler. An empty bundle means the
+    // component had no core modules (an empty / malformed input that
+    // survived parsing).
+    if (out_manifest.*.?.precompiledCores().len == 0) {
+        std.debug.print(
+            "Error: component has no AOT-compiled cores and `wamr {s}` is AOT-only.\n" ++
+                "  See issue #644.\n",
+            .{verb},
+        );
+        return 2;
+    }
+    return 0;
 }
 
 /// Assemble the merged `wasi:config/store@0.2.0-rc.1` backing slice
@@ -986,9 +1133,9 @@ fn runHttpComponent(
                 "Error: component trapped during initialization (see [component init trap] line above)\n",
                 .{},
             ),
-            error.ListenFailed => std.debug.print("Error: failed to bind --listen address\n", .{}),
+            error.ListenFailed => std.debug.print("Error: failed to bind --addr address\n", .{}),
             error.AddressInUse => std.debug.print(
-                "Error: --listen address already in use (another process is bound to this port)\n",
+                "Error: --addr address already in use (another process is bound to this port)\n",
                 .{},
             ),
             error.AcceptFailed => std.debug.print("Error: failed to accept HTTP connection\n", .{}),
@@ -1172,6 +1319,7 @@ const top_usage =
     \\
     \\Subcommands:
     \\  run       Run a .wasm or .cwasm file
+    \\  serve     Serve a wasi:http/incoming-handler component over HTTP
     \\  version   Print version and exit
     \\  help      Print this help
     \\
@@ -1194,11 +1342,6 @@ const run_usage =
     \\Options:
     \\  --stack-size=<bytes>     (ignored; kept for backward compat)
     \\  --heap-size=<bytes>      Reserved (currently ignored)
-    \\  --listen[=<ip:port>]     For components: serve WASI HTTP on the address.
-    \\                           Port 0 (and bare `--listen`, which means
-    \\                           127.0.0.1:0) requests a kernel-assigned
-    \\                           ephemeral port; the resolved address is
-    \\                           printed to stdout after bind.
     \\  --env KEY=VALUE          Set a WASI environment variable (repeatable)
     \\  --map-dir HOST::GUEST    Pre-open `HOST` host directory as `GUEST`
     \\                           inside the guest WASI sandbox (repeatable)
@@ -1223,21 +1366,6 @@ const run_usage =
     \\                           Loads on startup (missing file is OK),
     \\                           rewrites synchronously on every mutation.
     \\                           Omit to keep the default in-memory store.
-    \\  --tls-cert PATH          For components serving HTTP: PEM-encoded
-    \\                           certificate chain (leaf first). Requires
-    \\                           --listen and a matching --tls-key. Today
-    \\                           the cert + key are parsed + validated at
-    \\                           startup but the handshake is upstream-
-    \\                           blocked on Zig std (see cataggar/wamr#609);
-    \\                           the listener serves plaintext with a
-    \\                           single stderr warning.
-    \\  --tls-key PATH           For components serving HTTP: PEM-encoded
-    \\                           private key (PKCS#8, RSA, or EC). Pairs
-    \\                           with --tls-cert.
-    \\  --tls-pem PATH           For components serving HTTP: combined PEM
-    \\                           file containing both certificate chain
-    \\                           and private key. Mutually exclusive with
-    \\                           --tls-cert / --tls-key.
     \\  --precompiled-manifest PATH
     \\                           For components: load AOT-compiled cores by
     \\                           reading a `wamrc compile-component` manifest
@@ -1248,6 +1376,48 @@ const run_usage =
     \\                           `<input>.cwasm.json`. The manifest is
     \\                           mandatory: components without one fail
     \\                           with a clear error (issues #644, #680).
+    \\
+    \\To serve a wasi:http/incoming-handler component over HTTP, use
+    \\`wamr serve` instead (see `wamr serve help`).
+    \\
+;
+
+const serve_usage =
+    \\Usage: wamr serve [options] <component.wasm>
+    \\
+    \\Serve a `wasi:http/incoming-handler` component as a long-lived HTTP
+    \\server (the proxy world), aligned with `wasmtime serve`. AOT-only
+    \\like `wamr run`: the component needs a `wamrc compile-component`
+    \\manifest (an explicit --precompiled-manifest or a sibling
+    \\`<input>.cwasm.json`). Use `wamrc serve <component.wasm>` to
+    \\precompile-if-stale and serve in one step.
+    \\
+    \\Options:
+    \\  --addr <ip:port>         Bind address (an IP literal + port, no
+    \\                           hostname resolution). Default 127.0.0.1:8080.
+    \\                           Use `0.0.0.0:<port>` / `[::1]:<port>` for
+    \\                           broader binding. `--addr 127.0.0.1:0`
+    \\                           requests a kernel-assigned ephemeral port
+    \\                           and prints the resolved address to stdout
+    \\                           (handy for test drivers).
+    \\  --env KEY=VALUE          Set a WASI environment variable (repeatable)
+    \\  --log-level NAME         Filter `wasi:logging` calls below NAME. One
+    \\                           of trace|debug|info|warn|error|critical
+    \\                           (default: trace = admit all). Falls back to
+    \\                           the WAMR_LOG_LEVEL env var when absent.
+    \\  --tls-cert PATH          PEM-encoded certificate chain (leaf first).
+    \\                           Terminates HTTPS on each connection. Requires
+    \\                           a matching --tls-key.
+    \\  --tls-key PATH           PEM-encoded private key (PKCS#8, RSA, or EC).
+    \\                           Pairs with --tls-cert.
+    \\  --tls-pem PATH           Combined PEM file containing both certificate
+    \\                           chain and private key. Mutually exclusive
+    \\                           with --tls-cert / --tls-key.
+    \\  --precompiled-manifest PATH
+    \\                           Load AOT-compiled cores from a `wamrc
+    \\                           compile-component` manifest sidecar
+    \\                           (`<stem>.cwasm.json`). When omitted, a
+    \\                           sibling `<input>.cwasm.json` is auto-detected.
     \\
 ;
 
@@ -1276,11 +1446,24 @@ fn runHelp(io: std.Io, args: []const []const u8) u8 {
 
 test "subcommand parsing" {
     try std.testing.expectEqual(@as(?Subcommand, .run), parseSubcommand("run"));
+    try std.testing.expectEqual(@as(?Subcommand, .serve), parseSubcommand("serve"));
     try std.testing.expectEqual(@as(?Subcommand, .version), parseSubcommand("version"));
     try std.testing.expectEqual(@as(?Subcommand, .help), parseSubcommand("help"));
     try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand("--version"));
     try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand("foo.wasm"));
     try std.testing.expectEqual(@as(?Subcommand, null), parseSubcommand(""));
+}
+
+test "parseAddr accepts ipv4/ipv6 literals and rejects junk" {
+    const a = try parseAddr("127.0.0.1:8080");
+    try std.testing.expectEqual(@as(u16, 8080), a.getPort());
+    const eph = try parseAddr("127.0.0.1:0");
+    try std.testing.expectEqual(@as(u16, 0), eph.getPort());
+    const v6 = try parseAddr("[::1]:8080");
+    try std.testing.expectEqual(@as(u16, 8080), v6.getPort());
+    try std.testing.expectError(error.InvalidAddress, parseAddr(""));
+    try std.testing.expectError(error.InvalidAddress, parseAddr("127.0.0.1"));
+    try std.testing.expectError(error.InvalidAddress, parseAddr(":8080"));
 }
 
 test "parseMapDir splits HOST::GUEST" {

--- a/src/wasi/wasi.zig
+++ b/src/wasi/wasi.zig
@@ -327,10 +327,10 @@ pub const SOCKET_BASE_RIGHTS: u64 =
     RIGHTS_POLL_FD_READWRITE |
     RIGHTS_SOCK_SHUTDOWN;
 
-/// Rights granted to a listening socket preopen (the `--listen=` fd).
-/// It accepts new connections and is poll-able; it cannot itself be
-/// read from or written to, mirroring wasi-libc's expectation for a
-/// passive `socket(2)` + `listen(2)` fd.
+/// Rights granted to a listening socket preopen fd. It accepts new
+/// connections and is poll-able; it cannot itself be read from or
+/// written to, mirroring wasi-libc's expectation for a passive
+/// `socket(2)` + `listen(2)` fd.
 pub const SOCKET_LISTEN_RIGHTS: u64 =
     RIGHTS_SOCK_ACCEPT |
     RIGHTS_POLL_FD_READWRITE |

--- a/tests/component-http-petstore-smoke/driver.zig
+++ b/tests/component-http-petstore-smoke/driver.zig
@@ -1,6 +1,6 @@
 //! End-to-end smoke driver for `examples/zig-http-petstore`.
 //!
-//! Spawns `<wamr_exe> run --listen=127.0.0.1:<port> <component.wasm>` as
+//! Spawns `<wamr_exe> serve --addr=127.0.0.1:<port> <component.wasm>` as
 //! a subprocess and verifies the TypeSpec petstore API behaviour:
 //!
 //!   GET    /pets          -> 200, JSON list containing "Fluffy" + "Rex"
@@ -42,11 +42,11 @@ pub fn main(init: std.process.Init) !void {
         std.process.exit(2);
     };
 
-    const listen_arg = try std.fmt.allocPrint(allocator, "--listen=127.0.0.1:{d}", .{port});
-    defer allocator.free(listen_arg);
+    const addr_arg = try std.fmt.allocPrint(allocator, "--addr=127.0.0.1:{d}", .{port});
+    defer allocator.free(addr_arg);
 
     var child = try std.process.spawn(io, .{
-        .argv = &.{ wamr_exe, "run", listen_arg, component_path },
+        .argv = &.{ wamr_exe, "serve", addr_arg, component_path },
         .stdin = .ignore,
         .stdout = .inherit,
         .stderr = .inherit,

--- a/tests/component-http-smoke/driver.zig
+++ b/tests/component-http-smoke/driver.zig
@@ -1,6 +1,6 @@
 //! End-to-end smoke driver for `examples/zig-http`.
 //!
-//! Spawns `<wamr_exe> run --listen=127.0.0.1:<port> <component.wasm>` as
+//! Spawns `<wamr_exe> serve --addr=127.0.0.1:<port> <component.wasm>` as
 //! a subprocess and verifies the canonical HTTP-tutorial behaviour:
 //!
 //!   GET /         -> 200 "Hello, world!\n"
@@ -41,11 +41,11 @@ pub fn main(init: std.process.Init) !void {
         std.process.exit(2);
     };
 
-    const listen_arg = try std.fmt.allocPrint(allocator, "--listen=127.0.0.1:{d}", .{port});
-    defer allocator.free(listen_arg);
+    const addr_arg = try std.fmt.allocPrint(allocator, "--addr=127.0.0.1:{d}", .{port});
+    defer allocator.free(addr_arg);
 
     var child = try std.process.spawn(io, .{
-        .argv = &.{ wamr_exe, "run", listen_arg, component_path },
+        .argv = &.{ wamr_exe, "serve", addr_arg, component_path },
         .stdin = .ignore,
         .stdout = .inherit,
         .stderr = .inherit,

--- a/tests/wasi-testsuite-adapter/wamr-zig.py
+++ b/tests/wasi-testsuite-adapter/wamr-zig.py
@@ -174,38 +174,45 @@ def compute_argv(
 ) -> List[str]:
     argv: List[str] = []
     argv += WAMR
-    argv += ["run"]
     args, env, dirs = args_env_dirs
+
+    # `wasi:http/service` fixtures (`http-service.wasm`) export
+    # `wasi:http/incoming-handler@0.3.0.handle` and are served via the
+    # `serve` subcommand (#845); every other fixture runs as a
+    # `wasi:cli/run` command component (or core module) under `run`.
+    is_http_service = wasi_world == "wasi:http/service"
+    argv += ["serve"] if is_http_service else ["run"]
 
     for k, v in env.items():
         argv += ["--env", f"{k}={v}"]
 
-    for host, guest in _isolate_preopens(dirs):
-        argv += ["--map-dir", f"{host}::{guest}"]
+    # `--map-dir` / `--allow-net` are `run`-only host-config flags (the
+    # HTTP serve path does not wire filesystem / sockets preopens), so
+    # only emit them for the `run` verb.
+    if not is_http_service:
+        for host, guest in _isolate_preopens(dirs):
+            argv += ["--map-dir", f"{host}::{guest}"]
 
-    # wasi:sockets fixtures need an explicit allow-list to escape the
-    # adapter's default deny-all posture. Localhost is sufficient for
-    # every wasi-testsuite sockets fixture (they all bind/connect to
-    # 127.0.0.1 / ::1). (#520 wave 2)
-    if "sockets" in proposals:
-        argv += ["--allow-net", "127.0.0.0/8"]
-        argv += ["--allow-net", "::1/128"]
+        # wasi:sockets fixtures need an explicit allow-list to escape the
+        # adapter's default deny-all posture. Localhost is sufficient for
+        # every wasi-testsuite sockets fixture (they all bind/connect to
+        # 127.0.0.1 / ::1). (#520 wave 2)
+        if "sockets" in proposals:
+            argv += ["--allow-net", "127.0.0.0/8"]
+            argv += ["--allow-net", "::1/128"]
 
-    # `wasi:http/service` fixtures (`http-service.wasm`) export
-    # `wasi:http/incoming-handler@0.3.0.handle` and expect the host
-    # to bind a TCP listener, accept on it, and route incoming HTTP
-    # over the guest export. Bare `--listen` selects an ephemeral
-    # 127.0.0.1:0 bind and triggers `announce_listening` — the wamr
-    # CLI prints `http://<host>:<port>` to stderr so the
-    # wasi-testsuite `TestCaseRunner.get_http_server` URL-scrape
-    # succeeds. (#570)
-    if wasi_world == "wasi:http/service":
-        argv += ["--listen"]
+    # The host binds a TCP listener, accepts on it, and routes incoming
+    # HTTP over the guest export. `--addr 127.0.0.1:0` selects an
+    # ephemeral bind and triggers `announce_listening` — the wamr CLI
+    # prints `http://<host>:<port>` so the wasi-testsuite
+    # `TestCaseRunner.get_http_server` URL-scrape succeeds. (#570, #845)
+    if is_http_service:
+        argv += ["--addr", "127.0.0.1:0"]
 
     # Pre-compile the wasm fixture to its sibling AOT artifact: for
     # core wasm we get a `.cwasm`; for components we write a
     # `<stem>.cwasm.json` manifest + per-core `.cwasm` files that
-    # `wamr run` auto-discovers via sibling probing. (#680)
+    # `wamr run` / `wamr serve` auto-discover via sibling probing. (#680)
     argv += [_precompile(test_path)]
     argv += args
     return argv


### PR DESCRIPTION
Closes #845.

## Summary

Align wamr's HTTP-serving UX with `wasmtime serve` by splitting serving out of `wamr run` into a dedicated `serve` subcommand.

```sh
wasmtime serve zig-out/examples/zig-http.wasm   # 127.0.0.1:8080
wamrc    serve zig-out/examples/zig-http.wasm   # 127.0.0.1:8080
```

## Changes

- **`wamr serve <component.wasm> [options]`** — serves a `wasi:http/incoming-handler` component on a long-lived HTTP server.
  - `--addr <ip:port>` bind flag (IP literal + port, no hostname resolution), **default `127.0.0.1:8080`** (wasmtime's default).
  - `--addr 127.0.0.1:0` binds a kernel-assigned ephemeral port and prints the resolved address (for test drivers) — replaces the old bare `--listen`.
  - Keeps the TLS flags (`--tls-cert` / `--tls-key` / `--tls-pem`), plus `--env` / `--log-level` / `--precompiled-manifest`.
  - Component-only: rejects AOT core images and plain core wasm with a pointer at `run`.
- **`wamrc serve <component.wasm> [options]`** — mirrors `wamrc run`: precompile-if-stale, then spawn `wamr serve` (via `WAMR_BIN`) with stdio inherited, forwarding `--addr` / `--tls-*` / `--env` / `--log-level`.
- **Removed `--listen`** (and the TLS flags) from `wamr run`; HTTP serving now lives only under `serve`.
- Shared helpers keep the paths in sync: `loadComponentManifestOrPrint` (wamr) and `compileAndSpawn(verb, …)` (wamrc).
- Updated callers/docs: the wasi-testsuite adapter (`wasi:http/service` fixtures now use `serve --addr 127.0.0.1:0`), both http smoke drivers, `examples/zig-http(-petstore)` sources + READMEs, `examples/README.md`, and the top-level README TLS example.

## Verification

- `zig build test` — 83/83 steps, 4360/4483 tests pass (123 skipped).
- Manual end-to-end on Windows: `wamrc serve --addr 127.0.0.1:<port> zig-http.wasm` → `GET /` returns `200 "Hello, world!\n"`; `--addr 127.0.0.1:0` announces `Listening on …` / `http://…`; `wamrc serve --env FOO=bar --addr … app.wasm` (space-form forwarding) → 200; `wamr run --listen=…` now correctly errors `unknown option`.

Follow-up (out of scope, noted in #845): the serve loop closes the connection per request (`Connection: close`) vs wasmtime's keep-alive.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
