### PR TITLE
jit: in-process compile+run for components (#854)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -505,6 +505,27 @@ pub fn build(b: *std.Build) void {
         test_step.dependOn(&jit_hello_smoke.step);
     }
 
+    // #854: in-process JIT smoke test for components. Only meaningful
+    // for a `-Djit=true` build — spawns the just-built `wamr` directly
+    // against `stdio-echo.wasm` (the canonical end-to-end WASI-P2
+    // fixture, #156) with no sibling `.cwasm.json` manifest in sight,
+    // proving the component in-process JIT path compiles every core
+    // module and instantiates in one process/one command. Gated on
+    // `aot_trampoline_pool_target` (not just `aot_executable_target`)
+    // because `stdio-echo.wasm`'s WASI preview1 imports need the
+    // host-import trampoline pool, unsupported on Windows / macOS-aarch64
+    // (see the `760-aot-cli-exit` regression gate above for the same
+    // rationale).
+    if (jit and aot_trampoline_pool_target) {
+        const jit_component_smoke = b.addRunArtifact(exe);
+        jit_component_smoke.addArg("run");
+        jit_component_smoke.addFileArg(b.path("src/component/fixtures/stdio-echo.wasm"));
+        jit_component_smoke.setStdIn(.{ .bytes = "hello\n" });
+        jit_component_smoke.expectExitCode(0);
+        jit_component_smoke.expectStdOutEqual("echo: hello\n");
+        test_step.dependOn(&jit_component_smoke.step);
+    }
+
     // #760 regression: AOT `wasi:cli/exit.exit` must terminate the host
     // process with the requested discriminant rather than returning the
     // post-#714 sentinel through the canon-lower(aot) trampoline. Two

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -17,6 +17,7 @@ const builtin = @import("builtin");
 const ctypes = @import("types.zig");
 const component_loader = @import("loader.zig");
 const aot = @import("aot.zig");
+const core_backend = @import("core_backend.zig");
 const core_loader = @import("../runtime/interpreter/loader.zig");
 const frontend = @import("../compiler/frontend.zig");
 const passes = @import("../compiler/ir/passes.zig");
@@ -779,4 +780,112 @@ pub fn precompileComponent(
         .arena = result_arena,
         .allocator = allocator,
     };
