### PR TITLE
wasi: define threads feature contract

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const threads_feature = @import("src/threads_feature.zig");
 
 const fuzz_seed_wasms = [_][]const u8{
     "diamond_call_indirect_then_load.wasm",
@@ -95,10 +96,10 @@ pub fn build(b: *std.Build) void {
     const lib_pthread = b.option(bool, "lib_pthread", "Enable pthread library") orelse false;
     options.addOption(bool, "lib_pthread", lib_pthread);
 
-    const lib_wasi_threads = b.option(bool, "lib_wasi_threads", "Enable WASI threads") orelse false;
+    const lib_wasi_threads = b.option(bool, "lib_wasi_threads", "Enable the WASI threads configuration contract (production spawning is not implemented)") orelse false;
     options.addOption(bool, "lib_wasi_threads", lib_wasi_threads);
 
-    const thread_mgr = b.option(bool, "thread_mgr", "Enable thread manager") orelse false;
+    const thread_mgr = (b.option(bool, "thread_mgr", "Enable thread manager") orelse false) or lib_wasi_threads;
     options.addOption(bool, "thread_mgr", thread_mgr);
 
     const debug_interp = b.option(bool, "debug_interp", "Enable interpreter debugging") orelse false;
@@ -107,8 +108,14 @@ pub fn build(b: *std.Build) void {
     const bulk_memory = b.option(bool, "bulk_memory", "Enable bulk memory ops") orelse false;
     options.addOption(bool, "bulk_memory", bulk_memory);
 
-    const shared_memory = b.option(bool, "shared_memory", "Enable shared memory") orelse false;
+    const shared_memory = (b.option(bool, "shared_memory", "Enable shared memory") orelse false) or lib_wasi_threads;
     options.addOption(bool, "shared_memory", shared_memory);
+
+    const wasm_atomics = shared_memory or lib_wasi_threads;
+    options.addOption(bool, "wasm_atomics", wasm_atomics);
+
+    const heap_aux_stack_allocation = (b.option(bool, "heap_aux_stack_allocation", "Allocate auxiliary WASM stacks on the heap") orelse false) or lib_wasi_threads;
+    options.addOption(bool, "heap_aux_stack_allocation", heap_aux_stack_allocation);
 
     const tail_call = b.option(bool, "tail_call", "Enable tail call") orelse false;
     options.addOption(bool, "tail_call", tail_call);
@@ -134,6 +141,28 @@ pub fn build(b: *std.Build) void {
     const component_model = b.option(bool, "component_model", "Enable Component Model") orelse false;
     options.addOption(bool, "component_model", component_model);
 
+    const threads_inputs = threads_feature.Inputs{
+        .enabled = lib_wasi_threads,
+        .pointer_bits = target.result.ptrBitWidth(),
+        .wasm_host = switch (target_arch) {
+            .wasm32, .wasm64 => true,
+            else => false,
+        },
+        .single_threaded = target.result.os.tag == .freestanding,
+        .interp = interp,
+        .aot = aot,
+        .jit = jit,
+        .fast_jit = fast_jit,
+        .libc_wasi = libc_wasi,
+        .heap_aux_stack_allocation = heap_aux_stack_allocation,
+        .shared_memory = shared_memory,
+        .thread_manager = thread_mgr,
+        .wasm_atomics = wasm_atomics,
+    };
+    if (threads_feature.validationError(threads_inputs)) |err| {
+        std.debug.panic("invalid WASI threads configuration: {s}", .{threads_feature.validationMessage(err)});
+    }
+
     const network_tests = b.option(
         bool,
         "network_tests",
@@ -156,6 +185,22 @@ pub fn build(b: *std.Build) void {
 
     const config_module = options.createModule();
 
+    const threads_contract_test_module = b.createModule(.{
+        .root_source_file = b.path("src/config.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    threads_contract_test_module.addImport("config", config_module);
+    const threads_contract_tests = b.addTest(.{
+        .root_module = threads_contract_test_module,
+    });
+    const run_threads_contract_tests = b.addRunArtifact(threads_contract_tests);
+    const threads_contract_test_step = b.step(
+        "test-threads-contract",
+        "Run WASI threads feature-contract tests",
+    );
+    threads_contract_test_step.dependOn(&run_threads_contract_tests.step);
+
     // ── TLS library (cataggar/tls.zig, zig16 branch) ──────────────────
     // Pure-Zig TLS 1.2/1.3 client + server. Used for `wasi:http@0.3`
     // incoming-handler HTTPS termination (#609): upstream Zig std ships
@@ -166,6 +211,23 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     const tls_module = tls_dep.module("tls");
+
+    const threads_runtime_test_module = b.createModule(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    threads_runtime_test_module.addImport("config", config_module);
+    threads_runtime_test_module.addImport("tls", tls_module);
+    const threads_runtime_tests = b.addTest(.{
+        .root_module = threads_runtime_test_module,
+        .filters = &.{
+            "instantiate rejects configured WASI threads",
+            "host functions resolved for wasi thread-spawn import",
+        },
+    });
+    const run_threads_runtime_tests = b.addRunArtifact(threads_runtime_tests);
+    threads_contract_test_step.dependOn(&run_threads_runtime_tests.step);
 
     // ── Root module for the library ────────────────────────────────────
     const lib_module = b.createModule(.{

--- a/docs/design/wasi-threads.md
+++ b/docs/design/wasi-threads.md
@@ -50,7 +50,15 @@ operate on the shared linear memory and synchronise across threads.
    only. The existing `thread_manager.zig` shows the pattern (custom
    spinlock `Mutex` because Zig 0.16 moved `std.Thread.Mutex` behind
    `Io`).
-4. **`zig build test` stays green; no source changes in this PR.**
+4. **`zig build test` stays green.**
+
+`-Dlib_wasi_threads=true` is currently a configuration contract, not a
+production-support switch. It implies shared memory, the thread manager,
+WebAssembly atomics, and heap auxiliary stacks, requires a 64-bit native
+multithreaded interpreter build, and rejects AOT/JIT configurations. The
+public `config.wasi_threads` report keeps target, backend, configured
+capabilities, and implementation readiness separate; thread-spawn imports
+are rejected before allocation while readiness remains false.
 
 ## Upstream state
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -9,6 +9,7 @@
 
 const builtin = @import("builtin");
 const build_options = @import("config");
+pub const threads_feature = @import("threads_feature.zig");
 
 /// Product version string supplied by `zig build -Dversion=...`.
 pub const version: []const u8 = if (@hasDecl(build_options, "version")) build_options.version else "dev";
@@ -152,7 +153,8 @@ pub const lib_pthread = opt("lib_pthread", false);
 /// Enable pthread semaphore support.
 pub const lib_pthread_semaphore = opt("lib_pthread_semaphore", false);
 
-/// Enable WASI threads proposal.
+/// Enable the WASI threads configuration contract. Production spawning,
+/// atomics, synchronization, and AOT support remain separately reported.
 pub const lib_wasi_threads = opt("lib_wasi_threads", false);
 
 /// Allocate auxiliary stacks on the heap (follows lib_wasi_threads).
@@ -176,11 +178,15 @@ pub const bulk_memory = opt("bulk_memory", false);
 /// Optimized bulk-memory operations.
 pub const bulk_memory_opt = opt("bulk_memory_opt", false);
 
-/// Enable WASM shared memory proposal.
-pub const shared_memory = opt("shared_memory", false);
+/// Enable WASM shared memory proposal. Required by WASI threads.
+pub const shared_memory = opt("shared_memory", lib_wasi_threads);
 
-/// Enable the thread manager component.
-pub const thread_mgr = opt("thread_mgr", false);
+/// Enable the thread manager component. Required by WASI threads.
+pub const thread_mgr = opt("thread_mgr", lib_wasi_threads);
+
+/// Enable WebAssembly atomic instructions. This is a configuration
+/// capability, not a claim that the production threads semantics are complete.
+pub const wasm_atomics = opt("wasm_atomics", shared_memory);
 
 /// Enable source-level interpreter debugging.
 pub const debug_interp = opt("debug_interp", false);
@@ -456,6 +462,47 @@ pub const wasm_table_max_size: u32 = optInt(u32, "wasm_table_max_size", 1024);
 /// Maximum single allocation size under fuzz-testing (~2 GB).
 pub const wasm_mem_alloc_max_size: usize = if (fuzz_test) 2 * 1024 * 1024 * 1024 else 0;
 
+fn wasiThreadsInputs() threads_feature.Inputs {
+    return .{
+        .enabled = lib_wasi_threads,
+        .pointer_bits = @bitSizeOf(usize),
+        .wasm_host = switch (builtin.cpu.arch) {
+            .wasm32, .wasm64 => true,
+            else => false,
+        },
+        .single_threaded = builtin.single_threaded,
+        .interp = interp,
+        .aot = aot,
+        .jit = jit,
+        .fast_jit = fast_jit,
+        .libc_wasi = libc_wasi,
+        .heap_aux_stack_allocation = heap_aux_stack_allocation,
+        .shared_memory = shared_memory,
+        .thread_manager = thread_mgr,
+        .wasm_atomics = wasm_atomics,
+    };
+}
+
+/// Deterministic compile-time report for embedders and runtime preflight
+/// gates. `configuration_only` and `architecture_abi_not_implemented` are
+/// intentionally not support claims.
+pub const wasi_threads = threads_feature.report(wasiThreadsInputs());
+
+test "WASI threads build options match the published contract" {
+    const std = @import("std");
+
+    try std.testing.expectEqual(lib_wasi_threads, wasi_threads.enabled);
+    try std.testing.expectEqual(shared_memory, wasi_threads.configured.shared_memory);
+    try std.testing.expectEqual(thread_mgr, wasi_threads.configured.thread_manager);
+    try std.testing.expectEqual(wasm_atomics, wasi_threads.configured.wasm_atomics);
+    if (lib_wasi_threads) {
+        try std.testing.expect(wasi_threads.required.shared_memory);
+        try std.testing.expect(wasi_threads.configured.shared_memory);
+        try std.testing.expect(wasi_threads.configured.thread_manager);
+        try std.testing.expect(wasi_threads.configured.wasm_atomics);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Compile-time validation (mirrors the C #error checks)
 // ---------------------------------------------------------------------------
@@ -465,6 +512,6 @@ comptime {
         @compileError("orc_jit_backend_thread_num must be >= 1");
     if (orc_jit_compile_thread_num < 1)
         @compileError("orc_jit_compile_thread_num must be >= 1");
-    if (heap_aux_stack_allocation == false and lib_wasi_threads == true)
-        @compileError("heap_aux_stack_allocation must be enabled for WASI threads");
+    if (threads_feature.validationError(wasiThreadsInputs())) |err|
+        @compileError(threads_feature.validationMessage(err));
 }

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -1737,6 +1737,9 @@ pub const RuntimeError = error{
     /// still linked so importers of `src/root.zig` build cleanly on
     /// riscv64 / etc., but invoking it at runtime fails fast.
     UnsupportedArchitecture,
+    /// The feature contract is enabled, but production AOT thread spawning
+    /// and its architecture/ABI contract have not been implemented.
+    WasiThreadsAotNotImplemented,
     /// #857: mapping this instance's code would push total resident
     /// JIT/AOT executable code past `JitCodeCache.budget_bytes`. Only
     /// possible when a nonzero budget is configured (default is
@@ -1773,6 +1776,13 @@ pub fn instantiateWithOverrides(
     imported_function_overrides: []const ?*const anyopaque,
     imported_tag_overrides: []const ?*types.TagInstance,
 ) RuntimeError!*AotInstance {
+    if (comptime config.lib_wasi_threads and !config.wasi_threads.implementation.aot_thread_spawning) {
+        for (module.imports) |imp| {
+            if (imp.kind == .function and config.threads_feature.isThreadSpawnImport(imp.module_name, imp.field_name))
+                return error.WasiThreadsAotNotImplemented;
+        }
+    }
+
     std.debug.assert(imported_table_overrides.len == 0 or imported_table_overrides.len == module.importedTables().len);
     std.debug.assert(imported_memory_overrides.len == 0 or imported_memory_overrides.len == module.importedMemories().len);
     std.debug.assert(imported_global_overrides.len == 0 or imported_global_overrides.len == module.importedGlobals().len);
@@ -3633,6 +3643,24 @@ fn freeTags(tags: []*types.TagInstance, owned: []bool, allocator: std.mem.Alloca
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
+
+test "instantiate rejects configured WASI threads before AOT allocation" {
+    if (comptime !config.lib_wasi_threads) return error.SkipZigTest;
+
+    const imports = [_]aot_loader.AotImportDesc{.{
+        .module_name = "wasi",
+        .field_name = "thread-spawn",
+        .kind = .function,
+    }};
+    const module = aot_loader.AotModule{
+        .imports = &imports,
+        .import_function_count = 1,
+    };
+    try std.testing.expectError(
+        error.WasiThreadsAotNotImplemented,
+        instantiate(&module, std.testing.allocator),
+    );
+}
 
 test "instantiate: empty module" {
     const module = aot_loader.AotModule{};

--- a/src/runtime/interpreter/instance.zig
+++ b/src/runtime/interpreter/instance.zig
@@ -9,6 +9,7 @@ const types = @import("../common/types.zig");
 const leb128_mod = @import("../../shared/utils/leb128.zig");
 const ExecEnv = @import("../common/exec_env.zig").ExecEnv;
 const interp = @import("interp.zig");
+const config = @import("../../config.zig");
 
 pub const InstantiationError = error{
     OutOfMemory,
@@ -21,6 +22,7 @@ pub const InstantiationError = error{
     InvalidGlobalIndex,
     UnknownImport,
     StartFunctionFailed,
+    WasiThreadsNotImplemented,
 };
 
 /// Resolved imports passed during instantiation.
@@ -115,6 +117,13 @@ fn instantiateImpl(
     comptime HostImportsT: ?type,
     defer_start: bool,
 ) InstantiationError!*types.ModuleInstance {
+    if (comptime config.lib_wasi_threads and !config.wasi_threads.implementation.interpreter_thread_spawning) {
+        for (module.imports) |imp| {
+            if (imp.kind == .function and config.threads_feature.isThreadSpawnImport(imp.module_name, imp.field_name))
+                return error.WasiThreadsNotImplemented;
+        }
+    }
+
     const has_non_func_imports =
         module.import_global_count > 0 or
         module.import_memory_count > 0 or
@@ -1117,7 +1126,13 @@ test "instantiate: host functions resolved for wasi thread-spawn import" {
         .import_function_count = 1,
         .types = &func_types,
     };
-    const inst = try instantiate(&module, testing.allocator);
+    const inst = instantiate(&module, testing.allocator) catch |err| {
+        if (comptime config.lib_wasi_threads) {
+            try testing.expectEqual(error.WasiThreadsNotImplemented, err);
+            return;
+        }
+        return err;
+    };
     defer destroy(inst);
 
     // Host functions should be resolved

--- a/src/threads_feature.zig
+++ b/src/threads_feature.zig
@@ -1,0 +1,279 @@
+//! Compile-time contract for the legacy Preview 1 `wasi.thread-spawn`
+//! feature. This describes configuration and readiness; it does not make
+//! the existing thread/atomic prototypes production implementations.
+
+const std = @import("std");
+
+pub const TargetSupport = enum {
+    supported,
+    wasm_host,
+    unsupported_pointer_width,
+    single_threaded_host,
+};
+
+pub const BackendSupport = enum {
+    disabled,
+    target_unsupported,
+    configuration_only,
+    architecture_abi_not_implemented,
+};
+
+pub const Capabilities = struct {
+    shared_memory: bool,
+    thread_manager: bool,
+    wasm_atomics: bool,
+};
+
+pub const ImplementationStatus = struct {
+    resource_locking: bool = false,
+    interpreter_thread_spawning: bool = false,
+    wasm_atomics: bool = false,
+    aot_thread_spawning: bool = false,
+};
+
+pub const Inputs = struct {
+    enabled: bool,
+    pointer_bits: u16,
+    wasm_host: bool,
+    single_threaded: bool,
+    interp: bool,
+    aot: bool,
+    jit: bool,
+    fast_jit: bool,
+    libc_wasi: bool,
+    heap_aux_stack_allocation: bool,
+    shared_memory: bool,
+    thread_manager: bool,
+    wasm_atomics: bool,
+};
+
+pub const ValidationError = enum {
+    wasm_host,
+    unsupported_pointer_width,
+    single_threaded_host,
+    wasi_required,
+    interpreter_required,
+    aot_architecture_abi_not_implemented,
+    jit_backend_not_implemented,
+    fast_jit_backend_not_implemented,
+    heap_aux_stack_required,
+    shared_memory_required,
+    thread_manager_required,
+    wasm_atomics_required,
+};
+
+pub const Report = struct {
+    enabled: bool,
+    target: TargetSupport,
+    interpreter_backend: BackendSupport,
+    aot_backend: BackendSupport,
+    required: Capabilities,
+    configured: Capabilities,
+    implementation: ImplementationStatus = .{},
+};
+
+pub fn targetSupport(inputs: Inputs) TargetSupport {
+    if (inputs.wasm_host) return .wasm_host;
+    if (inputs.pointer_bits < 64) return .unsupported_pointer_width;
+    if (inputs.single_threaded) return .single_threaded_host;
+    return .supported;
+}
+
+pub fn validationError(inputs: Inputs) ?ValidationError {
+    if (!inputs.enabled) return null;
+
+    switch (targetSupport(inputs)) {
+        .supported => {},
+        .wasm_host => return .wasm_host,
+        .unsupported_pointer_width => return .unsupported_pointer_width,
+        .single_threaded_host => return .single_threaded_host,
+    }
+    if (!inputs.libc_wasi) return .wasi_required;
+    if (!inputs.interp) return .interpreter_required;
+    if (inputs.aot) return .aot_architecture_abi_not_implemented;
+    if (inputs.jit) return .jit_backend_not_implemented;
+    if (inputs.fast_jit) return .fast_jit_backend_not_implemented;
+    if (!inputs.heap_aux_stack_allocation) return .heap_aux_stack_required;
+    if (!inputs.shared_memory) return .shared_memory_required;
+    if (!inputs.thread_manager) return .thread_manager_required;
+    if (!inputs.wasm_atomics) return .wasm_atomics_required;
+    return null;
+}
+
+pub fn report(inputs: Inputs) Report {
+    const target = targetSupport(inputs);
+    const required = Capabilities{
+        .shared_memory = inputs.enabled,
+        .thread_manager = inputs.enabled,
+        .wasm_atomics = inputs.enabled,
+    };
+    const configured = Capabilities{
+        .shared_memory = inputs.shared_memory,
+        .thread_manager = inputs.thread_manager,
+        .wasm_atomics = inputs.wasm_atomics,
+    };
+    if (!inputs.enabled) {
+        return .{
+            .enabled = false,
+            .target = target,
+            .interpreter_backend = .disabled,
+            .aot_backend = .disabled,
+            .required = required,
+            .configured = configured,
+        };
+    }
+    if (target != .supported) {
+        return .{
+            .enabled = true,
+            .target = target,
+            .interpreter_backend = .target_unsupported,
+            .aot_backend = .target_unsupported,
+            .required = required,
+            .configured = configured,
+        };
+    }
+    return .{
+        .enabled = true,
+        .target = .supported,
+        .interpreter_backend = .configuration_only,
+        .aot_backend = .architecture_abi_not_implemented,
+        .required = required,
+        .configured = configured,
+    };
+}
+
+pub fn validationMessage(err: ValidationError) []const u8 {
+    return switch (err) {
+        .wasm_host => "lib_wasi_threads does not support wasm host execution",
+        .unsupported_pointer_width => "lib_wasi_threads requires a 64-bit host target",
+        .single_threaded_host => "lib_wasi_threads requires a multithreaded host target",
+        .wasi_required => "lib_wasi_threads requires libc_wasi",
+        .interpreter_required => "lib_wasi_threads requires the interpreter backend",
+        .aot_architecture_abi_not_implemented => "lib_wasi_threads AOT architecture/ABI support is not implemented; disable aot",
+        .jit_backend_not_implemented => "lib_wasi_threads is incompatible with the AOT-based JIT backend",
+        .fast_jit_backend_not_implemented => "lib_wasi_threads is incompatible with the fast JIT backend",
+        .heap_aux_stack_required => "lib_wasi_threads requires heap auxiliary stack allocation",
+        .shared_memory_required => "lib_wasi_threads requires shared memory",
+        .thread_manager_required => "lib_wasi_threads requires the thread manager",
+        .wasm_atomics_required => "lib_wasi_threads requires WebAssembly atomics",
+    };
+}
+
+pub fn isThreadSpawnImport(module_name: []const u8, field_name: []const u8) bool {
+    if (!std.mem.eql(u8, field_name, "thread-spawn")) return false;
+    return std.mem.eql(u8, module_name, "wasi") or
+        std.mem.eql(u8, module_name, "wasi_snapshot_preview1") or
+        std.mem.eql(u8, module_name, "wasi_unstable");
+}
+
+fn validEnabledInputs() Inputs {
+    return .{
+        .enabled = true,
+        .pointer_bits = 64,
+        .wasm_host = false,
+        .single_threaded = false,
+        .interp = true,
+        .aot = false,
+        .jit = false,
+        .fast_jit = false,
+        .libc_wasi = true,
+        .heap_aux_stack_allocation = true,
+        .shared_memory = true,
+        .thread_manager = true,
+        .wasm_atomics = true,
+    };
+}
+
+test "disabled contract preserves defaults without requiring thread capabilities" {
+    var inputs = validEnabledInputs();
+    inputs.enabled = false;
+    inputs.pointer_bits = 32;
+    inputs.wasm_host = true;
+    inputs.interp = false;
+    inputs.aot = true;
+    inputs.libc_wasi = false;
+    inputs.shared_memory = false;
+    inputs.thread_manager = false;
+    inputs.wasm_atomics = false;
+
+    try std.testing.expectEqual(@as(?ValidationError, null), validationError(inputs));
+    const actual = report(inputs);
+    try std.testing.expectEqual(TargetSupport.wasm_host, actual.target);
+    try std.testing.expectEqual(BackendSupport.disabled, actual.interpreter_backend);
+    try std.testing.expectEqual(BackendSupport.disabled, actual.aot_backend);
+    try std.testing.expect(!actual.required.shared_memory);
+}
+
+test "enabled configuration reports requirements without claiming implementation" {
+    const actual = report(validEnabledInputs());
+    try std.testing.expectEqual(@as(?ValidationError, null), validationError(validEnabledInputs()));
+    try std.testing.expectEqual(TargetSupport.supported, actual.target);
+    try std.testing.expectEqual(BackendSupport.configuration_only, actual.interpreter_backend);
+    try std.testing.expectEqual(BackendSupport.architecture_abi_not_implemented, actual.aot_backend);
+    try std.testing.expect(actual.required.shared_memory);
+    try std.testing.expect(actual.configured.shared_memory);
+    try std.testing.expect(!actual.implementation.resource_locking);
+    try std.testing.expect(!actual.implementation.interpreter_thread_spawning);
+    try std.testing.expect(!actual.implementation.wasm_atomics);
+    try std.testing.expect(!actual.implementation.aot_thread_spawning);
+}
+
+test "enabled contract rejects unsupported targets, backends, and missing capabilities" {
+    const Case = struct {
+        mutate: enum {
+            wasm_host,
+            pointer_width,
+            single_threaded,
+            wasi,
+            interpreter,
+            aot,
+            jit,
+            fast_jit,
+            aux_stack,
+            shared_memory,
+            thread_manager,
+            atomics,
+        },
+        expected: ValidationError,
+    };
+    const cases = [_]Case{
+        .{ .mutate = .wasm_host, .expected = .wasm_host },
+        .{ .mutate = .pointer_width, .expected = .unsupported_pointer_width },
+        .{ .mutate = .single_threaded, .expected = .single_threaded_host },
+        .{ .mutate = .wasi, .expected = .wasi_required },
+        .{ .mutate = .interpreter, .expected = .interpreter_required },
+        .{ .mutate = .aot, .expected = .aot_architecture_abi_not_implemented },
+        .{ .mutate = .jit, .expected = .jit_backend_not_implemented },
+        .{ .mutate = .fast_jit, .expected = .fast_jit_backend_not_implemented },
+        .{ .mutate = .aux_stack, .expected = .heap_aux_stack_required },
+        .{ .mutate = .shared_memory, .expected = .shared_memory_required },
+        .{ .mutate = .thread_manager, .expected = .thread_manager_required },
+        .{ .mutate = .atomics, .expected = .wasm_atomics_required },
+    };
+
+    for (cases) |case| {
+        var inputs = validEnabledInputs();
+        switch (case.mutate) {
+            .wasm_host => inputs.wasm_host = true,
+            .pointer_width => inputs.pointer_bits = 32,
+            .single_threaded => inputs.single_threaded = true,
+            .wasi => inputs.libc_wasi = false,
+            .interpreter => inputs.interp = false,
+            .aot => inputs.aot = true,
+            .jit => inputs.jit = true,
+            .fast_jit => inputs.fast_jit = true,
+            .aux_stack => inputs.heap_aux_stack_allocation = false,
+            .shared_memory => inputs.shared_memory = false,
+            .thread_manager => inputs.thread_manager = false,
+            .atomics => inputs.wasm_atomics = false,
+        }
+        try std.testing.expectEqual(case.expected, validationError(inputs).?);
+    }
+}
+
+test "thread-spawn import recognition is limited to Preview 1 WASI modules" {
+    try std.testing.expect(isThreadSpawnImport("wasi", "thread-spawn"));
+    try std.testing.expect(isThreadSpawnImport("wasi_snapshot_preview1", "thread-spawn"));
+    try std.testing.expect(!isThreadSpawnImport("env", "thread-spawn"));
+    try std.testing.expect(!isThreadSpawnImport("wasi", "proc_exit"));
+}


### PR DESCRIPTION
## Summary
- make `lib_wasi_threads` imply shared memory, thread manager, WebAssembly atomics, and heap auxiliary-stack configuration
- publish deterministic target/backend/capability/readiness reporting without claiming production spawning, synchronization, atomics, or AOT support
- reject unsupported target/backend combinations at build time and gated thread-spawn imports before interpreter/AOT allocation
- add focused disabled/enabled contract and runtime-gate tests

## Validation
- `zig build -Doptimize=Debug --summary all`
- `zig build -Dlib_wasi_threads=true -Daot=false -Doptimize=Debug --summary failures`
- `zig build test-threads-contract -Doptimize=Debug --summary all` (10 passed, 1 skipped)
- `zig build test-threads-contract -Dlib_wasi_threads=true -Daot=false -Doptimize=Debug --summary all` (11 passed)
- invalid-option probes: default AOT, x86 32-bit, wasm32 host, missing interpreter, JIT, and missing WASI all rejected with the expected diagnostic
- `git diff --check`

References #616 (`threads-feature-contract`).