### PR TITLE
docs(jit): CLI help text + README/INSTALL docs for JIT mode (#855)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,3 +63,19 @@ zig build -Doptimize=ReleaseSafe
 ```
 
 Binaries are written to `zig-out/bin/`.
+
+### JIT mode
+
+The pre-built binaries above (GitHub Releases, PyPI, `ghr`, `uv`, `pip`,
+`dist`) are all **AOT-only** — the release workflow does not pass
+`-Djit`. To get a `wamr` that compiles and runs a plain `.wasm` module
+directly in one step (no separate `wamrc` precompile), build from
+source with the flag added:
+
+```sh
+zig build -Doptimize=ReleaseSafe -Djit=true
+```
+
+See the [JIT mode section of the README](README.md#jit-mode) for what
+this trades off (bigger binary, per-invocation compile latency) and
+how the two flows compare.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,34 @@ See [INSTALL.md](INSTALL.md) for alternative installation methods (winget, uv, p
 ## Tools
 
  - **wamrc**: AOT compiler — compile a `.wasm` module to a native `.cwasm` binary (`wamrc compile foo.wasm`)
- - **wamr**: run a WebAssembly module — either a `.wasm` file via the stack-based interpreter, or a precompiled `.cwasm` file produced by `wamrc` (`wamr run foo.wasm`)
+ - **wamr**: run a precompiled `.cwasm` file (`wamr run foo.cwasm`), or a plain `.wasm` module directly when built with `-Djit=true` — see [JIT mode](#jit-mode) below
+
+## JIT mode
+
+By default `wamr` is **AOT-only**: it links only the runtime, not the
+compiler, so it stays small (~17 MB) and requires a precompiled
+`.cwasm` artifact for every module. Building with `-Djit=true` instead
+links the compiler in and adds an opt-in **in-process JIT**: `wamr run
+foo.wasm` compiles the module in memory and executes it in the same
+process, one command, no `.cwasm` artifact ever hits disk —
+[`wasmtime run`](https://wasmtime.dev)-style ergonomics, at the cost of
+a bigger binary (~25 MB) and per-invocation compile latency.
+
+| | AOT-only (default) | JIT (`-Djit=true`) |
+|---|---|---|
+| Build | `zig build -Doptimize=ReleaseSafe` | `zig build -Doptimize=ReleaseSafe -Djit=true` |
+| Core wasm | `wamrc compile foo.wasm` → `wamr run foo.cwasm` | `wamr run foo.wasm` |
+| Component | `wamrc compile-component foo.wasm` → `wamr run foo.wasm` (auto-detects the sidecar manifest) | `wamr run foo.wasm` (no manifest needed) |
+| One-shot testing | `wamrc run foo.wasm` (compiles, then spawns `wamr` as a subprocess) | `wamr run foo.wasm` (single process, no subprocess) |
+| Binary size / compiler | Small; no compiler linked in | Larger; compiler linked in |
+
+Both flows produce identical guest-observable behavior — the JIT path
+reuses the exact same compiler (`src/compiler`) and AOT loader/runtime
+(`src/runtime/aot`) as the two-step flow, just without the disk
+round-trip. `wamr serve` (the `wasi:http` server) supports the same
+JIT fallback for components with no sidecar manifest. See issue
+[#863](https://github.com/cataggar/wamr/issues/863) for the full plan
+and design rationale.
 
 ## Building
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1407,18 +1407,7 @@ const top_usage =
     \\
 ;
 
-const run_usage =
-    \\Usage: wamr run [options] <file.wasm|file.cwasm> [args...]
-    \\
-    \\The `wamr` CLI is AOT-only (issue #644):
-    \\  * `.cwasm`/`.aot` core modules (magic `\0aot`) run via the AOT
-    \\    runtime directly.
-    \\  * Component-model `.wasm` files run via AOT cores loaded from a
-    \\    `wamrc compile-component` manifest (see --precompiled-manifest below).
-    \\    Components without a manifest fail with a clear error.
-    \\  * Plain core wasm modules are not supported — pre-compile to
-    \\    `.cwasm`/`.aot` first.
-    \\
+const run_usage_options =
     \\Options:
     \\  --stack-size=<bytes>     (ignored; kept for backward compat)
     \\  --heap-size=<bytes>      Reserved (currently ignored)
@@ -1453,25 +1442,61 @@ const run_usage =
     \\                           `.cwasm` files resolve relative to the
     \\                           manifest's directory. When omitted, `wamr
     \\                           run` auto-detects a sibling
-    \\                           `<input>.cwasm.json`. The manifest is
-    \\                           mandatory: components without one fail
-    \\                           with a clear error (issues #644, #680).
+    \\                           `<input>.cwasm.json`.
     \\
     \\To serve a wasi:http/incoming-handler component over HTTP, use
     \\`wamr serve` instead (see `wamr serve help`).
     \\
 ;
 
-const serve_usage =
-    \\Usage: wamr serve [options] <component.wasm>
+// #855: `wamr run help` describes the behavior of *this specific binary*,
+// which is a comptime-known build (`wamr.config.jit`) — so rather than
+// one generic paragraph hedging over both configurations, `run_usage` is
+// comptime-selected between two accurate intros. See README.md's "JIT
+// mode" section for the side-by-side comparison of both build flavors.
+const run_usage_intro_aot_only =
+    \\Usage: wamr run [options] <file.wasm|file.cwasm> [args...]
     \\
-    \\Serve a `wasi:http/incoming-handler` component as a long-lived HTTP
-    \\server (the proxy world), aligned with `wasmtime serve`. AOT-only
-    \\like `wamr run`: the component needs a `wamrc compile-component`
-    \\manifest (an explicit --precompiled-manifest or a sibling
-    \\`<input>.cwasm.json`). Use `wamrc serve <component.wasm>` to
-    \\precompile-if-stale and serve in one step.
+    \\This `wamr` binary is AOT-only (no `-Djit` build support compiled
+    \\in; issue #644):
+    \\  * `.cwasm`/`.aot` core modules (magic `\0aot`) run via the AOT
+    \\    runtime directly.
+    \\  * Component-model `.wasm` files run via AOT cores loaded from a
+    \\    `wamrc compile-component` manifest (see --precompiled-manifest
+    \\    below). Components without a manifest fail with a clear error.
+    \\  * Plain core wasm modules are not supported — pre-compile to
+    \\    `.cwasm`/`.aot` first with `wamrc compile`, or use `wamrc run`
+    \\    to compile and execute in one step.
     \\
+    \\For a `wasmtime run`-style one-shot experience (`wamr run foo.wasm`
+    \\compiles and executes in one process, no `wamrc` step, no `.cwasm`
+    \\artifact), rebuild `wamr` with `-Djit=true` (issue #852).
+    \\
+    \\
+;
+
+const run_usage_intro_jit =
+    \\Usage: wamr run [options] <file.wasm|file.cwasm> [args...]
+    \\
+    \\This `wamr` binary was built with in-process JIT support
+    \\(`-Djit=true`; issues #852-#854):
+    \\  * Plain core `.wasm` modules are compiled in memory and executed
+    \\    in this same process — no `.cwasm` file is written, no `wamrc`
+    \\    subprocess is spawned.
+    \\  * Component-model `.wasm` files: a sibling `wamrc compile-component`
+    \\    manifest (or an explicit --precompiled-manifest below) is used
+    \\    when present; otherwise every core module is JIT-compiled in
+    \\    memory and instantiated directly — same zero-disk-artifact
+    \\    behavior as the core-wasm case.
+    \\  * `.cwasm`/`.aot` core modules (magic `\0aot`) still run via the
+    \\    AOT runtime directly, same as an AOT-only build.
+    \\
+    \\
+;
+
+const run_usage = if (wamr.config.jit) run_usage_intro_jit ++ run_usage_options else run_usage_intro_aot_only ++ run_usage_options;
+
+const serve_usage_options =
     \\Options:
     \\  --addr <ip:port>         Bind address (an IP literal + port, no
     \\                           hostname resolution). Default 127.0.0.1:8080.
@@ -1500,6 +1525,37 @@ const serve_usage =
     \\                           sibling `<input>.cwasm.json` is auto-detected.
     \\
 ;
+
+const serve_usage_intro_aot_only =
+    \\Usage: wamr serve [options] <component.wasm>
+    \\
+    \\Serve a `wasi:http/incoming-handler` component as a long-lived HTTP
+    \\server (the proxy world), aligned with `wasmtime serve`. This
+    \\`wamr` binary is AOT-only (no `-Djit` build support compiled in):
+    \\the component needs a `wamrc compile-component` manifest (an
+    \\explicit --precompiled-manifest or a sibling `<input>.cwasm.json`).
+    \\Use `wamrc serve <component.wasm>` to precompile-if-stale and serve
+    \\in one step, or rebuild `wamr` with `-Djit=true` (issue #852) to
+    \\serve directly without a manifest.
+    \\
+    \\
+;
+
+const serve_usage_intro_jit =
+    \\Usage: wamr serve [options] <component.wasm>
+    \\
+    \\Serve a `wasi:http/incoming-handler` component as a long-lived HTTP
+    \\server (the proxy world), aligned with `wasmtime serve`. This
+    \\`wamr` binary was built with in-process JIT support (`-Djit=true`;
+    \\issue #854): a sibling `wamrc compile-component` manifest (or an
+    \\explicit --precompiled-manifest below) is used when present;
+    \\otherwise every core module is JIT-compiled in memory and served
+    \\directly — no manifest, no `.cwasm` files written to disk.
+    \\
+    \\
+;
+
+const serve_usage = if (wamr.config.jit) serve_usage_intro_jit ++ serve_usage_options else serve_usage_intro_aot_only ++ serve_usage_options;
 
 const version_usage =
     \\Usage: wamr version


### PR DESCRIPTION
Closes #855. Part of the in-process JIT plan tracked in #863. Not stacked — branched fresh off `main` (all prerequisite JIT PRs already merged).

## What changed

- `src/main.zig`: `run_usage` and `serve_usage` are now comptime-selected (`if (wamr.config.jit) ... else ...`) between two accurate variants instead of one generic paragraph — `wamr run help` / `wamr serve help` describe exactly what *this specific binary* does, since `wamr.config.jit` is a comptime-known build option. The runtime hard-error messages already had `-Djit=true` hints from #853/#854; this extends the same accuracy to the static help text.
- `README.md`: replaced the stale `wamr` tool description (still implied a stack-based interpreter fallback that hasn't existed since #644/#680 made the CLI AOT-only) and added a "JIT mode" section with a side-by-side comparison table of the AOT-only and JIT workflows.
- `INSTALL.md`: added a "JIT mode" subsection noting all published pre-built binaries (GitHub Releases, PyPI, ghr, uv, pip, dist) are AOT-only — confirmed against `.github/workflows/release.yml`, which never passes `-Djit` — and that JIT requires building from source.

Deliberately left the `wamr --version` JIT-support indicator unimplemented (explicitly nice-to-have in the issue) to avoid touching the existing exact-match version-string test invariant in `build.zig` for no required benefit.

## Validation

- `zig build test --summary all` (default) and `zig build test -Djit=true --summary all` — both pass.
- Manually built both configs and printed `wamr run help` / `wamr serve help` side by side: each variant's intro paragraph accurately describes its own build, options list is shared/unchanged, and the blank-line formatting between the intro and "Options:" (a multiline-string-literal concatenation subtlety — my first draft accidentally dropped the blank line at the boundary) was verified correct in the actual rendered output for all four combinations.
- Re-verified current binary sizes (ReleaseSafe) cited in the new README table are still accurate: default ~17.19 MB, `-Djit=true` ~24.70 MB.

No behavior change — docs/messages only, as scoped by the issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>