### PR TITLE
docs(wasi): reconcile issue 616 status

### DIFF
--- a/docs/design/wasi-threads.md
+++ b/docs/design/wasi-threads.md
@@ -1,8 +1,9 @@
 # `wasi:threads` design — multi-threaded interpreter state isolation
 
-Status: **DRAFT** (design-only; no implementation in this PR).
+Status: **DRAFT** (prototypes exist; no production-wired guest-thread
+support).
 
-Tracking: [#583 B3](https://github.com/cataggar/wamr/issues/583).
+Tracking: [#616 B1](https://github.com/cataggar/wamr/issues/616).
 
 Author wave: W10-3.
 
@@ -15,6 +16,7 @@ without re-doing the upstream survey or the state inventory.
 ## Table of contents
 
 - [Overview](#overview)
+- [Current implementation status](#current-implementation-status)
 - [Upstream state](#upstream-state)
 - [Inventory of single-threaded assumptions](#inventory-of-single-threaded-assumptions)
 - [Design options](#design-options)
@@ -59,6 +61,20 @@ multithreaded interpreter build, and rejects AOT/JIT configurations. The
 public `config.wasi_threads` report keeps target, backend, configured
 capabilities, and implementation readiness separate; thread-spawn imports
 are rejected before allocation while readiness remains false.
+
+## Current implementation status
+
+The tree contains scaffolding in `ThreadManager`, `cloneForThread`,
+the atomic-opcode dispatcher, and the `wasi.thread-spawn` host import.
+These are prototypes, not production support. No default CLI or
+component path currently offers gated guest-thread execution.
+
+The production work remains the ordered plan below: make shared
+runtime and host resources safe; implement correct atomic
+wait/notify/fence behavior; spawn in both interpreter and AOT modes;
+isolate cancellation and per-thread component/WASI context; and pass
+the end-to-end correctness, conformance, and performance gates. This
+document does not treat any unmerged implementation wave as present.
 
 ## Upstream state
 
@@ -422,7 +438,7 @@ Each wave is a discrete PR with its own conformance gate.
 * No fixture regressions on `wasi-testsuite` / `wasi-p2-testsuite` /
   `wasi-p3-testsuite`.
 
-### Wave 2 — `std.Thread`-spawning wrapper for the interpreter loop
+### Wave 2 — `std.Thread` spawning for interpreter and AOT execution
 
 **Scope.**
 
@@ -430,6 +446,8 @@ Each wave is a discrete PR with its own conformance gate.
   gated by `config.lib_wasi_threads` (off by default). Re-enable it
   under a new build flag (`-Dlib_wasi_threads=true` already exists in
   [`build.zig:67`](../../build.zig)).
+* Wire both interpreter and AOT entry paths. A prototype that spawns
+  only an interpreter loop is not production-complete.
 * Pin down `cloneForThread` semantics: confirm the cloned globals,
   shared memories, shared tables, shared host_functions match
   `wasi-threads` spec section "instance-per-thread".
@@ -442,7 +460,8 @@ Each wave is a discrete PR with its own conformance gate.
 * `zig build test -Dlib_wasi_threads=true` green.
 * New fixture: `tests/wasi-threads-fixtures/spawn-and-join.wasm` that
   imports `wasi.thread-spawn`, exports `wasi_thread_start`, increments
-  a shared atomic counter from 8 threads, and asserts the final value.
+  a shared atomic counter from 8 threads, and asserts the final value
+  under both interpreter and AOT execution.
 * CRC mismatch indicates either the `cloneForThread` race or the
   non-atomic RMW gap — drive the diagnosis with the
   [`aot-diff-debug`](../../) skill plus the new
@@ -486,10 +505,11 @@ Each wave is a discrete PR with its own conformance gate.
   test suite when the suite contains threaded fixtures.
 * Wire `ThreadManager` lifetime to `ComponentInstance` /
   `WasiCliAdapter` so a `wasi.thread-spawn` from inside a component
-  is observable. Today's wiring works for **core-module-only** runs
-  (`runWasm` in `src/main.zig`) but not for `runLoadedComponent` —
-  fix that by retaining a per-`WasiCliAdapter` `ThreadManager` and
-  threading it into every `ExecEnv` the adapter creates.
+  is observable. The prototype wiring reaches **core-module-only**
+  runs (`runWasm` in `src/main.zig`) but not `runLoadedComponent` and
+  is not a production path. Fix that by retaining a per-`WasiCliAdapter`
+  `ThreadManager` and threading it into every `ExecEnv` the adapter
+  creates.
 * Document the
   Wasmtime-compat caveat: per spec, "a trap or WASI exit in one
   thread must end execution for all threads." We already have
@@ -595,7 +615,8 @@ A future "Wave 1 lands" PR may declare this design accepted iff:
    that, a stable wamr microbenchmark like `tests/perf/dispatch_loop`)
    regression ≤ 2 % under `-Doptimize=ReleaseFast`,
    `-Dlib_wasi_threads=false`. Documented in the wave's PR body.
-3. A working `wasi.thread-spawn` smoke test under `wamr` CLI:
+3. A working `wasi.thread-spawn` smoke test under `wamr` CLI in both
+   interpreter and AOT modes:
    ```console
    $ zig build -Dlib_wasi_threads=true
    $ ./zig-out/bin/wamr run tests/wasi-threads-fixtures/spawn-and-join.wasm
@@ -604,7 +625,7 @@ A future "Wave 1 lands" PR may declare this design accepted iff:
    ```
 4. `zig build wasi-testsuite` + `zig build wasi-p2-testsuite` +
    `zig build wasi-p3-testsuite` stay green with the default build
-   (`lib_wasi_threads = false`). No regression on the 72 + 5 + 40
+   (`lib_wasi_threads = false`). No regression on the 72 + 5 + 41
    fixture baseline.
 
 ## Out of scope
@@ -635,7 +656,8 @@ A future "Wave 1 lands" PR may declare this design accepted iff:
 * [`docs/wasi.md`](../wasi.md) — WASI feature matrix; this design
   doc is linked from the Roadmap section.
 * [`src/wasi/thread_manager.zig`](../../src/wasi/thread_manager.zig)
-  — the existing `wasi:threads@0.1.0` prototype (off by default).
+  — the existing `wasi:threads@0.1.0` prototype (off by default and
+  not production-wired).
 * [`src/wasi/host_functions.zig`](../../src/wasi/host_functions.zig)
   (`wasiThreadSpawn`, line ~46; registration line ~3209) — the
   `wasi.thread-spawn` host import.

--- a/docs/wasi-impl-audit.md
+++ b/docs/wasi-impl-audit.md
@@ -2,8 +2,8 @@
 
 | Field         | Value                                                  |
 | ------------- | ------------------------------------------------------ |
-| Origin commit | [`b8e6e566`](https://github.com/cataggar/wamr/commit/b8e6e566526c26deeebd12b9cfe103ae6142b0ed) |
-| Audit date    | 2026-07-15                                             |
+| Origin commit | [`05ea2181`](https://github.com/cataggar/wamr/commit/05ea21812c8df4d9bbdf713d6a70f8e4eacb3aec) |
+| Audit date    | 2026-07-16                                             |
 | Adapter file  | [`src/component/wasi_cli_adapter.zig`](../src/component/wasi_cli_adapter.zig) |
 | WIT/test pin  | [`wasi-testsuite@7d0a7811`](https://github.com/WebAssembly/wasi-testsuite/commit/7d0a78116fa9955dd2d113beb8583bc9648b6116) |
 | Tracker       | [#616 C1](https://github.com/cataggar/wamr/issues/616) (quarterly WIT-vs-implementation audit) |
@@ -186,10 +186,15 @@ the three unstable P3 timezone methods. Guest exports
 P2 `cli/run.run`, P2 `http/incoming-handler.handle`, and P3
 `cli/run.run` are also outside the host-import denominator.
 
-The final testsuite pin passes **41/41** under P3 AOT, **41/41** under
-P3 JIT, and **41/41** under Wasmtime parity. Those fixture results
-exercise only methods imported by those 41 binaries; they do **not**
-establish 351/352 method implementation coverage.
+After [PR #908](https://github.com/cataggar/wamr/pull/908), the final
+testsuite pin passes **41/41** under P3 AOT, **41/41** under P3 JIT,
+and **41/41** under Wasmtime parity. Those fixture results exercise
+only methods imported by those 41 binaries; they do **not** establish
+351/352 method implementation coverage. The stable host-import audit
+was completed by [PR #909](https://github.com/cataggar/wamr/pull/909):
+351/352 (99.7 %) are implemented, with only
+`wasi:filesystem/types.filesystem-error-code` returning canned
+`option::none`.
 
 **Changes found by this refresh:**
 
@@ -268,7 +273,9 @@ Coverage: `wasi:cli/stdout` 1/1 (100 %); `wasi:io/streams` 17/17
 ordinary splice restricts the fast path to pipe pairs and uses
 `SPLICE_F_NONBLOCK`, while blocking-splice waits and retries `EAGAIN`.
 Unsupported endpoint pairs and non-Linux targets still read and write
-through the bounded host scratch buffer.
+through the bounded host scratch buffer. The Linux fast path completed
+[#616 A2](https://github.com/cataggar/wamr/issues/616) in
+[PR #909](https://github.com/cataggar/wamr/pull/909).
 
 ### `wasi:cli/stderr`
 
@@ -664,7 +671,7 @@ Pinned WIT: [`types.wit`](https://github.com/WebAssembly/wasi-http/blob/d97efe47
 | `[method]future-trailers.get` | ✅ | :22067 | — |
 | `[resource-drop]future-trailers` | ✅ | :22068 | — |
 | `[constructor]request-options` | ✅ | :22070 | — |
-| `[method]request-options.connect-timeout` | ✅ | :22073 | 0.2-style unprefixed getter name (`get-` prefix only in 0.3). Stored in nanoseconds, copied into worker-owned state, and applied to initial DNS/TCP acquisition. Zig's lazy TLS handshake and automatic redirect reconnects are not covered by this deadline. |
+| `[method]request-options.connect-timeout` | ✅ | :22073 | 0.2-style unprefixed getter name (`get-` prefix only in 0.3). Stored in nanoseconds, copied into worker-owned state, and applied to initial DNS/TCP acquisition by PR #909. This is only the initial portion of #616 A1; Zig's lazy TLS handshake and automatic redirect reconnects are not covered by this deadline. |
 | `[method]request-options.set-connect-timeout` | ✅ | :22074 | Stores `option<duration>` (nanoseconds). Returns `result` ok unconditionally. |
 | `[method]request-options.first-byte-timeout` | ✅ | :22075 | Stored for round-tripping only; enforcing it requires a deadline-aware HTTP/TLS reader and remains #616 A1b/A7 work. |
 | `[method]request-options.set-first-byte-timeout` | ✅ | :22076 | Same as above; field `first_byte_timeout_ns`. |
@@ -993,7 +1000,7 @@ Unified `request` / `response` resource ([PR #487](https://github.com/cataggar/w
 | `[static]request.consume-body` | ✅ | :21945 |
 | `[resource-drop]request` | ✅ | :21946 |
 | `[constructor]request-options` | ✅ | :21948 |
-| `[method]request-options.get-connect-timeout` | ✅ | :21949 | Stored in nanoseconds, snapshotted when the request is constructed, and applied to initial DNS/TCP acquisition. The child options resource may be dropped before send. Zig's lazy TLS handshake and automatic redirect reconnects are not deadline-covered. |
+| `[method]request-options.get-connect-timeout` | ✅ | :21949 | Stored in nanoseconds, snapshotted when the request is constructed, and applied to initial DNS/TCP acquisition by PR #909. This is only the initial portion of #616 A1; the child options resource may be dropped before send. Zig's lazy TLS handshake and automatic redirect reconnects are not deadline-covered. |
 | `[method]request-options.set-connect-timeout` | ✅ | :21950 |
 | `[method]request-options.get-first-byte-timeout` | ✅ | :21951 | Round-trip only; deadline-aware HTTP/TLS reader support remains #616 A1b/A7 work. |
 | `[method]request-options.set-first-byte-timeout` | ✅ | :21952 |
@@ -1123,6 +1130,7 @@ Re-run this audit against any future `main` SHA by:
 5. Recomputing the table totals rather than carrying forward the prior
    summary.
 
-Previous refresh: `bf7ab7ef` (2026-07-13). Quarterly cadence:
-next review in mid-October 2026, tracked by
-[#616 C1](https://github.com/cataggar/wamr/issues/616).
+Previous refresh: `bf7ab7ef` (2026-07-13). This refresh completed
+[#616 C1](https://github.com/cataggar/wamr/issues/616) in
+[PR #909](https://github.com/cataggar/wamr/pull/909). Quarterly
+cadence: next review in mid-October 2026.

--- a/docs/wasi.md
+++ b/docs/wasi.md
@@ -18,11 +18,10 @@ seam where each interface name is version-multiplexed onto the matching
   environ-inheritance behavioral mismatch and a flaky upstream fixture
   that compares clock reads without accounting for second rollover,
   not crashes).
-* P3 unfiltered contract: `zig build wasi-p3-testsuite-unfiltered` —
-  all 41 `wasm32-wasip3` fixtures execute in both manifest AOT and
-  no-sidecar JIT mode, and all 41 pass after
-  [#881](https://github.com/cataggar/wamr/issues/881) and
-  [#905](https://github.com/cataggar/wamr/issues/905).
+* P3 conformance and parity: all 41 `wasm32-wasip3` fixtures pass in
+  manifest AOT, no-sidecar JIT, and Wasmtime 46.0.1 after
+  [PR #908](https://github.com/cataggar/wamr/pull/908). The unfiltered
+  WAMR gates execute the full corpus in both runtime modes.
 * Curated component gate: `zig build wasi-p2-testsuite` — 5 / 5 passing
   (`zig-hello`, `zig-exit`, `zig-calculator-cmd`, `mixed-zig-rust-calc`,
   `zig-http`).
@@ -45,7 +44,7 @@ seam where each interface name is version-multiplexed onto the matching
 | `wasi:cli`         | ✅ | ✅ | Real stdio capture, env / args / exit / terminal stubs. |
 | `wasi:clocks`      | ✅ | ✅ | Monotonic + wall / system clock; `wait-for` / `wait-until` host-driven. |
 | `wasi:filesystem`  | ✅ | ✅ | Full descriptor + preopens surface; sandboxed by `--preopen`. |
-| `wasi:http`        | ✅ | ✅ | Real outbound HTTP/HTTPS via `std.http.Client`; incoming-handler HTTP/1.1 (keep-alive / chunked / trailers / limits). HTTPS termination live (`--tls-cert` / `--tls-key` / `--tls-pem`): TLS 1.3 server handshake (RSA + ECDSA certs) via the `cataggar/tls.zig` dependency ([#609](https://github.com/cataggar/wamr/issues/609)). |
+| `wasi:http`        | ✅ | ✅ | Real outbound HTTP/HTTPS via `std.http.Client`; incoming-handler HTTP/1.1 (keep-alive / chunked / trailers / limits). HTTPS termination live (`--tls-cert` / `--tls-key` / `--tls-pem`): TLS 1.3 server handshake (RSA + ECDSA certs) via the `cataggar/tls.zig` dependency ([#799](https://github.com/cataggar/wamr/pull/799)). |
 | `wasi:io`          | ✅ | ✅ | `poll` / `error` / `streams`; P3 stream/future plumbing lives in the canonical ABI. |
 | `wasi:random`      | ✅ | ✅ | OS CSPRNG (`std.crypto.random`) + insecure variants + 128-bit seed. |
 | `wasi:sockets`     | ✅ | ✅ | TCP + UDP + DNS; allow-list gated; SO_REUSEADDR; Windows + POSIX parity. |
@@ -53,7 +52,7 @@ seam where each interface name is version-multiplexed onto the matching
 | `wasi:logging`     | ✅ | — | `wasi:logging@0.1.0-draft`: routes guest log calls to host stderr + `std.log.scoped(.wasi_guest)`. Level filter via `--log-level` / `WAMR_LOG_LEVEL`. |
 | `wasi:config`      | ✅ (rc.1) | — | Layered env (`WAMR_CONFIG_*`) + `--config-store=PATH.json` host adapter (#583 B6). |
 | `wasi:blobstore`   | — | — | Not implemented (#583 B7). |
-| `wasi:threads`     | — | — | Not implemented (#583 B3). |
+| `wasi:threads`     | — | — | Runtime and host-import prototypes exist, but guest threads are not production-wired or gated ([#616 B1](https://github.com/cataggar/wamr/issues/616)). |
 
 ✅ = shipped + gated by the conformance suite. — = not in scope today.
 
@@ -121,7 +120,7 @@ correspond 1:1 with the WIT functions / methods / `[constructor]` /
 | `wasi:sockets/types@0.3.0`               | 43 | `wasi-p3-testsuite` (`sockets-*`) | Unified TCP + UDP resource surface (#486 / #544 / #565); callback-driven async `run` resumption (#905). |
 | `wasi:sockets/ip-name-lookup@0.3.0`      |  1 | `wasi-p3-testsuite` | — |
 | `wasi:http/types@0.3.0`                  | 40 | `wasi-p3-testsuite` (`http-*`) | Unified `request` / `response` resource (#487 / #568). |
-| `wasi:http/handler@0.3.0`                |  1 | `wasi-p3-testsuite` (`http-service`) | Incoming-handler trampoline (#549 / #580); HTTP/1.1 keep-alive + chunked + trailers + 431/413 limits (#595); HTTPS termination live — TLS 1.3 server handshake (RSA + ECDSA certs) via the `cataggar/tls.zig` dependency (#609). |
+| `wasi:http/handler@0.3.0`                |  1 | `wasi-p3-testsuite` (`http-service`) | Incoming-handler trampoline (#549 / #580); HTTP/1.1 keep-alive + chunked + trailers + 431/413 limits (#595); HTTPS termination live — TLS 1.3 server handshake (RSA + ECDSA certs) via the `cataggar/tls.zig` dependency (#799). |
 | `wasi:http/client@0.3.0`                 |  1 | `wasi-p3-testsuite` (`http-request`, `http-fields`) | Outbound; async state machine (#583 A2 / #590). |
 
 `wasi-testsuite-expectations.toml` carries the narrow Preview-1 exceptions.
@@ -190,6 +189,14 @@ either added a new interface family or closed a tracker issue.
 | Outbound HTTP client async state machine                        | [#590](https://github.com/cataggar/wamr/pull/590) | #583 A2 |
 | `wasi:logging@0.1.x` host adapter                               | [#598](https://github.com/cataggar/wamr/pull/598) | #583 B5 |
 | `wasi:keyvalue@0.2.0-draft2` memory-store host adapter          | (this PR) | #583 B4 |
+| Incoming-handler HTTPS termination                              | [#799](https://github.com/cataggar/wamr/pull/799) | Closes #609. |
+
+### Hardening cycle 2 (umbrella: [#616](https://github.com/cataggar/wamr/issues/616))
+
+| Milestone | PR | Tracker status |
+| --------- | -- | -------------- |
+| P3 AOT/JIT/Wasmtime parity, 41 / 41 in each mode | [#908](https://github.com/cataggar/wamr/pull/908) | Parity matrix complete. |
+| Initial DNS/TCP connect deadlines; Linux `splice(2)`; calibrated blocking microbenchmark job; stable host-import audit | [#909](https://github.com/cataggar/wamr/pull/909) | Completes A2, A5, and C1. Only the initial DNS/TCP portion of A1 is complete; TLS handshakes, redirect reconnects, and first-/between-byte deadlines remain open. |
 
 ## Known limitations
 
@@ -197,6 +204,13 @@ Tracked under the post-Preview-3 umbrella
 [#583](https://github.com/cataggar/wamr/issues/583). Each bullet is a
 PR-sized child item; cross-references below match the section letters
 in that tracker.
+
+The current follow-up tracker is
+[#616](https://github.com/cataggar/wamr/issues/616). PR #909 completed
+A2, A5, and C1. Its A1 work applies the configured connect deadline
+only to initial DNS/TCP acquisition; lazy TLS handshakes, redirect
+reconnects, first-byte deadlines, and between-byte deadlines remain
+open.
 
 ### Already-shipped 0.3.0 surfaces (section A)
 
@@ -233,8 +247,11 @@ in that tracker.
   before the host call, and the executor never yields to a
   `memory.grow` between the bounds check and the driver return.
   ([#583 B2](https://github.com/cataggar/wamr/issues/583))
-* **`wasi:threads@0.3.x`** (preemptive threads) — not implemented;
-  upstream WIT still draft. ([#583 B3](https://github.com/cataggar/wamr/issues/583))
+* **Guest threads** — interpreter/runtime and `wasi.thread-spawn`
+  prototypes exist, but resource safety, correct atomics and
+  wait/notify/fence behavior, interpreter+AOT spawning,
+  cancellation/context isolation, and production gates remain open.
+  ([#616 B1](https://github.com/cataggar/wamr/issues/616))
 * **`wasi:keyvalue@0.2.x`** — memory-store host adapter shipped, with
   optional file-backed persistence and real compare-and-swap.
   Limitations: in-process `std.StringHashMapUnmanaged` only; no
@@ -275,6 +292,12 @@ in that tracker.
   41-fixture Preview 3 corpus through manifest AOT, no-sidecar JIT, and
   Wasmtime 46.0.1. All three modes pass 41 / 41 with zero parity deltas.
   ([#583 C1](https://github.com/cataggar/wamr/issues/583))
+* **Stable host-import audit.** Refreshed by
+  [PR #909](https://github.com/cataggar/wamr/pull/909): 351 / 352
+  methods are implemented (99.7 %), with no missing stable imports.
+  The only stub is P2
+  `wasi:filesystem/types.filesystem-error-code`, which ignores its
+  borrowed error and returns canned `option::none`.
 
 ## Build & test
 
@@ -400,10 +423,10 @@ The post-Preview-3 hardening tracker is
 additions (one PR per interface, gated behind the existing
 `populateWasiProviders` version-multiplex):
 
-* **`wasi:threads@0.3.x`** — [#583 B3](https://github.com/cataggar/wamr/issues/583).
+* **Guest threads** — [#616 B1](https://github.com/cataggar/wamr/issues/616).
   Design doc: [`docs/design/wasi-threads.md`](design/wasi-threads.md)
-  (multi-threaded interpreter state isolation; upstream-survey +
-  multi-wave implementation plan).
+  (prototype inventory, multi-threaded interpreter state isolation,
+  and production-gating plan).
 * **`wasi:keyvalue@0.2.x`** — [#583 B4](https://github.com/cataggar/wamr/issues/583).
 * ~~**`wasi:logging@0.1.x`**~~ — host adapter shipped (#583 B5); see the
   Preview-2 detail table for the registered methods.


### PR DESCRIPTION
## Summary
- align WASI docs with merged PRs #799, #908, and #909
- record 41/41 P3 parity and the 351/352 stable host-import audit
- clarify that wasi:threads code remains prototype-only and production work is tracked by #616

Updates #616.