+}
+
+/// In-memory counterpart to `precompileComponent` (#854): the same
+/// core-module walk and per-core `compileCoreWasm` calls, but with no
+/// filesystem I/O at all — no manifest JSON, no per-core `.cwasm`
+/// files, no per-core codegen cache directory. Used by the in-process
+/// JIT path so `wamr run some_component.wasm` (no sibling
+/// `.cwasm.json`) can compile and instantiate in one process.
+///
+/// Each returned `PrecompiledCore.core_wasm` borrows directly from
+/// `component_bytes` (this function's own zero-copy component parse
+/// uses a throwaway scratch arena for bookkeeping only — the byte
+/// slices themselves alias the caller's buffer and outlive it). A
+/// caller that later re-parses the *same* `component_bytes` buffer
+/// (e.g. `runComponent`'s own `component_loader.load` call during
+/// instantiation) gets byte-identical (ptr+len) slices for each core
+/// — the same zero-copy-parse invariant `loadManifest`'s doc comment
+/// already relies on for its `core_wasm` slice-identity matching in
+/// `findPrecompiled` — so this in-memory path is a drop-in swap for
+/// the on-disk manifest at the `PrecompiledCore` level.
+pub const InMemoryPrecompiled = struct {
+    /// One owned `.cwasm` buffer per compiled core, in the same order
+    /// as `pcs`. Freed by `deinit`.
+    cwasm_buffers: []const []u8,
+    /// Ready to pass as `Options.precompiled_cores`. Borrows from
+    /// `cwasm_buffers` (bytes) and the caller's `component_bytes`
+    /// (`core_wasm`); valid for the lifetime of this struct.
+    pcs: []const core_backend.PrecompiledCore,
+    allocator: std.mem.Allocator,
+
+    pub fn precompiledCores(self: *const InMemoryPrecompiled) []const core_backend.PrecompiledCore {
+        return self.pcs;
+    }
+
+    pub fn deinit(self: *InMemoryPrecompiled) void {
+        for (self.cwasm_buffers) |buf| self.allocator.free(buf);
+        self.allocator.free(self.cwasm_buffers);
+        self.allocator.free(self.pcs);
+    }
+};
+
+pub fn precompileComponentInMemory(
+    allocator: std.mem.Allocator,
+    component_bytes: []const u8,
+    opts: PrecompileOptions,
+) PrecompileError!InMemoryPrecompiled {
+    // Same recursive walk as `precompileComponent`'s `Walker` — visits
+    // every leaf core module anywhere in the (possibly composed,
+    // #676) component tree.
+    const CoreRef = struct {
+        data: []const u8,
+        local_idx: u32,
+    };
+    var core_data_list: std.ArrayList(CoreRef) = .empty;
+    defer core_data_list.deinit(allocator);
+    {
+        var load_arena = std.heap.ArenaAllocator.init(allocator);
+        defer load_arena.deinit();
+        const component = component_loader.load(component_bytes, load_arena.allocator()) catch
+            return error.InvalidComponent;
+        const Walker = struct {
+            fn walk(
+                comp: *const ctypes.Component,
+                list: *std.ArrayList(CoreRef),
+                alloc: std.mem.Allocator,
+            ) PrecompileError!void {
+                for (comp.core_modules, 0..) |cm, mi| {
+                    list.append(alloc, .{ .data = cm.data, .local_idx = @intCast(mi) }) catch
+                        return error.OutOfMemory;
+                }
+                for (comp.components) |child| {
+                    try walk(child, list, alloc);
+                }
+            }
+        };
+        try Walker.walk(&component, &core_data_list, allocator);
+    }
+
+    const n = core_data_list.items.len;
+    const cwasm_buffers = allocator.alloc([]u8, n) catch return error.OutOfMemory;
+    var built: usize = 0;
+    errdefer {
+        for (cwasm_buffers[0..built]) |b| allocator.free(b);
+        allocator.free(cwasm_buffers);
+    }
+    const pcs = allocator.alloc(core_backend.PrecompiledCore, n) catch return error.OutOfMemory;
+    errdefer allocator.free(pcs);
+
+    for (core_data_list.items, 0..) |core_ref, idx| {
+        // Override opts.module_idx per core so `:mod=N` bisect
+        // filters resolve correctly, matching `precompileComponent`.
+        var per_core_opts = opts;
+        per_core_opts.module_idx = @intCast(idx);
+
+        const cwasm = compileCoreWasm(allocator, core_ref.data, per_core_opts) catch |err| {
+            std.log.err("precompileComponentInMemory: core {d} compile failed: {s}", .{ idx, @errorName(err) });
+            return err;
+        };
+        cwasm_buffers[idx] = cwasm;
+        built += 1;
+        pcs[idx] = .{
+            .module_idx = core_ref.local_idx,
+            .cwasm_bytes = cwasm,
+            .core_wasm = core_ref.data,
+        };
+    }
+
+    return .{ .cwasm_buffers = cwasm_buffers, .pcs = pcs, .allocator = allocator };
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -406,12 +406,13 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
                 std.debug.print("Error: --config-store '{s}': {}\n", .{ config_store_path orelse "", err });
                 return 2;
             };
-            // #644 / #680: resolve the AOT precompiled-cores manifest
-            // (shared with `wamr serve`). The `LoadedManifest`'s lifetime
-            // must outlive `runComponent` because the mmapped `.cwasm`
-            // buffers it owns are borrowed by the `PrecompiledCore` slice
-            // handed to the instance loader.
-            var loaded_manifest: ?wamr.component_aot.LoadedManifest = null;
+            // #644 / #680 / #854: resolve the AOT precompiled-cores
+            // manifest (shared with `wamr serve`). The `ComponentCoresSource`'s
+            // lifetime must outlive `runComponent` because the mmapped
+            // (or, on a `-Djit=true` in-process JIT compile, heap-owned)
+            // `.cwasm` buffers it owns are borrowed by the `PrecompiledCore`
+            // slice handed to the instance loader.
+            var loaded_manifest: ?ComponentCoresSource = null;
             defer if (loaded_manifest) |*lm| lm.deinit();
             const manifest_rc = loadComponentManifestOrPrint(init, allocator, "run", path, wasm_data, precompiled_manifest, &loaded_manifest);
             if (manifest_rc != 0) return manifest_rc;
@@ -699,7 +700,7 @@ fn runServe(init: std.process.Init, allocator: std.mem.Allocator, serve_args: []
         break :blk parsed;
     };
 
