### PR TITLE
ci: bump pinned cataggar/wabt to v3.0.0-dev.16 (dev.15 was never published)

### DIFF
--- a/.github/actions/install-wasi-sdk-wabt/action.yml
+++ b/.github/actions/install-wasi-sdk-wabt/action.yml
@@ -5,7 +5,7 @@
 #   - https://github.com/WebAssembly/wasi-sdk/releases
 #   - https://github.com/cataggar/wabt/releases
 
-# Install WASI-SDK at /opt and wabt via ghr (cataggar/wabt v3.0.0-dev.15).
+# Install WASI-SDK at /opt and wabt via ghr (cataggar/wabt v3.0.0-dev.16).
 # /opt is the assumed location widely used in the project for wasi-sdk;
 # wabt lands in $HOME/.local/bin via ghr (added to GITHUB_PATH).
 name: Install WASI-SDK and wabt

--- a/.github/actions/wabt-install/action.yml
+++ b/.github/actions/wabt-install/action.yml
@@ -14,10 +14,10 @@ description: |
 inputs:
   version:
     description: |
-      cataggar/wabt release tag (e.g. v3.0.0-dev.15). Bump the default here to
+      cataggar/wabt release tag (e.g. v3.0.0-dev.16). Bump the default here to
       roll the pinned version across every caller.
     required: false
-    default: 'v3.0.0-dev.15'
+    default: 'v3.0.0-dev.16'
 
 runs:
   using: composite


### PR DESCRIPTION
The pinned `cataggar/wabt@v3.0.0-dev.15` release does not exist — the published releases jump from `v3.0.0-dev.14` to `v3.0.0-dev.16`. `ghr install` therefore fails with `HTTP 404: release not found`, breaking every wabt-dependent CI job (`component-examples`, `component-examples-wasmtime`, `wasi-p2-testsuite`) on `main` and all open PRs (e.g. #847).

Bumps the default pin in the shared `.github/actions/wabt-install` action to the published `v3.0.0-dev.16` (and fixes the stale comment in `install-wasi-sdk-wabt`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>