### PR TITLE
jit: wire real semantics into the -Djit build flag (#852)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -61,7 +61,7 @@ pub fn build(b: *std.Build) void {
     const fast_interp = b.option(bool, "fast_interp", "Enable fast interpreter") orelse true;
     options.addOption(bool, "fast_interp", fast_interp);
 
-    const jit = b.option(bool, "jit", "Enable LLVM JIT") orelse false;
+    const jit = b.option(bool, "jit", "Enable the in-process JIT (compile+run a .wasm in one step, opt-in — see #852)") orelse false;
     options.addOption(bool, "jit", jit);
 
     const fast_jit = b.option(bool, "fast_jit", "Enable fast JIT") orelse false;

--- a/src/config.zig
+++ b/src/config.zig
@@ -97,10 +97,21 @@ pub const dynamic_aot_debug = opt("dynamic_aot_debug", false);
 /// Force word-aligned reads (needed on some MCUs).
 pub const word_align_read = opt("word_align_read", false);
 
-/// Enable LLVM-based JIT (requires AOT).
+/// Enable the in-process JIT: compile a `.wasm` module with this fork's own
+/// AOT compiler (`src/compiler`) and execute it in the same process, in one
+/// step (no `wamrc compile` / `wamr run <cwasm>` split, no subprocess spawn,
+/// no mandatory `.cwasm` artifact on disk). Default `false` so the plain
+/// `wamr` binary stays the small, AOT-only artifact PR #695 produced; opt in
+/// with `-Djit=true` for a `wasmtime run`-style compile+run experience. Not
+/// related to the never-implemented upstream C WAMR `WAMR_BUILD_JIT` (LLVM
+/// ORC JIT) option this flag name was inherited from — this fork has no
+/// LLVM dependency. See issue #852.
 pub const jit = if (aot) opt("jit", false) else false;
 
-/// Enable lazy JIT compilation (requires JIT).
+/// Enable lazy, per-function on-demand compilation on top of `jit`: compile
+/// a function only on its first call instead of the whole module up front.
+/// Requires `jit`. Not yet implemented — see the design spike tracked in
+/// issue #862.
 pub const lazy_jit = if (jit) opt("lazy_jit", false) else false;
 
 /// Enable the lightweight fast JIT backend.

--- a/src/main.zig
+++ b/src/main.zig
@@ -1444,6 +1444,28 @@ fn runHelp(io: std.Io, args: []const []const u8) u8 {
     return 0;
 }
 
+// #852: proves `-Djit=true` actually threads through to a real, reachable
+// reference to the in-process compiler from `main.zig`'s module graph —
+// not just a config plumbing exercise. `wamr.config.jit` is a comptime-known
+// build option, so under the default `-Djit=false` build Zig's comptime
+// branch elimination drops everything below the early return, and this
+// test (like the rest of `zig build test`'s output) never links
+// `component_aot_compile` into the *production* `wamr`/`wamrc` executables
+// either way — those are built from a separate, test-free module (see
+// `exe_module` vs `exe_test_module` in build.zig). Full end-to-end
+// `wamr run foo.wasm` in-process compile+execute CLI wiring is #853/#854;
+// this only proves the flag is live.
+test "config.jit gates in-process compiler reachability from main.zig (#852)" {
+    if (!wamr.config.jit) return error.SkipZigTest;
+
+    // Minimal valid core wasm module: magic + version, no sections.
+    const empty_core_wasm = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 };
+    const cwasm = try wamr.component_aot_compile.compileCoreWasm(std.testing.allocator, &empty_core_wasm, .{});
+    defer std.testing.allocator.free(cwasm);
+    try std.testing.expect(cwasm.len >= 8);
+    try std.testing.expectEqual(@as(u32, wamr.emit_aot.aot_magic), std.mem.readInt(u32, cwasm[0..4], .little));
+}
+
 test "subcommand parsing" {
     try std.testing.expectEqual(@as(?Subcommand, .run), parseSubcommand("run"));
     try std.testing.expectEqual(@as(?Subcommand, .serve), parseSubcommand("serve"));


### PR DESCRIPTION
Closes #852. First slice of the in-process JIT plan tracked in #863.

## What changed

- `src/config.zig`: rewrote the `jit`/`lazy_jit` doc comments — they were leftover mirrors of upstream C WAMR's `WAMR_BUILD_JIT` (LLVM ORC JIT) option and did nothing in this from-scratch Zig compiler/runtime. Now documents the real intent: gate an opt-in, in-process compile+run capability.
- `build.zig`: updated the `-Djit` option description to match.
- `src/main.zig`: added a reachability test gated by `if (!wamr.config.jit) return error.SkipZigTest;` that calls `wamr.component_aot_compile.compileCoreWasm` directly — proving the flag is live and the compiler is reachable from `main.zig`'s module graph, without adding any user-facing CLI behavior yet (that's #853/#854).

## Why this is safe for the default (small, AOT-only) `wamr` binary

`config.jit` is a comptime-known build option. Zig's comptime branch elimination fully drops the guarded code (and therefore never references `component_aot_compile`) when `-Djit` is unset (default `false`), matching how PR #695 kept the compiler out of the default binary via non-reachability rather than manual module-graph surgery.

The production `wamr`/`wamrc` executables (`exe_module` in build.zig) don't reference `config.jit` at all yet — only the test module does — so there is currently zero behavior change either way for `zig build` (no `-Doptimize`/test flags). Full CLI wiring lands in #853 (core wasm) and #854 (components).

## Validation

- `zig build -Doptimize=ReleaseSafe --prefix /tmp/wamr-jit-off` vs `zig build -Doptimize=ReleaseSafe -Djit=true --prefix /tmp/wamr-jit-on`: **`wamr` binary size is byte-identical (17187024 bytes)** between the two; only a few bytes of embedded build-options metadata differ (sha256 differs, size does not).
- Manually verified the new test actually *executes* under `-Djit=true`: temporarily replaced its assertion with `expect(false)` — the build **failed** under `-Djit=true` and **still passed** under the default build (branch fully eliminated, not silently skipped-looking-like-a-no-op). Reverted before committing.
- `zig build test --summary all` (default) — all pass.
- `zig build test -Djit=true --summary all` — all pass, including the new test.
- `zig build` (default, production) — succeeds unchanged.

A dedicated `-Djit=true` CI job is deferred to #856 (parity validation), per the milestone order in #863.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>