-    var loaded_manifest: ?wamr.component_aot.LoadedManifest = null;
+    var loaded_manifest: ?ComponentCoresSource = null;
     defer if (loaded_manifest) |*lm| lm.deinit();
     const manifest_rc = loadComponentManifestOrPrint(init, allocator, "serve", path, wasm_data, precompiled_manifest, &loaded_manifest);
     if (manifest_rc != 0) return manifest_rc;
@@ -768,22 +769,56 @@ fn parseAddr(spec: []const u8) !std.Io.net.IpAddress {
     return std.Io.net.IpAddress.parse(host, port);
 }
 
+/// Result of `loadComponentManifestOrPrint`: either an on-disk manifest
+/// (explicit `--precompiled-manifest` or an auto-detected sibling
+/// `<stem>.cwasm.json`) or, on a `-Djit=true` build with no manifest
+/// found, an in-process JIT compile of the component (#854). Both
+/// variants expose the same `[]const PrecompiledCore` surface that
+/// `runComponent` / `runHttpComponent` already consume, so callers
+/// downstream of `loadComponentManifestOrPrint` don't need to care
+/// which path produced the cores.
+const ComponentCoresSource = union(enum) {
+    manifest: wamr.component_aot.LoadedManifest,
+    in_memory: wamr.component_aot_compile.InMemoryPrecompiled,
+
+    fn precompiledCores(self: *const ComponentCoresSource) []const wamr.component_core_backend.PrecompiledCore {
+        return switch (self.*) {
+            .manifest => |*m| m.precompiledCores(),
+            .in_memory => |*im| im.precompiledCores(),
+        };
+    }
+
+    fn deinit(self: *ComponentCoresSource) void {
+        switch (self.*) {
+            .manifest => |*m| m.deinit(),
+            .in_memory => |*im| im.deinit(),
+        }
+    }
+};
+
 /// Resolve the AOT precompiled-cores manifest for a component, shared by
 /// `wamr run` and `wamr serve` (#644 / #680 / #845).
 ///
 /// The `wamr` CLI is AOT-only and the runtime no longer embeds the
 /// compiler, so every component core must be available as a precompiled
-/// `.cwasm` or instantiation fails hard. Resolution order:
+/// `.cwasm` or instantiation fails hard — unless this binary was built
+/// with `-Djit=true` (#852), in which case the last resolution step
+/// compiles in memory instead of erroring. Resolution order:
 ///
 ///   * `--precompiled-manifest <path>` (explicit): any error opening /
 ///     validating the manifest is fatal so the user knows the AOT path
-///     isn't being taken.
+///     isn't being taken — this always reads from disk, even on a
+///     `-Djit=true` build, since the user explicitly asked for that
+///     artifact.
 ///   * sibling `<input>.cwasm.json` (auto-detect): used when present and
 ///     valid.
-///   * neither found → hard error directing the user at `wamrc`.
+///   * neither found, `-Djit=true`: in-process JIT compile (#854) — no
+///     manifest, no `.cwasm` files, zero filesystem I/O.
+///   * neither found, default build: hard error directing the user at
+///     `wamrc`.
 ///
-/// On success returns 0 and sets `out_manifest`. On failure prints a
-/// diagnostic and returns a non-zero exit code; `out_manifest` may still
+/// On success returns 0 and sets `out_source`. On failure prints a
+/// diagnostic and returns a non-zero exit code; `out_source` may still
 /// be set (the caller's `defer …deinit()` handles cleanup either way).
 /// `verb` is the invoking subcommand ("run" / "serve") and only flavours
 /// the error text.
