### PR TITLE
fix(build): disambiguate wamr artifacts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -196,10 +196,14 @@ pub fn build(b: *std.Build) void {
     exe_module.addImport("wamr", lib_module);
 
     const exe = b.addExecutable(.{
-        .name = "wamr",
+        .name = "wamr-exe",
         .root_module = exe_module,
     });
-    b.installArtifact(exe);
+    // Keep dependency artifact names unique without changing the installed CLI name.
+    const install_exe = b.addInstallArtifact(exe, .{
+        .dest_sub_path = b.fmt("wamr{s}", .{target.result.exeFileExt()}),
+    });
+    b.getInstallStep().dependOn(&install_exe.step);
 
     // ── wamrc AOT compiler ────────────────────────────────────────────
     const wamrc_module = b.createModule(.{
@@ -525,6 +529,10 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_exe_unit_tests.step);
+
+    const artifact_consumer_test = b.addSystemCommand(&.{ b.graph.zig_exe, "build" });
+    artifact_consumer_test.setCwd(b.path("tests/artifact-consumer"));
+    test_step.dependOn(&artifact_consumer_test.step);
 
     // wamrc unit tests (subcommand parsing, deriveOutputPath).
     const wamrc_test_module = b.createModule(.{

--- a/tests/artifact-consumer/build.zig
+++ b/tests/artifact-consumer/build.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const wamr = b.dependency("wamr", .{
+        .target = b.standardTargetOptions(.{}),
+        .optimize = b.standardOptimizeOption(.{}),
+    });
+
+    if (wamr.artifact("wamr").kind != .lib)
+        @panic("wamr artifact must resolve to the library");
+    if (wamr.artifact("wamr-exe").kind != .exe)
+        @panic("wamr-exe artifact must resolve to the executable");
+}

--- a/tests/artifact-consumer/build.zig.zon
+++ b/tests/artifact-consumer/build.zig.zon
@@ -1,0 +1,15 @@
+.{
+    .name = .wamr_artifact_consumer,
+    .version = "0.0.0",
+    .fingerprint = 0xbc921572d20defa9,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .wamr = .{
+            .path = "../..",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+    },
+}


### PR DESCRIPTION
## Summary

- keep `wamr` uniquely addressable as the library artifact
- expose the executable artifact as `wamr-exe` while installing the CLI as `wamr`
- add a downstream Zig dependency regression fixture

Closes #851