### PR TITLE
#859: JIT compile-path thread-safety audit + concurrent stress test

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -863,6 +863,22 @@ pub fn build(b: *std.Build) void {
     const run_aot_high_funcidx_tests = b.addRunArtifact(aot_high_funcidx_tests);
     test_step.dependOn(&run_aot_high_funcidx_tests.step);
 
+    // #859: thread-safety stress test for the in-process JIT compile
+    // entry points — N threads independently compile+load+instantiate+
+    // execute+destroy a small AOT module concurrently and each must
+    // observe the correct, uncorrupted result for its own distinct input.
+    const jit_thread_safety_module = b.createModule(.{
+        .root_source_file = b.path("src/tests/jit_thread_safety_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    jit_thread_safety_module.addImport("wamr", lib_module);
+    const jit_thread_safety_tests = b.addTest(.{
+        .root_module = jit_thread_safety_module,
+    });
+    const run_jit_thread_safety_tests = b.addRunArtifact(jit_thread_safety_tests);
+    test_step.dependOn(&run_jit_thread_safety_tests.step);
+
     // #625 phase 1: AOT-backed component-core smoke test. Lives in its
     // own test step for the same reason `differential.zig` does:
     // `aot_harness.zig` cannot be pulled into the `wamr` lib module

--- a/src/compiler/aot_bisect.zig
+++ b/src/compiler/aot_bisect.zig
@@ -79,6 +79,19 @@ pub const ParseError = error{
 /// Lifetime: the env parser leaks the backing slices into the GPA
 /// passed to `parseFromEnv` for the process lifetime — `wamrc` is a
 /// short-lived CLI tool and these are tens of bytes.
+///
+/// #859 thread-safety note: this is genuinely shared, unsynchronized,
+/// process-wide mutable state — not `threadlocal`. Every compile call
+/// (`compileCoreWasm` et al.) reads it once, early, via a plain
+/// (non-atomic) load into that call's own `PrecompileOptions.bisect`
+/// snapshot. Both shipped entry points (`wamr`, `wamrc`) only ever
+/// call `parseFromEnv` once, at single-threaded CLI startup, strictly
+/// before any compile begins — so there is no actual concurrent
+/// access today. An embedder driving the library API directly MUST
+/// preserve that same invariant: call `parseFromEnv` (or assign
+/// `global` directly) only before spawning any concurrent compiles,
+/// never while other threads may be mid-`compileCoreWasm`. There is
+/// no lock guarding this field.
 pub var global: Spec = .{};
 
 /// Pull the bisect env vars out of `env` and stamp `global` with the

--- a/src/component/core_backend.zig
+++ b/src/component/core_backend.zig
@@ -149,6 +149,16 @@ pub const PrecompiledCore = struct {
 /// `debugAotEnabled` from any code path that wants to surface AOT
 /// instantiation / call / trap details that would otherwise be
 /// swallowed by the `error.Trap` envelope (see #644).
+///
+/// #859 thread-safety note: genuinely shared, unsynchronized,
+/// process-wide mutable state (not `threadlocal`), read during AOT
+/// dispatch/instantiation — not compilation itself, but audited
+/// alongside `aot_bisect.global` since it's the same class of risk.
+/// `main.zig` only ever calls `setDebugAotEnabled` once, at
+/// single-threaded startup, before any compile/run/dispatch activity
+/// begins. An embedder must preserve that invariant — configure this
+/// before spawning concurrent work, not while other threads may be
+/// reading it via `debugAotEnabled`. No lock guards this field.
 var aot_debug_enabled: bool = false;
 
 pub fn setDebugAotEnabled(on: bool) void {
@@ -164,6 +174,10 @@ pub fn debugAotEnabled() bool {
 /// default; `main.zig` sets it during startup when `WAMR_TRAP_CROSS_MEMORY_THUNK`
 /// is set to a non-empty / non-`0` / non-`false` value. See the dispatcher
 /// in `executor.dispatchAotCrossInstance` and #719 Bug B for context.
+///
+/// #859 thread-safety note: same shape and same contract as
+/// `aot_debug_enabled` above — configure once at startup, before any
+/// concurrent compile/run/dispatch activity, never mid-flight.
 var trap_cross_memory_enabled: bool = false;
 
 pub fn setTrapCrossMemoryEnabled(on: bool) void {

--- a/src/tests/jit_thread_safety_test.zig
+++ b/src/tests/jit_thread_safety_test.zig
@@ -1,0 +1,151 @@
+//! #859 — thread-safety stress test for the in-process JIT compile
+//! entry points.
+//!
+//! Audit summary (full writeup in the PR description / commit
+//! message): `src/compiler/**` has exactly one genuinely shared,
+//! non-`threadlocal` mutable global — `aot_bisect.global` (the #761
+//! codegen-bisection spec) — plus two more in
+//! `src/component/core_backend.zig`: `aot_debug_enabled` and
+//! `trap_cross_memory_enabled`. All three are diagnostic/debug-only
+//! toggles that both shipped CLIs (`wamr`, `wamrc`) set exactly once,
+//! at startup, from an env var, before any compile or run activity
+//! begins — never touched again during the process lifetime. Every
+//! other piece of per-compile state (IR module, pass pipeline,
+//! codegen buffers, `codegen_cache.Cache`) is either a function-local
+//! value or explicitly threaded through call parameters — nothing is
+//! shared across concurrent compiles by default. `threadlocal var`
+//! usage elsewhere (`verifier.zig`, `analysis.zig`, `passes.zig`) is
+//! inherently per-thread-safe by construction and not a concern.
+//!
+//! Conclusion: **yes, two threads can call `compileCoreWasm` /
+//! `precompileComponentInMemory` concurrently on distinct modules
+//! without corrupting each other's output** — *provided* the three
+//! diagnostic globals above are left untouched during the concurrent
+//! window, which matches how both CLIs already use them (configure
+//! once at startup, never reconfigure mid-flight). This test proves
+//! the positive case: N threads each independently compile, load,
+//! instantiate, execute, and destroy a small AOT module at the same
+//! time, and every thread observes the correct, uncorrupted result
+//! for its own distinct input.
+
+const std = @import("std");
+const wamr = @import("wamr");
+
+const aot_loader_mod = wamr.aot_loader;
+const aot_runtime_mod = wamr.aot_runtime;
+const component_aot_compile = wamr.component_aot_compile;
+
+const can_exec_aot = switch (@import("builtin").cpu.arch) {
+    .x86_64, .aarch64 => true,
+    else => false,
+};
+
+// The "add42" core wasm fixture already used elsewhere in this test
+// suite (e.g. `component_aot_canonlift_test.zig`): one exported
+// function `add42(x: i32) -> i32` computing `x + 42`. Small, no
+// imports, deterministic — ideal for a concurrent-compile stress test
+// since each thread can pick a distinct input and independently
+// verify its own output.
+const add42_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    0x03, 0x02, 0x01, 0x00,
+    0x05, 0x03, 0x01, 0x00, 0x01,
+    0x07, 0x12, 0x02,
+    0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
+    0x05, 'a', 'd', 'd', '4', '2', 0x00, 0x00,
+    0x0a, 0x09, 0x01, 0x07, 0x00,
+    0x20, 0x00,
+    0x41, 0x2a,
+    0x6a,
+    0x0b,
+};
+
+const ThreadCount = 8;
+
+const ThreadResult = struct {
+    ok: bool = false,
+    got: i32 = 0,
+    want: i32 = 0,
+    err_name: []const u8 = "",
+};
+
+fn compileLoadRunDestroy(idx: usize, result: *ThreadResult, gpa: std.mem.Allocator) void {
+    // Distinct input per thread, so a cross-thread mixup (reading
+    // another thread's compiled code, IR, or result) shows up as a
+    // wrong `got` value rather than being masked by every thread
+    // computing the same answer.
+    const input: i32 = @intCast(idx * 1000);
+    result.want = input + 42;
+
+    const cwasm = component_aot_compile.compileCoreWasm(gpa, &add42_wasm, .{}) catch |err| {
+        result.err_name = @errorName(err);
+        return;
+    };
+    defer gpa.free(cwasm);
+
+    var module = aot_loader_mod.load(cwasm, gpa) catch |err| {
+        result.err_name = @errorName(err);
+        return;
+    };
+    defer aot_loader_mod.unload(&module, gpa);
+
+    const inst = aot_runtime_mod.instantiate(&module, gpa) catch |err| {
+        result.err_name = @errorName(err);
+        return;
+    };
+    defer aot_runtime_mod.destroy(inst);
+
+    aot_runtime_mod.mapCodeExecutable(inst) catch |err| {
+        result.err_name = @errorName(err);
+        return;
+    };
+
+    const func_idx = aot_runtime_mod.findExportFunc(inst, "add42") orelse {
+        result.err_name = "add42 export not found";
+        return;
+    };
+
+    var results_buf: [1]aot_runtime_mod.ScalarResult = undefined;
+    const results = aot_runtime_mod.callFuncScalar(
+        inst,
+        func_idx,
+        &.{.i32},
+        &.{.i32},
+        &.{.{ .i32 = input }},
+        &results_buf,
+    ) catch |err| {
+        result.err_name = @errorName(err);
+        return;
+    };
+
+    result.got = switch (results[0]) {
+        .i32 => |v| v,
+        else => {
+            result.err_name = "unexpected result type";
+            return;
+        },
+    };
+    result.ok = true;
+}
+
+test "#859: N threads JIT-compiling+running distinct calls concurrently all get correct, uncorrupted results" {
+    if (comptime !can_exec_aot) return error.SkipZigTest;
+
+    const gpa = std.testing.allocator;
+    var results: [ThreadCount]ThreadResult = [_]ThreadResult{.{}} ** ThreadCount;
+    var threads: [ThreadCount]std.Thread = undefined;
+
+    for (0..ThreadCount) |i| {
+        threads[i] = try std.Thread.spawn(.{}, compileLoadRunDestroy, .{ i, &results[i], gpa });
+    }
+    for (threads) |t| t.join();
+
+    for (results, 0..) |r, i| {
+        if (r.err_name.len > 0) {
+            std.debug.print("thread {d} failed: {s}\n", .{ i, r.err_name });
+        }
+        try std.testing.expect(r.ok);
+        try std.testing.expectEqual(r.want, r.got);
+    }
+}


### PR DESCRIPTION
## Summary

Audits `src/compiler/**` and the component-level in-memory compile
path (`src/component/aot_compile.zig`, `core_backend.zig`) for shared
mutable state that could make concurrent JIT compiles (e.g. compiling
two distinct modules on separate threads) unsafe.

## Findings

Exhaustive grep for module-level (column-0) `var`/`pub var` declarations found:

- **`aot_bisect.global`** (the #761 codegen-bisection spec) — the only
  genuinely shared, non-`threadlocal` mutable global in
  `src/compiler/**`. Read once per compile call; written only once at
  single-threaded CLI startup via `parseFromEnv`.
- **`core_backend.aot_debug_enabled`** and
  **`core_backend.trap_cross_memory_enabled`** — same shape/risk
  class, used during AOT instantiation/dispatch rather than
  compilation itself. Both are runtime diagnostic toggles set once at
  CLI startup via env vars.
- `codegen_cache.zig` has **zero** global state (purely functional,
  caller-owned `Cache` structs).
- Five `threadlocal var` usages (`verifier.zig`, `analysis.zig` x2,
  `passes.zig`) are inherently per-thread-safe by construction — not a
  concern.

**Conclusion:** the actual compile pipeline (frontend/passes/codegen/emit)
has no shared mutable state. Two threads can safely call
`compileCoreWasm`/`precompileComponentInMemory` concurrently on
distinct modules, *provided* the three diagnostic globals above are
configured before spawning concurrent work (matching how both shipped
CLIs — `wamr`, `wamrc` — already use them), never reconfigured
mid-flight.

## Changes

- Added explicit thread-safety doc comments to all three found
  globals, documenting the "configure once at startup, before
  spawning concurrent work" contract for embedders driving the
  library API directly.
- Added `src/tests/jit_thread_safety_test.zig`: 8 threads concurrently
  compile+load+instantiate+run+destroy a small "add42" AOT module,
  each with a distinct input/expected-output pair, asserting no
  cross-thread corruption of results.
- Wired the new test into `build.zig`'s `test_step`.

## Validation

- `zig build test --summary all`: all pass, including 8/8 new stress
  test iterations, repeated multiple times with no flakes.
- `zig build test -Djit=true --summary all`: all pass.

Closes #859. Part of the #863 JIT tracking plan (Milestone 2 hardening).