@@ -794,14 +829,15 @@ fn loadComponentManifestOrPrint(
     path: []const u8,
     wasm_data: []const u8,
     precompiled_manifest: ?[]const u8,
-    out_manifest: *?wamr.component_aot.LoadedManifest,
+    out_source: *?ComponentCoresSource,
 ) u8 {
     if (precompiled_manifest) |mp| {
-        out_manifest.* = wamr.component_aot.loadManifest(allocator, mp, wasm_data) catch |err| {
+        const loaded = wamr.component_aot.loadManifest(allocator, mp, wasm_data) catch |err| {
             std.debug.print("Error: --precompiled-manifest '{s}': {s}\n", .{ mp, loadManifestErrorMessage(err) });
             return 2;
         };
-        const n = out_manifest.*.?.precompiledCores().len;
+        out_source.* = .{ .manifest = loaded };
+        const n = out_source.*.?.precompiledCores().len;
         if (wamr.component_core_backend.debugAotEnabled())
             std.debug.print("wamr: loaded AOT manifest from {s} ({d} core{s} precompiled)\n", .{ mp, n, if (n == 1) @as([]const u8, "") else "s" });
     } else {
@@ -818,33 +854,50 @@ fn loadComponentManifestOrPrint(
             break :blk true;
         };
         if (!exists) {
-            std.debug.print(
-                "Error: no AOT manifest found for '{s}'. The `wamr` runtime no longer embeds the compiler (#680).\n" ++
-                    "  Run `wamrc compile-component {s}` to produce '{s}', or\n" ++
-                    "  run `wamrc {s} {s}` to compile and serve/execute in one step.\n",
-                .{ path, path, sibling, verb, path },
-            );
-            return 2;
+            if (comptime wamr.config.jit) {
+                // #854: in-process JIT. Compile every core module of
+                // the component in memory and instantiate directly —
+                // no manifest, no `.cwasm` files written to disk.
+                const in_mem = wamr.component_aot_compile.precompileComponentInMemory(allocator, wasm_data, .{}) catch |err| {
+                    std.debug.print("Error: JIT compile of component '{s}' failed: {s}\n", .{ path, @errorName(err) });
+                    return 1;
+                };
+                out_source.* = .{ .in_memory = in_mem };
+                const n = out_source.*.?.precompiledCores().len;
+                if (wamr.component_core_backend.debugAotEnabled())
+                    std.debug.print("wamr: JIT-compiled {d} core{s} for {s} (in-process, no disk artifact)\n", .{ n, if (n == 1) @as([]const u8, "") else "s", path });
+            } else {
+                std.debug.print(
+                    "Error: no AOT manifest found for '{s}'. The `wamr` runtime no longer embeds the compiler (#680).\n" ++
+                        "  Run `wamrc compile-component {s}` to produce '{s}', or\n" ++
+                        "  run `wamrc {s} {s}` to compile and serve/execute in one step, or\n" ++
+                        "  rebuild `wamr` with `-Djit=true` for in-process compile+run (#852/#854).\n",
+                    .{ path, path, sibling, verb, path },
+                );
+                return 2;
+            }
+        } else {
+            const loaded = wamr.component_aot.loadManifest(allocator, sibling, wasm_data) catch |err| {
+                std.debug.print(
+                    "Error: AOT manifest at '{s}' is stale or invalid: {s}.\n" ++
+                        "  Rebuild it with `wamrc compile-component {s}` or run `wamrc {s} {s}`.\n",
+                    .{ sibling, loadManifestErrorMessage(err), path, verb, path },
+                );
+                return 2;
+            };
+            out_source.* = .{ .manifest = loaded };
+            const n = out_source.*.?.precompiledCores().len;
+            if (wamr.component_core_backend.debugAotEnabled())
+                std.debug.print("wamr: loaded AOT manifest from {s} ({d} core{s} precompiled)\n", .{ sibling, n, if (n == 1) @as([]const u8, "") else "s" });
         }
-        out_manifest.* = wamr.component_aot.loadManifest(allocator, sibling, wasm_data) catch |err| {
-            std.debug.print(
-                "Error: AOT manifest at '{s}' is stale or invalid: {s}.\n" ++
-                    "  Rebuild it with `wamrc compile-component {s}` or run `wamrc {s} {s}`.\n",
-                .{ sibling, loadManifestErrorMessage(err), path, verb, path },
-            );
-            return 2;
-        };
-        const n = out_manifest.*.?.precompiledCores().len;
-        if (wamr.component_core_backend.debugAotEnabled())
-            std.debug.print("wamr: loaded AOT manifest from {s} ({d} core{s} precompiled)\n", .{ sibling, n, if (n == 1) @as([]const u8, "") else "s" });
     }
 
     // #644: AOT-only policy. `wamr run`/`serve` require a precompiled
     // bundle for every component — there is no interp fallback at the CLI
-    // surface and no in-process compiler. An empty bundle means the
-    // component had no core modules (an empty / malformed input that
-    // survived parsing).
-    if (out_manifest.*.?.precompiledCores().len == 0) {
+    // surface, and no in-process compiler unless `-Djit=true`. An empty
+    // bundle means the component had no core modules (an empty /
+    // malformed input that survived parsing).
+    if (out_source.*.?.precompiledCores().len == 0) {
         std.debug.print(
             "Error: component has no AOT-compiled cores and `wamr {s}` is AOT-only.\n" ++
                 "  See issue #644.\n",


### PR DESCRIPTION
Closes #854. Stacked on #865 (#853), which is stacked on #864 (#852) — **base branch is `853-jit-core-wasm`, not `main`**; rebase down the chain as those merge. Part of the in-process JIT plan tracked in #863.

## What changed

Behind `-Djit=true`, `wamr run some_component.wasm` and `wamr serve some_component.wasm` now compile every core module of a WASI-P2 component in memory and instantiate directly, when no sibling `<stem>.cwasm.json` manifest is found — no manifest JSON, no per-core `.cwasm` files written to disk.

- `src/component/aot_compile.zig`: new `precompileComponentInMemory` + `InMemoryPrecompiled`, the in-memory counterpart to `precompileComponent`. Same recursive core-module walk (handles composed/nested components per #676) and per-core `compileCoreWasm` calls, but returns compiled `.cwasm` bytes directly instead of writing them (or a manifest) to disk. Each `PrecompiledCore.core_wasm` borrows from the caller's `component_bytes`; because `component_loader.load`'s parse is zero-copy, a later independent parse of the *same* buffer (e.g. `runComponent`'s own instantiate-time parse) produces byte-identical (ptr+len) slices for each core, so the existing `core_wasm` slice-identity matching in `findPrecompiled` works unchanged — the same invariant the on-disk manifest path already relies on.
- `src/main.zig`: `loadComponentManifestOrPrint` (shared by `run` and `serve`) now falls back to the in-memory path — gated by `comptime wamr.config.jit` — instead of hard-erroring when no sibling manifest is found. Introduced `ComponentCoresSource`, a small tagged union over the on-disk `LoadedManifest` and the new `InMemoryPrecompiled`, so both `run` and `serve`'s call sites keep working against one `precompiledCores()`/`deinit()` surface regardless of which path produced the cores. An explicit `--precompiled-manifest <path>` still always reads from disk, on any build.
- `build.zig`: new `stdio-echo.wasm`-based smoke test (gated on `jit and aot_trampoline_pool_target`, matching the existing #760 regression gate's rationale for host-import-trampoline-dependent fixtures) that runs the just-built `wamr` directly against the canonical end-to-end WASI-P2 fixture (#156) with piped stdin, and checks stdout byte-for-byte.

## Validation

- `zig build test --summary all` (default): 87/87 build steps, 4478/4486 tests passed (8 skipped) — unchanged from #853.
- `zig build test -Djit=true --summary all`: 89/89 build steps (+2 total: the #853 core-wasm smoke plus this PR's new component smoke), 4479/4486 tests passed (7 skipped).
- Manually verified the new component smoke step actually executes under `-Djit=true` (temporarily swapped in a wrong expected stdout value: build failed under `-Djit=true`, still passed under default). Reverted before committing.
- Manual end-to-end checks (`-Djit=true` and default built to separate prefixes, clean scratch dirs to avoid stale-manifest false positives from unrelated prior work in `/tmp`):
  - `wamr run stdio-echo.wasm` (jit=true, no manifest): prints `echo: hello`, exit 0, **zero files written**.
  - Same output byte-for-byte from the existing two-step `wamrc compile-component` + `wamr run` flow (default build).
  - Default build's `wamr run`/`wamr serve` still hard-error (exit 2) on a manifest-less component, now with a `-Djit=true` hint.
  - `wamr serve --addr 127.0.0.1:PORT zig-http.wasm` (jit=true, no manifest, using the `examples/zig-http` fixture): `curl /` → `200 Hello, world!`, `curl /missing` → `404`, zero files written — confirms the `--listen`/`wamr serve` acceptance criterion from the issue.
  - `strace -f -e trace=execve,clone,fork` during the `run` JIT path shows no subprocess spawned by `wamr` itself.

Note: while testing `wamr serve` I hit an environment/tooling mismatch unrelated to this PR — the locally-installed `wabt` CLI was older than the `v3.0.0-dev.17` this repo pins, so `zig build examples` failed with `unknown option '--world'`. Confirmed pre-existing on a clean `origin/main` checkout too; not something this PR touches. Also noticed a pre-existing `DebugAllocator` leak warning from `wamrc compile-component` (also reproduced on clean `origin/main`) — unrelated to this change, not filing separately as it's a diagnostic-only warning with no effect on exit code or correctness.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>