### PR TITLE
ci: profile P3 on matched ARM64 platforms

### DIFF
--- a/.github/workflows/wasi-p3-macos-profile.yml
+++ b/.github/workflows/wasi-p3-macos-profile.yml
@@ -1,0 +1,214 @@
+name: WASI P3 macOS ARM64 profile
+
+# Manual, non-blocking investigation for #616 D3. This is deliberately not a
+# PR/push gate: it compares native hosted ARM64 machines at one exact revision,
+# validates every retained unfiltered suite sample at 41/41, and keeps timing
+# policy separate from normal conformance and Linux x86_64 benchmark budgets.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: wasi-p3-macos-profile-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    name: Measure (${{ matrix.platform_id }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform_id: macos-arm64
+            runner: macos-14
+          - platform_id: linux-arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Install Zig 0.16.0
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Configure isolated Zig caches
+        uses: ./.github/actions/zig-cache
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install wasi-testsuite runner dependencies
+        run: pip install -r tests/wasi-testsuite/test-runner/requirements.txt
+
+      - name: Record raw host metadata
+        env:
+          OUT: wasi-p3-measure-${{ matrix.platform_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$OUT"
+          {
+            uname -a
+            if command -v sw_vers >/dev/null; then sw_vers; fi
+            if command -v sysctl >/dev/null; then
+              sysctl -n machdep.cpu.brand_string 2>/dev/null || true
+              sysctl -n hw.memsize 2>/dev/null || true
+            fi
+            if command -v lscpu >/dev/null; then lscpu; fi
+          } > "$OUT/platform.txt"
+          env | LC_ALL=C sort | grep -E \
+            '^(ImageOS|RUNNER_|ZIG_(GLOBAL|LOCAL)_CACHE_DIR)=' \
+            > "$OUT/runner-environment.txt"
+
+      - name: Build ReleaseSafe AOT tools
+        run: zig build -Doptimize=ReleaseSafe
+
+      - name: Measure AOT — 5 cold and 10 warm unfiltered suites
+        env:
+          WAMR: ${{ github.workspace }}/zig-out/bin/wamr
+          WAMRC: ${{ github.workspace }}/zig-out/bin/wamrc
+        run: |
+          python3 scripts/wasi_p3_profile.py run \
+            --mode aot \
+            --platform-id '${{ matrix.platform_id }}' \
+            --cold-samples 5 \
+            --warm-samples 10 \
+            --output-dir 'wasi-p3-measure-${{ matrix.platform_id }}/aot'
+
+      - name: Characterize wasi-microbench without budget enforcement
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT='wasi-p3-measure-${{ matrix.platform_id }}/microbench'
+          mkdir -p "$OUT"
+          zig build wasi-microbench -Doptimize=ReleaseSafe -- \
+            --samples 10 \
+            --warmup 2 \
+            --no-budget \
+            --json "$OUT/report.json" \
+            > "$OUT/report.txt" 2>&1
+
+      - name: Build ReleaseSafe JIT tools
+        run: zig build -Doptimize=ReleaseSafe -Djit=true
+
+      - name: Measure JIT equivalent — 5 cold and 10 warm unfiltered suites
+        env:
+          WAMR: ${{ github.workspace }}/zig-out/bin/wamr
+          WAMRC: ${{ github.workspace }}/zig-out/bin/wamrc
+        run: |
+          python3 scripts/wasi_p3_profile.py run \
+            --mode jit \
+            --platform-id '${{ matrix.platform_id }}' \
+            --cold-samples 5 \
+            --warm-samples 10 \
+            --output-dir 'wasi-p3-measure-${{ matrix.platform_id }}/jit'
+
+      - name: Upload raw measurements and conformance reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: wasi-p3-measure-${{ matrix.platform_id }}
+          path: wasi-p3-measure-${{ matrix.platform_id }}/
+          if-no-files-found: error
+          retention-days: 90
+
+  aggregate:
+    name: Validate and aggregate
+    needs: measure
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download matched measurements
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: wasi-p3-measure-*
+          path: measurements
+
+      - name: Require 60 valid 41/41 samples and aggregate
+        run: |
+          python3 scripts/wasi_p3_profile_aggregate.py \
+            --input-dir measurements \
+            --output-dir aggregate
+
+      - name: Upload structured aggregate and profile plan
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: wasi-p3-matched-aggregate
+          path: aggregate/
+          if-no-files-found: error
+          retention-days: 90
+
+  sample-macos:
+    name: Capture macOS sampling profiles
+    needs: aggregate
+    runs-on: macos-14
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Install Zig 0.16.0
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Configure isolated Zig caches
+        uses: ./.github/actions/zig-cache
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install wasi-testsuite runner dependencies
+        run: pip install -r tests/wasi-testsuite/test-runner/requirements.txt
+
+      - name: Download validated profile selection
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: wasi-p3-matched-aggregate
+          path: aggregate
+
+      - name: Build and profile ReleaseSafe AOT phases
+        env:
+          WAMR: ${{ github.workspace }}/zig-out/bin/wamr
+          WAMRC: ${{ github.workspace }}/zig-out/bin/wamrc
+        run: |
+          zig build -Doptimize=ReleaseSafe
+          python3 scripts/wasi_p3_profile.py profile \
+            --mode aot \
+            --selection aggregate/profile-selection.json \
+            --output-dir profiles
+
+      - name: Build and profile ReleaseSafe JIT phases
+        env:
+          WAMR: ${{ github.workspace }}/zig-out/bin/wamr
+          WAMRC: ${{ github.workspace }}/zig-out/bin/wamrc
+        run: |
+          zig build -Doptimize=ReleaseSafe -Djit=true
+          python3 scripts/wasi_p3_profile.py profile \
+            --mode jit \
+            --selection aggregate/profile-selection.json \
+            --output-dir profiles
+
+      - name: Upload macOS sampling profiles
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: wasi-p3-macos-sampling-profiles
+          path: profiles/
+          if-no-files-found: error
+          retention-days: 90

--- a/scripts/wasi_p3_profile.py
+++ b/scripts/wasi_p3_profile.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Collect reproducible WASI P3 phase timings and macOS sample profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shlex
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+EXPECTED_FIXTURES = 41
+ROOT = Path(__file__).resolve().parent.parent
+SUITE = (
+    ROOT
+    / "tests"
+    / "wasi-testsuite"
+    / "tests"
+    / "rust"
+    / "testsuite"
+    / "wasm32-wasip3"
+)
+UNFILTERED = ROOT / "tests" / "wasi-p3-unfiltered.py"
+PHASES = {
+    "component_precompile",
+    "core_precompile",
+    "fixture_execution",
+}
+
+
+class ProfileDataError(ValueError):
+    """Raised when a timing artifact violates the versioned contract."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ProfileDataError(message)
+
+
+def validate_event(event: dict[str, Any]) -> None:
+    _require(event.get("schema_version") == SCHEMA_VERSION, "event schema_version")
+    _require(event.get("event") == "phase_timing", "event kind")
+    _require(event.get("mode") in {"aot", "jit"}, "event mode")
+    _require(isinstance(event.get("fixture"), str) and event["fixture"], "event fixture")
+    _require(event.get("phase") in PHASES, "event phase")
+    _require(event.get("artifact_kind") in {"component", "core"}, "artifact kind")
+    _require(event.get("cache") in {"miss", "hit", "bypass", "n/a"}, "event cache")
+    _require(
+        isinstance(event.get("duration_ns"), int) and event["duration_ns"] >= 0,
+        "event duration_ns",
+    )
+
+
+def validate_run_document(document: dict[str, Any]) -> None:
+    _require(document.get("schema_version") == SCHEMA_VERSION, "run schema_version")
+    _require(document.get("kind") == "wasi-p3-profile-runs", "run kind")
+    metadata = document.get("metadata")
+    _require(isinstance(metadata, dict), "run metadata")
+    _require(metadata.get("mode") in {"aot", "jit"}, "metadata mode")
+    _require(isinstance(metadata.get("platform_id"), str), "metadata platform_id")
+    _require(isinstance(metadata.get("commit"), str), "metadata commit")
+    samples = document.get("samples")
+    _require(isinstance(samples, list), "samples")
+    for sample in samples:
+        _require(isinstance(sample, dict), "sample object")
+        _require(sample.get("temperature") in {"cold", "warm"}, "sample temperature")
+        _require(isinstance(sample.get("index"), int), "sample index")
+        _require(isinstance(sample.get("valid"), bool), "sample valid")
+        _require(isinstance(sample.get("suite_duration_ns"), int), "suite duration")
+        counts = sample.get("counts")
+        _require(isinstance(counts, dict), "sample counts")
+        for name in ("fixtures", "executed", "passed", "failed"):
+            _require(isinstance(counts.get(name), int), f"counts.{name}")
+        events = sample.get("events")
+        _require(isinstance(events, list), "sample events")
+        for event in events:
+            _require(isinstance(event, dict), "event object")
+            validate_event(event)
+
+
+def _command_version(command: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"unavailable: {exc}"
+    output = (result.stdout or result.stderr).strip().splitlines()
+    return output[0] if output else f"exit {result.returncode}"
+
+
+def collect_metadata(mode: str, platform_id: str) -> dict[str, Any]:
+    wamr = shlex.split(os.getenv("WAMR", str(ROOT / "zig-out" / "bin" / "wamr")))
+    wamrc = shlex.split(os.getenv("WAMRC", str(ROOT / "zig-out" / "bin" / "wamrc")))
+    return {
+        "platform_id": platform_id,
+        "mode": mode,
+        "optimize": "ReleaseSafe",
+        "commit": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+        ).strip(),
+        "collected_at": datetime.now(timezone.utc).isoformat(),
+        "host": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "version": platform.version(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+            "python": platform.python_version(),
+            "runner_name": os.getenv("RUNNER_NAME", ""),
+            "runner_image": os.getenv("ImageOS", ""),
+            "runner_os": os.getenv("RUNNER_OS", ""),
+            "runner_arch": os.getenv("RUNNER_ARCH", ""),
+        },
+        "tools": {
+            "zig": _command_version(["zig", "version"]),
+            "wamr": _command_version(wamr + ["version"]),
+            "wamrc": _command_version(wamrc + ["version"]),
+        },
+        "cache": {
+            "zig_global_cache_dir": os.getenv("ZIG_GLOBAL_CACHE_DIR", ""),
+            "zig_local_cache_dir": os.getenv("ZIG_LOCAL_CACHE_DIR", ""),
+            "aot_sidecars": "mtime sibling cache",
+            "jit": "in-process; no persistent compiled-artifact cache",
+        },
+    }
+
+
+def _remove_sidecars() -> None:
+    for pattern in ("*.cwasm", "*.cwasm.json"):
+        for sidecar in SUITE.glob(pattern):
+            sidecar.unlink()
+
+
+def parse_jsonl(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    with path.open(encoding="UTF-8") as source:
+        for line_number, line in enumerate(source, 1):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ProfileDataError(f"{path}:{line_number}: {exc}") from exc
+            _require(isinstance(event, dict), f"{path}:{line_number}: event object")
+            validate_event(event)
+            events.append(event)
+    return events
+
+
+def _report_counts(report: Path) -> dict[str, int]:
+    data = json.loads(report.read_text(encoding="UTF-8"))
+    suites = data.get("results", [])
+    _require(len(suites) == 1, f"{report}: expected one suite")
+    tests = suites[0].get("tests", [])
+    executed = [test for test in tests if test.get("executed")]
+    passed = [test for test in executed if not test.get("failures")]
+    return {
+        "fixtures": len(tests),
+        "executed": len(executed),
+        "passed": len(passed),
+        "failed": len(executed) - len(passed),
+    }
+
+
+def _sample_is_valid(
+    mode: str,
+    temperature: str,
+    returncode: int,
+    counts: dict[str, int],
+    events: list[dict[str, Any]],
+) -> tuple[bool, list[str]]:
+    errors: list[str] = []
+    if returncode:
+        errors.append(f"runner exit {returncode}")
+    if counts != {
+        "fixtures": EXPECTED_FIXTURES,
+        "executed": EXPECTED_FIXTURES,
+        "passed": EXPECTED_FIXTURES,
+        "failed": 0,
+    }:
+        errors.append(f"conformance counts {counts}, expected 41/41")
+
+    executions = [e for e in events if e["phase"] == "fixture_execution"]
+    precompiles = [e for e in events if e["phase"].endswith("_precompile")]
+    if len(executions) != EXPECTED_FIXTURES:
+        errors.append(f"execution events={len(executions)}, expected 41")
+    if len(precompiles) != EXPECTED_FIXTURES:
+        errors.append(f"precompile events={len(precompiles)}, expected 41")
+    if len({e["fixture"] for e in executions}) != EXPECTED_FIXTURES:
+        errors.append("execution fixture names are not unique")
+    expected_cache = (
+        "bypass" if mode == "jit" else "miss" if temperature == "cold" else "hit"
+    )
+    wrong_cache = [e["fixture"] for e in precompiles if e["cache"] != expected_cache]
+    if wrong_cache:
+        errors.append(
+            f"{len(wrong_cache)} precompile events did not use cache={expected_cache}"
+        )
+    return not errors, errors
+
+
+def _run_sample(
+    mode: str,
+    temperature: str,
+    index: int,
+    output_dir: Path,
+) -> dict[str, Any]:
+    run_id = f"{mode}-{temperature}-{index:02d}"
+    raw_dir = output_dir / "raw"
+    report_dir = output_dir / "reports"
+    log_dir = output_dir / "logs"
+    for directory in (raw_dir, report_dir, log_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+    timing = (raw_dir / f"{run_id}.jsonl").resolve()
+    report = (report_dir / f"{run_id}.json").resolve()
+    log = log_dir / f"{run_id}.log"
+    timing.unlink(missing_ok=True)
+    report.unlink(missing_ok=True)
+
+    if mode == "aot" and temperature == "cold":
+        _remove_sidecars()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "WAMR_PROFILE_TIMINGS": str(timing),
+            "WAMR_PROFILE_RUN_ID": run_id,
+            "WAMR_PROFILE_MODE": mode,
+            "WAMR_P3_REPORT": str(report),
+        }
+    )
+    if mode == "jit":
+        env["WAMR_JIT_TESTSUITE"] = "1"
+    else:
+        env.pop("WAMR_JIT_TESTSUITE", None)
+
+    started_ns = time.perf_counter_ns()
+    with log.open("w", encoding="UTF-8") as output:
+        proc = subprocess.run(
+            [sys.executable, str(UNFILTERED)],
+            cwd=ROOT,
+            env=env,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    suite_duration_ns = time.perf_counter_ns() - started_ns
+
+    counts = (
+        _report_counts(report)
+        if report.is_file()
+        else {"fixtures": 0, "executed": 0, "passed": 0, "failed": 0}
+    )
+    events = parse_jsonl(timing) if timing.is_file() else []
+    valid, errors = _sample_is_valid(
+        mode, temperature, proc.returncode, counts, events
+    )
+    print(
+        f"{run_id}: valid={valid} passed={counts['passed']}/"
+        f"{EXPECTED_FIXTURES} elapsed={suite_duration_ns / 1e9:.3f}s",
+        flush=True,
+    )
+    return {
+        "id": run_id,
+        "temperature": temperature,
+        "index": index,
+        "valid": valid,
+        "errors": errors,
+        "returncode": proc.returncode,
+        "suite_duration_ns": suite_duration_ns,
+        "counts": counts,
+        "events": events,
+        "raw_timing": str(timing.relative_to(output_dir.resolve())),
+        "report": str(report.relative_to(output_dir.resolve())),
+        "log": str(log.resolve().relative_to(output_dir.resolve())),
+    }
+
+
+def run_collection(args: argparse.Namespace) -> int:
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    document = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "wasi-p3-profile-runs",
+        "metadata": collect_metadata(args.mode, args.platform_id),
+        "plan": {
+            "cold_samples": args.cold_samples,
+            "warm_samples": args.warm_samples,
+            "optimize": "ReleaseSafe",
+        },
+        "samples": [],
+    }
+    destination = output_dir / "samples.json"
+    for temperature, count in (
+        ("cold", args.cold_samples),
+        ("warm", args.warm_samples),
+    ):
+        for index in range(1, count + 1):
+            document["samples"].append(
+                _run_sample(args.mode, temperature, index, output_dir)
+            )
+            destination.write_text(
+                json.dumps(document, indent=2) + "\n", encoding="UTF-8"
+            )
+    validate_run_document(document)
+    return 0 if all(sample["valid"] for sample in document["samples"]) else 1
+
+
+def run_profile(args: argparse.Namespace) -> int:
+    selection = json.loads(args.selection.read_text(encoding="UTF-8"))
+    requested = [
+        item for item in selection.get("profiles", []) if item.get("mode") == args.mode
+    ]
+    if not requested:
+        print(f"No {args.mode} profiles selected.")
+        return 0
+
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _remove_sidecars()
+    timing = output_dir / f"profile-{args.mode}.jsonl"
+    report = output_dir / f"profile-{args.mode}-report.json"
+    log = output_dir / f"profile-{args.mode}.log"
+    env = os.environ.copy()
+    env.update(
+        {
+            "WAMR_PROFILE_TIMINGS": str(timing),
+            "WAMR_PROFILE_RUN_ID": f"profile-{args.mode}",
+            "WAMR_PROFILE_MODE": args.mode,
+            "WAMR_PROFILE_SELECTION": str(args.selection.resolve()),
+            "WAMR_PROFILE_OUTPUT_DIR": str(output_dir),
+            "WAMR_P3_REPORT": str(report),
+            "WAMR_TESTSUITE_TIMEOUT": "300",
+        }
+    )
+    if args.mode == "jit":
+        env["WAMR_JIT_TESTSUITE"] = "1"
+    else:
+        env.pop("WAMR_JIT_TESTSUITE", None)
+    with log.open("w", encoding="UTF-8") as output:
+        proc = subprocess.run(
+            [sys.executable, str(UNFILTERED)],
+            cwd=ROOT,
+            env=env,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+
+    missing = []
+    for item in requested:
+        profile = (
+            output_dir
+            / f"{item['fixture']}-{item['phase']}-{args.mode}.sample.txt"
+        )
+        if not profile.is_file() or profile.stat().st_size == 0:
+            missing.append(profile.name)
+    if proc.returncode or missing:
+        print(
+            f"profile {args.mode} failed: runner={proc.returncode}, missing={missing}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Captured {len(requested)} {args.mode} sampling profile(s).")
+    return 0
+
+
+def _positive_int(raw: str) -> int:
+    value = int(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    collect = subparsers.add_parser("run", help="collect cold/warm suite samples")
+    collect.add_argument("--mode", choices=("aot", "jit"), required=True)
+    collect.add_argument("--platform-id", required=True)
+    collect.add_argument("--output-dir", type=Path, required=True)
+    collect.add_argument("--cold-samples", type=_positive_int, default=5)
+    collect.add_argument("--warm-samples", type=_positive_int, default=10)
+    collect.set_defaults(func=run_collection)
+
+    profile = subparsers.add_parser("profile", help="capture selected macOS samples")
+    profile.add_argument("--mode", choices=("aot", "jit"), required=True)
+    profile.add_argument("--selection", type=Path, required=True)
+    profile.add_argument("--output-dir", type=Path, required=True)
+    profile.set_defaults(func=run_profile)
+
+    args = parser.parse_args()
+    try:
+        return args.func(args)
+    except (OSError, ProfileDataError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wasi_p3_profile_aggregate.py
+++ b/scripts/wasi_p3_profile_aggregate.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Validate and aggregate matched macOS/Linux ARM64 WASI P3 profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from wasi_p3_profile import (
+    EXPECTED_FIXTURES,
+    PHASES,
+    ProfileDataError,
+    SCHEMA_VERSION,
+    validate_run_document,
+)
+
+
+EXPECTED_PLATFORMS = {"macos-arm64", "linux-arm64"}
+EXPECTED_MODES = {"aot", "jit"}
+EXPECTED_SAMPLE_COUNTS = {"cold": 5, "warm": 10}
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ProfileDataError(message)
+
+
+def _percentile(values: Iterable[int], percentile: float) -> int:
+    ordered = sorted(values)
+    _require(bool(ordered), "cannot summarize an empty sample")
+    index = min(len(ordered) - 1, max(0, int(len(ordered) * percentile + 0.999) - 1))
+    return ordered[index]
+
+
+def _stats(values: list[int]) -> dict[str, int]:
+    return {
+        "samples": len(values),
+        "min_ns": min(values),
+        "median_ns": int(statistics.median(values)),
+        "p95_ns": _percentile(values, 0.95),
+        "max_ns": max(values),
+    }
+
+
+def _load_documents(input_dir: Path) -> list[tuple[Path, dict[str, Any]]]:
+    documents: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted(input_dir.rglob("samples.json")):
+        document = json.loads(path.read_text(encoding="UTF-8"))
+        validate_run_document(document)
+        documents.append((path, document))
+    _require(bool(documents), f"no samples.json documents under {input_dir}")
+    return documents
+
+
+def _validate_plan(documents: list[tuple[Path, dict[str, Any]]]) -> str:
+    keys: set[tuple[str, str]] = set()
+    commits: set[str] = set()
+    for path, document in documents:
+        metadata = document["metadata"]
+        platform_id = metadata["platform_id"]
+        mode = metadata["mode"]
+        _require(platform_id in EXPECTED_PLATFORMS, f"{path}: platform {platform_id}")
+        _require(mode in EXPECTED_MODES, f"{path}: mode {mode}")
+        _require(metadata.get("optimize") == "ReleaseSafe", f"{path}: optimize mode")
+        host = metadata.get("host")
+        tools = metadata.get("tools")
+        cache = metadata.get("cache")
+        _require(isinstance(host, dict), f"{path}: host metadata")
+        _require(isinstance(tools, dict), f"{path}: tool metadata")
+        _require(isinstance(cache, dict), f"{path}: cache metadata")
+        machine = str(host.get("machine", "")).lower()
+        _require(machine in {"arm64", "aarch64"}, f"{path}: non-ARM64 host {machine}")
+        expected_system = "Darwin" if platform_id == "macos-arm64" else "Linux"
+        _require(host.get("system") == expected_system, f"{path}: host system")
+        _require(
+            all(tools.get(name) for name in ("zig", "wamr", "wamrc")),
+            f"{path}: tools",
+        )
+        _require((platform_id, mode) not in keys, f"duplicate {platform_id}/{mode}")
+        keys.add((platform_id, mode))
+        commits.add(metadata["commit"])
+        samples = document["samples"]
+        for temperature, expected in EXPECTED_SAMPLE_COUNTS.items():
+            selected = [s for s in samples if s["temperature"] == temperature]
+            _require(
+                len(selected) == expected,
+                f"{path}: {temperature} samples={len(selected)}, expected={expected}",
+            )
+        _require(all(s["valid"] for s in samples), f"{path}: invalid suite sample")
+        for sample in samples:
+            _require(
+                sample["counts"]
+                == {
+                    "fixtures": EXPECTED_FIXTURES,
+                    "executed": EXPECTED_FIXTURES,
+                    "passed": EXPECTED_FIXTURES,
+                    "failed": 0,
+                },
+                f"{path}: {sample['id']} did not pass 41/41",
+            )
+    expected_keys = {
+        (platform_id, mode)
+        for platform_id in EXPECTED_PLATFORMS
+        for mode in EXPECTED_MODES
+    }
+    _require(keys == expected_keys, f"platform/mode set {keys}, expected {expected_keys}")
+    _require(len(commits) == 1, f"measurements use different revisions: {commits}")
+    return next(iter(commits))
+
+
+def _load_microbench(
+    documents: list[tuple[Path, dict[str, Any]]]
+) -> dict[str, dict[str, Any]]:
+    reports: dict[str, dict[str, Any]] = {}
+    for path, document in documents:
+        platform_id = document["metadata"]["platform_id"]
+        if platform_id in reports:
+            continue
+        candidate = path.parent.parent / "microbench" / "report.json"
+        _require(candidate.is_file(), f"missing {platform_id} microbench {candidate}")
+        report = json.loads(candidate.read_text(encoding="UTF-8"))
+        scenarios = report.get("scenarios")
+        _require(isinstance(scenarios, list) and len(scenarios) == 4, candidate.as_posix())
+        _require(
+            all(item.get("verdict") == "no-budget" for item in scenarios),
+            f"{candidate}: budget enforcement was not disabled",
+        )
+        reports[platform_id] = report
+    _require(set(reports) == EXPECTED_PLATFORMS, "microbench platform set")
+    return reports
+
+
+def _suite_rows(
+    documents: list[tuple[Path, dict[str, Any]]]
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str, str], list[int]] = defaultdict(list)
+    for _, document in documents:
+        metadata = document["metadata"]
+        for sample in document["samples"]:
+            grouped[
+                (metadata["platform_id"], metadata["mode"], sample["temperature"])
+            ].append(sample["suite_duration_ns"])
+    return [
+        {
+            "platform_id": key[0],
+            "mode": key[1],
+            "temperature": key[2],
+            **_stats(values),
+        }
+        for key, values in sorted(grouped.items())
+    ]
+
+
+def _phase_values(
+    documents: list[tuple[Path, dict[str, Any]]]
+) -> tuple[
+    dict[tuple[str, str, str, str, str], list[int]],
+    dict[tuple[str, str, str, int, str, str], int],
+]:
+    grouped: dict[tuple[str, str, str, str, str], list[int]] = defaultdict(list)
+    paired: dict[tuple[str, str, str, int, str, str], int] = {}
+    for _, document in documents:
+        metadata = document["metadata"]
+        for sample in document["samples"]:
+            for event in sample["events"]:
+                grouped[
+                    (
+                        metadata["platform_id"],
+                        metadata["mode"],
+                        sample["temperature"],
+                        event["phase"],
+                        event["fixture"],
+                    )
+                ].append(event["duration_ns"])
+                paired[
+                    (
+                        metadata["platform_id"],
+                        metadata["mode"],
+                        sample["temperature"],
+                        sample["index"],
+                        event["phase"],
+                        event["fixture"],
+                    )
+                ] = event["duration_ns"]
+    return grouped, paired
+
+
+def _phase_rows(
+    grouped: dict[tuple[str, str, str, str, str], list[int]]
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "platform_id": key[0],
+            "mode": key[1],
+            "temperature": key[2],
+            "phase": key[3],
+            "fixture": key[4],
+            **_stats(values),
+        }
+        for key, values in sorted(grouped.items())
+    ]
+
+
+def _profile_selection(
+    grouped: dict[tuple[str, str, str, str, str], list[int]],
+    paired: dict[tuple[str, str, str, int, str, str], int],
+    suites: list[dict[str, Any]],
+) -> dict[str, Any]:
+    selected: dict[tuple[str, str, str], set[str]] = defaultdict(set)
+
+    for mode in EXPECTED_MODES:
+        selected[(mode, "http-fields", "fixture_execution")].add(
+            "required http-fields baseline"
+        )
+
+    suite_medians = {
+        (row["platform_id"], row["mode"], row["temperature"]): row["median_ns"]
+        for row in suites
+    }
+    for key, values in grouped.items():
+        platform_id, mode, temperature, phase, fixture = key
+        if platform_id != "macos-arm64":
+            continue
+        phase_median = statistics.median(values)
+        suite_median = suite_medians[(platform_id, mode, temperature)]
+        share = phase_median / suite_median if suite_median else 0.0
+        if share >= 0.20:
+            selected[(mode, fixture, phase)].add(
+                f"{temperature} median is {share:.1%} of suite wall time"
+            )
+
+    candidates = {
+        (mode, phase, fixture)
+        for platform_id, mode, _, phase, fixture in grouped
+        if platform_id == "macos-arm64"
+    }
+    for mode, phase, fixture in candidates:
+        ratios: list[float] = []
+        temperatures: set[str] = set()
+        for temperature, count in EXPECTED_SAMPLE_COUNTS.items():
+            cell: list[float] = []
+            for index in range(1, count + 1):
+                mac = paired.get(
+                    ("macos-arm64", mode, temperature, index, phase, fixture)
+                )
+                linux = paired.get(
+                    ("linux-arm64", mode, temperature, index, phase, fixture)
+                )
+                if mac is not None and linux is not None and linux > 0:
+                    cell.append(mac / linux)
+            if cell:
+                temperatures.add(temperature)
+                ratios.extend(cell)
+        if not ratios or temperatures != {"cold", "warm"}:
+            continue
+        fraction = sum(ratio >= 2.0 for ratio in ratios) / len(ratios)
+        cell_medians = []
+        for temperature in ("cold", "warm"):
+            mac_values = grouped[
+                ("macos-arm64", mode, temperature, phase, fixture)
+            ]
+            linux_values = grouped[
+                ("linux-arm64", mode, temperature, phase, fixture)
+            ]
+            linux_median = statistics.median(linux_values)
+            if linux_median <= 0:
+                break
+            cell_medians.append(statistics.median(mac_values) / linux_median)
+        if (
+            len(cell_medians) == 2
+            and min(cell_medians) >= 2.0
+            and fraction >= 0.80
+        ):
+            selected[(mode, fixture, phase)].add(
+                "macOS/Linux median >=2x in cold and warm cells "
+                f"({fraction:.0%} paired samples >=2x)"
+            )
+
+    profiles = [
+        {
+            "mode": mode,
+            "fixture": fixture,
+            "phase": phase,
+            "reasons": sorted(reasons),
+        }
+        for (mode, fixture, phase), reasons in sorted(selected.items())
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "wasi-p3-profile-selection",
+        "profiles": profiles,
+    }
+
+
+def validate_aggregate_document(document: dict[str, Any]) -> None:
+    _require(document.get("schema_version") == SCHEMA_VERSION, "aggregate schema")
+    _require(document.get("kind") == "wasi-p3-profile-aggregate", "aggregate kind")
+    _require(isinstance(document.get("commit"), str), "aggregate commit")
+    suite = document.get("suite")
+    _require(isinstance(suite, list) and len(suite) == 8, "aggregate suite rows")
+    phases = document.get("phases")
+    _require(isinstance(phases, list) and phases, "aggregate phase rows")
+    for row in phases:
+        _require(row.get("phase") in PHASES, "aggregate phase")
+        _require(isinstance(row.get("median_ns"), int), "aggregate phase median")
+
+
+def _markdown(
+    document: dict[str, Any],
+    selection: dict[str, Any],
+    microbench: dict[str, dict[str, Any]],
+) -> str:
+    date = datetime.now(timezone.utc).date().isoformat()
+    lines = [
+        f"# WASI P3 macOS ARM64 performance investigation — {date}",
+        "",
+        f"Revision: `{document['commit']}`.",
+        "",
+        "All 60 measured suite runs were valid unfiltered ReleaseSafe runs: "
+        "5 cold + 10 warm for AOT and JIT on each native ARM64 platform, "
+        "with every sample passing 41/41.",
+        "",
+        "## Suite wall time",
+        "",
+        "| platform | mode | cache state | samples | median ms | p95 ms |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for row in document["suite"]:
+        lines.append(
+            f"| {row['platform_id']} | {row['mode']} | {row['temperature']} | "
+            f"{row['samples']} | {row['median_ns'] / 1e6:.3f} | "
+            f"{row['p95_ns'] / 1e6:.3f} |"
+        )
+    lines += [
+        "",
+        "## Sampling-profile selection",
+        "",
+        "| mode | fixture | phase | reason |",
+        "|---|---|---|---|",
+    ]
+    for item in selection["profiles"]:
+        lines.append(
+            f"| {item['mode']} | {item['fixture']} | {item['phase']} | "
+            f"{'; '.join(item['reasons'])} |"
+        )
+    lines += [
+        "",
+        "## WASI microbenchmark (budget disabled)",
+        "",
+        "| platform | scenario | median ns | p95 ns |",
+        "|---|---|---:|---:|",
+    ]
+    for platform_id in sorted(microbench):
+        for scenario in microbench[platform_id]["scenarios"]:
+            lines.append(
+                f"| {platform_id} | {scenario['name']} | "
+                f"{scenario['median_ns']} | {scenario['p95_ns']} |"
+            )
+    lines += [
+        "",
+        "The existing Linux x86_64 budgets were not applied or changed. This "
+        "manual workflow is non-blocking and does not alter normal conformance gates.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def aggregate(args: argparse.Namespace) -> int:
+    documents = _load_documents(args.input_dir)
+    commit = _validate_plan(documents)
+    microbench = _load_microbench(documents)
+    suites = _suite_rows(documents)
+    grouped, paired = _phase_values(documents)
+    phases = _phase_rows(grouped)
+    selection = _profile_selection(grouped, paired, suites)
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "wasi-p3-profile-aggregate",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "commit": commit,
+        "valid": True,
+        "contract": {
+            "platforms": sorted(EXPECTED_PLATFORMS),
+            "modes": sorted(EXPECTED_MODES),
+            "cold_samples_per_platform_mode": 5,
+            "warm_samples_per_platform_mode": 10,
+            "fixtures_per_sample": EXPECTED_FIXTURES,
+        },
+        "suite": suites,
+        "phases": phases,
+        "microbench": microbench,
+    }
+    validate_aggregate_document(result)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "aggregate.json").write_text(
+        json.dumps(result, indent=2) + "\n", encoding="UTF-8"
+    )
+    (args.output_dir / "profile-selection.json").write_text(
+        json.dumps(selection, indent=2) + "\n", encoding="UTF-8"
+    )
+    (args.output_dir / "report.md").write_text(
+        _markdown(result, selection, microbench), encoding="UTF-8"
+    )
+    print(
+        f"Validated 60 41/41 suite samples at {commit}; "
+        f"selected {len(selection['profiles'])} profiles."
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        return aggregate(args)
+    except (OSError, json.JSONDecodeError, ProfileDataError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wasi_p3_sample_launch.py
+++ b/scripts/wasi_p3_sample_launch.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Launch a process stopped, attach macOS `sample`, then resume it."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command:
+        parser.error("missing command after --")
+    if sys.platform != "darwin":
+        parser.error("macOS sampling profiles require Darwin")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    child = os.fork()
+    if child == 0:
+        os.kill(os.getpid(), signal.SIGSTOP)
+        os.execvp(command[0], command)
+
+    _, stopped = os.waitpid(child, os.WUNTRACED)
+    if not os.WIFSTOPPED(stopped):
+        return 125
+
+    def forward(signum, _frame):
+        try:
+            os.kill(child, signum)
+        except ProcessLookupError:
+            pass
+
+    for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+        signal.signal(signum, forward)
+
+    with args.log.open("wb") as log:
+        sampler = subprocess.Popen(
+            [
+                "/usr/bin/sample",
+                str(child),
+                "300",
+                "1",
+                "-file",
+                str(args.output),
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+        # The target remains stopped while sample resolves and attaches.
+        time.sleep(0.25)
+        os.kill(child, signal.SIGCONT)
+        while True:
+            try:
+                _, status = os.waitpid(child, 0)
+                break
+            except InterruptedError:
+                continue
+        try:
+            sampler.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            sampler.terminate()
+            sampler.wait(timeout=10)
+
+    if not args.output.is_file() or args.output.stat().st_size == 0:
+        return 125
+    if os.WIFEXITED(status):
+        return os.WEXITSTATUS(status)
+    if os.WIFSIGNALED(status):
+        return 128 + os.WTERMSIG(status)
+    return 125
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmarks/wasi-p3-profile/README.md
+++ b/tests/benchmarks/wasi-p3-profile/README.md
@@ -1,0 +1,16 @@
+# WASI P3 macOS ARM64 profiling
+
+The manual `wasi-p3-macos-profile.yml` workflow compares the same revision on
+native macOS and Linux ARM64. It runs ReleaseSafe AOT and supported in-process
+JIT modes, with 5 cold and 10 warm unfiltered samples per mode/platform.
+Every retained sample must pass 41/41.
+
+`WAMR_PROFILE_TIMINGS` opts into JSONL phase events. The adapter records
+component/core precompile time and cache state; the in-tree runner launcher
+records guest-process execution without wrapping or changing guest streams.
+Normal conformance runs are unchanged when the variable is absent.
+
+The workflow also runs `wasi-microbench --no-budget`; Linux x86_64 budgets are
+deliberately not reused for macOS. The aggregate job validates both JSON
+schemas and selects macOS sampling profiles for `http-fields`, phases taking
+at least 20% of suite wall time, and phases consistently at least 2x Linux.

--- a/tests/benchmarks/wasi-p3-profile/aggregate.schema.json
+++ b/tests/benchmarks/wasi-p3-profile/aggregate.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cataggar/wamr/tests/benchmarks/wasi-p3-profile/aggregate.schema.json",
+  "title": "WASI P3 matched-platform aggregate",
+  "type": "object",
+  "required": [
+    "schema_version", "kind", "generated_at", "commit", "valid",
+    "contract", "suite", "phases", "microbench"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "wasi-p3-profile-aggregate" },
+    "commit": { "type": "string", "minLength": 40, "maxLength": 40 },
+    "valid": { "const": true },
+    "contract": { "type": "object" },
+    "suite": {
+      "type": "array",
+      "minItems": 8,
+      "maxItems": 8,
+      "items": { "$ref": "#/$defs/stat" }
+    },
+    "phases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "allOf": [
+          { "$ref": "#/$defs/stat" },
+          {
+            "type": "object",
+            "required": ["phase", "fixture"],
+            "properties": {
+              "phase": {
+                "enum": ["component_precompile", "core_precompile", "fixture_execution"]
+              },
+              "fixture": { "type": "string", "minLength": 1 }
+            }
+          }
+        ]
+      }
+    },
+    "microbench": { "type": "object" }
+  },
+  "$defs": {
+    "stat": {
+      "type": "object",
+      "required": [
+        "platform_id", "mode", "temperature", "samples",
+        "min_ns", "median_ns", "p95_ns", "max_ns"
+      ],
+      "properties": {
+        "platform_id": { "enum": ["macos-arm64", "linux-arm64"] },
+        "mode": { "enum": ["aot", "jit"] },
+        "temperature": { "enum": ["cold", "warm"] },
+        "samples": { "type": "integer", "minimum": 1 },
+        "min_ns": { "type": "integer", "minimum": 0 },
+        "median_ns": { "type": "integer", "minimum": 0 },
+        "p95_ns": { "type": "integer", "minimum": 0 },
+        "max_ns": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/tests/benchmarks/wasi-p3-profile/run.schema.json
+++ b/tests/benchmarks/wasi-p3-profile/run.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cataggar/wamr/tests/benchmarks/wasi-p3-profile/run.schema.json",
+  "title": "WASI P3 profile runs",
+  "type": "object",
+  "required": ["schema_version", "kind", "metadata", "plan", "samples"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "wasi-p3-profile-runs" },
+    "metadata": {
+      "type": "object",
+      "required": ["platform_id", "mode", "optimize", "commit", "host", "tools", "cache"],
+      "properties": {
+        "platform_id": { "type": "string" },
+        "mode": { "enum": ["aot", "jit"] },
+        "optimize": { "const": "ReleaseSafe" },
+        "commit": { "type": "string", "minLength": 40, "maxLength": 40 },
+        "host": { "type": "object" },
+        "tools": { "type": "object" },
+        "cache": { "type": "object" }
+      }
+    },
+    "plan": {
+      "type": "object",
+      "required": ["cold_samples", "warm_samples", "optimize"]
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id", "temperature", "index", "valid", "errors", "returncode",
+          "suite_duration_ns", "counts", "events"
+        ],
+        "properties": {
+          "temperature": { "enum": ["cold", "warm"] },
+          "valid": { "type": "boolean" },
+          "suite_duration_ns": { "type": "integer", "minimum": 0 },
+          "events": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/event" }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "event": {
+      "type": "object",
+      "required": [
+        "schema_version", "event", "run_id", "mode", "fixture", "phase",
+        "artifact_kind", "cache", "duration_ns", "pid"
+      ],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "event": { "const": "phase_timing" },
+        "mode": { "enum": ["aot", "jit"] },
+        "fixture": { "type": "string", "minLength": 1 },
+        "phase": {
+          "enum": ["component_precompile", "core_precompile", "fixture_execution"]
+        },
+        "artifact_kind": { "enum": ["component", "core"] },
+        "cache": { "enum": ["miss", "hit", "bypass", "n/a"] },
+        "duration_ns": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/tests/test_wasi_p3_profile.py
+++ b/tests/test_wasi_p3_profile.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Unit tests for P3 timing instrumentation and artifact aggregation."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import wasi_p3_profile as profile  # noqa: E402
+import wasi_p3_profile_aggregate as aggregate  # noqa: E402
+
+
+def _load_adapter():
+    path = ROOT / "tests" / "wasi-testsuite-adapter" / "wamr-zig.py"
+    spec = importlib.util.spec_from_file_location("wamr_zig_profile_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ProfileTestCase(unittest.TestCase):
+    scratch = ROOT / "zig-out" / "wasi-p3-profile-unit"
+
+    def setUp(self) -> None:
+        shutil.rmtree(self.scratch, ignore_errors=True)
+        self.scratch.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.scratch, ignore_errors=True)
+
+    def test_jsonl_parser_rejects_unknown_phase(self) -> None:
+        path = self.scratch / "bad.jsonl"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "event": "phase_timing",
+                    "run_id": "aot-cold-01",
+                    "mode": "aot",
+                    "fixture": "noop",
+                    "phase": "combined",
+                    "artifact_kind": "core",
+                    "cache": "miss",
+                    "duration_ns": 1,
+                    "pid": 1,
+                }
+            )
+            + "\n",
+            encoding="UTF-8",
+        )
+        with self.assertRaises(profile.ProfileDataError):
+            profile.parse_jsonl(path)
+
+    def test_adapter_records_core_miss_and_hit_only_when_enabled(self) -> None:
+        adapter = _load_adapter()
+        wasm = self.scratch / "fixture.wasm"
+        wasm.write_bytes(b"\x00asm\x01\x00\x00\x00")
+        timing = self.scratch / "timings.jsonl"
+
+        def fake_compile(command, fixture, phase):
+            del fixture, phase
+            Path(command[command.index("-o") + 1]).write_bytes(b"cwasm")
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "WAMR_PROFILE_TIMINGS": str(timing),
+                "WAMR_PROFILE_RUN_ID": "aot-cold-01",
+                "WAMR_PROFILE_MODE": "aot",
+            },
+            clear=False,
+        ), mock.patch.object(adapter, "_run_compile", side_effect=fake_compile):
+            compiled = adapter._precompile(str(wasm))
+            self.assertEqual(Path(compiled), wasm.with_suffix(".cwasm"))
+            adapter._precompile(str(wasm))
+
+        events = profile.parse_jsonl(timing)
+        self.assertEqual([event["cache"] for event in events], ["miss", "hit"])
+        self.assertTrue(all(event["phase"] == "core_precompile" for event in events))
+
+        timing.unlink()
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+            adapter, "_run_compile", side_effect=fake_compile
+        ):
+            wasm.with_suffix(".cwasm").unlink()
+            adapter._precompile(str(wasm))
+        self.assertFalse(timing.exists())
+
+    def test_default_compute_argv_has_no_instrumentation_wrapper(self) -> None:
+        adapter = _load_adapter()
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+            adapter, "_precompile", return_value="fixture.cwasm"
+        ):
+            argv = adapter.compute_argv(
+                "fixture.wasm", ([], {}, None), [], "wasi:cli/command", "wasm32-wasip3"
+            )
+        self.assertEqual(argv, adapter.WAMR + ["run", "fixture.cwasm"])
+
+    def test_checked_in_schemas_match_parser_phases(self) -> None:
+        run_schema = json.loads(
+            (
+                ROOT
+                / "tests"
+                / "benchmarks"
+                / "wasi-p3-profile"
+                / "run.schema.json"
+            ).read_text(encoding="UTF-8")
+        )
+        aggregate_schema = json.loads(
+            (
+                ROOT
+                / "tests"
+                / "benchmarks"
+                / "wasi-p3-profile"
+                / "aggregate.schema.json"
+            ).read_text(encoding="UTF-8")
+        )
+        self.assertEqual(run_schema["properties"]["schema_version"]["const"], 1)
+        self.assertEqual(
+            set(run_schema["$defs"]["event"]["properties"]["phase"]["enum"]),
+            profile.PHASES,
+        )
+        self.assertEqual(
+            aggregate_schema["properties"]["kind"]["const"],
+            "wasi-p3-profile-aggregate",
+        )
+
+    def _write_run(self, platform_id: str, mode: str) -> None:
+        base = self.scratch / f"wasi-p3-measure-{platform_id}"
+        mode_dir = base / mode
+        mode_dir.mkdir(parents=True, exist_ok=True)
+        samples = []
+        for temperature, count in (("cold", 5), ("warm", 10)):
+            for index in range(1, count + 1):
+                events = []
+                for fixture_index in range(profile.EXPECTED_FIXTURES):
+                    fixture = (
+                        "http-fields" if fixture_index == 0 else f"fixture-{fixture_index}"
+                    )
+                    scale = 3 if platform_id == "macos-arm64" else 1
+                    events += [
+                        {
+                            "schema_version": 1,
+                            "event": "phase_timing",
+                            "run_id": f"{mode}-{temperature}-{index:02d}",
+                            "mode": mode,
+                            "fixture": fixture,
+                            "phase": "component_precompile",
+                            "artifact_kind": "component",
+                            "cache": (
+                                "bypass"
+                                if mode == "jit"
+                                else "miss"
+                                if temperature == "cold"
+                                else "hit"
+                            ),
+                            "duration_ns": 0 if mode == "jit" else 100 * scale,
+                            "pid": 1,
+                        },
+                        {
+                            "schema_version": 1,
+                            "event": "phase_timing",
+                            "run_id": f"{mode}-{temperature}-{index:02d}",
+                            "mode": mode,
+                            "fixture": fixture,
+                            "phase": "fixture_execution",
+                            "artifact_kind": "component",
+                            "cache": "n/a",
+                            "duration_ns": (
+                                300_000_000 * scale
+                                if fixture == "http-fields"
+                                else 1_000_000 * scale
+                            ),
+                            "pid": 1,
+                        },
+                    ]
+                samples.append(
+                    {
+                        "id": f"{mode}-{temperature}-{index:02d}",
+                        "temperature": temperature,
+                        "index": index,
+                        "valid": True,
+                        "errors": [],
+                        "returncode": 0,
+                        "suite_duration_ns": 1_000_000_000 * scale,
+                        "counts": {
+                            "fixtures": 41,
+                            "executed": 41,
+                            "passed": 41,
+                            "failed": 0,
+                        },
+                        "events": events,
+                    }
+                )
+        document = {
+            "schema_version": 1,
+            "kind": "wasi-p3-profile-runs",
+            "metadata": {
+                "platform_id": platform_id,
+                "mode": mode,
+                "optimize": "ReleaseSafe",
+                "commit": "a" * 40,
+                "host": {
+                    "system": "Darwin" if platform_id == "macos-arm64" else "Linux",
+                    "machine": "arm64" if platform_id == "macos-arm64" else "aarch64",
+                },
+                "tools": {"zig": "0.16.0", "wamr": "wamr dev", "wamrc": "wamrc dev"},
+                "cache": {"zig_global_cache_dir": "isolated"},
+            },
+            "plan": {
+                "cold_samples": 5,
+                "warm_samples": 10,
+                "optimize": "ReleaseSafe",
+            },
+            "samples": samples,
+        }
+        (mode_dir / "samples.json").write_text(
+            json.dumps(document), encoding="UTF-8"
+        )
+        microbench = base / "microbench"
+        microbench.mkdir(exist_ok=True)
+        (microbench / "report.json").write_text(
+            json.dumps(
+                {
+                    "scenarios": [
+                        {
+                            "name": f"scenario-{i}",
+                            "median_ns": 10,
+                            "p95_ns": 12,
+                            "verdict": "no-budget",
+                        }
+                        for i in range(4)
+                    ]
+                }
+            ),
+            encoding="UTF-8",
+        )
+
+    def test_aggregate_requires_matched_valid_41_of_41_samples(self) -> None:
+        for platform_id in ("macos-arm64", "linux-arm64"):
+            for mode in ("aot", "jit"):
+                self._write_run(platform_id, mode)
+        output = self.scratch / "aggregate"
+        result = aggregate.aggregate(
+            argparse.Namespace(input_dir=self.scratch, output_dir=output)
+        )
+        self.assertEqual(result, 0)
+        document = json.loads(
+            (output / "aggregate.json").read_text(encoding="UTF-8")
+        )
+        aggregate.validate_aggregate_document(document)
+        selection = json.loads(
+            (output / "profile-selection.json").read_text(encoding="UTF-8")
+        )
+        keys = {
+            (item["mode"], item["fixture"], item["phase"])
+            for item in selection["profiles"]
+        }
+        self.assertIn(("aot", "http-fields", "fixture_execution"), keys)
+        self.assertIn(("jit", "http-fields", "fixture_execution"), keys)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/wasi-p3-unfiltered.py
+++ b/tests/wasi-p3-unfiltered.py
@@ -39,9 +39,15 @@ def main() -> int:
             )
             return 2
 
-    report = _ROOT / "zig-out" / (
-        "wasi-p3-unfiltered-jit.json" if jit else "wasi-p3-unfiltered-aot.json"
+    report_override = os.environ.get("WAMR_P3_REPORT")
+    report = (
+        Path(report_override)
+        if report_override
+        else _ROOT
+        / "zig-out"
+        / ("wasi-p3-unfiltered-jit.json" if jit else "wasi-p3-unfiltered-aot.json")
     )
+    report.parent.mkdir(parents=True, exist_ok=True)
     report.unlink(missing_ok=True)
     cmd = [
         sys.executable,

--- a/tests/wasi-testsuite-adapter/wamr-zig.py
+++ b/tests/wasi-testsuite-adapter/wamr-zig.py
@@ -19,12 +19,14 @@ resulting `.cwasm` to `wamr run`. Set `WAMRC` to point at the freshly-built
 then to `PATH`.
 """
 
+import json
 import os
 import shlex
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -51,6 +53,93 @@ def _resolve_wamrc() -> List[str]:
 
 
 WAMRC = _resolve_wamrc()
+_SAMPLE_LAUNCHER = (
+    Path(__file__).resolve().parent.parent.parent
+    / "scripts"
+    / "wasi_p3_sample_launch.py"
+)
+
+
+def _emit_timing(
+    fixture: Path,
+    phase: str,
+    artifact_kind: str,
+    duration_ns: int,
+    cache: str,
+) -> None:
+    """Append one opt-in timing event without touching guest streams."""
+    output = os.getenv("WAMR_PROFILE_TIMINGS")
+    if not output:
+        return
+    event = {
+        "schema_version": 1,
+        "event": "phase_timing",
+        "run_id": os.getenv("WAMR_PROFILE_RUN_ID", ""),
+        "mode": os.getenv(
+            "WAMR_PROFILE_MODE",
+            "jit" if os.getenv("WAMR_JIT_TESTSUITE") else "aot",
+        ),
+        "fixture": fixture.stem,
+        "phase": phase,
+        "artifact_kind": artifact_kind,
+        "cache": cache,
+        "duration_ns": duration_ns,
+        "pid": os.getpid(),
+    }
+    encoded = (json.dumps(event, sort_keys=True) + "\n").encode("UTF-8")
+    fd = os.open(output, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644)
+    try:
+        os.write(fd, encoded)
+    finally:
+        os.close(fd)
+
+
+def _profile_requested(fixture: Path, phase: str) -> bool:
+    selection_path = os.getenv("WAMR_PROFILE_SELECTION")
+    if not selection_path:
+        return False
+    try:
+        selection = json.loads(Path(selection_path).read_text(encoding="UTF-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    mode = os.getenv("WAMR_PROFILE_MODE", "aot")
+    return any(
+        item.get("mode") == mode
+        and item.get("fixture") == fixture.stem
+        and item.get("phase") == phase
+        for item in selection.get("profiles", [])
+    )
+
+
+def _profile_command(cmd: List[str], fixture: Path, phase: str) -> List[str]:
+    profile_dir = os.getenv("WAMR_PROFILE_OUTPUT_DIR")
+    if not profile_dir or not _profile_requested(fixture, phase):
+        return cmd
+
+    output_dir = Path(profile_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    mode = os.getenv("WAMR_PROFILE_MODE", "aot")
+    profile = output_dir / f"{fixture.stem}-{phase}-{mode}.sample.txt"
+    log = output_dir / f"{fixture.stem}-{phase}-{mode}.sample.log"
+    return [
+        sys.executable,
+        str(_SAMPLE_LAUNCHER),
+        "--output",
+        str(profile),
+        "--log",
+        str(log),
+        "--",
+        *cmd,
+    ]
+
+
+def _run_compile(cmd: List[str], fixture: Path, phase: str) -> None:
+    """Run wamrc, optionally attaching macOS's sampling profiler."""
+    subprocess.run(
+        _profile_command(cmd, fixture, phase),
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
 
 
 def get_name() -> str:
@@ -164,29 +253,60 @@ def _precompile(test_path: str) -> str:
     same compiler and AOT loader/runtime — only the "when" differs.
     """
     if os.getenv("WAMR_JIT_TESTSUITE"):
+        if os.getenv("WAMR_PROFILE_TIMINGS"):
+            p = Path(test_path)
+            artifact_kind = "component" if _is_component(p) else "core"
+            _emit_timing(
+                p,
+                f"{artifact_kind}_precompile",
+                artifact_kind,
+                0,
+                "bypass",
+            )
         return test_path
     p = Path(test_path)
     if p.suffix != ".wasm":
         return test_path
-    if _is_component(p):
+    started_ns = time.perf_counter_ns()
+    is_component = _is_component(p)
+    artifact_kind = "component" if is_component else "core"
+    phase = f"{artifact_kind}_precompile"
+    if is_component:
         manifest = p.with_suffix(".cwasm.json")
         if not manifest.exists() or manifest.stat().st_mtime < p.stat().st_mtime:
             # `wamrc compile-component` already disables the IR
             # verifier internally (compileCoreWasm hard-codes
             # verify_mode=.off), so no extra flag is needed here.
-            subprocess.run(
+            _run_compile(
                 WAMRC + ["compile-component", "-o", str(manifest), str(p)],
-                check=True,
-                stdout=subprocess.DEVNULL,
+                p,
+                phase,
+            )
+            _emit_timing(
+                p, phase, artifact_kind, time.perf_counter_ns() - started_ns, "miss"
+            )
+        else:
+            _emit_timing(
+                p, phase, artifact_kind, time.perf_counter_ns() - started_ns, "hit"
             )
         return test_path
     cwasm = p.with_suffix(".cwasm")
     if cwasm.exists() and cwasm.stat().st_mtime >= p.stat().st_mtime:
+        _emit_timing(
+            p, phase, artifact_kind, time.perf_counter_ns() - started_ns, "hit"
+        )
         return str(cwasm)
-    subprocess.run(
+    _run_compile(
         WAMRC + ["compile", "--no-verify-ir", "-o", str(cwasm), str(p)],
-        check=True,
-        stdout=subprocess.DEVNULL,
+        p,
+        phase,
+    )
+    _emit_timing(
+        p,
+        phase,
+        artifact_kind,
+        time.perf_counter_ns() - started_ns,
+        "miss",
     )
     return str(cwasm)
 
@@ -242,4 +362,4 @@ def compute_argv(
     # `wamr run` / `wamr serve` auto-discover via sibling probing. (#680)
     argv += [_precompile(test_path)]
     argv += args
-    return argv
+    return _profile_command(argv, Path(test_path), "fixture_execution")

--- a/tests/wasi-testsuite-runner-patch/wasi_test_runner.py
+++ b/tests/wasi-testsuite-runner-patch/wasi_test_runner.py
@@ -2,12 +2,18 @@
 
 The upstream runner now obtains its wait timeout from the runtime adapter.
 `wamr-zig.py` implements that hook using `WAMR_TESTSUITE_TIMEOUT`, so this
-launcher only needs to make the vendored package importable and delegate to
-its entry point.
+launcher makes the vendored package importable and delegates to its entry
+point. When `WAMR_PROFILE_TIMINGS` is set, it also records process execution
+time after adapter-side precompilation. The hook is entirely opt-in and does
+not wrap the guest process or alter its streams/argv.
 """
 
+import json
+import os
 import sys
+import time
 from pathlib import Path
+from typing import Any
 
 _THIS_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _THIS_DIR.parent.parent
@@ -18,6 +24,72 @@ _UPSTREAM_RUNNER_DIR = _REPO_ROOT / "tests" / "wasi-testsuite" / "test-runner"
 sys.path.insert(0, str(_UPSTREAM_RUNNER_DIR))
 
 from wasi_test_runner import __main__ as _upstream_main  # noqa: E402
+from wasi_test_runner import test_suite_runner as _suite_runner  # noqa: E402
+
+
+def _append_event(event: dict[str, Any]) -> None:
+    output = os.getenv("WAMR_PROFILE_TIMINGS")
+    if not output:
+        return
+    encoded = (json.dumps(event, sort_keys=True) + "\n").encode("UTF-8")
+    fd = os.open(output, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644)
+    try:
+        os.write(fd, encoded)
+    finally:
+        os.close(fd)
+
+
+def _install_profile_hooks() -> None:
+    if not os.getenv("WAMR_PROFILE_TIMINGS"):
+        return
+
+    original_run = _suite_runner.TestCaseRunner.do_run
+    original_wait = _suite_runner.TestCaseRunner._wait
+
+    def timed_run(self: Any, run: Any) -> None:
+        original_run(self, run)
+        if self._proc is None:
+            return
+        self._wamr_started_ns = time.perf_counter_ns()
+
+    def timed_wait(self: Any, timeout: float | None) -> tuple[int, str, str]:
+        started_ns = getattr(self, "_wamr_started_ns", None)
+        try:
+            result = original_wait(self, timeout)
+            return result
+        finally:
+            finished_ns = time.perf_counter_ns()
+            if started_ns is not None:
+                fixture = Path(self._test_path).stem
+                with Path(self._test_path).open("rb") as wasm:
+                    artifact_kind = (
+                        "component"
+                        if wasm.read(8)[4:8] == b"\x0d\x00\x01\x00"
+                        else "core"
+                    )
+                _append_event(
+                    {
+                        "schema_version": 1,
+                        "event": "phase_timing",
+                        "run_id": os.getenv("WAMR_PROFILE_RUN_ID", ""),
+                        "mode": os.getenv(
+                            "WAMR_PROFILE_MODE",
+                            "jit" if os.getenv("WAMR_JIT_TESTSUITE") else "aot",
+                        ),
+                        "fixture": fixture,
+                        "phase": "fixture_execution",
+                        "artifact_kind": artifact_kind,
+                        "cache": "n/a",
+                        "duration_ns": finished_ns - started_ns,
+                        "pid": os.getpid(),
+                    }
+                )
+
+    _suite_runner.TestCaseRunner.do_run = timed_run
+    _suite_runner.TestCaseRunner._wait = timed_wait
+
+
+_install_profile_hooks()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add opt-in P3 component/core precompile and fixture-execution JSONL timing without changing default guest argv/streams
- add a manual, non-blocking native macOS ARM64 vs Linux ARM64 workflow with strict same-revision 41/41 validation for 5 cold + 10 warm ReleaseSafe AOT and JIT runs
- collect no-budget WASI microbenchmark data, structured/raw artifacts, and macOS sampling profiles selected from measured hotspots
- add schemas, parsers, aggregation, and unit coverage

Refs #616 (D3).

## Validation
- `python3 -m unittest -v tests/test_wasi_p3_profile.py`
- `zig build -Doptimize=ReleaseSafe`
- default unfiltered AOT: 41/41
- instrumented AOT cold + warm: 41/41 each, 82 phase events each
- instrumented JIT cold + warm: 41/41 each, 82 phase events each
- `git diff --check`

The dated benchmark report is intentionally deferred until this workflow is merged and produces valid native-runner artifacts.