### PR TITLE
#860 JIT M3.1: fast/baseline compile preset as the JIT default

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -879,6 +879,23 @@ pub fn build(b: *std.Build) void {
     const run_jit_thread_safety_tests = b.addRunArtifact(jit_thread_safety_tests);
     test_step.dependOn(&run_jit_thread_safety_tests.step);
 
+    // #860: fast/baseline compile preset correctness + compile-time
+    // comparison against the full pipeline (CoreMark fixture).
+    const jit_fast_preset_module = b.createModule(.{
+        .root_source_file = b.path("src/tests/jit_fast_preset_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    jit_fast_preset_module.addImport("wamr", lib_module);
+    jit_fast_preset_module.addAnonymousImport("coremark_wasm", .{
+        .root_source_file = b.path("tests/benchmarks/coremark/coremark_wasi.wasm"),
+    });
+    const jit_fast_preset_tests = b.addTest(.{
+        .root_module = jit_fast_preset_module,
+    });
+    const run_jit_fast_preset_tests = b.addRunArtifact(jit_fast_preset_tests);
+    test_step.dependOn(&run_jit_fast_preset_tests.step);
+
     // #625 phase 1: AOT-backed component-core smoke test. Lives in its
     // own test step for the same reason `differential.zig` does:
     // `aot_harness.zig` cannot be pulled into the `wamr` lib module

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -8962,6 +8962,84 @@ pub fn defaultPassesForTargetWithOptions(target: TargetArch, options: CompileOpt
     };
 }
 
+/// #860: selects which pass pipeline `compileCoreWasm`/`precompileComponent`
+/// runs. `wamrc compile`'s on-disk `.cwasm` is written once and reused
+/// across many runs, so its default (`.full`) optimizes for steady-state
+/// throughput. The in-process JIT path compiles synchronously on every
+/// `wamr run`/`wamr serve` invocation — compile latency is part of the
+/// user-visible cold start — so it defaults to `.fast` instead (see
+/// `jit_fast_passes` / `x86_64_jit_fast_passes` below).
+pub const PassPreset = enum { full, fast };
+
+/// #860 fast/baseline JIT preset: keeps only the cheap, purely-local
+/// peephole passes (no dominator-tree or loop-analysis construction) plus
+/// the final dead-code cleanup. Empirically, on a CoreMark compile,
+/// `globalValueNumbering`, `forwardRedundantLoadsDominator` and
+/// `hoistLoopInvariantCode` alone account for the majority of optimizer
+/// time (dominator-tree / loop-analysis construction that mainly pays off
+/// over many iterations of a long-running module) — see the PR
+/// description for the measured breakdown. `tailDuplicateSmallJoins`,
+/// `threadChainedConditionalBranches`, `unrollSmallFixedLoops` /
+/// `inductionVariableSimplification`, the redundant-load-forwarding pair,
+/// `deadStoreElimination`, and the loop-bounds-check passes are all
+/// dropped for the same reason: they either restructure the CFG/duplicate
+/// code (raising codegen input size) or require a loop/dominator
+/// analysis pass to be (re)computed. Skipping any subset of these is
+/// always semantically safe — `PrecompileOptions.optimize = false`
+/// (skipping *all* passes) is itself a supported, tested configuration
+/// (see aot_bisect), so any smaller subset is as well.
+const jit_fast_passes: []const PassFn = &.{
+    &forwardLocalGet,
+    &constantFold,
+    &algebraicSimplify,
+    &strengthReduceMul,
+    &strengthReduceMulShiftAdd,
+    &strengthReduceDivRem,
+    &foldConstantBranches,
+    &foldInverseCompareEqz,
+    &foldSelectOnEqz,
+    &foldSignExtendingLoad,
+    &foldFloatUnaryIdempotents,
+    &foldWrapOfExtend,
+    &deadCodeAndLocalSetCleanup,
+    &foldLoadStoreOffset,
+};
+
+/// x86-64 variant of `jit_fast_passes`: adds `foldBranchOnEqz`, which
+/// mirrors `x86_64_default_passes` including that same cheap peephole
+/// fold (it's x86_64-only for the same reason noted on
+/// `x86_64_default_passes` above).
+const x86_64_jit_fast_passes: []const PassFn = &.{
+    &forwardLocalGet,
+    &constantFold,
+    &algebraicSimplify,
+    &strengthReduceMul,
+    &strengthReduceMulShiftAdd,
+    &strengthReduceDivRem,
+    &foldConstantBranches,
+    &foldInverseCompareEqz,
+    &foldBranchOnEqz,
+    &foldSelectOnEqz,
+    &foldSignExtendingLoad,
+    &foldFloatUnaryIdempotents,
+    &foldWrapOfExtend,
+    &deadCodeAndLocalSetCleanup,
+    &foldLoadStoreOffset,
+};
+
+/// Resolve `preset` to the concrete pass list for `target`. `.full`
+/// delegates to `defaultPassesForTarget` (identical to today's
+/// behavior); `.fast` returns the #860 baseline JIT preset above.
+pub fn passesForPreset(target: TargetArch, preset: PassPreset) []const PassFn {
+    return switch (preset) {
+        .full => defaultPassesForTarget(target),
+        .fast => switch (target) {
+            .x86_64 => x86_64_jit_fast_passes,
+            .aarch64 => jit_fast_passes,
+        },
+    };
+}
+
 // ── Block Reordering ────────────────────────────────────────────────────────
 
 const DfsEntry = struct { block: ir.BlockId, child_idx: usize };

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -79,6 +79,15 @@ pub const PrecompileOptions = struct {
     /// `-O0` we know it's in the optimization pipeline; if it persists the
     /// bug is in the frontend / SSA / codegen.
     optimize: bool = true,
+    /// #860: which pass pipeline to run when `optimize` is true. Defaults
+    /// to `.full` (today's `defaultPassesForTarget` pipeline, unchanged)
+    /// so `wamrc compile`'s output is untouched by this option's
+    /// existence; the in-process JIT call sites in `src/main.zig`
+    /// explicitly pass `.fast` as their default (overridable via
+    /// `WAMR_JIT_FULL_OPT`) since compile latency there is part of the
+    /// user-visible cold start rather than a one-time cost amortized
+    /// over many runs of a cached `.cwasm`.
+    pass_preset: passes.PassPreset = .full,
     /// #761 Phase 2: per-core codegen cache directory. When non-null,
     /// `precompileComponent` reads `<dir>/core<N>.cache` for each core
     /// (if present, header-compatible) to reuse cached per-function
@@ -171,7 +180,7 @@ pub fn compileCoreWasmCached(
     if (opts.optimize) {
         _ = passes.runPassesWithOptions(
             &ir_module,
-            passes.defaultPassesForTarget(opts.target_arch),
+            passes.passesForPreset(opts.target_arch, opts.pass_preset),
             allocator,
             .{
                 // The default `opts.verify_mode` matches single-module

--- a/src/main.zig
+++ b/src/main.zig
@@ -157,6 +157,25 @@ fn runVersion(io: std.Io, args: []const []const u8) !u8 {
     return 0;
 }
 
+/// #860: default optimization-pass preset for the in-process JIT compile
+/// path (`wamr run`/`wamr serve` under `-Djit=true`). The JIT compiles
+/// synchronously on every invocation — compile latency is part of the
+/// user-visible cold start — unlike `wamrc compile`, whose `.cwasm` is
+/// written once and reused across many runs. Default to `.fast` (skips
+/// the passes that mainly pay off on long-running steady-state code:
+/// global value numbering, loop-invariant hoisting, dominator-based
+/// redundant-load forwarding, tail duplication, loop-bounds-check
+/// hoisting/elision — see `passes.jit_fast_passes` for the full
+/// rationale). Set `WAMR_JIT_FULL_OPT` to a non-empty / non-`0` /
+/// non-`false` value to opt back into the full pipeline (better
+/// steady-state throughput, higher compile latency) for both call
+/// sites below.
+fn jitPassPresetFromEnv(env: *const std.process.Environ.Map) wamr.passes.PassPreset {
+    const v = env.get("WAMR_JIT_FULL_OPT") orelse return .fast;
+    const on = !(v.len == 0 or std.mem.eql(u8, v, "0") or std.mem.eql(u8, v, "false"));
+    return if (on) .full else .fast;
+}
+
 fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []const []const u8) !u8 {
     if (run_args.len == 1 and std.mem.eql(u8, run_args[0], "help")) {
         writeStdout(init.io, run_usage);
@@ -449,7 +468,12 @@ fn runRun(init: std.process.Init, allocator: std.mem.Allocator, run_args: []cons
         // file or was just produced by the compiler above; it's the
         // same load/instantiate/execute path a precompiled `.cwasm`
         // takes today.
-        const cwasm = wamr.component_aot_compile.compileCoreWasm(allocator, wasm_data, .{}) catch |err| {
+        // #860: default to the fast/baseline compile preset (see
+        // `jitPassPresetFromEnv`) rather than `wamrc compile`'s
+        // steady-state-optimized default.
+        const cwasm = wamr.component_aot_compile.compileCoreWasm(allocator, wasm_data, .{
+            .pass_preset = jitPassPresetFromEnv(init.environ_map),
+        }) catch |err| {
             std.debug.print("Error: JIT compile of '{s}' failed: {s}\n", .{ path, @errorName(err) });
             return 1;
         };
@@ -875,7 +899,12 @@ fn loadComponentManifestOrPrint(
                 // #854: in-process JIT. Compile every core module of
                 // the component in memory and instantiate directly —
                 // no manifest, no `.cwasm` files written to disk.
-                const in_mem = wamr.component_aot_compile.precompileComponentInMemory(allocator, wasm_data, .{}) catch |err| {
+                // #860: default to the fast/baseline compile preset
+                // (see `jitPassPresetFromEnv`) rather than `wamrc
+                // compile`'s steady-state-optimized default.
+                const in_mem = wamr.component_aot_compile.precompileComponentInMemory(allocator, wasm_data, .{
+                    .pass_preset = jitPassPresetFromEnv(init.environ_map),
+                }) catch |err| {
                     std.debug.print("Error: JIT compile of component '{s}' failed: {s}\n", .{ path, @errorName(err) });
                     return 1;
                 };

--- a/src/tests/jit_fast_preset_test.zig
+++ b/src/tests/jit_fast_preset_test.zig
@@ -1,0 +1,152 @@
+//! #860 — fast/baseline compile preset for the in-process JIT path.
+//!
+//! Two things are verified here:
+//!
+//!  1. Correctness: the `.fast` preset (`passes.jit_fast_passes` /
+//!     `x86_64_jit_fast_passes`) still produces a correctly-executing
+//!     AOT module — skipping the heavier global-analysis passes must
+//!     never change observable behavior, only compile latency /
+//!     steady-state codegen quality.
+//!  2. The measured effect: compiling a real, non-trivial module
+//!     (CoreMark) with `.fast` is faster than the `.full` default and
+//!     the resulting `.cwasm` still loads successfully. This is a
+//!     coarse regression guard (`fast` must not regress to `>= full`
+//!     time) rather than a strict perf gate — see the PR description
+//!     for the actual measured numbers on this repo's benchmark
+//!     hardware, gathered via `WAMR_AOT_PASS_TIMING=1 wamrc compile`
+//!     (aggregated per-pass elapsed time) plus direct `.full` vs
+//!     `.fast` timing of `compileCoreWasm` itself.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const wamr = @import("wamr");
+
+const aot_loader_mod = wamr.aot_loader;
+const aot_runtime_mod = wamr.aot_runtime;
+const component_aot_compile = wamr.component_aot_compile;
+
+const can_exec_aot = switch (@import("builtin").cpu.arch) {
+    .x86_64, .aarch64 => true,
+    else => false,
+};
+
+/// Portable monotonic-clock read in nanoseconds, mirroring
+/// `passes.passTimingNowNs` (this repo's `std` version has no
+/// `std.time.Timer`).
+fn nowNs() u64 {
+    return switch (comptime builtin.os.tag) {
+        .linux => blk: {
+            const linux = std.os.linux;
+            var ts: linux.timespec = undefined;
+            const rc = linux.clock_gettime(.MONOTONIC, &ts);
+            if (rc != 0) break :blk 0;
+            break :blk @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+        },
+        .macos, .ios, .tvos, .watchos, .visionos => blk: {
+            var ts: std.c.timespec = undefined;
+            if (std.c.clock_gettime(.MONOTONIC, &ts) != 0) break :blk 0;
+            break :blk @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+        },
+        .windows => blk: {
+            const ntdll = std.os.windows.ntdll;
+            var counter: std.os.windows.LARGE_INTEGER = undefined;
+            var freq: std.os.windows.LARGE_INTEGER = undefined;
+            _ = ntdll.RtlQueryPerformanceCounter(&counter);
+            _ = ntdll.RtlQueryPerformanceFrequency(&freq);
+            const ticks: u128 = @intCast(counter);
+            const hz: u128 = @intCast(freq);
+            break :blk @as(u64, @truncate(ticks * std.time.ns_per_s / hz));
+        },
+        else => 0,
+    };
+}
+
+// Same "add42" fixture used by `jit_thread_safety_test.zig`: one
+// exported function `add42(x: i32) -> i32` computing `x + 42`.
+const add42_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    0x03, 0x02, 0x01, 0x00,
+    0x05, 0x03, 0x01, 0x00, 0x01,
+    0x07, 0x12, 0x02,
+    0x06, 'm', 'e', 'm', 'o', 'r', 'y', 0x02, 0x00,
+    0x05, 'a', 'd', 'd', '4', '2', 0x00, 0x00,
+    0x0a, 0x09, 0x01, 0x07, 0x00,
+    0x20, 0x00,
+    0x41, 0x2a,
+    0x6a,
+    0x0b,
+};
+
+// CoreMark's WASI core module: 73 functions, loops, and branches —
+// unlike `add42_wasm` this actually exercises the passes the `.fast`
+// preset skips (loop-invariant hoisting, GVN, dominator-based
+// redundant-load forwarding), so it's the fixture used for the
+// compile-time comparison below.
+const coremark_wasm = @embedFile("coremark_wasm");
+
+test "#860: .fast preset produces a correctly-executing module" {
+    if (comptime !can_exec_aot) return error.SkipZigTest;
+
+    const gpa = std.testing.allocator;
+    const cwasm = try component_aot_compile.compileCoreWasm(gpa, &add42_wasm, .{
+        .pass_preset = .fast,
+    });
+    defer gpa.free(cwasm);
+
+    var module = try aot_loader_mod.load(cwasm, gpa);
+    defer aot_loader_mod.unload(&module, gpa);
+
+    const inst = try aot_runtime_mod.instantiate(&module, gpa);
+    defer aot_runtime_mod.destroy(inst);
+    try aot_runtime_mod.mapCodeExecutable(inst);
+
+    const func_idx = aot_runtime_mod.findExportFunc(inst, "add42") orelse return error.ExportNotFound;
+    var results_buf: [1]aot_runtime_mod.ScalarResult = undefined;
+    const results = try aot_runtime_mod.callFuncScalar(
+        inst,
+        func_idx,
+        &.{.i32},
+        &.{.i32},
+        &.{.{ .i32 = 100 }},
+        &results_buf,
+    );
+    try std.testing.expectEqual(@as(i32, 142), results[0].i32);
+}
+
+test "#860: .fast preset compiles CoreMark faster than .full and still loads" {
+    if (comptime !can_exec_aot) return error.SkipZigTest;
+
+    const gpa = std.testing.allocator;
+
+    const full_start = nowNs();
+    const full_cwasm = try component_aot_compile.compileCoreWasm(gpa, coremark_wasm, .{
+        .pass_preset = .full,
+    });
+    defer gpa.free(full_cwasm);
+    const full_ns = nowNs() - full_start;
+
+    const fast_start = nowNs();
+    const fast_cwasm = try component_aot_compile.compileCoreWasm(gpa, coremark_wasm, .{
+        .pass_preset = .fast,
+    });
+    defer gpa.free(fast_cwasm);
+    const fast_ns = nowNs() - fast_start;
+
+    std.debug.print(
+        "[#860] CoreMark compileCoreWasm: full={d}us ({d} bytes) fast={d}us ({d} bytes)\n",
+        .{ full_ns / 1000, full_cwasm.len, fast_ns / 1000, fast_cwasm.len },
+    );
+
+    // Both presets must produce a module that still loads (correctness);
+    // the JIT default (`.fast`) must not be slower than `.full` — this
+    // is a loose regression guard, not a strict perf gate, since CI
+    // hardware timing has noise, but `.fast` doing strictly less work
+    // than `.full` should never lose on any host.
+    var full_module = try aot_loader_mod.load(full_cwasm, gpa);
+    defer aot_loader_mod.unload(&full_module, gpa);
+    var fast_module = try aot_loader_mod.load(fast_cwasm, gpa);
+    defer aot_loader_mod.unload(&fast_module, gpa);
+
+    try std.testing.expect(fast_ns <= full_ns);
+}


### PR DESCRIPTION
## Summary

Picks and wires a fast/low-latency compilation preset as the **default** for the in-process JIT path, distinct from `wamrc compile`'s default (which optimizes for steady-state throughput since its output is cached to disk and reused across many runs).

## What changed

- Added `passes.PassPreset` (`.full` / `.fast`) and two new pass-list constants (`jit_fast_passes` / `x86_64_jit_fast_passes`) alongside the existing `defaultPassesForTarget` machinery.
- `.fast` keeps only the cheap, purely-local peephole passes (constant folding, algebraic simplification, strength reduction, local forwarding, dead-code cleanup) and drops everything that requires building a dominator tree or loop analysis: global value numbering, loop-invariant hoisting, dominator-based redundant-load forwarding, tail duplication, CFG-restructuring branch threading, induction-variable simplification / loop unrolling, dead-store elimination, and loop-bounds-check hoisting/elision.
- `PrecompileOptions.pass_preset` defaults to `.full`, so `wamrc compile`'s behavior is **fully unaffected** by default (verified: byte-for-byte identical `.cwasm` output before/after, see below).
- The two in-process JIT call sites in `src/main.zig` (`wamr run` / `wamr serve` under `-Djit=true`) now default to `.fast` via a new `jitPassPresetFromEnv` helper, overridable with `WAMR_JIT_FULL_OPT=1` for users who want the JIT path to also produce fully-optimized code at the cost of compile latency.

## Measured compile-time reduction

Directly calling `compileCoreWasm` (ReleaseFast, no CLI/process overhead) on CoreMark's 73-function WASI core module:

| preset | compile time | `.cwasm` size |
|---|---|---|
| `.full` (today's default) | 1,189,880 µs (~1.19s) | 170,231 bytes |
| `.fast` (new JIT default) | 940,379 µs (~0.94s) | 183,435 bytes |

**~21% compile-time reduction**, ~7.8% larger generated code (expected — `.fast` skips the same passes that shrink code size along with the ones that improve steady-state throughput).

A `WAMR_AOT_PASS_TIMING=1 wamrc compile` breakdown (aggregated per-pass elapsed time across all 73 functions, Debug build) confirmed `globalValueNumbering`, `forwardRedundantLoadsDominator`, and `hoistLoopInvariantCode` alone account for the majority of optimizer time — exactly the dominator-tree / loop-analysis passes `.fast` drops:

```
pass_name                             total_ms    count     avg_ms
promoteLocalsToSSA                      450.19       73     6.1669   (frontend, not a pass)
deadCodeAndLocalSetCleanup              376.24      156     2.4118   (kept in .fast)
globalValueNumbering                    251.28      156     1.6108   (dropped)
forwardRedundantLoadsDominator          216.76      156     1.3895   (dropped)
hoistLoopInvariantCode                  147.41      156     0.9449   (dropped)
```

`wamrc compile tests/benchmarks/coremark/coremark_wasi.wasm` produces a **byte-for-byte identical** `.cwasm` before/after this change — its default pipeline (`.full`) is untouched.

## Tests

Added `src/tests/jit_fast_preset_test.zig`:
- Correctness: `.fast` preset still produces a correctly-executing module (`add42` fixture).
- `.fast` compiles CoreMark faster than `.full` and the result still loads successfully (loose regression guard, not a strict perf gate — CI timing has noise, but `.fast` doing strictly less work than `.full` should never lose on any host).

## Validation

- `zig build test --summary all`: all pass (pre-existing #872 ReleaseFast/ReleaseSafe differential SIMD NaN failures are unrelated, already tracked separately).
- `zig build test -Djit=true --summary all`: all pass.

Closes #860. Part of the #863 JIT tracking plan (Milestone 3 tuning).
