### PR TITLE
jit: W^X hygiene audit for the in-process JIT compile->map->execute path (#858)

### DIFF
--- a/docs/design/jit-wx-hygiene.md
+++ b/docs/design/jit-wx-hygiene.md
@@ -1,0 +1,136 @@
+# JIT compile→map→execute W^X hygiene
+
+Status: **IMPLEMENTED** (see `platform.mapExecutableCode`, `src/platform/platform.zig`).
+
+Tracking: [#858](https://github.com/cataggar/wamr/issues/858) (part of the in-process JIT plan, [#863](https://github.com/cataggar/wamr/issues/863)).
+
+## Scope
+
+Every JIT compile produces native code that must go from "just written
+by the compiler, sitting in a wasm module's `text_section`" to "mapped,
+executable, and callable" without a window where a page is
+simultaneously writable **and** executable (W^X) — and, on Apple
+Silicon, without violating macOS's `MAP_JIT` requirements for
+JIT-compiled code. This note documents the guarantee for the one call
+site that matters for the in-process JIT: `runtime.zig:mapCodeExecutable`,
+which every `wamr run`/`wamr serve` JIT compile (core wasm or
+per-component core) and every `.cwasm`-file load routes through.
+
+The host-import trampoline pool (`src/runtime/aot/host_trampolines.zig`)
+has its own, pre-existing W^X handling for a structurally different
+allocation pattern (one big pool mapped once, individual trampolines
+written into sub-slots lazily) and is **out of scope** here — it
+already uses the same underlying primitives (`platform.jitWriteProtect`,
+`platform.macos_jit`) this note describes, just composed differently
+because it's a pool allocator rather than a single-blob mapper. See
+["Why `host_trampolines.zig` wasn't refactored"](#why-host_trampolineszig-wasnt-refactored) below.
+
+## The primitive: `platform.mapExecutableCode`
+
+```zig
+pub fn mapExecutableCode(code: []const u8) ?[*]u8
+```
+
+Maps `code.len` bytes, copies `code` in, flushes the instruction cache,
+and returns the region in its final executable-and-not-writable state
+— or `null` on any failure. The caller `platform.munmap`s it when done
+(`AotInstance.destroy` already does this; see `JitCodeCache`, #857).
+
+Two strategies, selected at comptime via `platform.macos_jit`
+(`= is_macos and builtin.cpu.arch == .aarch64`):
+
+### Linux, Windows, x86_64 macOS — RW → RX `mprotect`
+
+1. `mmap` a fresh **RW** (not exec) region.
+2. `memcpy` the compiled code in.
+3. `icacheFlush` (a no-op on x86/x86_64; real cache-line invalidation
+   on aarch64/arm).
+4. `mprotect` the region to **RX** (not writable).
+
+**Guarantee**: the region is RW-only until step 4's single `mprotect`
+call, and RX-only from that point on. Nothing writes to it after step
+4 (no call site retains a mutable view past `mapCodeExecutable`
+returning). No other thread can observe a W+X page: exec permission
+doesn't exist until the `mprotect` syscall completes, and by then the
+write is already finished.
+
+This is the path exercised by the `linux-x64`, `linux-arm64`, and
+`windows-x64` CI jobs (`.github/workflows/ci.yml`) and by the
+`mapExecutableCode: mapped code is genuinely callable` unit test
+(`src/platform/platform.zig`), which maps a tiny real function body and
+calls it through a function pointer — proving the region is truly
+executable, not just readable.
+
+### macOS aarch64 (Apple Silicon) — `MAP_JIT` + per-thread toggle
+
+Apple Silicon's hardened-runtime JIT model doesn't support "mmap RW,
+then mprotect to RX" for JIT-compiled code: a region has to be mapped
+`MAP_JIT` (RWX at the VMA/mapping level) up front, and the actual
+write-vs-execute enforcement is a **per-thread** toggle via
+`pthread_jit_write_protect_np`, which Zig's `platform.jitWriteProtect`
+wraps. A `MAP_JIT` region's protection cannot be changed after the
+fact with a second `mprotect` the way a normal page's can.
+
+1. `mmap` with `MAP_JIT` set and `RWX` requested — the OS grants the
+   *capability*, not simultaneous access for every thread.
+2. `jitWriteProtect(false)` — this thread flips to write-enabled
+   (execute-disabled) for its view of the mapping.
+3. `memcpy` the compiled code in.
+4. `jitWriteProtect(true)` — this thread flips back to
+   execute-enabled (write-disabled).
+5. `icacheFlush`.
+
+**Guarantee**: at every point in time, *this thread's* view of the
+page is either write-enabled-and-execute-disabled or
+execute-enabled-and-write-disabled, never both — the OS enforces this
+per-thread, not by revoking the underlying RWX mapping. A new thread
+that later calls into this code starts in the execute-enabled default
+state for `MAP_JIT` regions, so no additional toggling is needed on
+the executing thread as long as it never itself calls
+`jitWriteProtect(false)` on this mapping.
+
+This mirrors the pattern `host_trampolines.zig`'s `TrampolinePool`
+already established and validated for the host-import trampoline pool
+(used by every AOT component test that exercises cross-instance /
+canon-lower dispatch).
+
+## What's verified vs. what isn't
+
+| Target | Verified how |
+|---|---|
+| Linux x86_64 | CI (`linux-x64` job) + local dev VM; `mapExecutableCode` unit test calls mapped code through a function pointer. |
+| Linux aarch64 | CI (`linux-arm64` self-hosted runner); same unit test, plus the aarch64 `icacheFlush` d-cache/i-cache line invalidation path. |
+| Windows x86_64 | CI (`windows-x64` job); same unit test (NT API `mmap`/`mprotect` path, shared with the non-macOS-JIT branch since Windows isn't `macos_jit`). |
+| macOS x86_64 | **Not covered by CI** (no macOS runner in `.github/workflows/ci.yml`) — but this target isn't `macos_jit`, so it takes the same well-covered RW→RX `mprotect` path as Linux/Windows. Low risk. |
+| macOS aarch64 (Apple Silicon) | **Not covered by CI or local testing** — no macOS hardware was available to implement this. The `MAP_JIT` + `jitWriteProtect` code path is new for `mapCodeExecutable` (though the same primitives are already exercised in production by `host_trampolines.zig`'s trampoline pool, which every AOT component end-to-end test exercises indirectly). **Follow-up filed**: [#874](https://github.com/cataggar/wamr/issues/874) asks a maintainer with Apple Silicon hardware to validate `wamr run <core.wasm>` / `wamr serve <component.wasm>` on a `-Djit=true` macOS aarch64 build and confirm no `MAP_JIT`-related crash or trap, rather than leaving this a silent gap. |
+
+## Why `host_trampolines.zig` wasn't refactored
+
+`TrampolinePool.initWithCap` maps one large region up front (sized for
+`cap` slots), zero-fills it, and then writes individual trampoline
+stubs into sub-slots **lazily**, one at a time, as imports are
+resolved — each stub write itself wrapped in its own
+`jitWriteProtect(false) … jitWriteProtect(true)` pair (see
+`TrampolinePool.installStub`-equivalent call sites at
+`host_trampolines.zig:625-631`). This is a pool-allocator pattern:
+many writes over the pool's lifetime, not "compile once, map once."
+
+`mapExecutableCode` is deliberately the opposite shape: one call maps
+*and* writes *and* finalizes a single, complete code blob — the shape
+`mapCodeExecutable` needs (a whole AOT module's `text_section` is
+final before mapping). Forcing the pool to go through
+`mapExecutableCode` would mean either (a) writing all `cap` slots
+before the first mapping call (defeating the pool's lazy-fill design
+and cache locality benefits), or (b) `mapExecutableCode` growing a
+second lazy-write mode that only the pool would ever use. Neither is
+worth the risk for this issue's scope; the pool already correctly uses
+the same two underlying primitives (`platform.macos_jit`,
+`platform.jitWriteProtect`) this note describes, just composed for its
+own allocation shape.
+
+## See also
+
+- `src/platform/platform.zig` — `mapExecutableCode`, `jitWriteProtect`, `macos_jit`.
+- `src/runtime/aot/runtime.zig` — `mapCodeExecutable` (the JIT/AOT call site this note covers).
+- `src/runtime/aot/host_trampolines.zig` — the pre-existing, differently-shaped W^X handling for the host-import trampoline pool.
+- [#857](https://github.com/cataggar/wamr/issues/857) — `JitCodeCache` registry (tracks/bounds resident JIT code across repeated compiles; orthogonal to this note's mapping-strategy concern).

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -722,7 +722,10 @@ test "mapExecutableCode: mapped code is genuinely callable" {
     const mem = mapExecutableCode(body) orelse return error.MapExecutableCodeFailed;
     defer munmap(mem, body.len);
 
-    const f: *const fn () callconv(.c) i32 = @ptrCast(mem);
+    // `mem` is typed as `[*]u8` (alignment 1) but is always backed by a
+    // page-aligned `mmap` allocation at runtime, so re-asserting the
+    // (much stricter) function-pointer alignment here is sound.
+    const f: *const fn () callconv(.c) i32 = @ptrCast(@alignCast(mem));
     try std.testing.expectEqual(@as(i32, 42), f());
 }
 

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -556,6 +556,80 @@ pub fn jitWriteProtect(enable: bool) void {
     }
 }
 
+/// #858: map `size` bytes, copy `code` into them, flush the
+/// instruction cache, and leave the region executable-and-not-writable
+/// — the single primitive every "JIT compile → map → execute" call
+/// site (`runtime.zig:mapCodeExecutable`, and `host_trampolines.zig`'s
+/// pool, which pre-dates this and inlines the same dance) should use,
+/// so the W^X handling only has to be gotten right in one place.
+///
+/// Two genuinely different strategies, chosen at comptime per target:
+///
+///   * Everywhere except macOS aarch64: `mmap` RW, `memcpy` the code
+///     in, `mprotect` to RX. The region is never simultaneously
+///     writable and executable — it's RW-only until the single
+///     `mprotect` call flips it to RX-only, and nothing writes to it
+///     afterward.
+///   * macOS aarch64 (Apple Silicon): a plain RW→RX `mprotect`
+///     transition is not the supported JIT pattern — the region is
+///     mapped `MAP_JIT` (RWX at the VMA level) up front, and actual
+///     write-vs-execute enforcement is a **per-thread** toggle via
+///     `pthread_jit_write_protect_np` (`jitWriteProtect`). A MAP_JIT
+///     page's protection cannot be changed after the fact with a
+///     second `mprotect` the way a normal page's can. This mirrors the
+///     pattern `host_trampolines.zig`'s `TrampolinePool.initWithCap`
+///     already established for the host-import trampoline pool; this
+///     function is the generalization for the JIT-compiled-code path.
+///
+/// Returns `null` on any mmap/mprotect failure. The caller owns the
+/// returned region and must `munmap` it (via `platform.munmap`) when
+/// done — `munmap` doesn't need to know which strategy mapped it.
+pub fn mapExecutableCode(code: []const u8) ?[*]u8 {
+    if (code.len == 0) return null;
+
+    if (comptime macos_jit) {
+        const map_flags: std.posix.MAP = .{ .TYPE = .PRIVATE, .ANONYMOUS = true, .JIT = true };
+        const mapped = std.posix.mmap(
+            null,
+            code.len,
+            .{ .READ = true, .WRITE = true, .EXEC = true },
+            map_flags,
+            -1,
+            0,
+        ) catch return null;
+        const mem: [*]u8 = mapped.ptr;
+
+        // This thread starts execute-protected (write-disabled) on a
+        // fresh MAP_JIT region; flip to writable for the copy, flush
+        // the icache, then flip back to executable before returning —
+        // any thread that later *executes* this code (including this
+        // one) must be in the execute-enabled state, which is both
+        // the default for new threads and what we leave this thread in.
+        jitWriteProtect(false);
+        @memcpy(mem[0..code.len], code);
+        jitWriteProtect(true);
+        icacheFlush(mem, code.len);
+        return mem;
+    }
+
+    // 1. Allocate RW pages.
+    const mem = mmap(null, code.len, .{ .read = true, .write = true }, .{}) orelse return null;
+
+    // 2. Copy native code in.
+    @memcpy(mem[0..code.len], code);
+
+    // 3. Flush instruction cache (required on AArch64, no-op on x86-64).
+    icacheFlush(mem, code.len);
+
+    // 4. Transition to RX (W^X) — the region is RW-only up to this
+    // point and RX-only from this point on; never both at once.
+    mprotect(mem, code.len, .{ .read = true, .exec = true }) catch {
+        munmap(mem, code.len);
+        return null;
+    };
+    return mem;
+}
+
 fn icacheFlushAarch64(start: [*]u8, len: usize) void {
     if (is_macos) {
         // macOS: use sys_icache_invalidate from libsystem.
@@ -622,6 +696,38 @@ test "mmap/munmap roundtrip" {
     try std.testing.expectEqual(@as(u8, 0xCD), ptr[size - 1]);
 
     munmap(ptr, size);
+}
+
+test "mapExecutableCode: mapped code is genuinely callable" {
+    if (comptime builtin.cpu.arch != .x86_64 and builtin.cpu.arch != .aarch64) return error.SkipZigTest;
+
+    // Minimal native function body for the host arch: load 42 into the
+    // integer return register and return. Proves the mapped region is
+    // truly executable (not just readable) — if `mapExecutableCode`
+    // mismapped or mis-flushed the icache, calling through the
+    // function pointer below would crash or return garbage instead of
+    // exactly 42.
+    const body: []const u8 = switch (builtin.cpu.arch) {
+        .x86_64 => &[_]u8{
+            0xB8, 0x2A, 0x00, 0x00, 0x00, // mov eax, 42
+            0xC3, // ret
+        },
+        .aarch64 => &[_]u8{
+            0x40, 0x05, 0x80, 0x52, // mov w0, #42
+            0xC0, 0x03, 0x5F, 0xD6, // ret
+        },
+        else => unreachable,
+    };
+
+    const mem = mapExecutableCode(body) orelse return error.MapExecutableCodeFailed;
+    defer munmap(mem, body.len);
+
+    const f: *const fn () callconv(.c) i32 = @ptrCast(mem);
+    try std.testing.expectEqual(@as(i32, 42), f());
+}
+
+test "mapExecutableCode: rejects empty input" {
+    try std.testing.expectEqual(@as(?[*]u8, null), mapExecutableCode(&.{}));
 }
 
 test "mprotect changes permissions" {

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -1951,21 +1951,14 @@ pub fn mapCodeExecutable(inst: *AotInstance) RuntimeError!void {
         // unbounded / eventually OOMing.
         try JitCodeCache.checkBudget(text.len);
 
-        // 1. Allocate RW pages
-        mem = platform.mmap(null, text.len, .{ .read = true, .write = true }, .{}) orelse
-            return error.CodeMappingFailed;
-
-        // 2. Copy native code
-        @memcpy(mem[0..text.len], text);
-
-        // 3. Flush instruction cache (required on AArch64, no-op on x86-64)
-        if (comptime native_arch == .aarch64) {
-            platform.icacheFlush(mem, text.len);
-        }
-
-        // 4. Transition to RX (W^X)
-        platform.mprotect(mem, text.len, .{ .read = true, .exec = true }) catch
-            return error.CodeMappingFailed;
+        // #858: `platform.mapExecutableCode` owns the W^X mapping
+        // strategy (plain RW→RX `mprotect` on most targets; `MAP_JIT` +
+        // per-thread `pthread_jit_write_protect_np` toggling on macOS
+        // aarch64, where a post-hoc `mprotect` can't re-grant exec on a
+        // MAP_JIT region) and flushes the instruction cache internally,
+        // so this call site no longer needs an arch-specific
+        // `icacheFlush` branch of its own.
+        mem = platform.mapExecutableCode(text) orelse return error.CodeMappingFailed;
 
         inst.code_base = mem;
         inst.code_size = text.len;


### PR DESCRIPTION
Closes #858. Part of the in-process JIT plan tracked in #863. Not stacked — branched fresh off `main`, but **overlaps with #873 (#857)** in `mapCodeExecutable`'s body (both PRs touch the same function). Will need a rebase to reconcile whichever of the two merges second — I'll handle that once #873's merge status is known.

## Findings

- Linux (x86_64/aarch64) and Windows (x86_64): the existing RW-mmap → memcpy → mprotect-to-RX sequence already never produces a simultaneously writable-and-executable page — verified by inspection and by a new unit test that maps a real function body and calls it through a function pointer.
- macOS aarch64 (Apple Silicon): `mapCodeExecutable` used the *same* RW→RX `mprotect` sequence as every other target, but Apple Silicon's JIT model doesn't support a post-hoc `mprotect` re-granting exec permission on demand — it requires `MAP_JIT` + per-thread `pthread_jit_write_protect_np` toggling instead. This was already correctly wired for the host-import trampoline pool (`host_trampolines.zig`, `platform.jitWriteProtect` / `platform.macos_jit`) but never extended to the actual JIT/AOT code-mapping path — exactly the gap #858 predicted.

## What changed

- `src/platform/platform.zig`: new `mapExecutableCode(code: []const u8) ?[*]u8` — the single shared primitive for "map, write, flush icache, make executable" that `mapCodeExecutable` (and any future JIT-adjacent call site) should use instead of hand-rolling the mmap/mprotect dance. Chooses the right strategy at comptime via `platform.macos_jit`: the existing RW→RX `mprotect` path everywhere except macOS aarch64, and the `MAP_JIT` + `jitWriteProtect` dance (mirroring `host_trampolines.zig`'s already-established pattern) there. Two new unit tests: one maps a tiny real function body and calls it through a function pointer (proving genuine executability, not just a readable region), the other confirms empty input is rejected.
- `src/runtime/aot/runtime.zig`: `mapCodeExecutable` now delegates entirely to `platform.mapExecutableCode`, dropping its own inline mmap/memcpy/icacheFlush/mprotect sequence (including the arch-specific `if (native_arch == .aarch64)` icache-flush gate, since `icacheFlush` already no-ops internally on x86/x86_64).
- `docs/design/jit-wx-hygiene.md`: design note documenting the guarantee per OS/arch, what's actually been verified (CI covers Linux x86_64/aarch64 + Windows x86_64; macOS x86_64 takes the well-covered non-JIT path since it isn't `macos_jit`), and — per the issue's own acceptance criteria — an explicit callout that the macOS aarch64 `MAP_JIT` path has **not** been validated on real hardware (no macOS runner in CI, no macOS access during implementation). Filed **#874** asking a maintainer with Apple Silicon hardware to validate it, rather than silently shipping an untested gap. Also documents why `host_trampolines.zig`'s pool allocator wasn't refactored onto the new primitive (different allocation shape: lazy per-slot writes into one pre-sized pool vs. one-shot map-and-finalize a complete code blob).

## Validation

- `zig build test --summary all` (default): 87/87 build steps, 4480/4488 tests passed (8 skipped) — 2 new (`mapExecutableCode` tests), all passing.
- `zig build test -Djit=true --summary all`: same, unchanged; the #853/#854 JIT smoke tests (which exercise `mapCodeExecutable` through the real CLI JIT path) still pass through the refactored code.
- `zig build` (default, production): unaffected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>