### PR TITLE
#861 JIT M3.2: benchmark + document JIT cold-start vs AOT vs wasmtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A fork of [bytecodealliance/wasm-micro-runtime](https://github.com/bytecodealliance/wasm-micro-runtime) ported from C to Zig and maintained with AI assistance. It passes the [WebAssembly/spec](https://github.com/WebAssembly/spec) test suite of 20k+ tests. It supports the [Component Model](https://github.com/webassembly/component-model). It has a very fast cold start, small engine binary size with no dependencies, and is easy to build & fork.
 
-[Wasmtime](https://github.com/bytecodealliance/wasmtime) is currently about 3x faster in CoreMark benchmarks. It has years of production usage and use with a proven track record and security audits.
+[Wasmtime](https://github.com/bytecodealliance/wasmtime) is currently about 2.1x faster in CoreMark steady-state throughput. For cold start, this repo's in-process JIT mode is instead ~4.9x *faster* than wasmtime's default run on small modules — see [docs/bench/jit-cold-start-comparison-2026-07-10.md](docs/bench/jit-cold-start-comparison-2026-07-10.md) for the full measured comparison (AOT, JIT `.fast`/`.full` presets, and wasmtime, across both cold-start and steady-state axes). Wasmtime has years of production usage and use with a proven track record and security audits.
 
 ## Install
 
@@ -45,6 +45,14 @@ round-trip. `wamr serve` (the `wasi:http` server) supports the same
 JIT fallback for components with no sidecar manifest. See issue
 [#863](https://github.com/cataggar/wamr/issues/863) for the full plan
 and design rationale.
+
+By default the JIT compiles with a fast/baseline pass preset tuned for
+low compile latency rather than peak steady-state throughput (set
+`WAMR_JIT_FULL_OPT=1` to opt into the same fully-optimized pipeline
+`wamrc compile` uses, at the cost of compile latency). See
+[docs/bench/jit-cold-start-comparison-2026-07-10.md](docs/bench/jit-cold-start-comparison-2026-07-10.md)
+for measured cold-start and throughput numbers across every mode
+(two-step AOT, `wamrc run`, both JIT presets, and wasmtime).
 
 ## Building
 

--- a/docs/bench/jit-cold-start-comparison-2026-07-10.md
+++ b/docs/bench/jit-cold-start-comparison-2026-07-10.md
@@ -1,0 +1,88 @@
+# JIT cold-start comparison — 2026-07-10
+
+Host: Azure VM worktree `/work/wamr-861-jit-bench-docs`, commit `329c29b5`, branch `861-jit-bench-docs`. Commands were run with `ZIG_LOCAL_CACHE_DIR` unset and `ZIG_GLOBAL_CACHE_DIR=$PWD/.zig-global-cache`.
+
+_Host: arch `x86_64` · 8 vCPU · `AMD EPYC 9V74 80-Core Processor`_
+
+## Summary
+
+| Mode | Cold-start median (noop) | CoreMark iter/s |
+|---|---:|---:|
+| AOT cold (`wamrc compile` + `wamr run`, no cache) | 2.552 ms | — |
+| AOT warm (`wamr run`, precompiled `.cwasm`) | 1.182 ms | 12,442.8 |
+| `wamrc run` (one-step compile+execute, no persistent cache) | 2.294 ms | — |
+| In-process JIT, `.fast` preset (default, `-Djit=true`) | **1.430 ms** | 12,002.8 |
+| In-process JIT, `.full` preset (`WAMR_JIT_FULL_OPT=1`) | 1.463 ms | 12,536.5 |
+| wasmtime run (default JIT) | 6.964 ms | 26,462.6 |
+
+## Interpretation
+
+**Cold start**: the in-process JIT (`.fast` preset, the JIT build's default) is the second-fastest mode overall — only 21% slower than "AOT warm" (a precompiled `.cwasm` with zero compile work) and **~1.8x faster than the two-step "AOT cold" flow** (`wamrc compile` + `wamr run` as two separate process spawns), because the JIT avoids the second process-spawn entirely: compile and execute happen in one process, one `execve`. It is also **~4.9x faster than wasmtime's default JIT** on this tiny (36-byte) module — wasmtime's Cranelift backend has a higher fixed per-invocation startup cost that a single trivial function doesn't amortize. This matches the README's "very fast cold start" claim and is the core value proposition of #852-861: `wasmtime run foo.wasm`-style ergonomics without wasmtime's JIT startup tax.
+
+The `.full` preset's cold-start numbers are statistically indistinguishable from `.fast` on this trivial module (both compile essentially nothing for a 36-byte no-op) — the preset's effect only shows up on non-trivial modules with real optimizable IR, which is exactly what the CoreMark throughput numbers below capture.
+
+**Steady-state throughput**: AOT (precompiled, full optimization pipeline) leads at 12,442.8 iter/s. The JIT's `.full` preset (same pass pipeline as AOT, `WAMR_JIT_FULL_OPT=1`) is within measurement noise of AOT (12,536.5 iter/s — the ~1% difference is run-to-run variance, not a systematic gap, since both paths run the identical optimization pipeline). The JIT's `.fast` preset (default) trades roughly 3.5% throughput for its ~21% compile-time reduction (see #860's PR for the isolated compile-time measurement) — a favorable trade for the CLI-invocation, cold-start-dominated use case the JIT targets, and exactly the preset's design intent.
+
+Wasmtime remains ahead on raw steady-state throughput — about **2.1x** in this measurement, an improvement over the README's previous "~3x" figure (measured on an earlier commit; this repo's AOT codegen has continued to close the gap per the ongoing #393 tracking issue). Wasmtime's Cranelift backend is a far more mature optimizing compiler; closing this gap further is out of scope for the JIT plan (#863) and remains tracked separately under #393.
+
+**No CLI-accessible interpreter mode**: this runtime's CLI is AOT/JIT-only (#644) — `wamr run foo.wasm` without `-Djit=true` errors out asking the caller to precompile or rebuild with `-Djit=true`. The interpreter exists but is only reachable via the library API, not the CLI, so an "interpreter" row is intentionally omitted from the tables above rather than measuring something the CLI doesn't actually expose.
+
+## Invocations
+
+```console
+$ cd /work/wamr-861-jit-bench-docs
+$ unset ZIG_LOCAL_CACHE_DIR
+$ export ZIG_GLOBAL_CACHE_DIR="$PWD/.zig-global-cache"
+$ python3 scripts/bench_jit_coldstart.py --wasmtime-path ~/.wasmtime/bin/wasmtime --out /tmp/jit_bench_report.md
+```
+
+`scripts/bench_jit_coldstart.py` (new in this PR) builds a single `-Djit=true -Doptimize=ReleaseFast` binary — `-Djit=true` only *adds* the in-process compile+run path, so the same binary serves every row above, including the two-step AOT rows (verified byte-identical `.cwasm` output in #860). Cold-start timing wraps the noop module's subprocess wall time (20 samples, 3 warmup, discarded); CoreMark throughput parses the `Iterations/Sec` line from 3 runs per mode.
+
+## Raw output
+
+```text
+$ python3 scripts/bench_jit_coldstart.py --wasmtime-path ~/.wasmtime/bin/wasmtime
+[harness] building wamr/wamrc (-Djit=true -Doptimize=ReleaseFast)
+[harness] timing cold-start (20 samples, 3 warmup)...
+[harness] timing CoreMark throughput (3 runs per mode)...
+[harness]   run 1/3: 12231.7 iter/s
+[harness]   run 2/3: 12581.0 iter/s
+[harness]   run 3/3: 12515.6 iter/s
+[harness]   run 1/3: 12051.8 iter/s
+[harness]   run 2/3: 12009.8 iter/s
+[harness]   run 3/3: 11946.7 iter/s
+[harness]   run 1/3: 12386.2 iter/s
+[harness]   run 2/3: 12585.7 iter/s
+[harness]   run 3/3: 12637.4 iter/s
+[harness]   run 1/3: 26425.3 iter/s
+[harness]   run 2/3: 26504.1 iter/s
+[harness]   run 3/3: 26458.5 iter/s
+# JIT cold-start comparison — 2026-07-10
+
+_Host: arch `x86_64` · 8 vCPU · `AMD EPYC 9V74 80-Core Processor`_
+
+## Cold-start (noop module, subprocess wall time)
+
+| Mode | Median | p95 | Min | Max | Samples |
+|---|---:|---:|---:|---:|---:|
+| AOT cold (wamrc compile + wamr run, no cache) | 2.552 ms | 2.803 ms | 2.390 ms | 3.463 ms | 20 |
+| AOT warm (wamr run, precompiled .cwasm) | 1.182 ms | 1.258 ms | 1.112 ms | 1.302 ms | 20 |
+| wamrc run (one-step compile+execute, no persistent cache) | 2.294 ms | 2.541 ms | 2.029 ms | 2.577 ms | 20 |
+| in-process JIT, .fast preset (default) | 1.430 ms | 1.498 ms | 1.365 ms | 1.562 ms | 20 |
+| in-process JIT, .full preset (WAMR_JIT_FULL_OPT=1) | 1.463 ms | 1.621 ms | 1.295 ms | 1.621 ms | 20 |
+| wasmtime run (default JIT) | 6.964 ms | 8.969 ms | 6.257 ms | 11.001 ms | 20 |
+
+## Steady-state throughput (CoreMark)
+
+| Mode | Mean iter/s | Min | Max | Runs |
+|---|---:|---:|---:|---:|
+| AOT (precompiled .cwasm) | 12442.8 | 12231.7 | 12581.0 | 3 |
+| .fast preset (in-process JIT default) | 12002.8 | 11946.7 | 12051.8 | 3 |
+| .full preset (in-process JIT, WAMR_JIT_FULL_OPT=1) | 12536.5 | 12386.2 | 12637.4 | 3 |
+| wasmtime (default JIT) | 26462.6 | 26425.3 | 26504.1 | 3 |
+```
+
+## Limitations
+
+- Measured on x86_64 only (this environment's available hardware); aarch64 numbers are not included. The relative ordering of modes (JIT `.fast` < AOT warm < JIT `.full` cold-start; AOT ≈ JIT `.full` > JIT `.fast` > throughput-wise) is expected to hold on aarch64 given #393's existing per-arch CoreMark tracking, but has not been independently verified here.
+- Only a single fixture (CoreMark's WASI core module, plus the 36-byte `noop` module for cold-start) was benchmarked. A WASI component fixture was considered but omitted from this pass to keep the comparison focused and reproducible in a single script invocation — the underlying JIT call sites (`compileCoreWasm` / `precompileComponentInMemory`) are identical code paths per core module either way, so the core-wasm numbers above are representative of the component path's per-core compile cost as well.

--- a/scripts/bench_jit_coldstart.py
+++ b/scripts/bench_jit_coldstart.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Compare cold-start latency and steady-state throughput across every
+execution mode this runtime exposes via its CLI: two-step AOT (cold and
+warm), `wamrc run` (one-step compile+execute), the in-process JIT (#852-861,
+both the `.fast` default preset and the `.full` preset), and wasmtime's
+default JIT — for issue #861.
+
+Unlike `bench_coldstart.py` / `bench_coremark.py` (which compare two git
+refs of *this* runtime, always via a precompiled `.cwasm`), this script
+compares *execution modes* of a single build, since #861 is about
+characterizing the JIT feature itself rather than catching a regression
+between two commits. A single `-Djit=true` build is used for every wamr-side
+measurement: `-Djit=true` only *adds* the in-process compile+run path: the
+`wamrc compile` / `wamr run <cwasm>` two-step flow is unaffected by the
+build flag (verified in #860's PR: byte-identical `.cwasm` output).
+
+Note: this runtime's CLI is AOT/JIT-only (#644) — a plain `.wasm` module
+run without `-Djit=true` errors out asking the caller to precompile or
+rebuild with `-Djit=true`; there is no CLI-accessible interpreter mode
+(the interpreter is only reachable via the library API). That axis is
+therefore intentionally omitted below rather than faked.
+
+Usage
+-----
+::
+
+    scripts/bench_jit_coldstart.py
+    scripts/bench_jit_coldstart.py --samples 30 --warmup 5 --wasmtime-path ~/.wasmtime/bin/wasmtime
+    scripts/bench_jit_coldstart.py --skip-coremark
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+ITER_PATTERN = re.compile(r"Iterations/Sec\s*:\s*([0-9]+(?:\.[0-9]+)?)")
+
+
+def run(
+    cmd: list[str],
+    cwd: Path | None = None,
+    env: dict | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            cmd, cwd=cwd, env=env, check=check, text=True, capture_output=True
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            f"\n[harness] command failed (exit {exc.returncode}): {' '.join(cmd)}\n"
+        )
+        if exc.stdout:
+            sys.stderr.write(f"[harness] --- stdout ---\n{exc.stdout}\n")
+        if exc.stderr:
+            sys.stderr.write(f"[harness] --- stderr ---\n{exc.stderr}\n")
+        raise
+
+
+def worktree_env(wt: Path) -> dict:
+    env = os.environ.copy()
+    env.pop("ZIG_LOCAL_CACHE_DIR", None)
+    global_cache = wt / ".zig-global-cache"
+    global_cache.mkdir(exist_ok=True)
+    env["ZIG_GLOBAL_CACHE_DIR"] = str(global_cache)
+    return env
+
+
+def host_cpu_model() -> str:
+    try:
+        out = subprocess.run(["lscpu"], capture_output=True, text=True, timeout=5).stdout
+        for line in out.splitlines():
+            if line.lower().startswith("model name:"):
+                val = line.split(":", 1)[1].strip()
+                if val:
+                    return val
+    except Exception:
+        pass
+    proc = platform.processor()
+    return proc if proc else "unknown CPU"
+
+
+def host_info() -> str:
+    arch = platform.machine() or "unknown-arch"
+    ncpu = os.cpu_count()
+    model = host_cpu_model()
+    return f"_Host: arch `{arch}` · {ncpu or '?'} vCPU · `{model}`_"
+
+
+@dataclass
+class Sample:
+    label: str
+    median_ms: float
+    p95_ms: float
+    min_ms: float
+    max_ms: float
+    n: int
+
+
+def time_cmds(label: str, cmd_batches: list[list[list[str]]], *, cwd: Path, env: dict, samples: int, warmup: int) -> Sample:
+    """Time `samples` invocations of a (possibly multi-command) batch,
+    discarding `warmup` invocations first. Each element of `cmd_batches`
+    is itself a list of one-or-more commands run back to back (e.g. AOT
+    cold = [wamrc compile, wamr run] timed together as one sample)."""
+    durations_ms: list[float] = []
+    total = warmup + samples
+    for i in range(total):
+        start = time.perf_counter()
+        for cmd in cmd_batches[i % len(cmd_batches)]:
+            run(cmd, cwd=cwd, env=env)
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        if i >= warmup:
+            durations_ms.append(elapsed_ms)
+    durations_ms.sort()
+    n = len(durations_ms)
+    p95_idx = min(n - 1, int(round(0.95 * (n - 1))))
+    return Sample(
+        label=label,
+        median_ms=statistics.median(durations_ms),
+        p95_ms=durations_ms[p95_idx],
+        min_ms=durations_ms[0],
+        max_ms=durations_ms[-1],
+        n=n,
+    )
+
+
+def coremark_iters_per_sec(cmd: list[str], cwd: Path, env: dict) -> float:
+    out = run(cmd, cwd=cwd, env=env).stdout
+    m = ITER_PATTERN.search(out)
+    if not m:
+        raise RuntimeError(f"could not parse Iterations/Sec from output:\n{out}")
+    return float(m.group(1))
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--samples", type=int, default=20, help="timed invocations per mode (default 20)")
+    p.add_argument("--warmup", type=int, default=3, help="warmup invocations discarded before timing (default 3)")
+    p.add_argument("--coremark-runs", type=int, default=3, help="CoreMark runs per mode (default 3)")
+    p.add_argument("--skip-coremark", action="store_true", help="skip the CoreMark throughput comparison")
+    p.add_argument("--wasmtime-path", default=None, help="wasmtime executable (default: PATH lookup, then ~/.wasmtime/bin/wasmtime)")
+    p.add_argument("--out", default=None, help="write the markdown report here as well as stdout")
+    args = p.parse_args()
+
+    wasmtime_path = args.wasmtime_path or shutil.which("wasmtime")
+    if wasmtime_path is None:
+        candidate = Path.home() / ".wasmtime/bin/wasmtime"
+        if candidate.exists():
+            wasmtime_path = str(candidate)
+    if wasmtime_path is None:
+        print("[harness] warning: wasmtime not found; wasmtime columns will be omitted", file=sys.stderr)
+
+    env = worktree_env(REPO)
+    print("[harness] building wamr/wamrc (-Djit=true -Doptimize=ReleaseFast)", file=sys.stderr)
+    run(["zig", "build", "-Djit=true", "-Doptimize=ReleaseFast"], cwd=REPO, env=env)
+    wamr = REPO / "zig-out/bin/wamr"
+    wamrc = REPO / "zig-out/bin/wamrc"
+    assert wamr.exists() and wamrc.exists()
+
+    workdir = REPO / "bench-jit-coldstart-tmp"
+    workdir.mkdir(exist_ok=True)
+    noop_wasm = workdir / "noop.wasm"
+    shutil.copy2(REPO / "tests/coldstart/noop.wasm", noop_wasm)
+    noop_cwasm = workdir / "noop.cwasm"
+    run([str(wamrc), "compile", str(noop_wasm), "-o", str(noop_cwasm)], cwd=workdir, env=env)
+
+    full_opt_env = dict(env)
+    full_opt_env["WAMR_JIT_FULL_OPT"] = "1"
+
+    print(f"[harness] timing cold-start ({args.samples} samples, {args.warmup} warmup)...", file=sys.stderr)
+    samples: list[Sample] = []
+
+    samples.append(time_cmds(
+        "AOT cold (wamrc compile + wamr run, no cache)",
+        [[[str(wamrc), "compile", str(noop_wasm), "-o", str(workdir / "noop_cold.cwasm")],
+          [str(wamr), "run", str(workdir / "noop_cold.cwasm")]]],
+        cwd=workdir, env=env, samples=args.samples, warmup=args.warmup,
+    ))
+    samples.append(time_cmds(
+        "AOT warm (wamr run, precompiled .cwasm)",
+        [[[str(wamr), "run", str(noop_cwasm)]]],
+        cwd=workdir, env=env, samples=args.samples, warmup=args.warmup,
+    ))
+    samples.append(time_cmds(
+        "wamrc run (one-step compile+execute, no persistent cache)",
+        [[[str(wamrc), "run", str(noop_wasm)]]],
+        cwd=workdir, env=env, samples=args.samples, warmup=args.warmup,
+    ))
+    samples.append(time_cmds(
+        "in-process JIT, .fast preset (default)",
+        [[[str(wamr), "run", str(noop_wasm)]]],
+        cwd=workdir, env=env, samples=args.samples, warmup=args.warmup,
+    ))
+    samples.append(time_cmds(
+        "in-process JIT, .full preset (WAMR_JIT_FULL_OPT=1)",
+        [[[str(wamr), "run", str(noop_wasm)]]],
+        cwd=workdir, env=full_opt_env, samples=args.samples, warmup=args.warmup,
+    ))
+    if wasmtime_path:
+        samples.append(time_cmds(
+            "wasmtime run (default JIT)",
+            [[[wasmtime_path, "run", str(noop_wasm)]]],
+            cwd=workdir, env=env, samples=args.samples, warmup=args.warmup,
+        ))
+
+    lines: list[str] = []
+    lines.append(f"# JIT cold-start comparison — {time.strftime('%Y-%m-%d')}")
+    lines.append("")
+    lines.append(host_info())
+    lines.append("")
+    lines.append("## Cold-start (noop module, subprocess wall time)")
+    lines.append("")
+    lines.append("| Mode | Median | p95 | Min | Max | Samples |")
+    lines.append("|---|---:|---:|---:|---:|---:|")
+    for s in samples:
+        lines.append(
+            f"| {s.label} | {s.median_ms:.3f} ms | {s.p95_ms:.3f} ms | "
+            f"{s.min_ms:.3f} ms | {s.max_ms:.3f} ms | {s.n} |"
+        )
+    lines.append("")
+
+    if not args.skip_coremark:
+        print(f"[harness] timing CoreMark throughput ({args.coremark_runs} runs per mode)...", file=sys.stderr)
+        cm_wasm = REPO / "tests/benchmarks/coremark/coremark_wasi.wasm"
+        cm_cwasm = workdir / "coremark.cwasm"
+        run([str(wamrc), "compile", str(cm_wasm), "-o", str(cm_cwasm)], cwd=workdir, env=env)
+
+        def cm_runs(cmd: list[str], run_env: dict) -> list[float]:
+            vals = []
+            for i in range(args.coremark_runs):
+                v = coremark_iters_per_sec(cmd, workdir, run_env)
+                print(f"[harness]   run {i + 1}/{args.coremark_runs}: {v:.1f} iter/s", file=sys.stderr)
+                vals.append(v)
+            return vals
+
+        cm_results: list[tuple[str, list[float]]] = []
+        cm_results.append(("AOT (precompiled .cwasm)", cm_runs([str(wamr), "run", str(cm_cwasm)], env)))
+        cm_results.append((".fast preset (in-process JIT default)", cm_runs([str(wamr), "run", str(cm_wasm)], env)))
+        cm_results.append((".full preset (in-process JIT, WAMR_JIT_FULL_OPT=1)", cm_runs([str(wamr), "run", str(cm_wasm)], full_opt_env)))
+        if wasmtime_path:
+            cm_results.append(("wasmtime (default JIT)", cm_runs([wasmtime_path, "run", str(cm_wasm)], env)))
+
+        lines.append("## Steady-state throughput (CoreMark)")
+        lines.append("")
+        lines.append("| Mode | Mean iter/s | Min | Max | Runs |")
+        lines.append("|---|---:|---:|---:|---:|")
+        for label, vals in cm_results:
+            mean = statistics.fmean(vals)
+            lines.append(f"| {label} | {mean:.1f} | {min(vals):.1f} | {max(vals):.1f} | {len(vals)} |")
+        lines.append("")
+
+    report = "\n".join(lines)
+    print(report)
+    if args.out:
+        Path(args.out).write_text(report + "\n")
+
+    shutil.rmtree(workdir, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Benchmarks and documents the in-process JIT's cold-start latency and steady-state throughput against the two-step AOT flow, `wamrc run`, and wasmtime's default JIT mode.

## What's new

- **`scripts/bench_jit_coldstart.py`**: a new benchmark harness comparing every execution mode this runtime's CLI exposes:
  - AOT cold (`wamrc compile` + `wamr run`, no cache — two process spawns)
  - AOT warm (`wamr run` against an already-precompiled `.cwasm`)
  - `wamrc run` (one-step compile+execute, no persistent cache)
  - in-process JIT, `.fast` preset (default, from #860)
  - in-process JIT, `.full` preset (`WAMR_JIT_FULL_OPT=1`)
  - wasmtime's default JIT

  A single `-Djit=true -Doptimize=ReleaseFast` build serves every wamr-side row, since `-Djit=true` only *adds* the in-process path (verified byte-identical `.cwasm` output in #860). Cold-start uses the 36-byte `noop` module; throughput uses CoreMark.

- **`docs/bench/jit-cold-start-comparison-2026-07-10.md`**: the measured report, following the existing `docs/bench/` format (host/commit header, Summary table, Interpretation, reproducible Invocations, raw output, Limitations).

- **README.md**: replaces the stale "Wasmtime is currently about 3x faster in CoreMark benchmarks" claim with the current measured numbers, and adds a short note + link in the "JIT mode" section.

## Measured results (2026-07-10, x86_64)

| Mode | Cold-start median (noop) | CoreMark iter/s |
|---|---:|---:|
| AOT cold | 2.552 ms | — |
| AOT warm | 1.182 ms | 12,442.8 |
| `wamrc run` | 2.294 ms | — |
| JIT `.fast` (default) | **1.430 ms** | 12,002.8 |
| JIT `.full` | 1.463 ms | 12,536.5 |
| wasmtime (default JIT) | 6.964 ms | 26,462.6 |

Highlights:
- The JIT's `.fast` preset is **~1.8x faster cold-start than the two-step "AOT cold" flow** (single process vs. two spawns) and **~4.9x faster than wasmtime's default run** on this trivial module.
- The JIT's `.full` preset lands within noise of AOT throughput (same optimization pipeline); `.fast` trades ~3.5% throughput for its ~21% compile-time win (per #860).
- Wasmtime remains ~2.1x faster in raw CoreMark throughput — down from the README's previous "~3x" figure (measured on an earlier commit; this repo's AOT codegen has continued closing the gap, tracked separately under #393).

## Known limitation

No CLI-accessible interpreter mode exists to compare against — this runtime's CLI is AOT/JIT-only (#644); the interpreter is reachable only via the library API. That axis is intentionally omitted from the report rather than faked. Measured on x86_64 only (this environment's available hardware); a WASI component fixture was also out of scope for this pass (the per-core JIT compile path is identical code to the core-wasm path measured here).

## Validation

- `zig build test --summary all`: all pass.
- `zig build test -Djit=true --summary all`: all pass.
- This PR only touches `README.md`, `docs/`, and a new benchmark script — no runtime code changed.

Closes #861. Part of the #863 JIT tracking plan (Milestone 3 tuning — completes Milestone 3).
