### PR TITLE
runtime: add stable shared-memory parking

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -604,6 +604,24 @@ pub fn build(b: *std.Build) void {
     });
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
+    const shared_memory_unit_tests = b.addTest(.{
+        .root_module = test_module,
+        .filters = &.{
+            "SharedMemory:",
+            "ParkingLot:",
+            "MemoryInstance: shared",
+            "emit: memory section round-trip",
+            "emit: import section round-trip",
+            "reserved address space",
+        },
+    });
+    const run_shared_memory_unit_tests = b.addRunArtifact(shared_memory_unit_tests);
+    const shared_memory_test_step = b.step(
+        "test-shared-memory",
+        "Run stable shared-memory and parking-lot tests",
+    );
+    shared_memory_test_step.dependOn(&run_shared_memory_unit_tests.step);
+
     const exe_test_module = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,

--- a/docs/design/wasi-threads.md
+++ b/docs/design/wasi-threads.md
@@ -1,9 +1,9 @@
 # `wasi:threads` design — multi-threaded interpreter state isolation
 
-Status: **DRAFT** (prototypes exist; no production-wired guest-thread
-support).
+Status: **DRAFT** (shared-memory/parking foundation implemented; opcode
+atomicity and production spawning remain incomplete).
 
-Tracking: [#616 B1](https://github.com/cataggar/wamr/issues/616).
+Tracking: [#616 B1.3](https://github.com/cataggar/wamr/issues/616).
 
 Author wave: W10-3.
 
@@ -69,12 +69,24 @@ the atomic-opcode dispatcher, and the `wasi.thread-spawn` host import.
 These are prototypes, not production support. No default CLI or
 component path currently offers gated guest-thread execution.
 
-The production work remains the ordered plan below: make shared
-runtime and host resources safe; implement correct atomic
-wait/notify/fence behavior; spawn in both interpreter and AOT modes;
-isolate cancellation and per-thread component/WASI context; and pass
-the end-to-end correctness, conformance, and performance gates. This
-document does not treat any unmerged implementation wave as present.
+Shared memories now use a refcounted control block with an immutable base.
+Instantiation reserves the declared maximum up front and fails if that
+reservation cannot be created; it never falls back to relocating `realloc`.
+Grow commits in place under one lock, preserves zero fill, and publishes
+current bytes/pages with release stores consumed by acquire accessors.
+
+`src/platform/parking_lot.zig` provides keyed wait32/wait64, exact notify,
+monotonic deadlines, address/all cancellation, and draining shutdown. The
+value comparison and waiter insertion share one bucket lock. Its native wait
+word uses Linux futex, macOS ulock, or Windows WaitOnAddress; Windows linear
+memory uses NT reserve/commit. These APIs are intentionally independent of
+opcode lowering so the remaining atomic load/store/RMW audit can use them.
+
+The remaining production work follows the ordered plan below: make all
+shared runtime and host resources safe; complete atomic opcode and fence
+behavior; spawn in both interpreter and AOT modes; isolate cancellation and
+per-thread component/WASI context; and pass the end-to-end correctness,
+conformance, and performance gates.
 
 ## Upstream state
 
@@ -474,11 +486,10 @@ Each wave is a discrete PR with its own conformance gate.
 * Audit `interp.zig:3349`–`3700+` (`atomic_prefix` dispatch). Replace
   every non-atomic load/store/RMW with `@atomicLoad`, `@atomicStore`,
   `@atomicRmw`, `@cmpxchgStrong` against the underlying `[]u8`.
-* Implement `memory.atomic.wait32`, `memory.atomic.wait64`,
-  `memory.atomic.notify` using a per-`MemoryInstance` futex table
-  (linear-probing hashmap of `address → ParkingLot`). Zig 0.16's
-  `std.Thread.Futex` has the primitive we need, gated through the
-  custom-Mutex pattern.
+* Route `memory.atomic.wait32`, `memory.atomic.wait64`, and
+  `memory.atomic.notify` through the implemented per-memory keyed parking
+  lot. The runtime helpers are wired; opcode validation and the surrounding
+  atomic load/store/RMW audit remain part of this wave.
 * Treat `atomic.fence` as `@fence(.seq_cst)` (today it is a documented
   no-op).
 * Reject `shared` memories that are not declared `shared` in the
@@ -587,13 +598,10 @@ Each wave is a discrete PR with its own conformance gate.
    `ComponentInstance` to `ExecEnv`. The Preview-1 surface only ever
    re-enters at the exported `wasi_thread_start` core function, so
    this is naturally enforced today.
-5. **Memory-grow under concurrent atomics.** `MemoryInstance.grow`
-   reallocates the underlying `[]u8`. Other threads holding a
-   `*MemoryInstance` pointer plus a cached slice into `data` will see
-   a use-after-free. Either (a) lock `memory.grow` against all atomic
-   accesses (kills perf), or (b) follow the upstream `threads` spec
-   and use page-table indirection so `grow` only appends. Tracking
-   issue for Wave 3.
+5. **Memory-grow under concurrent atomics.** Resolved for shared memory:
+   reserve the declared maximum, keep the base immutable, serialize commit,
+   and release/acquire-publish the visible extent. Non-shared memories keep
+   their compatible allocator/reservation behavior.
 6. **Should each thread have its own `WasiCliAdapter` slot for
    `stdin` / `stdout` / `stderr`?** No — stdio writes go through the
    kernel which already serialises. The OutputStream's internal

--- a/src/api/host.zig
+++ b/src/api/host.zig
@@ -55,7 +55,7 @@ pub const HostContext = struct {
         const mem = if (env.module_inst.memories.len > 0) env.module_inst.memories[0] else null;
         return .{
             .mem_base = if (mem) |m| m.data.ptr else null,
-            .mem_len = if (mem) |m| m.data.len else 0,
+            .mem_len = if (mem) |m| m.byteLen() else 0,
         };
     }
 

--- a/src/compiler/emit_aot.zig
+++ b/src/compiler/emit_aot.zig
@@ -4,7 +4,7 @@
 //! The output format matches what `runtime/aot/loader.zig` expects:
 //!
 //!   [4 bytes] magic (0x746f6100)
-//!   [4 bytes] version (7)
+//!   [4 bytes] version (8)
 //!   [sections...] each: [4 bytes type] [4 bytes size] [payload]
 
 const std = @import("std");
@@ -14,7 +14,7 @@ const types = @import("../runtime/common/types.zig");
 pub const aot_magic: u32 = 0x746f6100;
 
 /// AOT format version.
-pub const aot_version: u32 = 7;
+pub const aot_version: u32 = 8;
 
 /// Export kinds (matches WebAssembly spec §2.5 and runtime ExternalKind).
 pub const ExternalKind = enum(u8) {
@@ -57,6 +57,7 @@ pub const ImportEntry = struct {
     memory_min: u32 = 0,
     memory_max: ?u32 = null,
     memory_is64: bool = false,
+    memory_shared: bool = false,
     global_val_type: types.ValType = .i32,
     global_mutable: bool = false,
     /// Function-type index describing the tag's parameter signature
@@ -68,6 +69,7 @@ pub const ImportEntry = struct {
 pub const MemoryEntry = struct {
     min_pages: u32,
     max_pages: ?u32,
+    is_shared: bool = false,
 };
 
 pub const TableEntry = struct {
@@ -249,6 +251,7 @@ pub fn emit(
                             try tmp.append(allocator, 0);
                         }
                         try tmp.append(allocator, if (imp.memory_is64) 1 else 0);
+                        try tmp.append(allocator, if (imp.memory_shared) 1 else 0);
                     },
                     .global => {
                         try tmp.append(allocator, @intFromEnum(imp.global_val_type));
@@ -266,7 +269,7 @@ pub fn emit(
         }
     }
 
-    // Section 9: memories (min_pages, has_max, max_pages per entry)
+    // Section 9: memories (min_pages, has_max, max_pages, shared per entry)
     if (memories) |mem_list| {
         if (mem_list.len > 0) {
             var tmp: std.ArrayList(u8) = .empty;
@@ -280,6 +283,7 @@ pub fn emit(
                 } else {
                     try tmp.append(allocator, 0);
                 }
+                try tmp.append(allocator, if (mem.is_shared) 1 else 0);
             }
             try emitSection(allocator, &buf, 9, tmp.items);
         }
@@ -561,6 +565,7 @@ test "emit: import section round-trip" {
         .{ .module_name = "wasi_snapshot_preview1", .field_name = "fd_write", .kind = .function, .func_type_idx = 0 },
         .{ .module_name = "env", .field_name = "tbl", .kind = .table, .table_elem_type = .funcref, .table_min = 8, .table_max = 8 },
         .{ .module_name = "wasi_snapshot_preview1", .field_name = "clock_time_get", .kind = .function, .func_type_idx = 1 },
+        .{ .module_name = "env", .field_name = "shared_mem", .kind = .memory, .memory_min = 1, .memory_max = 8, .memory_shared = true },
     };
     const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, &import_entries, null, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
@@ -569,7 +574,7 @@ test "emit: import section round-trip" {
     defer aot_loader.unload(&module, allocator);
 
     try std.testing.expectEqual(@as(u32, 2), module.import_function_count);
-    try std.testing.expectEqual(@as(usize, 3), module.imports.len);
+    try std.testing.expectEqual(@as(usize, 4), module.imports.len);
     try std.testing.expect(std.mem.eql(u8, module.imports[0].module_name, "wasi_snapshot_preview1"));
     try std.testing.expect(std.mem.eql(u8, module.imports[0].field_name, "fd_write"));
     try std.testing.expectEqual(types.ExternalKind.table, module.imports[1].kind);
@@ -580,6 +585,9 @@ test "emit: import section round-trip" {
     try std.testing.expectEqual(types.ValType.funcref, module.imported_tables[0].elem_type);
     try std.testing.expectEqual(@as(u32, 8), module.imported_tables[0].min);
     try std.testing.expectEqual(@as(?u32, 8), module.imported_tables[0].max);
+    try std.testing.expectEqual(@as(usize, 1), module.imported_memories.len);
+    try std.testing.expect(module.imported_memories[0].is_shared);
+    try std.testing.expectEqual(@as(?u32, 8), module.imported_memories[0].max);
 }
 
 test "emit: memory section round-trip" {
@@ -588,7 +596,7 @@ test "emit: memory section round-trip" {
 
     const mem_entries = [_]MemoryEntry{
         .{ .min_pages = 2, .max_pages = null },
-        .{ .min_pages = 1, .max_pages = 256 },
+        .{ .min_pages = 1, .max_pages = 256, .is_shared = true },
     };
     const data = try emit(allocator, &.{}, &.{}, &.{}, .{}, null, null, &mem_entries, null, null, null, null, null, null, null, null);
     defer allocator.free(data);
@@ -601,6 +609,7 @@ test "emit: memory section round-trip" {
     try std.testing.expect(module.memories[0].limits.max == null);
     try std.testing.expectEqual(@as(u64, 1), module.memories[1].limits.min);
     try std.testing.expectEqual(@as(u64, 256), module.memories[1].limits.max.?);
+    try std.testing.expect(module.memories[1].is_shared);
 }
 
 test "emit: locally-defined table section round-trip (#681)" {

--- a/src/compiler/main.zig
+++ b/src/compiler/main.zig
@@ -548,6 +548,7 @@ fn runCompile(init: std.process.Init, allocator: std.mem.Allocator, sub_args: []
         try mem_entries.append(allocator, .{
             .min_pages = @intCast(mem.limits.min),
             .max_pages = if (mem.limits.max) |m| @as(?u32, @intCast(m)) else null,
+            .is_shared = mem.is_shared,
         });
     }
 

--- a/src/component/aot_compile.zig
+++ b/src/component/aot_compile.zig
@@ -488,6 +488,7 @@ pub fn compileCoreWasmCached(
                     .memory_min = @intCast(memory_type.limits.min),
                     .memory_max = if (memory_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
                     .memory_is64 = memory_type.is_memory64,
+                    .memory_shared = memory_type.is_shared,
                 }) catch return error.OutOfMemory;
             },
             .global => {
@@ -517,6 +518,7 @@ pub fn compileCoreWasmCached(
         mem_entries.append(ea, .{
             .min_pages = @intCast(mem.limits.min),
             .max_pages = if (mem.limits.max) |m| @as(?u32, @intCast(m)) else null,
+            .is_shared = mem.is_shared,
         }) catch return error.OutOfMemory;
     }
 

--- a/src/component/executor.zig
+++ b/src/component/executor.zig
@@ -1705,7 +1705,7 @@ fn typeSize(registry: TypeRegistry, t: ctypes.ValType) u32 {
 fn strictCanonMemory(ctx: *const ComponentTrampolineCtx) ![]const u8 {
     const mem_idx = ctx.lower_opts.memory_idx orelse 0;
     const mem = ctx.comp_inst.resolveTopLevelMemory(mem_idx) orelse return error.MemoryNotAvailable;
-    return mem.data;
+    return mem.bytes();
 }
 
 fn validateCanonPtrLenValue(mem: []const u8, val: InterfaceValue, t: ctypes.ValType, registry: TypeRegistry, context: []const u8) !void {
@@ -7369,7 +7369,7 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
         for (ctx.param_types, 0..) |pt, i| {
             const al = typeAlign(registry, pt);
             offset = abi.alignUp(offset, al);
-            args[i] = loadInterfaceValue(mem.data, offset, pt, registry, allocator) catch |err|
+            args[i] = loadInterfaceValue(mem.bytes(), offset, pt, registry, allocator) catch |err|
                 return trampolineTrap(env, ctx, err, .lift_args);
             offset += typeSize(registry, pt);
         }
@@ -7488,7 +7488,7 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
                             const mem_idx = ctx.lower_opts.memory_idx.?;
                             const mem = ctx.comp_inst.resolveTopLevelMemory(mem_idx) orelse
                                 return trampolineTrap(env, ctx, error.MemoryNotAvailable, .memory_resolve);
-                            if (@as(u64, result_dest_ptr) + bytes.len > mem.data.len) {
+                            if (@as(u64, result_dest_ptr) + bytes.len > mem.byteLen()) {
                                 return trampolineTrap(env, ctx, error.MemoryNotAvailable, .lower_results);
                             }
                             @memcpy(mem.data[result_dest_ptr .. result_dest_ptr + bytes.len], bytes);
@@ -7520,11 +7520,11 @@ pub fn componentTrampoline(env_opaque: *anyopaque, ctx_opaque: ?*anyopaque) core
         var offset: u32 = result_dest_ptr;
         for (results, ctx.result_types) |r, t| {
             if (typeContainsPtrLen(t, registry)) {
-                validateCanonPtrLenValue(mem.data, r, t, registry, "canon-lift") catch |err| return trampolineTrap(env, ctx, err, .lower_results);
+                validateCanonPtrLenValue(mem.bytes(), r, t, registry, "canon-lift") catch |err| return trampolineTrap(env, ctx, err, .lower_results);
             }
             const al = typeAlign(registry, t);
             offset = abi.alignUp(offset, al);
-            storeInterfaceValue(mem.data, offset, r, t, registry) catch |err|
+            storeInterfaceValue(mem.bytes(), offset, r, t, registry) catch |err|
                 return trampolineTrap(env, ctx, err, .lower_results);
             offset += typeSize(registry, t);
         }
@@ -8279,7 +8279,7 @@ fn dispatchAotAsyncComponentTrampoline(
         var offset = params_ptr;
         for (ctx.param_types, 0..) |param_type, i| {
             offset = abi.alignUp(offset, typeAlign(registry, param_type));
-            args[i] = try loadInterfaceValue(memory.data, offset, param_type, registry, allocator);
+            args[i] = try loadInterfaceValue(memory.bytes(), offset, param_type, registry, allocator);
             offset += typeSize(registry, param_type);
         }
     } else {
@@ -8309,7 +8309,7 @@ fn dispatchAotAsyncComponentTrampoline(
         if (!typeContainsPtrLen(param_type, registry)) continue;
         if (strict_mem == null) {
             const memory = caller_memory orelse return error.MemoryNotAvailable;
-            strict_mem = memory.data;
+            strict_mem = memory.bytes();
         }
         try validateCanonPtrLenValue(strict_mem.?, arg, param_type, registry, "canon-lift");
     }
@@ -8356,7 +8356,7 @@ fn dispatchAotAsyncComponentTrampoline(
                 if (future.state == .ready or future.state == .closed) {
                     if (future.payload) |bytes| {
                         const memory = caller_memory orelse return error.MemoryNotAvailable;
-                        if (@as(u64, result_dest_ptr) + bytes.len > memory.data.len)
+                        if (@as(u64, result_dest_ptr) + bytes.len > memory.byteLen())
                             return error.MemoryNotAvailable;
                         @memcpy(memory.data[result_dest_ptr .. result_dest_ptr + bytes.len], bytes);
                     }
@@ -8450,7 +8450,7 @@ fn dispatchAotComponentTrampoline(
     results_filled = results.len;
     if (debugAotEnabled()) {
         const mem_idx = ctx.lower_opts.memory_idx orelse 0;
-        const trace_mem = if (ctx.comp_inst.resolveTopLevelMemory(mem_idx)) |mem| mem.data else null;
+        const trace_mem = if (ctx.comp_inst.resolveTopLevelMemory(mem_idx)) |mem| mem.bytes() else null;
         traceCanonLowerCall(ctx, lowered_sig, trace_mem, mem_idx, args, results, result_dest_ptr);
     }
 
@@ -8463,11 +8463,11 @@ fn dispatchAotComponentTrampoline(
         var offset: u32 = result_dest_ptr;
         for (results, ctx.result_types) |r, t| {
             if (typeContainsPtrLen(t, registry)) {
-                validateCanonPtrLenValue(mem.data, r, t, registry, "canon-lift") catch return error.LiftedResultInvariantViolated;
+                validateCanonPtrLenValue(mem.bytes(), r, t, registry, "canon-lift") catch return error.LiftedResultInvariantViolated;
             }
             const al = typeAlign(registry, t);
             offset = abi.alignUp(offset, al);
-            try storeInterfaceValue(mem.data, offset, r, t, registry);
+            try storeInterfaceValue(mem.bytes(), offset, r, t, registry);
             offset += typeSize(registry, t);
         }
         return 0;

--- a/src/component/instance.zig
+++ b/src/component/instance.zig
@@ -744,13 +744,13 @@ pub const ComponentInstance = struct {
         if (self.current_lower_call_ctx) |cctx| {
             if (cctx.memory) |mem| {
                 const end = @as(usize, ptr) + @as(usize, len);
-                if (end > mem.data.len) return null;
+                if (end > mem.byteLen()) return null;
                 return mem.data[ptr..end];
             }
         }
         const mem = self.canonicalMemory() orelse return null;
         const end = @as(usize, ptr) + @as(usize, len);
-        if (end > mem.data.len) return null;
+        if (end > mem.byteLen()) return null;
         return mem.data[ptr..end];
     }
 
@@ -896,13 +896,13 @@ pub const ComponentInstance = struct {
         if (self.current_lower_call_ctx) |cctx| {
             if (cctx.memory) |mem| {
                 const end = @as(usize, ptr) + @as(usize, len);
-                if (end > mem.data.len) return null;
+                if (end > mem.byteLen()) return null;
                 return mem.data[ptr..end];
             }
         }
         const mem = self.canonicalMemory() orelse return null;
         const end = @as(usize, ptr) + @as(usize, len);
-        if (end > mem.data.len) return null;
+        if (end > mem.byteLen()) return null;
         return mem.data[ptr..end];
     }
 

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -17540,7 +17540,7 @@ pub const WasiCliAdapter = struct {
         var lifted_entries: []HttpFieldEntry = &.{};
         if (list.len > 0) {
             const mem = ci.canonicalMemory() orelse return error.OutOfBoundsMemory;
-            lifted_entries = liftFieldEntries(self.allocator, mem.data, list.ptr, list.len) catch |e| switch (e) {
+            lifted_entries = liftFieldEntries(self.allocator, mem.bytes(), list.ptr, list.len) catch |e| switch (e) {
                 error.InvalidFieldSyntax => {
                     results[0] = try httpHeaderErr(allocator, .invalid_syntax);
                     return;
@@ -17837,7 +17837,7 @@ pub const WasiCliAdapter = struct {
             const stride0: u32 = 8;
             const total0 = std.math.mul(u32, vals_pl.len, stride0) catch return error.InvalidArgs;
             const list_end0 = std.math.add(u32, vals_pl.ptr, total0) catch return error.InvalidArgs;
-            if (list_end0 > mem_for_scan.data.len) return error.OutOfBoundsMemory;
+            if (list_end0 > mem_for_scan.byteLen()) return error.OutOfBoundsMemory;
             var sc: u32 = 0;
             while (sc < vals_pl.len) : (sc += 1) {
                 const off = vals_pl.ptr + sc * stride0;
@@ -17845,7 +17845,7 @@ pub const WasiCliAdapter = struct {
                 const inner_len = std.mem.readInt(u32, mem_for_scan.data[off + 4 ..][0..4], .little);
                 const inner_bytes: []const u8 = if (inner_len == 0) "" else blk: {
                     const end = std.math.add(u32, inner_ptr, inner_len) catch return error.OutOfBoundsMemory;
-                    if (end > mem_for_scan.data.len) return error.OutOfBoundsMemory;
+                    if (end > mem_for_scan.byteLen()) return error.OutOfBoundsMemory;
                     break :blk mem_for_scan.data[inner_ptr..end];
                 };
                 if (!isValidFieldValue(inner_bytes)) {
@@ -17880,7 +17880,7 @@ pub const WasiCliAdapter = struct {
                 ""
             else blk: {
                 const end = std.math.add(u32, inner_ptr, inner_len) catch return error.OutOfBoundsMemory;
-                if (end > mem.data.len) return error.OutOfBoundsMemory;
+                if (end > mem.byteLen()) return error.OutOfBoundsMemory;
                 break :blk mem.data[inner_ptr..end];
             };
 

--- a/src/platform/parking_lot.zig
+++ b/src/platform/parking_lot.zig
@@ -1,0 +1,669 @@
+//! Backend-neutral parking for WebAssembly atomic wait/notify.
+//!
+//! Waiters are keyed by the guest address. The value comparison and queue
+//! insertion happen while holding the same bucket lock, which closes the
+//! notify-before-enqueue race. Each waiter has a private OS wait word so an
+//! exact number of matching waiters can be selected and woken.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const platform = @import("platform.zig");
+
+const is_linux = builtin.os.tag == .linux;
+const is_macos = builtin.os.tag == .macos;
+const is_windows = builtin.os.tag == .windows;
+
+pub const WaitResult = enum(u32) {
+    notified = 0,
+    not_equal = 1,
+    timed_out = 2,
+    cancelled = 3,
+    closed = 4,
+};
+
+pub const BackendError = error{
+    InvalidAddress,
+    InvalidArgument,
+    Unsupported,
+    SystemFailure,
+};
+
+const OsWaitResult = enum {
+    awakened,
+    timed_out,
+    spurious,
+};
+
+const SpinMutex = struct {
+    state: std.atomic.Value(u8) = .init(0),
+
+    fn lock(self: *SpinMutex) void {
+        while (self.state.cmpxchgWeak(0, 1, .acquire, .monotonic) != null)
+            std.atomic.spinLoopHint();
+    }
+
+    fn unlock(self: *SpinMutex) void {
+        self.state.store(0, .release);
+    }
+};
+
+const Outcome = enum(u32) {
+    waiting,
+    notified,
+    cancelled,
+    closed,
+};
+
+const Waiter = struct {
+    next: ?*Waiter = null,
+    key: usize,
+    outcome: std.atomic.Value(u32) = .init(@intFromEnum(Outcome.waiting)),
+};
+
+const Bucket = struct {
+    mutex: SpinMutex = .{},
+    head: ?*Waiter = null,
+};
+
+/// A keyed parking lot with explicit cancellation and quiescent shutdown.
+///
+/// `deinit` first prevents new waits, then wakes every queued waiter and
+/// waits until all active `wait32`/`wait64` calls have returned. The object
+/// may therefore be embedded in another refcounted control block.
+pub const ParkingLot = struct {
+    const bucket_count = 64;
+    const closing_bit: u32 = 1 << 31;
+    const active_mask: u32 = closing_bit - 1;
+
+    buckets: [bucket_count]Bucket = @splat(.{}),
+    lifecycle: std.atomic.Value(u32) = .init(0),
+
+    pub fn init() ParkingLot {
+        return .{};
+    }
+
+    pub fn wait32(
+        self: *ParkingLot,
+        address: *align(@alignOf(u32)) const u32,
+        expected: u32,
+        timeout_ns: i64,
+    ) BackendError!WaitResult {
+        return self.waitValue(u32, address, expected, timeout_ns);
+    }
+
+    pub fn wait64(
+        self: *ParkingLot,
+        address: *align(@alignOf(u64)) const u64,
+        expected: u64,
+        timeout_ns: i64,
+    ) BackendError!WaitResult {
+        return self.waitValue(u64, address, expected, timeout_ns);
+    }
+
+    fn waitValue(
+        self: *ParkingLot,
+        comptime T: type,
+        address: *align(@alignOf(T)) const T,
+        expected: T,
+        timeout_ns: i64,
+    ) BackendError!WaitResult {
+        if (!self.enter()) return .closed;
+        defer self.leave();
+
+        const key = @intFromPtr(address);
+        const bucket = self.bucketFor(key);
+        var waiter = Waiter{ .key = key };
+
+        bucket.mutex.lock();
+        if (self.lifecycle.load(.acquire) & closing_bit != 0) {
+            bucket.mutex.unlock();
+            return .closed;
+        }
+        if (@atomicLoad(T, address, .seq_cst) != expected) {
+            bucket.mutex.unlock();
+            return .not_equal;
+        }
+        if (timeout_ns == 0) {
+            bucket.mutex.unlock();
+            return .timed_out;
+        }
+        waiter.next = bucket.head;
+        bucket.head = &waiter;
+        bucket.mutex.unlock();
+
+        const deadline_ns: ?u64 = if (timeout_ns < 0)
+            null
+        else
+            std.math.add(u64, monotonicNowNs(), @intCast(timeout_ns)) catch
+                std.math.maxInt(u64);
+
+        while (true) {
+            const outcome: Outcome = @enumFromInt(waiter.outcome.load(.acquire));
+            if (outcome != .waiting) return outcomeToResult(outcome);
+
+            const remaining_ns: ?u64 = if (deadline_ns) |deadline| remaining: {
+                const now = monotonicNowNs();
+                if (now >= deadline) {
+                    bucket.mutex.lock();
+                    const final = self.removeTimedOutLocked(bucket, &waiter);
+                    bucket.mutex.unlock();
+                    return final;
+                }
+                break :remaining deadline - now;
+            } else null;
+
+            const os_result = osWait(
+                &waiter.outcome.raw,
+                @intFromEnum(Outcome.waiting),
+                remaining_ns,
+            ) catch |err| {
+                bucket.mutex.lock();
+                const final_outcome: Outcome = @enumFromInt(waiter.outcome.load(.acquire));
+                if (final_outcome != .waiting) {
+                    bucket.mutex.unlock();
+                    return outcomeToResult(final_outcome);
+                }
+                self.removeLocked(bucket, &waiter);
+                waiter.outcome.store(@intFromEnum(Outcome.cancelled), .release);
+                bucket.mutex.unlock();
+                return err;
+            };
+            switch (os_result) {
+                .awakened, .spurious => continue,
+                .timed_out => {
+                    if (deadline_ns) |deadline| {
+                        if (monotonicNowNs() < deadline) continue;
+                    }
+                    bucket.mutex.lock();
+                    const final = self.removeTimedOutLocked(bucket, &waiter);
+                    bucket.mutex.unlock();
+                    return final;
+                },
+            }
+        }
+    }
+
+    fn removeTimedOutLocked(self: *ParkingLot, bucket: *Bucket, waiter: *Waiter) WaitResult {
+        const outcome: Outcome = @enumFromInt(waiter.outcome.load(.acquire));
+        if (outcome != .waiting) return outcomeToResult(outcome);
+
+        self.removeLocked(bucket, waiter);
+        waiter.outcome.store(@intFromEnum(Outcome.cancelled), .release);
+        return .timed_out;
+    }
+
+    fn removeLocked(self: *ParkingLot, bucket: *Bucket, waiter: *Waiter) void {
+        _ = self;
+        var link = &bucket.head;
+        while (link.*) |candidate| {
+            if (candidate == waiter) {
+                link.* = candidate.next;
+                return;
+            }
+            link = &candidate.next;
+        }
+    }
+
+    /// Wake up to `count` waiters at exactly `address`.
+    pub fn notify(self: *ParkingLot, address: *const anyopaque, count: u32) BackendError!u32 {
+        if (count == 0) return 0;
+        return self.wakeKey(@intFromPtr(address), count, .notified);
+    }
+
+    /// Cancel every waiter at exactly `address`.
+    pub fn cancel(self: *ParkingLot, address: *const anyopaque) BackendError!u32 {
+        return self.wakeKey(@intFromPtr(address), std.math.maxInt(u32), .cancelled);
+    }
+
+    /// Cancel all waiters. This is the group-cancellation primitive.
+    pub fn cancelAll(self: *ParkingLot) BackendError!u32 {
+        var total: u32 = 0;
+        for (0..bucket_count) |i| {
+            const bucket = &self.buckets[i];
+            bucket.mutex.lock();
+            while (bucket.head) |w| {
+                bucket.head = w.next;
+                w.outcome.store(@intFromEnum(Outcome.cancelled), .release);
+                osWake(&w.outcome.raw) catch |err| {
+                    bucket.mutex.unlock();
+                    return err;
+                };
+                total +|= 1;
+            }
+            bucket.mutex.unlock();
+        }
+        return total;
+    }
+
+    fn wakeKey(self: *ParkingLot, key: usize, count: u32, outcome: Outcome) BackendError!u32 {
+        const bucket = self.bucketFor(key);
+        bucket.mutex.lock();
+        defer bucket.mutex.unlock();
+
+        var woken: u32 = 0;
+        var link = &bucket.head;
+        while (link.*) |waiter| {
+            if (waiter.key != key or woken >= count) {
+                link = &waiter.next;
+                continue;
+            }
+            link.* = waiter.next;
+            waiter.outcome.store(@intFromEnum(outcome), .release);
+            try osWake(&waiter.outcome.raw);
+            woken += 1;
+        }
+        return woken;
+    }
+
+    /// Number of currently queued waiters for a key. Intended for
+    /// diagnostics and deterministic native tests.
+    pub fn waiterCount(self: *ParkingLot, address: *const anyopaque) u32 {
+        const key = @intFromPtr(address);
+        const bucket = self.bucketFor(key);
+        bucket.mutex.lock();
+        defer bucket.mutex.unlock();
+
+        var count: u32 = 0;
+        var waiter = bucket.head;
+        while (waiter) |w| : (waiter = w.next) {
+            if (w.key == key) count += 1;
+        }
+        return count;
+    }
+
+    /// Wake all waiters and wait for their stack-allocated queue nodes to
+    /// leave the parking lot.
+    pub fn deinit(self: *ParkingLot) void {
+        _ = self.lifecycle.fetchOr(closing_bit, .acq_rel);
+        self.closeAll();
+
+        while (self.lifecycle.load(.acquire) & active_mask != 0) {
+            const observed = self.lifecycle.load(.acquire);
+            _ = osWait(&self.lifecycle.raw, observed, null) catch |err| switch (err) {
+                error.InvalidAddress,
+                error.InvalidArgument,
+                error.Unsupported,
+                error.SystemFailure,
+                => platform.usleep(100),
+            };
+        }
+    }
+
+    fn closeAll(self: *ParkingLot) void {
+        for (0..bucket_count) |i| {
+            const bucket = &self.buckets[i];
+            bucket.mutex.lock();
+            var waiter = bucket.head;
+            bucket.head = null;
+            while (waiter) |w| {
+                waiter = w.next;
+                w.outcome.store(@intFromEnum(Outcome.closed), .release);
+                osWake(&w.outcome.raw) catch |err| switch (err) {
+                    error.InvalidAddress,
+                    error.InvalidArgument,
+                    error.Unsupported,
+                    error.SystemFailure,
+                    => {},
+                };
+            }
+            bucket.mutex.unlock();
+        }
+    }
+
+    fn enter(self: *ParkingLot) bool {
+        var state = self.lifecycle.load(.acquire);
+        while (true) {
+            if (state & closing_bit != 0) return false;
+            if (state & active_mask == active_mask) return false;
+            state = self.lifecycle.cmpxchgWeak(
+                state,
+                state + 1,
+                .acquire,
+                .monotonic,
+            ) orelse return true;
+        }
+    }
+
+    fn leave(self: *ParkingLot) void {
+        const old = self.lifecycle.fetchSub(1, .release);
+        if (old == closing_bit | 1) {
+            _ = self.lifecycle.load(.acquire);
+            osWakeAll(&self.lifecycle.raw) catch |err| switch (err) {
+                error.InvalidAddress,
+                error.InvalidArgument,
+                error.Unsupported,
+                error.SystemFailure,
+                => {},
+            };
+        }
+    }
+
+    fn bucketFor(self: *ParkingLot, key: usize) *Bucket {
+        const multiplier: usize = @truncate(0x9E3779B97F4A7C15);
+        const hash = key *% multiplier;
+        const shift = @bitSizeOf(usize) - @ctz(@as(usize, bucket_count));
+        return &self.buckets[hash >> shift];
+    }
+};
+
+fn outcomeToResult(outcome: Outcome) WaitResult {
+    return switch (outcome) {
+        .waiting => unreachable,
+        .notified => .notified,
+        .cancelled => .cancelled,
+        .closed => .closed,
+    };
+}
+
+fn monotonicNowNs() u64 {
+    return std.math.mul(u64, platform.timeGetBootUs(), std.time.ns_per_us) catch
+        std.math.maxInt(u64);
+}
+
+fn osWait(word: *const u32, expected: u32, timeout_ns: ?u64) BackendError!OsWaitResult {
+    if (comptime is_linux) return linuxWait(word, expected, timeout_ns);
+    if (comptime is_macos) return macosWait(word, expected, timeout_ns);
+    if (comptime is_windows) return windowsWait(word, expected, timeout_ns);
+    return error.Unsupported;
+}
+
+fn osWake(word: *const u32) BackendError!void {
+    if (comptime is_linux) return linuxWake(word, 1);
+    if (comptime is_macos) return macosWake(word, false);
+    if (comptime is_windows) {
+        std.os.windows.ntdll.RtlWakeAddressSingle(word);
+        return;
+    }
+    return error.Unsupported;
+}
+
+fn osWakeAll(word: *const u32) BackendError!void {
+    if (comptime is_linux) return linuxWake(word, std.math.maxInt(i32));
+    if (comptime is_macos) return macosWake(word, true);
+    if (comptime is_windows) {
+        std.os.windows.ntdll.RtlWakeAddressAll(word);
+        return;
+    }
+    return error.Unsupported;
+}
+
+fn linuxWait(word: *const u32, expected: u32, timeout_ns: ?u64) BackendError!OsWaitResult {
+    if (!is_linux) unreachable;
+    const linux = std.os.linux;
+    var ts_buffer: linux.timespec = undefined;
+    const ts: ?*linux.timespec = if (timeout_ns) |ns| ts: {
+        if (ns == 0) return .timed_out;
+        ts_buffer = .{
+            .sec = @intCast(ns / std.time.ns_per_s),
+            .nsec = @intCast(ns % std.time.ns_per_s),
+        };
+        break :ts &ts_buffer;
+    } else null;
+    const rc = linux.futex_4arg(word, .{ .cmd = .WAIT, .private = true }, expected, ts);
+    return mapLinuxWaitErrno(linux.errno(rc));
+}
+
+fn mapLinuxWaitErrno(err: std.os.linux.E) BackendError!OsWaitResult {
+    return switch (err) {
+        .SUCCESS => .awakened,
+        .AGAIN, .INTR => .spurious,
+        .TIMEDOUT => .timed_out,
+        .FAULT => error.InvalidAddress,
+        .INVAL => error.InvalidArgument,
+        .NOSYS => error.Unsupported,
+        else => error.SystemFailure,
+    };
+}
+
+fn linuxWake(word: *const u32, count: u32) BackendError!void {
+    if (!is_linux) unreachable;
+    const linux = std.os.linux;
+    const rc = linux.futex_3arg(word, .{ .cmd = .WAKE, .private = true }, count);
+    switch (linux.errno(rc)) {
+        .SUCCESS => {},
+        .FAULT => return error.InvalidAddress,
+        .INVAL => return error.InvalidArgument,
+        .NOSYS => return error.Unsupported,
+        else => return error.SystemFailure,
+    }
+}
+
+fn macosWait(word: *const u32, expected: u32, timeout_ns: ?u64) BackendError!OsWaitResult {
+    if (!is_macos) unreachable;
+    const flags: std.c.UL = .{ .op = .COMPARE_AND_WAIT, .NO_ERRNO = true };
+    const timeout_us: u32 = if (timeout_ns) |ns|
+        @intCast(@min(
+            @max(@as(u64, 1), (ns +| (std.time.ns_per_us - 1)) / std.time.ns_per_us),
+            std.math.maxInt(u32),
+        ))
+    else
+        0;
+    const status = std.c.__ulock_wait(flags, word, expected, timeout_us);
+    if (status >= 0) return .awakened;
+    return mapDarwinWaitErrno(@enumFromInt(-status));
+}
+
+fn mapDarwinWaitErrno(err: std.c.E) BackendError!OsWaitResult {
+    return switch (err) {
+        .INTR, .CANCELED, .FAULT => .spurious,
+        .TIMEDOUT => .timed_out,
+        .INVAL => error.InvalidArgument,
+        .NOSYS => error.Unsupported,
+        else => error.SystemFailure,
+    };
+}
+
+fn macosWake(word: *const u32, all: bool) BackendError!void {
+    if (!is_macos) unreachable;
+    const flags: std.c.UL = .{
+        .op = .COMPARE_AND_WAIT,
+        .NO_ERRNO = true,
+        .WAKE_ALL = all,
+    };
+    while (true) {
+        const status = std.c.__ulock_wake(flags, word, 0);
+        if (status >= 0) return;
+        switch (@as(std.c.E, @enumFromInt(-status))) {
+            .INTR, .CANCELED => continue,
+            .NOENT => return,
+            .FAULT => return error.InvalidAddress,
+            .INVAL => return error.InvalidArgument,
+            .NOSYS => return error.Unsupported,
+            else => return error.SystemFailure,
+        }
+    }
+}
+
+fn windowsWait(word: *const u32, expected: u32, timeout_ns: ?u64) BackendError!OsWaitResult {
+    if (!is_windows) unreachable;
+    const windows = std.os.windows;
+    var expected_copy = expected;
+    var timeout: windows.LARGE_INTEGER = undefined;
+    const timeout_ptr: ?*const windows.LARGE_INTEGER = if (timeout_ns) |ns| timeout: {
+        if (ns == 0) return .timed_out;
+        const ticks = @min(
+            (ns +| 99) / 100,
+            @as(u64, @intCast(std.math.maxInt(i64))),
+        );
+        timeout = -@as(i64, @intCast(@max(ticks, 1)));
+        break :timeout &timeout;
+    } else null;
+    const status = windows.ntdll.RtlWaitOnAddress(
+        word,
+        &expected_copy,
+        @sizeOf(u32),
+        timeout_ptr,
+    );
+    return mapWindowsWaitStatus(status);
+}
+
+fn mapWindowsWaitStatus(status: std.os.windows.NTSTATUS) BackendError!OsWaitResult {
+    return switch (status) {
+        .SUCCESS => .awakened,
+        .TIMEOUT => .timed_out,
+        .ALERTED, .USER_APC => .spurious,
+        .ACCESS_VIOLATION => error.InvalidAddress,
+        .INVALID_PARAMETER => error.InvalidArgument,
+        .NOT_IMPLEMENTED => error.Unsupported,
+        else => error.SystemFailure,
+    };
+}
+
+const WaitThreadCtx = struct {
+    lot: *ParkingLot,
+    word32: ?*align(4) u32 = null,
+    word64: ?*align(8) u64 = null,
+    expected32: u32 = 7,
+    expected64: u64 = 11,
+    result: *WaitResult,
+};
+
+fn waitThread(ctx: WaitThreadCtx) void {
+    ctx.result.* = if (ctx.word32) |word|
+        ctx.lot.wait32(word, ctx.expected32, -1) catch |err| switch (err) {
+            error.InvalidAddress,
+            error.InvalidArgument,
+            error.Unsupported,
+            error.SystemFailure,
+            => .closed,
+        }
+    else
+        ctx.lot.wait64(ctx.word64.?, ctx.expected64, -1) catch |err| switch (err) {
+            error.InvalidAddress,
+            error.InvalidArgument,
+            error.Unsupported,
+            error.SystemFailure,
+            => .closed,
+        };
+}
+
+fn waitUntilQueued(lot: *ParkingLot, address: *const anyopaque, count: u32) !void {
+    const deadline = monotonicNowNs() +| (2 * std.time.ns_per_s);
+    while (lot.waiterCount(address) != count) {
+        if (monotonicNowNs() >= deadline) return error.TestExpectedEqual;
+        platform.usleep(50);
+    }
+}
+
+test "ParkingLot: wait mismatch does not enqueue" {
+    var lot = ParkingLot.init();
+    defer lot.deinit();
+    var word: u32 align(4) = 9;
+    try std.testing.expectEqual(WaitResult.not_equal, try lot.wait32(&word, 7, -1));
+    try std.testing.expectEqual(@as(u32, 0), lot.waiterCount(&word));
+}
+
+test "ParkingLot: wait32 and wait64 use monotonic accurate timeouts" {
+    var lot = ParkingLot.init();
+    defer lot.deinit();
+    var word32: u32 align(4) = 7;
+    var word64: u64 align(8) = 11;
+
+    const lower = 10 * std.time.ns_per_ms;
+    const upper = 1 * std.time.ns_per_s;
+    const timeout = 30 * std.time.ns_per_ms;
+
+    var start = monotonicNowNs();
+    try std.testing.expectEqual(WaitResult.timed_out, try lot.wait32(&word32, 7, timeout));
+    var elapsed = monotonicNowNs() - start;
+    try std.testing.expect(elapsed >= lower and elapsed <= upper);
+
+    start = monotonicNowNs();
+    try std.testing.expectEqual(WaitResult.timed_out, try lot.wait64(&word64, 11, timeout));
+    elapsed = monotonicNowNs() - start;
+    try std.testing.expect(elapsed >= lower and elapsed <= upper);
+}
+
+test "ParkingLot: notify returns exact counts" {
+    var lot = ParkingLot.init();
+    defer lot.deinit();
+    var word: u32 align(4) = 7;
+    var results: [4]WaitResult = @splat(.closed);
+    var threads: [4]std.Thread = undefined;
+    for (&threads, 0..) |*thread, i| {
+        thread.* = try std.Thread.spawn(.{}, waitThread, .{WaitThreadCtx{
+            .lot = &lot,
+            .word32 = &word,
+            .result = &results[i],
+        }});
+    }
+    try waitUntilQueued(&lot, &word, 4);
+    try std.testing.expectEqual(@as(u32, 2), try lot.notify(&word, 2));
+    try std.testing.expectEqual(@as(u32, 2), try lot.notify(&word, 20));
+    try std.testing.expectEqual(@as(u32, 0), try lot.notify(&word, 1));
+    for (threads) |thread| thread.join();
+    for (results) |result| try std.testing.expectEqual(WaitResult.notified, result);
+}
+
+test "ParkingLot: no lost wakeup under stress" {
+    var lot = ParkingLot.init();
+    defer lot.deinit();
+    var word: u32 align(4) = 7;
+
+    for (0..500) |_| {
+        @atomicStore(u32, &word, 7, .seq_cst);
+        var result: WaitResult = .closed;
+        const thread = try std.Thread.spawn(.{}, waitThread, .{WaitThreadCtx{
+            .lot = &lot,
+            .word32 = &word,
+            .result = &result,
+        }});
+        @atomicStore(u32, &word, 9, .seq_cst);
+        const woken = try lot.notify(&word, 1);
+        thread.join();
+        try std.testing.expect(woken <= 1);
+        try std.testing.expect(result == .notified or result == .not_equal);
+    }
+}
+
+test "ParkingLot: cancellation wakes waiters" {
+    var lot = ParkingLot.init();
+    defer lot.deinit();
+    var word: u64 align(8) = 11;
+    var result: WaitResult = .closed;
+    const thread = try std.Thread.spawn(.{}, waitThread, .{WaitThreadCtx{
+        .lot = &lot,
+        .word64 = &word,
+        .result = &result,
+    }});
+    try waitUntilQueued(&lot, &word, 1);
+    try std.testing.expectEqual(@as(u32, 1), try lot.cancelAll());
+    thread.join();
+    try std.testing.expectEqual(WaitResult.cancelled, result);
+}
+
+test "ParkingLot: deinit wakes and drains waiters" {
+    var lot = ParkingLot.init();
+    var word: u32 align(4) = 7;
+    var result: WaitResult = .not_equal;
+    const thread = try std.Thread.spawn(.{}, waitThread, .{WaitThreadCtx{
+        .lot = &lot,
+        .word32 = &word,
+        .result = &result,
+    }});
+    try waitUntilQueued(&lot, &word, 1);
+    lot.deinit();
+    thread.join();
+    try std.testing.expectEqual(WaitResult.closed, result);
+}
+
+test "ParkingLot: platform error mapping" {
+    if (comptime is_linux) {
+        try std.testing.expectError(error.InvalidAddress, mapLinuxWaitErrno(.FAULT));
+        try std.testing.expectError(error.InvalidArgument, mapLinuxWaitErrno(.INVAL));
+        try std.testing.expectError(error.Unsupported, mapLinuxWaitErrno(.NOSYS));
+        try std.testing.expectEqual(OsWaitResult.spurious, try mapLinuxWaitErrno(.INTR));
+        try std.testing.expectEqual(OsWaitResult.timed_out, try mapLinuxWaitErrno(.TIMEDOUT));
+    } else if (comptime is_macos) {
+        try std.testing.expectError(error.InvalidArgument, mapDarwinWaitErrno(.INVAL));
+        try std.testing.expectError(error.Unsupported, mapDarwinWaitErrno(.NOSYS));
+        try std.testing.expectEqual(OsWaitResult.spurious, try mapDarwinWaitErrno(.INTR));
+        try std.testing.expectEqual(OsWaitResult.timed_out, try mapDarwinWaitErrno(.TIMEDOUT));
+    } else if (comptime is_windows) {
+        try std.testing.expectError(error.InvalidAddress, mapWindowsWaitStatus(.ACCESS_VIOLATION));
+        try std.testing.expectError(error.InvalidArgument, mapWindowsWaitStatus(.INVALID_PARAMETER));
+        try std.testing.expectError(error.Unsupported, mapWindowsWaitStatus(.NOT_IMPLEMENTED));
+        try std.testing.expectEqual(OsWaitResult.spurious, try mapWindowsWaitStatus(.ALERTED));
+        try std.testing.expectEqual(OsWaitResult.timed_out, try mapWindowsWaitStatus(.TIMEOUT));
+    }
+}

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -259,10 +259,9 @@ fn mprotectPosix(addr: [*]u8, size: usize, prot: MemProt) !void {
 // existing addresses.
 
 /// True on platforms where `reserveAddressSpace` + `commitPages` are
-/// supported. On unsupported platforms callers must fall back to the
-/// pre-#752 `allocator.realloc` path (which moves the buffer and is
-/// unsafe for external-string aliases).
-pub const supports_reserved_memory: bool = !is_windows;
+/// supported. POSIX uses an anonymous `PROT_NONE` mapping followed by
+/// `mprotect`; Windows uses one NT reserve followed by in-place commits.
+pub const supports_reserved_memory: bool = true;
 
 /// Reserve `size` bytes of virtual address space, no physical pages
 /// backed. Returns the base pointer or null on failure. Free with
@@ -270,11 +269,18 @@ pub const supports_reserved_memory: bool = !is_windows;
 pub fn reserveAddressSpace(size: usize) ?[*]align(page_size) u8 {
     if (size == 0) return null;
     if (is_windows) {
-        // Windows: reservation needs a separate commit step — gate at
-        // call sites via `supports_reserved_memory` and fall back to
-        // the allocator path here. (Tracking a Windows-native
-        // reserve/commit implementation as a follow-up.)
-        return null;
+        var base: ?[*]u8 = null;
+        var region_size = size;
+        const status = ntdll.NtAllocateVirtualMemory(
+            win.GetCurrentProcess(),
+            @ptrCast(&base),
+            0,
+            &region_size,
+            .{ .RESERVE = true },
+            .{ .NOACCESS = true },
+        );
+        if (status != .SUCCESS) return null;
+        return @alignCast(base orelse return null);
     }
     const ptr = mmap(null, size, .{}, .{}) orelse return null;
     return @alignCast(ptr);
@@ -284,7 +290,17 @@ pub fn reserveAddressSpace(size: usize) ?[*]align(page_size) u8 {
 /// `reserveAddressSpace` call's `size`.
 pub fn releaseAddressSpace(addr: [*]align(page_size) u8, size: usize) void {
     if (size == 0) return;
-    if (is_windows) unreachable;
+    if (is_windows) {
+        var base: ?[*]u8 = addr;
+        var region_size: usize = 0;
+        _ = ntdll.NtFreeVirtualMemory(
+            win.GetCurrentProcess(),
+            @ptrCast(&base),
+            &region_size,
+            .{ .RELEASE = true },
+        );
+        return;
+    }
     munmap(addr, size);
 }
 
@@ -294,7 +310,20 @@ pub fn releaseAddressSpace(addr: [*]align(page_size) u8, size: usize) void {
 /// access. Returns `error.MprotectFailed` on failure.
 pub fn commitPages(addr: [*]align(page_size) u8, size: usize) !void {
     if (size == 0) return;
-    if (is_windows) unreachable;
+    if (is_windows) {
+        var base: ?[*]u8 = addr;
+        var region_size = size;
+        const status = ntdll.NtAllocateVirtualMemory(
+            win.GetCurrentProcess(),
+            @ptrCast(&base),
+            0,
+            &region_size,
+            .{ .COMMIT = true },
+            .{ .READWRITE = true },
+        );
+        if (status != .SUCCESS or base != addr) return error.CommitFailed;
+        return;
+    }
     try mprotect(addr, size, .{ .read = true, .write = true });
 }
 
@@ -750,6 +779,23 @@ test "mprotect changes permissions" {
     try mprotect(ptr, size, .{ .read = true, .write = true });
     ptr[0] = 99;
     try std.testing.expectEqual(@as(u8, 99), ptr[0]);
+}
+
+test "reserved address space commits in place with zero fill" {
+    if (!supports_reserved_memory) return error.SkipZigTest;
+    const size = 2 * 65536;
+    const ptr = reserveAddressSpace(size) orelse return error.ReserveFailed;
+    defer releaseAddressSpace(ptr, size);
+
+    try commitPages(ptr, 65536);
+    try std.testing.expectEqual(@as(u8, 0), ptr[0]);
+    try std.testing.expectEqual(@as(u8, 0), ptr[65535]);
+    ptr[0] = 0xA5;
+
+    try commitPages(@alignCast(ptr + 65536), 65536);
+    try std.testing.expectEqual(@as(u8, 0xA5), ptr[0]);
+    try std.testing.expectEqual(@as(u8, 0), ptr[65536]);
+    try std.testing.expectEqual(@as(u8, 0), ptr[size - 1]);
 }
 
 test "selfThread returns non-zero" {

--- a/src/root.zig
+++ b/src/root.zig
@@ -20,6 +20,9 @@ pub const host = @import("api/host.zig");
 /// Core WebAssembly types.
 pub const types = @import("runtime/common/types.zig");
 
+/// Stable shared-memory reservation, publication, and grow control block.
+pub const shared_memory = @import("runtime/common/shared_memory.zig");
+
 /// Execution environment (operand stack, call frames).
 pub const exec_env = @import("runtime/common/exec_env.zig");
 
@@ -187,6 +190,9 @@ pub const component_async_canon = @import("component/async_canon.zig");
 // Phase 1: Foundation layer
 /// Platform abstraction (mmap, threads, time, cache flush).
 pub const platform = @import("platform/platform.zig");
+
+/// Backend-neutral keyed wait/notify parking lot.
+pub const parking_lot = @import("platform/parking_lot.zig");
 
 /// Memory allocators (EMS pool allocator, default allocator).
 pub const mem_alloc = @import("shared/mem_alloc/allocator.zig");

--- a/src/runtime/aot/loader.zig
+++ b/src/runtime/aot/loader.zig
@@ -79,6 +79,7 @@ pub const ImportedMemoryDesc = struct {
     min: u32,
     max: ?u32,
     is64: bool = false,
+    is_shared: bool = false,
 };
 
 pub const ImportedGlobalDesc = struct {
@@ -643,12 +644,14 @@ fn parseImportSection(reader: *BinaryReader, section_size: u32, module: *AotModu
                 const has_max = try reader.readByte();
                 const max: ?u32 = if (has_max != 0) try reader.readU32Le() else null;
                 const is64 = (try reader.readByte()) != 0;
+                const is_shared = (try reader.readByte()) != 0;
                 memory_descs.append(allocator, .{
                     .module_name = mod_name,
                     .name = field_name,
                     .min = min,
                     .max = max,
                     .is64 = is64,
+                    .is_shared = is_shared,
                 }) catch return error.OutOfMemory;
             },
             .global => {
@@ -725,8 +728,10 @@ fn parseMemorySection(reader: *BinaryReader, section_size: u32, module: *AotModu
         const min_pages = try reader.readU32Le();
         const has_max = try reader.readByte();
         const max_pages: ?u64 = if (has_max != 0) @as(u64, try reader.readU32Le()) else null;
+        const is_shared = (try reader.readByte()) != 0;
         mem_types[i] = .{
             .limits = .{ .min = min_pages, .max = max_pages },
+            .is_shared = is_shared,
         };
     }
 

--- a/src/runtime/aot/runtime.zig
+++ b/src/runtime/aot/runtime.zig
@@ -1028,46 +1028,68 @@ pub fn aotThrowUncaught(vmctx: *VmCtx, tag_inst: *types.TagInstance) callconv(.c
 /// Returns: 0 = woken by notify, 1 = not-equal, 2 = timed-out.
 pub fn aotAtomicWait32(vmctx: *VmCtx, addr: u32, expected: u32, timeout_lo: u32, timeout_hi: u32) callconv(.c) i32 {
     const timeout_ns: i64 = @bitCast(@as(u64, timeout_hi) << 32 | @as(u64, timeout_lo));
-    if (vmctx.memory_base == 0) return 1;
-    if (@as(u64, addr) + 4 > vmctx.memory_size) return 1;
-    const mem: [*]u8 = @ptrFromInt(vmctx.memory_base);
-    const current = std.mem.readInt(u32, @as(*const [4]u8, @ptrCast(mem + addr)), .little);
-    if (current != expected) return 1; // not-equal
-
-    // In single-threaded mode, no other thread can wake us, so we'd block
-    // forever. Return timed-out (2) immediately for timeout >= 0, or
-    // block forever for timeout == -1 (infinite).
-    // TODO: with real threading, use OS futex to block.
-    if (timeout_ns < 0) {
-        // Infinite wait in single-threaded mode would deadlock.
-        // Spec says this is valid behavior (trap or block indefinitely).
-        return 2; // timed-out
-    }
-    return 2; // timed-out
+    const mem = aotWaitMemory(vmctx, addr, 4) orelse return 1;
+    const result = mem.wait32(addr, expected, timeout_ns) catch |err| switch (err) {
+        error.NotShared => return 1,
+        error.OutOfBounds,
+        error.Unaligned,
+        error.InvalidAddress,
+        error.InvalidArgument,
+        error.Unsupported,
+        error.SystemFailure,
+        => return 2,
+    };
+    return switch (result) {
+        .notified, .not_equal, .timed_out => @intCast(@intFromEnum(result)),
+        .cancelled, .closed => 2,
+    };
 }
 
 /// Host helper for `memory.atomic.wait64`.
 pub fn aotAtomicWait64(vmctx: *VmCtx, addr: u32, exp_lo: u32, exp_hi: u32, timeout_lo: u32, timeout_hi: u32) callconv(.c) i32 {
     const expected: u64 = @as(u64, exp_hi) << 32 | @as(u64, exp_lo);
     const timeout_ns: i64 = @bitCast(@as(u64, timeout_hi) << 32 | @as(u64, timeout_lo));
-    if (vmctx.memory_base == 0) return 1;
-    if (@as(u64, addr) + 8 > vmctx.memory_size) return 1;
-    const mem: [*]u8 = @ptrFromInt(vmctx.memory_base);
-    const current = std.mem.readInt(u64, @as(*const [8]u8, @ptrCast(mem + addr)), .little);
-    if (current != expected) return 1;
-    _ = timeout_ns;
-    return 2; // timed-out (single-threaded)
+    const mem = aotWaitMemory(vmctx, addr, 8) orelse return 1;
+    const result = mem.wait64(addr, expected, timeout_ns) catch |err| switch (err) {
+        error.NotShared => return 1,
+        error.OutOfBounds,
+        error.Unaligned,
+        error.InvalidAddress,
+        error.InvalidArgument,
+        error.Unsupported,
+        error.SystemFailure,
+        => return 2,
+    };
+    return switch (result) {
+        .notified, .not_equal, .timed_out => @intCast(@intFromEnum(result)),
+        .cancelled, .closed => 2,
+    };
 }
 
 /// Host helper for `memory.atomic.notify`.
 /// Wakes up to `count` threads waiting on `mem[addr]`.
 /// Returns the number of threads actually woken.
 pub fn aotAtomicNotify(vmctx: *VmCtx, addr: u32, count: u32) callconv(.c) i32 {
-    // In single-threaded mode, no threads are ever waiting.
-    _ = vmctx;
-    _ = addr;
-    _ = count;
-    return 0;
+    const mem = aotWaitMemory(vmctx, addr, 4) orelse return 0;
+    return @intCast(mem.notify(addr, count) catch |err| switch (err) {
+        error.NotShared,
+        error.OutOfBounds,
+        error.Unaligned,
+        error.InvalidAddress,
+        error.InvalidArgument,
+        error.Unsupported,
+        error.SystemFailure,
+        => return 0,
+    });
+}
+
+fn aotWaitMemory(vmctx: *VmCtx, addr: u32, width: u32) ?*types.MemoryInstance {
+    if (vmctx.instance_ptr == 0) return null;
+    const inst: *AotInstance = @ptrFromInt(vmctx.instance_ptr);
+    if (inst.memories.len == 0) return null;
+    const mem = inst.memories[0];
+    if (@as(u64, addr) + width > mem.byteLen()) return null;
+    return mem;
 }
 
 /// Host helper invoked from AOT-compiled `memory.grow` sites.
@@ -1090,10 +1112,12 @@ pub fn memGrowHelper(vmctx: *VmCtx, delta_pages: i32) callconv(.c) i32 {
     // `data.ptr`; the reserved path keeps it pinned, preserving
     // external aliases held outside the vmctx-subscriber mechanism.)
     const old_pages = mem.grow(delta, inst.allocator) catch return -1;
-    const new_pages = mem.current_pages;
+    const new_pages = mem.pageCount();
     refreshVmCtxMemory(vmctx, mem);
 
     if (mem.data.ptr != old_data_ptr or new_pages != old_pages) {
+        mem.subscriber_mutex.lock();
+        defer mem.subscriber_mutex.unlock();
         for (mem.vmctx_subscribers.items) |subscriber_opaque| {
             const subscriber: *VmCtx = @ptrCast(@alignCast(subscriber_opaque));
             if (subscriber == vmctx) continue;
@@ -1834,7 +1858,7 @@ pub fn instantiateWithOverrides(
         if (seg.memory_idx < inst.memories_owned.len and !inst.memories_owned[seg.memory_idx]) continue;
         const mem = inst.memories[seg.memory_idx];
         const end = @as(usize, seg.offset) + seg.data.len;
-        if (end > mem.data.len) continue;
+        if (end > mem.byteLen()) continue;
         @memcpy(mem.data[seg.offset..][0..seg.data.len], seg.data);
     }
 
@@ -1986,9 +2010,9 @@ pub fn destroy(inst: *AotInstance) void {
 
 fn refreshVmCtxMemory(vmctx: *VmCtx, mem: *types.MemoryInstance) void {
     vmctx.memory_base = @intFromPtr(mem.data.ptr);
-    vmctx.memory_size = @as(usize, mem.current_pages) * types.MemoryInstance.page_size;
-    vmctx.memory_max_size = mem.data.len;
-    vmctx.memory_pages = mem.current_pages;
+    vmctx.memory_size = mem.byteLen();
+    vmctx.memory_max_size = if (mem.shared_control) |control| control.reserved_bytes else mem.data.len;
+    vmctx.memory_pages = mem.pageCount();
     // #719 forensic aid: when the trap-OOB dump env var is set, also log
     // the host base addr for every memory we attach so a gdb hardware
     // watchpoint can be placed on `mem_base + wasm_offset` cheaply.
@@ -3232,6 +3256,7 @@ fn allocateMemories(
                 .max = if (desc.max) |max| @as(u64, max) else null,
             },
             .is_memory64 = desc.is64,
+            .is_shared = desc.is_shared,
         };
         memories[i] = try allocateOneMemory(mem_type, allocator);
         owned[i] = true;
@@ -3249,6 +3274,13 @@ fn allocateMemories(
 }
 
 fn allocateOneMemory(mem_type: types.MemoryType, allocator: std.mem.Allocator) RuntimeError!*types.MemoryInstance {
+    if (mem_type.is_shared) {
+        // Shared memories must never fall back to allocator.realloc: every
+        // owner and parked address depends on an immutable base.
+        return types.MemoryInstance.createShared(mem_type, allocator) catch
+            return error.OutOfMemory;
+    }
+
     const initial_pages: u32 = @intCast(@min(mem_type.limits.min, 65536));
     const max_pages: u32 = @intCast(@min(mem_type.limits.max orelse 65536, 65536));
 

--- a/src/runtime/common/shared_memory.zig
+++ b/src/runtime/common/shared_memory.zig
@@ -1,0 +1,301 @@
+//! Stable shared linear-memory backing and atomic size publication.
+
+const std = @import("std");
+const platform = @import("../../platform/platform.zig");
+const parking = @import("../../platform/parking_lot.zig");
+
+pub const wasm_page_size: usize = 65536;
+pub const page_size_min: u29 = std.heap.page_size_min;
+
+pub const CreateError = error{
+    InvalidLimits,
+    SizeOverflow,
+    ReserveFailed,
+    CommitFailed,
+    OutOfMemory,
+};
+
+pub const GrowError = error{
+    MemoryGrowFailed,
+};
+
+pub const WaitError = parking.BackendError || error{
+    OutOfBounds,
+    Unaligned,
+};
+
+const SpinMutex = struct {
+    state: std.atomic.Value(u8) = .init(0),
+
+    fn lock(self: *SpinMutex) void {
+        while (self.state.cmpxchgWeak(0, 1, .acquire, .monotonic) != null)
+            std.atomic.spinLoopHint();
+    }
+
+    fn unlock(self: *SpinMutex) void {
+        self.state.store(0, .release);
+    }
+};
+
+/// Portable control block shared by every owner of a shared linear memory.
+///
+/// The reservation and `base` never change. A successful grow commits the
+/// next range while holding `grow_mutex`, then publishes bytes followed by
+/// pages with release stores. Readers use acquire loads.
+pub const Control = struct {
+    base: [*]align(page_size_min) u8,
+    reserved_bytes: usize,
+    max_pages: u32,
+    current_pages: std.atomic.Value(u32),
+    current_bytes: std.atomic.Value(usize),
+    ref_count: std.atomic.Value(u32) = .init(1),
+    grow_mutex: SpinMutex = .{},
+    parking_lot: parking.ParkingLot = .init(),
+
+    pub fn create(
+        initial_pages: u32,
+        max_pages: u32,
+        allocator: std.mem.Allocator,
+    ) CreateError!*Control {
+        if (!platform.supports_reserved_memory) return error.ReserveFailed;
+        if (max_pages == 0 or initial_pages > max_pages) return error.InvalidLimits;
+        const reserved_bytes = std.math.mul(usize, max_pages, wasm_page_size) catch
+            return error.SizeOverflow;
+        const initial_bytes = std.math.mul(usize, initial_pages, wasm_page_size) catch
+            return error.SizeOverflow;
+
+        const base = platform.reserveAddressSpace(reserved_bytes) orelse
+            return error.ReserveFailed;
+        errdefer platform.releaseAddressSpace(base, reserved_bytes);
+        platform.commitPages(base, initial_bytes) catch return error.CommitFailed;
+
+        const control = allocator.create(Control) catch return error.OutOfMemory;
+        control.* = .{
+            .base = base,
+            .reserved_bytes = reserved_bytes,
+            .max_pages = max_pages,
+            .current_pages = .init(initial_pages),
+            .current_bytes = .init(initial_bytes),
+        };
+        return control;
+    }
+
+    pub fn destroy(self: *Control, allocator: std.mem.Allocator) void {
+        self.parking_lot.deinit();
+        platform.releaseAddressSpace(self.base, self.reserved_bytes);
+        allocator.destroy(self);
+    }
+
+    pub fn retain(self: *Control) bool {
+        var count = self.ref_count.load(.acquire);
+        while (count != 0) {
+            if (count == std.math.maxInt(u32)) return false;
+            count = self.ref_count.cmpxchgWeak(
+                count,
+                count + 1,
+                .acquire,
+                .monotonic,
+            ) orelse return true;
+        }
+        return false;
+    }
+
+    /// Drop one owner. Returns true to the owner responsible for destruction.
+    pub fn release(self: *Control) bool {
+        const previous = self.ref_count.fetchSub(1, .acq_rel);
+        std.debug.assert(previous != 0);
+        return previous == 1;
+    }
+
+    pub fn referenceCount(self: *const Control) u32 {
+        return self.ref_count.load(.acquire);
+    }
+
+    pub fn pageCount(self: *const Control) u32 {
+        return self.current_pages.load(.acquire);
+    }
+
+    pub fn byteLen(self: *const Control) usize {
+        return self.current_bytes.load(.acquire);
+    }
+
+    pub fn capacity(self: *Control) []u8 {
+        return self.base[0..self.reserved_bytes];
+    }
+
+    pub fn bytes(self: *Control) []u8 {
+        return self.base[0..self.byteLen()];
+    }
+
+    pub fn grow(self: *Control, delta_pages: u32) GrowError!u32 {
+        self.grow_mutex.lock();
+        defer self.grow_mutex.unlock();
+
+        const old_pages = self.current_pages.load(.monotonic);
+        const new_pages = std.math.add(u32, old_pages, delta_pages) catch
+            return error.MemoryGrowFailed;
+        if (new_pages > self.max_pages) return error.MemoryGrowFailed;
+
+        const old_bytes = self.current_bytes.load(.monotonic);
+        const new_bytes = std.math.mul(usize, new_pages, wasm_page_size) catch
+            return error.MemoryGrowFailed;
+        if (new_bytes > self.reserved_bytes) return error.MemoryGrowFailed;
+
+        if (new_bytes > old_bytes) {
+            platform.commitPages(
+                @alignCast(self.base + old_bytes),
+                new_bytes - old_bytes,
+            ) catch return error.MemoryGrowFailed;
+        }
+
+        // The release publication makes the completed commit and the
+        // platform-provided zero fill visible before the larger size.
+        self.current_bytes.store(new_bytes, .release);
+        self.current_pages.store(new_pages, .release);
+        return old_pages;
+    }
+
+    pub fn wait32(
+        self: *Control,
+        offset: usize,
+        expected: u32,
+        timeout_ns: i64,
+    ) WaitError!parking.WaitResult {
+        if (offset & (@alignOf(u32) - 1) != 0) return error.Unaligned;
+        if (!rangeInBounds(offset, @sizeOf(u32), self.byteLen())) return error.OutOfBounds;
+        const address: *align(@alignOf(u32)) const u32 =
+            @ptrCast(@alignCast(self.base + offset));
+        return self.parking_lot.wait32(address, expected, timeout_ns);
+    }
+
+    pub fn wait64(
+        self: *Control,
+        offset: usize,
+        expected: u64,
+        timeout_ns: i64,
+    ) WaitError!parking.WaitResult {
+        if (offset & (@alignOf(u64) - 1) != 0) return error.Unaligned;
+        if (!rangeInBounds(offset, @sizeOf(u64), self.byteLen())) return error.OutOfBounds;
+        const address: *align(@alignOf(u64)) const u64 =
+            @ptrCast(@alignCast(self.base + offset));
+        return self.parking_lot.wait64(address, expected, timeout_ns);
+    }
+
+    pub fn notify(self: *Control, offset: usize, count: u32) WaitError!u32 {
+        if (offset & (@alignOf(u32) - 1) != 0) return error.Unaligned;
+        if (!rangeInBounds(offset, @sizeOf(u32), self.byteLen())) return error.OutOfBounds;
+        return self.parking_lot.notify(self.base + offset, count);
+    }
+
+    pub fn cancelAddress(self: *Control, offset: usize) WaitError!u32 {
+        if (offset >= self.byteLen()) return error.OutOfBounds;
+        return self.parking_lot.cancel(self.base + offset);
+    }
+
+    pub fn cancelAll(self: *Control) parking.BackendError!u32 {
+        return self.parking_lot.cancelAll();
+    }
+};
+
+fn rangeInBounds(offset: usize, width: usize, limit: usize) bool {
+    const end = std.math.add(usize, offset, width) catch return false;
+    return end <= limit;
+}
+
+const GrowCtx = struct {
+    control: *Control,
+    old_pages: *u32,
+};
+
+fn growThread(ctx: GrowCtx) void {
+    ctx.old_pages.* = ctx.control.grow(1) catch std.math.maxInt(u32);
+}
+
+const PublicationCtx = struct {
+    control: *Control,
+    saw_zero: *bool,
+};
+
+fn publicationReader(ctx: PublicationCtx) void {
+    while (ctx.control.byteLen() < 2 * wasm_page_size)
+        std.atomic.spinLoopHint();
+    ctx.saw_zero.* = ctx.control.base[2 * wasm_page_size - 1] == 0;
+}
+
+test "SharedMemory: reserve commit grow failure and zero fill" {
+    if (!platform.supports_reserved_memory) return error.SkipZigTest;
+    const control = try Control.create(1, 4, std.testing.allocator);
+    defer {
+        std.debug.assert(control.release());
+        control.destroy(std.testing.allocator);
+    }
+
+    const base = control.base;
+    control.base[0] = 0xA5;
+    try std.testing.expectEqual(@as(u32, 1), try control.grow(2));
+    try std.testing.expectEqual(base, control.base);
+    try std.testing.expectEqual(@as(u32, 3), control.pageCount());
+    try std.testing.expectEqual(@as(usize, 3 * wasm_page_size), control.byteLen());
+    try std.testing.expectEqual(@as(u8, 0xA5), control.base[0]);
+    try std.testing.expectEqual(@as(u8, 0), control.base[wasm_page_size]);
+    try std.testing.expectEqual(@as(u8, 0), control.base[3 * wasm_page_size - 1]);
+
+    try std.testing.expectError(error.MemoryGrowFailed, control.grow(2));
+    try std.testing.expectEqual(@as(u32, 3), control.pageCount());
+    try std.testing.expectEqual(@as(usize, 3 * wasm_page_size), control.byteLen());
+}
+
+test "SharedMemory: concurrent grow is serialized and base remains stable" {
+    if (!platform.supports_reserved_memory) return error.SkipZigTest;
+    const control = try Control.create(1, 8, std.testing.allocator);
+    defer {
+        std.debug.assert(control.release());
+        control.destroy(std.testing.allocator);
+    }
+    const base = control.base;
+    var old_pages: [4]u32 = @splat(0);
+    var threads: [4]std.Thread = undefined;
+    for (&threads, 0..) |*thread, i| {
+        thread.* = try std.Thread.spawn(.{}, growThread, .{GrowCtx{
+            .control = control,
+            .old_pages = &old_pages[i],
+        }});
+    }
+    for (threads) |thread| thread.join();
+
+    std.mem.sort(u32, &old_pages, {}, std.sort.asc(u32));
+    try std.testing.expectEqualSlices(u32, &.{ 1, 2, 3, 4 }, &old_pages);
+    try std.testing.expectEqual(@as(u32, 5), control.pageCount());
+    try std.testing.expectEqual(base, control.base);
+}
+
+test "SharedMemory: acquire size publication follows committed zero fill" {
+    if (!platform.supports_reserved_memory) return error.SkipZigTest;
+    const control = try Control.create(1, 2, std.testing.allocator);
+    defer {
+        std.debug.assert(control.release());
+        control.destroy(std.testing.allocator);
+    }
+
+    var saw_zero = false;
+    const reader = try std.Thread.spawn(.{}, publicationReader, .{PublicationCtx{
+        .control = control,
+        .saw_zero = &saw_zero,
+    }});
+    try std.testing.expectEqual(@as(u32, 1), try control.grow(1));
+    reader.join();
+    try std.testing.expect(saw_zero);
+    try std.testing.expectEqual(@as(u32, 2), control.pageCount());
+}
+
+test "SharedMemory: wait APIs validate bounds and alignment" {
+    if (!platform.supports_reserved_memory) return error.SkipZigTest;
+    const control = try Control.create(1, 2, std.testing.allocator);
+    defer {
+        std.debug.assert(control.release());
+        control.destroy(std.testing.allocator);
+    }
+    try std.testing.expectError(error.Unaligned, control.wait32(1, 0, 0));
+    try std.testing.expectError(error.OutOfBounds, control.wait64(wasm_page_size, 0, 0));
+    try std.testing.expectError(error.OutOfBounds, control.notify(wasm_page_size, 1));
+}

--- a/src/runtime/common/types.zig
+++ b/src/runtime/common/types.zig
@@ -2,50 +2,8 @@
 
 const std = @import("std");
 const platform = @import("../../platform/platform.zig");
-
-/// Simple spinlock mutex (Zig 0.16 moved std.Thread.Mutex behind Io).
-const Mutex = struct {
-    state: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
-    pub const init: Mutex = .{ .state = std.atomic.Value(u8).init(0) };
-    pub fn lock(self: *Mutex) void {
-        while (self.state.cmpxchgWeak(0, 1, .acquire, .monotonic) != null)
-            std.atomic.spinLoopHint();
-    }
-    pub fn unlock(self: *Mutex) void {
-        self.state.store(0, .release);
-    }
-};
-
-/// Simple condition variable (spin-based, for atomic wait/notify).
-const Condition = struct {
-    flag: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
-    pub fn wait(self: *Condition, mutex: *Mutex) void {
-        mutex.unlock();
-        while (self.flag.load(.acquire) == 0)
-            std.atomic.spinLoopHint();
-        self.flag.store(0, .release);
-        mutex.lock();
-    }
-    pub fn timedWait(self: *Condition, mutex: *Mutex, _: u64) error{Timeout}!void {
-        mutex.unlock();
-        // Spin-based: no real timed wait, just yield briefly then timeout
-        var spins: u32 = 0;
-        while (spins < 1000) : (spins += 1) {
-            if (self.flag.load(.acquire) != 0) {
-                self.flag.store(0, .release);
-                mutex.lock();
-                return;
-            }
-            std.atomic.spinLoopHint();
-        }
-        mutex.lock();
-        return error.Timeout;
-    }
-
-    pub fn signal(self: *Condition) void {
-        self.flag.store(1, .release);
-    }
-};
+const shared_memory = @import("shared_memory.zig");
+const parking_lot = @import("../../platform/parking_lot.zig");
 
 /// WebAssembly value types (§2.3.1)
 pub const ValType = enum(u8) {
@@ -280,7 +238,7 @@ pub const component_version: u32 = 0x0001_000d;
 pub const aot_magic: u32 = 0x746f6100; // "\0aot"
 
 /// AOT format version
-pub const aot_version: u32 = 7;
+pub const aot_version: u32 = 8;
 
 test "ValType: numeric classification" {
     try std.testing.expect(ValType.i32.isNumeric());
@@ -499,20 +457,28 @@ pub const NameSection = struct {
 /// Runtime memory instance (refcounted for cross-module sharing)
 pub const MemoryInstance = struct {
     memory_type: MemoryType,
+    /// For non-shared memory this is the allocated/visible buffer. For
+    /// shared memory it is the immutable full reservation; callers must use
+    /// `byteLen`/`bytes` for the acquire-published visible extent.
     data: []u8,
+    /// Legacy non-shared page count. Shared readers use `pageCount`.
     current_pages: u32,
     max_pages: u32,
+    /// Legacy non-shared reference count. Shared lifetime is maintained by
+    /// the atomic count in `shared_control`.
     ref_count: u32 = 1,
+    /// Present exactly for shared memories. Owns the immutable reservation,
+    /// atomic size publication, serialized grow, and keyed parking lot.
+    shared_control: ?*shared_memory.Control = null,
     /// AOT vmctx mirrors that currently reference this memory. Stored as
     /// opaque pointers to avoid a common/types.zig -> aot/runtime.zig cycle.
     vmctx_subscribers: std.ArrayListUnmanaged(*anyopaque) = .empty,
-    /// Waiter queue for memory.atomic.wait/notify (shared memory only).
-    /// Heap-allocated and shared across threads via ref counting.
-    waiter_queue: ?*WaiterQueue = null,
+    subscriber_mutex: platform.Mutex = .init,
     /// When non-null, `data.ptr == reserved_base` and `[reserved_base,
     /// reserved_base+reserved_size)` is a stable virtual address
-    /// reservation (POSIX mmap, Windows VirtualAlloc). `grow` extends
-    /// `data.len` in place by committing more pages — the pointer
+    /// reservation (POSIX mmap, Windows VirtualAlloc). Non-shared `grow`
+    /// extends `data.len`; shared `data.len` is the constant reservation
+    /// capacity and `byteLen` publishes the committed extent. The pointer
     /// never moves, so external aliases into this memory (e.g.
     /// SpiderMonkey/StarlingMonkey external strings, host-held slices
     /// taken before a `memory.grow`) remain valid. Issue #752: TCGC's
@@ -544,9 +510,8 @@ pub const MemoryInstance = struct {
     /// memory survive any `memory.grow` calls. (Issue #752.)
     ///
     /// `cap_pages` should be `min(mem_type.limits.max orelse 65536, 65536)`.
-    /// On platforms without reservation support (Windows for now), or
-    /// when the OS reservation fails, this function returns null and the
-    /// caller is expected to fall back to the legacy
+    /// When the OS reservation fails, this function returns null and the
+    /// non-shared caller may fall back to the legacy
     /// `allocator.realloc`-backed path (which may relocate `data.ptr`
     /// on grow). The caller owns release via `MemoryInstance.release`.
     pub fn createReserved(
@@ -555,6 +520,7 @@ pub const MemoryInstance = struct {
         cap_pages: u32,
         allocator: std.mem.Allocator,
     ) ?*MemoryInstance {
+        if (mem_type.is_shared) return null;
         if (!platform.supports_reserved_memory) return null;
         if (cap_pages == 0) return null;
         const reserved_size: usize = @as(usize, cap_pages) * page_size;
@@ -586,7 +552,64 @@ pub const MemoryInstance = struct {
         return mem;
     }
 
+    /// Create shared memory. The declared maximum is mandatory and its
+    /// entire virtual address range is reserved before this function
+    /// succeeds. There is deliberately no relocating allocator fallback.
+    pub fn createShared(
+        mem_type: MemoryType,
+        allocator: std.mem.Allocator,
+    ) shared_memory.CreateError!*MemoryInstance {
+        if (!mem_type.is_shared) return error.InvalidLimits;
+        const max_u64 = mem_type.limits.max orelse return error.InvalidLimits;
+        if (mem_type.limits.min > max_u64 or max_u64 > 65536)
+            return error.InvalidLimits;
+        const initial_pages: u32 = @intCast(mem_type.limits.min);
+        const max_pages: u32 = @intCast(max_u64);
+        const control = try shared_memory.Control.create(initial_pages, max_pages, allocator);
+        errdefer {
+            std.debug.assert(control.release());
+            control.destroy(allocator);
+        }
+
+        const mem = allocator.create(MemoryInstance) catch return error.OutOfMemory;
+        mem.* = .{
+            .memory_type = mem_type,
+            .data = control.capacity(),
+            .current_pages = initial_pages,
+            .max_pages = max_pages,
+            .shared_control = control,
+            .reserved_base = control.base,
+            .reserved_size = control.reserved_bytes,
+        };
+        return mem;
+    }
+
+    /// Acquire-published current page count.
+    pub fn pageCount(self: *const MemoryInstance) u32 {
+        if (self.shared_control) |control| return control.pageCount();
+        return self.current_pages;
+    }
+
+    /// Acquire-published current byte length.
+    pub fn byteLen(self: *const MemoryInstance) usize {
+        if (self.shared_control) |control| return control.byteLen();
+        return self.data.len;
+    }
+
+    /// Visible memory slice. For shared memory the slice length is formed
+    /// only after the acquire load in `byteLen`.
+    pub fn bytes(self: *MemoryInstance) []u8 {
+        return self.data[0..self.byteLen()];
+    }
+
+    pub const SharedWaitError = shared_memory.WaitError || error{NotShared};
+
     pub fn grow(self: *MemoryInstance, delta: u32, allocator: std.mem.Allocator) !u32 {
+        if (self.shared_control) |control| {
+            return control.grow(delta) catch |err| switch (err) {
+                error.MemoryGrowFailed => error.MemoryGrowFailed,
+            };
+        }
         const old_pages = self.current_pages;
         const new_pages = std.math.add(u32, old_pages, delta) catch return error.MemoryGrowFailed;
         if (self.memory_type.limits.max) |max| {
@@ -617,10 +640,36 @@ pub const MemoryInstance = struct {
     }
 
     pub fn retain(self: *MemoryInstance) void {
+        if (self.shared_control) |control| {
+            std.debug.assert(control.retain());
+            return;
+        }
         self.ref_count += 1;
     }
 
+    pub fn wait32(self: *MemoryInstance, offset: usize, expected: u32, timeout_ns: i64) SharedWaitError!parking_lot.WaitResult {
+        const control = self.shared_control orelse return error.NotShared;
+        return control.wait32(offset, expected, timeout_ns);
+    }
+
+    pub fn wait64(self: *MemoryInstance, offset: usize, expected: u64, timeout_ns: i64) SharedWaitError!parking_lot.WaitResult {
+        const control = self.shared_control orelse return error.NotShared;
+        return control.wait64(offset, expected, timeout_ns);
+    }
+
+    pub fn notify(self: *MemoryInstance, offset: usize, count: u32) SharedWaitError!u32 {
+        const control = self.shared_control orelse return error.NotShared;
+        return control.notify(offset, count);
+    }
+
+    pub fn cancelWaiters(self: *MemoryInstance) parking_lot.BackendError!u32 {
+        const control = self.shared_control orelse return 0;
+        return control.cancelAll();
+    }
+
     pub fn subscribeVmCtx(self: *MemoryInstance, vmctx: *anyopaque, allocator: std.mem.Allocator) !void {
+        self.subscriber_mutex.lock();
+        defer self.subscriber_mutex.unlock();
         for (self.vmctx_subscribers.items) |subscriber| {
             if (subscriber == vmctx) return;
         }
@@ -628,6 +677,8 @@ pub const MemoryInstance = struct {
     }
 
     pub fn unsubscribeVmCtx(self: *MemoryInstance, vmctx: *anyopaque) void {
+        self.subscriber_mutex.lock();
+        defer self.subscriber_mutex.unlock();
         for (self.vmctx_subscribers.items, 0..) |subscriber, i| {
             if (subscriber == vmctx) {
                 _ = self.vmctx_subscribers.swapRemove(i);
@@ -637,9 +688,15 @@ pub const MemoryInstance = struct {
     }
 
     pub fn release(self: *MemoryInstance, allocator: std.mem.Allocator) void {
+        if (self.shared_control) |control| {
+            if (!control.release()) return;
+            self.vmctx_subscribers.deinit(allocator);
+            control.destroy(allocator);
+            allocator.destroy(self);
+            return;
+        }
         self.ref_count -= 1;
         if (self.ref_count == 0) {
-            if (self.waiter_queue) |wq| wq.deinit(allocator);
             self.vmctx_subscribers.deinit(allocator);
             if (self.reserved_base) |base| {
                 platform.releaseAddressSpace(base, self.reserved_size);
@@ -648,90 +705,6 @@ pub const MemoryInstance = struct {
             }
             allocator.destroy(self);
         }
-    }
-};
-
-/// Waiter queue for memory.atomic.wait/notify.
-/// Each waiter is heap-allocated for pointer stability while threads block.
-pub const WaiterQueue = struct {
-    mutex: Mutex = .init,
-    /// Heap-allocated waiter nodes for pointer stability.
-    waiters: std.ArrayListUnmanaged(*Waiter) = .empty,
-
-    pub const Waiter = struct {
-        address: u32,
-        cond: Condition = .{},
-        woken: bool = false,
-    };
-
-    pub fn deinit(self: *WaiterQueue, allocator: std.mem.Allocator) void {
-        for (self.waiters.items) |w| allocator.destroy(w);
-        self.waiters.deinit(allocator);
-        allocator.destroy(self);
-    }
-
-    /// Park the calling thread until woken or timed out.
-    /// Returns: 0 = woken, 2 = timed out.
-    pub fn wait(self: *WaiterQueue, address: u32, timeout_ns: i64, allocator: std.mem.Allocator) u32 {
-        self.mutex.lock();
-
-        const waiter = allocator.create(Waiter) catch {
-            self.mutex.unlock();
-            return 2; // treat alloc failure as timeout
-        };
-        waiter.* = .{ .address = address };
-
-        self.waiters.append(allocator, waiter) catch {
-            allocator.destroy(waiter);
-            self.mutex.unlock();
-            return 2;
-        };
-
-        defer {
-            // Remove self from waiters list
-            for (self.waiters.items, 0..) |w, i| {
-                if (w == waiter) {
-                    _ = self.waiters.swapRemove(i);
-                    break;
-                }
-            }
-            allocator.destroy(waiter);
-            self.mutex.unlock();
-        }
-
-        if (timeout_ns < 0) {
-            // Infinite wait
-            while (!waiter.woken) {
-                waiter.cond.wait(&self.mutex);
-            }
-            return 0; // woken
-        } else {
-            const timeout: u64 = @intCast(timeout_ns);
-            while (!waiter.woken) {
-                waiter.cond.timedWait(&self.mutex, timeout) catch {
-                    // Timed out
-                    return if (waiter.woken) 0 else 2;
-                };
-            }
-            return 0; // woken
-        }
-    }
-
-    /// Wake up to `count` waiters at the given address. Returns number woken.
-    pub fn notify(self: *WaiterQueue, address: u32, count: u32) u32 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        var woken: u32 = 0;
-        for (self.waiters.items) |w| {
-            if (woken >= count) break;
-            if (w.address == address) {
-                w.woken = true;
-                w.cond.signal();
-                woken += 1;
-            }
-        }
-        return woken;
     }
 };
 
@@ -1108,6 +1081,44 @@ test "MemoryInstance: createReserved keeps data.ptr stable across grow" {
     // Growing past the cap fails.
     try std.testing.expectError(error.MemoryGrowFailed, mem.grow(1, allocator));
     try std.testing.expectEqual(@as(u32, 8), mem.current_pages);
+}
+
+test "MemoryInstance: shared control keeps base stable and lifetime refcounted" {
+    if (!platform.supports_reserved_memory) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    const mem_type: MemoryType = .{
+        .limits = .{ .min = 1, .max = 3 },
+        .is_shared = true,
+    };
+    const mem = try MemoryInstance.createShared(mem_type, allocator);
+
+    const base = mem.data.ptr;
+    try std.testing.expectEqual(@as(usize, 3 * MemoryInstance.page_size), mem.data.len);
+    try std.testing.expectEqual(@as(usize, MemoryInstance.page_size), mem.byteLen());
+    try std.testing.expectEqual(@as(u32, 1), mem.pageCount());
+    try std.testing.expectEqual(@as(u32, 1), mem.shared_control.?.referenceCount());
+
+    mem.retain();
+    try std.testing.expectEqual(@as(u32, 2), mem.shared_control.?.referenceCount());
+    mem.release(allocator);
+    try std.testing.expectEqual(@as(u32, 1), mem.shared_control.?.referenceCount());
+
+    try std.testing.expectEqual(@as(u32, 1), try mem.grow(1, allocator));
+    try std.testing.expectEqual(base, mem.data.ptr);
+    try std.testing.expectEqual(@as(usize, 2 * MemoryInstance.page_size), mem.byteLen());
+    try std.testing.expectEqual(@as(u8, 0), mem.data[2 * MemoryInstance.page_size - 1]);
+    mem.release(allocator);
+}
+
+test "MemoryInstance: shared creation requires declared maximum" {
+    const mem_type: MemoryType = .{
+        .limits = .{ .min = 1 },
+        .is_shared = true,
+    };
+    try std.testing.expectError(
+        error.InvalidLimits,
+        MemoryInstance.createShared(mem_type, std.testing.allocator),
+    );
 }
 
 test "WasmModule: getFuncType for import and local functions" {

--- a/src/runtime/interpreter/instance.zig
+++ b/src/runtime/interpreter/instance.zig
@@ -149,15 +149,6 @@ fn instantiateImpl(
     inst.memories = try allocateMemories(module, allocator, import_ctx);
     errdefer freeMemories(inst.memories, allocator);
 
-    // Initialize waiter queues for shared memories
-    for (inst.memories) |mem| {
-        if (mem.memory_type.is_shared and mem.waiter_queue == null) {
-            const wq = allocator.create(types.WaiterQueue) catch return error.OutOfMemory;
-            wq.* = .{};
-            mem.waiter_queue = wq;
-        }
-    }
-
     inst.tables = try allocateTables(module, allocator, import_ctx);
     errdefer freeTables(inst.tables, allocator);
 
@@ -394,6 +385,13 @@ fn allocateMemories(module: *const types.WasmModule, allocator: std.mem.Allocato
 
     // Heap-allocate local memories
     for (module.memories, 0..) |mem_type, i| {
+        if (mem_type.is_shared) {
+            mems[import_count + i] = types.MemoryInstance.createShared(mem_type, allocator) catch
+                return error.MemoryAllocationFailed;
+            local_init += 1;
+            continue;
+        }
+
         const min_pages: u32 = @intCast(@min(mem_type.limits.min, 65536));
         const max_pages: u32 = @intCast(@min(mem_type.limits.max orelse 65536, 65536));
         const initial_size = @as(usize, min_pages) * types.MemoryInstance.page_size;
@@ -833,7 +831,7 @@ fn applyDataSegments(module: *const types.WasmModule, memories: []*types.MemoryI
             @as(u64, evalInitExprAsU32(seg.offset, globals) catch return error.DataSegmentOutOfBounds);
 
         const end = offset + seg.data.len;
-        if (end > mem.data.len) return error.DataSegmentOutOfBounds;
+        if (end > mem.byteLen()) return error.DataSegmentOutOfBounds;
 
         const off: usize = @intCast(offset);
         @memcpy(mem.data[off..][0..seg.data.len], seg.data);
@@ -994,6 +992,36 @@ test "instantiate: module with one memory page" {
     try testing.expectEqual(@as(usize, 65536), inst.memories[0].data.len);
     // Memory should be zero-initialized.
     for (inst.memories[0].data) |b| try testing.expectEqual(@as(u8, 0), b);
+}
+
+test "MemoryInstance: shared instantiation reserves declared maximum" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const data = wasm_header ++ [_]u8{
+        // shared memory requires and declares max: min=1, max=3
+        0x05, 0x04, 0x01, 0x03, 0x01, 0x03,
+    };
+    const module = try loader.load(&data, arena.allocator());
+    const inst = try instantiate(&module, testing.allocator);
+    defer destroy(inst);
+
+    const mem = inst.memories[0];
+    try testing.expect(mem.shared_control != null);
+    try testing.expectEqual(@as(usize, 3 * types.MemoryInstance.page_size), mem.data.len);
+    try testing.expectEqual(@as(usize, types.MemoryInstance.page_size), mem.byteLen());
+    try testing.expectEqual(mem.data.ptr, mem.reserved_base.?);
+}
+
+test "MemoryInstance: shared declaration without maximum is rejected" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const data = wasm_header ++ [_]u8{
+        // shared flag without has-max is invalid.
+        0x05, 0x03, 0x01, 0x02, 0x01,
+    };
+    try testing.expectError(error.InvalidLimits, loader.load(&data, arena.allocator()));
 }
 
 test "instantiate: module with table" {

--- a/src/runtime/interpreter/interp.zig
+++ b/src/runtime/interpreter/interp.zig
@@ -83,6 +83,7 @@ pub const TrapError = error{
     UnknownFunction,
     UnknownOpcode,
     UnalignedAtomicAccess,
+    ThreadCancelled,
     UncaughtException,
 };
 
@@ -2153,7 +2154,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 4, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 4, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 try env.pushI32(std.mem.readInt(i32, mem.data[a..][0..4], .little));
             },
@@ -2161,7 +2162,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 1, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 1, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const signed_byte: i8 = @bitCast(mem.data[@intCast(addr)]);
                 try env.pushI32(@as(i32, signed_byte));
             },
@@ -2169,14 +2170,14 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 1, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 1, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 try env.pushI32(@as(i32, @intCast(mem.data[@intCast(addr)])));
             },
             .i32_load16_s => {
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 2, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 2, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 const val: i16 = std.mem.readInt(i16, mem.data[a..][0..2], .little);
                 try env.pushI32(@as(i32, val));
@@ -2185,7 +2186,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 2, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 2, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 const val: u16 = std.mem.readInt(u16, mem.data[a..][0..2], .little);
                 try env.pushI32(@as(i32, @intCast(val)));
@@ -2197,7 +2198,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const val = try env.popI32();
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 4, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 4, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 std.mem.writeInt(i32, mem.data[a..][0..4], val, .little);
             },
@@ -2206,7 +2207,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const val = try env.popI32();
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 1, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 1, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 mem.data[@intCast(addr)] = @truncate(@as(u32, @bitCast(val)));
             },
             .i32_store16 => {
@@ -2214,7 +2215,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const val = try env.popI32();
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 2, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 2, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 std.mem.writeInt(u16, mem.data[a..][0..2], @truncate(@as(u32, @bitCast(val))), .little);
             },
@@ -2224,7 +2225,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 8, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 8, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 try env.pushI64(std.mem.readInt(i64, mem.data[a..][0..8], .little));
             },
@@ -2232,7 +2233,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 1, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 1, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const signed_byte: i8 = @bitCast(mem.data[@intCast(addr)]);
                 try env.pushI64(@as(i64, signed_byte));
             },
@@ -2240,14 +2241,14 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 1, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 1, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 try env.pushI64(@as(i64, @intCast(mem.data[@intCast(addr)])));
             },
             .i64_load16_s => {
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 2, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 2, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 const val: i16 = std.mem.readInt(i16, mem.data[a..][0..2], .little);
                 try env.pushI64(@as(i64, val));
@@ -2256,7 +2257,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 2, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 2, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 const val: u16 = std.mem.readInt(u16, mem.data[a..][0..2], .little);
                 try env.pushI64(@as(i64, @intCast(val)));
@@ -2265,7 +2266,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 4, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 4, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 const val: i32 = std.mem.readInt(i32, mem.data[a..][0..4], .little);
                 try env.pushI64(@as(i64, val));
@@ -2274,7 +2275,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 4, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 4, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 const val: u32 = std.mem.readInt(u32, mem.data[a..][0..4], .little);
                 try env.pushI64(@as(i64, @intCast(val)));
@@ -2286,7 +2287,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const val = try env.popI64();
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 8, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 8, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 std.mem.writeInt(i64, mem.data[a..][0..8], val, .little);
             },
@@ -2295,7 +2296,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const val = try env.popI64();
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 1, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 1, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 mem.data[@intCast(addr)] = @truncate(@as(u64, @bitCast(val)));
             },
             .i64_store16 => {
@@ -2303,7 +2304,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const val = try env.popI64();
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 2, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 2, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 std.mem.writeInt(u16, mem.data[a..][0..2], @truncate(@as(u64, @bitCast(val))), .little);
             },
@@ -2312,7 +2313,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const val = try env.popI64();
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 4, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 4, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 std.mem.writeInt(u32, mem.data[a..][0..4], @truncate(@as(u64, @bitCast(val))), .little);
             },
@@ -2322,7 +2323,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 4, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 4, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 try env.pushF32(@bitCast(std.mem.readInt(u32, mem.data[a..][0..4], .little)));
             },
@@ -2331,7 +2332,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const val = try env.popF32();
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 4, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 4, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 std.mem.writeInt(u32, mem.data[a..][0..4], @bitCast(val), .little);
             },
@@ -2341,7 +2342,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const ma = readMemarg(code, &ip);
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 8, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 8, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 try env.pushF64(@bitCast(std.mem.readInt(u64, mem.data[a..][0..8], .little)));
             },
@@ -2350,7 +2351,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const val = try env.popF64();
                 const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
                 const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-                if (!memInBounds(addr, 8, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                if (!memInBounds(addr, 8, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                 const a: usize = @intCast(addr);
                 std.mem.writeInt(u64, mem.data[a..][0..8], @bitCast(val), .little);
             },
@@ -2360,9 +2361,9 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 const mem_idx = readU32(code, &ip);
                 const mem = env.module_inst.getMemory(mem_idx) orelse return error.OutOfBoundsMemoryAccess;
                 if (mem.memory_type.is_memory64) {
-                    try env.pushI64(@intCast(mem.current_pages));
+                    try env.pushI64(@intCast(mem.pageCount()));
                 } else {
-                    try env.pushI32(@intCast(mem.current_pages));
+                    try env.pushI32(@intCast(mem.pageCount()));
                 }
             },
             .memory_grow => {
@@ -3034,7 +3035,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                             continue;
                         }
                         const seg = module.data_segments[data_idx];
-                        if (!memInBounds(src, n, seg.data.len) or !memInBounds(dst, n, mem.data.len))
+                        if (!memInBounds(src, n, seg.data.len) or !memInBounds(dst, n, mem.byteLen()))
                             return error.OutOfBoundsMemoryAccess;
                         const d: usize = @intCast(dst);
                         const s: usize = @intCast(src);
@@ -3057,7 +3058,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                         const n: u64 = if (is_64) @bitCast(try env.popI64()) else @as(u64, @as(u32, @bitCast(try env.popI32())));
                         const src: u64 = if (is_64) @bitCast(try env.popI64()) else @as(u64, @as(u32, @bitCast(try env.popI32())));
                         const dst: u64 = if (is_64) @bitCast(try env.popI64()) else @as(u64, @as(u32, @bitCast(try env.popI32())));
-                        if (!memInBounds(dst, n, dst_mem.data.len) or !memInBounds(src, n, src_mem.data.len)) {
+                        if (!memInBounds(dst, n, dst_mem.byteLen()) or !memInBounds(src, n, src_mem.byteLen())) {
                             return error.OutOfBoundsMemoryAccess;
                         }
                         const d: usize = @intCast(dst);
@@ -3080,7 +3081,7 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                         const n: u64 = if (is_64) @bitCast(try env.popI64()) else @as(u64, @as(u32, @bitCast(try env.popI32())));
                         const val: u8 = @truncate(@as(u32, @bitCast(try env.popI32())));
                         const dst: u64 = if (is_64) @bitCast(try env.popI64()) else @as(u64, @as(u32, @bitCast(try env.popI32())));
-                        if (!memInBounds(dst, n, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+                        if (!memInBounds(dst, n, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
                         const d: usize = @intCast(dst);
                         const len: usize = @intCast(n);
                         @memset(mem.data[d .. d + len], val);
@@ -3438,13 +3439,18 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                         // Alignment check: notify address must be 4-byte aligned
                         if (effective_addr & 3 != 0) return error.UnalignedAtomicAccess;
                         const mem = env.module_inst.getMemory(0) orelse return error.OutOfBoundsMemoryAccess;
-                        if (effective_addr >= mem.data.len) return error.OutOfBoundsMemoryAccess;
-                        if (mem.waiter_queue) |wq| {
-                            const woken = wq.notify(effective_addr, count);
-                            try env.pushI32(@bitCast(woken));
-                        } else {
-                            try env.pushI32(0); // no waiter queue = no waiters
-                        }
+                        if (@as(u64, effective_addr) + 4 > mem.byteLen()) return error.OutOfBoundsMemoryAccess;
+                        const woken = mem.notify(effective_addr, count) catch |err| switch (err) {
+                            error.NotShared => 0,
+                            error.OutOfBounds => return error.OutOfBoundsMemoryAccess,
+                            error.Unaligned => return error.UnalignedAtomicAccess,
+                            error.InvalidAddress,
+                            error.InvalidArgument,
+                            error.Unsupported,
+                            error.SystemFailure,
+                            => return error.OutOfBoundsMemoryAccess,
+                        };
+                        try env.pushI32(@bitCast(woken));
                     },
                     0x01 => { // memory.atomic.wait32
                         _ = readU32(code, &ip); // align
@@ -3455,23 +3461,24 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                         const effective_addr = addr +% offset;
                         if (effective_addr & 3 != 0) return error.UnalignedAtomicAccess;
                         const mem = env.module_inst.getMemory(0) orelse return error.OutOfBoundsMemoryAccess;
-                        if (!memInBounds(effective_addr, 4, mem.data.len)) return error.OutOfBoundsMemoryAccess;
-                        const wq = mem.waiter_queue orelse {
-                            try env.pushI32(1); // no shared memory = "not equal"
-                            continue;
+                        if (!memInBounds(effective_addr, 4, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
+                        const result = mem.wait32(
+                            effective_addr,
+                            @bitCast(expected),
+                            timeout,
+                        ) catch |err| switch (err) {
+                            error.NotShared => .not_equal,
+                            error.OutOfBounds => return error.OutOfBoundsMemoryAccess,
+                            error.Unaligned => return error.UnalignedAtomicAccess,
+                            error.InvalidAddress,
+                            error.InvalidArgument,
+                            error.Unsupported,
+                            error.SystemFailure,
+                            => return error.OutOfBoundsMemoryAccess,
                         };
-                        // Load current value and compare under the waiter queue lock.
-                        // The mutex provides synchronization, so a regular read suffices.
-                        wq.mutex.lock();
-                        const current: i32 = @bitCast(std.mem.readInt(u32, mem.data[effective_addr..][0..4], .little));
-                        if (current != expected) {
-                            wq.mutex.unlock();
-                            try env.pushI32(1); // "not equal"
-                        } else {
-                            // Park — the wait method will unlock the mutex after enqueuing
-                            wq.mutex.unlock();
-                            const result = wq.wait(effective_addr, timeout, env.allocator);
-                            try env.pushI32(@bitCast(result));
+                        switch (result) {
+                            .notified, .not_equal, .timed_out => try env.pushI32(@intCast(@intFromEnum(result))),
+                            .cancelled, .closed => return error.ThreadCancelled,
                         }
                     },
                     0x02 => { // memory.atomic.wait64
@@ -3483,20 +3490,24 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                         const effective_addr = addr +% offset;
                         if (effective_addr & 7 != 0) return error.UnalignedAtomicAccess;
                         const mem = env.module_inst.getMemory(0) orelse return error.OutOfBoundsMemoryAccess;
-                        if (!memInBounds(effective_addr, 8, mem.data.len)) return error.OutOfBoundsMemoryAccess;
-                        const wq = mem.waiter_queue orelse {
-                            try env.pushI32(1);
-                            continue;
+                        if (!memInBounds(effective_addr, 8, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
+                        const result = mem.wait64(
+                            effective_addr,
+                            @bitCast(expected),
+                            timeout,
+                        ) catch |err| switch (err) {
+                            error.NotShared => .not_equal,
+                            error.OutOfBounds => return error.OutOfBoundsMemoryAccess,
+                            error.Unaligned => return error.UnalignedAtomicAccess,
+                            error.InvalidAddress,
+                            error.InvalidArgument,
+                            error.Unsupported,
+                            error.SystemFailure,
+                            => return error.OutOfBoundsMemoryAccess,
                         };
-                        wq.mutex.lock();
-                        const current: i64 = @bitCast(std.mem.readInt(u64, mem.data[effective_addr..][0..8], .little));
-                        if (current != expected) {
-                            wq.mutex.unlock();
-                            try env.pushI32(1);
-                        } else {
-                            wq.mutex.unlock();
-                            const result = wq.wait(effective_addr, timeout, env.allocator);
-                            try env.pushI32(@bitCast(result));
+                        switch (result) {
+                            .notified, .not_equal, .timed_out => try env.pushI32(@intCast(@intFromEnum(result))),
+                            .cancelled, .closed => return error.ThreadCancelled,
                         }
                     },
                     else => return error.UnknownOpcode,
@@ -3567,7 +3578,7 @@ fn getAtomicAddr(env: *ExecEnv, code: []const u8, ip: *usize, comptime size: u32
     const ma = readMemarg(code, ip);
     const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
     const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-    if (!memInBounds(addr, size, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+    if (!memInBounds(addr, size, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
     // Alignment check (atomics require natural alignment)
     if (addr % size != 0) return error.UnalignedAtomicAccess;
     return .{ .ptr = mem.data.ptr + @as(usize, @intCast(addr)), .addr = @intCast(addr) };
@@ -3592,7 +3603,7 @@ fn atomicStore(env: *ExecEnv, code: []const u8, ip: *usize, comptime T: type, co
     const val: T = @truncate(@as(u32, @bitCast(try env.popI32())));
     const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
     const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-    if (!memInBounds(addr, size, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+    if (!memInBounds(addr, size, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
     if (addr % size != 0) return error.UnalignedAtomicAccess;
     const ptr: *T = @ptrCast(@alignCast(mem.data.ptr + @as(usize, @intCast(addr))));
     doAtomicStore(T, ptr, val);
@@ -3603,7 +3614,7 @@ fn atomicStore64(env: *ExecEnv, code: []const u8, ip: *usize, comptime T: type, 
     const val: T = @truncate(@as(u64, @bitCast(try env.popI64())));
     const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
     const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-    if (!memInBounds(addr, size, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+    if (!memInBounds(addr, size, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
     if (addr % size != 0) return error.UnalignedAtomicAccess;
     const ptr: *T = @ptrCast(@alignCast(mem.data.ptr + @as(usize, @intCast(addr))));
     doAtomicStore(T, ptr, val);
@@ -3614,7 +3625,7 @@ fn atomicRmw(env: *ExecEnv, code: []const u8, ip: *usize, comptime T: type, comp
     const val: T = @truncate(@as(u32, @bitCast(try env.popI32())));
     const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
     const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-    if (!memInBounds(addr, size, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+    if (!memInBounds(addr, size, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
     if (addr % size != 0) return error.UnalignedAtomicAccess;
     const ptr: *T = @ptrCast(@alignCast(mem.data.ptr + @as(usize, @intCast(addr))));
     const old = doAtomicRmw(T, ptr, op, val);
@@ -3626,7 +3637,7 @@ fn atomicRmw64(env: *ExecEnv, code: []const u8, ip: *usize, comptime T: type, co
     const val: T = @truncate(@as(u64, @bitCast(try env.popI64())));
     const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
     const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-    if (!memInBounds(addr, size, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+    if (!memInBounds(addr, size, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
     if (addr % size != 0) return error.UnalignedAtomicAccess;
     const ptr: *T = @ptrCast(@alignCast(mem.data.ptr + @as(usize, @intCast(addr))));
     const old = doAtomicRmw(T, ptr, op, val);
@@ -3639,7 +3650,7 @@ fn atomicCmpxchg(env: *ExecEnv, code: []const u8, ip: *usize, comptime T: type, 
     const expected: T = @truncate(@as(u32, @bitCast(try env.popI32())));
     const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
     const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-    if (!memInBounds(addr, size, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+    if (!memInBounds(addr, size, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
     if (addr % size != 0) return error.UnalignedAtomicAccess;
     const ptr: *T = @ptrCast(@alignCast(mem.data.ptr + @as(usize, @intCast(addr))));
     const result = doAtomicCmpxchg(T, ptr, expected, replacement);
@@ -3653,7 +3664,7 @@ fn atomicCmpxchg64(env: *ExecEnv, code: []const u8, ip: *usize, comptime T: type
     const expected: T = @truncate(@as(u64, @bitCast(try env.popI64())));
     const addr = try popMemAddr(env, ma.mem_idx) +% ma.offset;
     const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-    if (!memInBounds(addr, size, mem.data.len)) return error.OutOfBoundsMemoryAccess;
+    if (!memInBounds(addr, size, mem.byteLen())) return error.OutOfBoundsMemoryAccess;
     if (addr % size != 0) return error.UnalignedAtomicAccess;
     const ptr: *T = @ptrCast(@alignCast(mem.data.ptr + @as(usize, @intCast(addr))));
     const result = doAtomicCmpxchg(T, ptr, expected, replacement);

--- a/src/runtime/interpreter/loader.zig
+++ b/src/runtime/interpreter/loader.zig
@@ -1734,6 +1734,7 @@ fn hasGcOpcodes(code: []const u8) bool {
 
 fn validateMemoryLimits(mem: types.MemoryType) LoadError!void {
     const max_pages: u64 = if (mem.is_memory64) (1 << 48) else 65536;
+    if (mem.is_shared and mem.limits.max == null) return error.InvalidLimits;
     if (mem.limits.min > max_pages) return error.InvalidLimits;
     if (mem.limits.max) |max| {
         if (max > max_pages) return error.InvalidLimits;

--- a/src/runtime/interpreter/simd.zig
+++ b/src/runtime/interpreter/simd.zig
@@ -97,7 +97,7 @@ fn getMemSlice(env: *ExecEnv, ma: Memarg, size: u64) SimdError![]u8 {
     const base: u32 = @bitCast(popI32(env) catch return error.StackUnderflow);
     const addr = @as(u64, base) + ma.offset;
     const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-    if (addr + size > mem.data.len) return error.OutOfBoundsMemoryAccess;
+    if (addr + size > mem.byteLen()) return error.OutOfBoundsMemoryAccess;
     const a: usize = @intCast(addr);
     return mem.data[a..][0..@intCast(size)];
 }
@@ -233,7 +233,7 @@ pub fn executeSIMD(env: *ExecEnv, code: []const u8, ip: *usize) SimdError!void {
             const base: u32 = @bitCast(try popI32(env));
             const addr = @as(u64, base) + ma.offset;
             const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-            if (addr + 16 > mem.data.len) return error.OutOfBoundsMemoryAccess;
+            if (addr + 16 > mem.byteLen()) return error.OutOfBoundsMemoryAccess;
             const a: usize = @intCast(addr);
             std.mem.writeInt(u128, mem.data[a..][0..16], val, .little);
         },
@@ -796,7 +796,7 @@ fn storeLane(env: *ExecEnv, code: []const u8, ip: *usize, comptime byte_width: c
     const base: u32 = @bitCast(popI32(env) catch return error.StackUnderflow);
     const addr = @as(u64, base) + ma.offset;
     const mem = env.module_inst.getMemory(ma.mem_idx) orelse return error.OutOfBoundsMemoryAccess;
-    if (addr + byte_width > mem.data.len) return error.OutOfBoundsMemoryAccess;
+    if (addr + byte_width > mem.byteLen()) return error.OutOfBoundsMemoryAccess;
     const a: usize = @intCast(addr);
     @memcpy(mem.data[a..][0..byte_width], v[lane_idx * byte_width ..][0..byte_width]);
 }

--- a/src/tests/aot_harness.zig
+++ b/src/tests/aot_harness.zig
@@ -371,7 +371,7 @@ pub const Harness = struct {
             if (seg.memory_idx >= h.inst.memories.len) continue;
             const mem = h.inst.memories[seg.memory_idx];
             const end = @as(usize, seg.offset) + seg.data.len;
-            if (end > mem.data.len) continue;
+            if (end > mem.byteLen()) continue;
             @memcpy(mem.data[seg.offset..][0..seg.data.len], seg.data);
         }
 
@@ -629,9 +629,9 @@ pub const Harness = struct {
         vmctx.* = .{};
         if (inst.memories.len > 0) {
             vmctx.memory_base = @intFromPtr(inst.memories[0].data.ptr);
-            vmctx.memory_size = @as(usize, inst.memories[0].current_pages) * types.MemoryInstance.page_size;
-            vmctx.memory_max_size = inst.memories[0].data.len;
-            vmctx.memory_pages = inst.memories[0].current_pages;
+            vmctx.memory_size = inst.memories[0].byteLen();
+            vmctx.memory_max_size = if (inst.memories[0].shared_control) |control| control.reserved_bytes else inst.memories[0].data.len;
+            vmctx.memory_pages = inst.memories[0].pageCount();
         }
         const globals_buf = allocator.alloc(u128, aot_runtime.globalStorageWordCount(inst)) catch {
             allocator.destroy(vmctx);
@@ -1105,6 +1105,7 @@ fn compileToAot(
                     .memory_min = @intCast(memory_type.limits.min),
                     .memory_max = if (memory_type.limits.max) |m| @as(?u32, @intCast(m)) else null,
                     .memory_is64 = memory_type.is_memory64,
+                    .memory_shared = memory_type.is_shared,
                 });
             },
             .global => {
@@ -1143,6 +1144,7 @@ fn compileToAot(
         try mem_entries.append(a, .{
             .min_pages = @intCast(mem.limits.min),
             .max_pages = if (mem.limits.max) |m| @as(?u32, @intCast(m)) else null,
+            .is_shared = mem.is_shared,
         });
     }
 

--- a/src/wasi/thread_manager.zig
+++ b/src/wasi/thread_manager.zig
@@ -285,22 +285,12 @@ test "ModuleInstance: cloneForThread shares memory" {
 
     // Create a parent module with shared memory
     var module = types.WasmModule{};
-    const mem_data = try allocator.alloc(u8, 65536);
-    defer allocator.free(mem_data);
-    @memset(mem_data, 0);
-    mem_data[0] = 42; // write a value
-
-    var mem_inst = try allocator.create(types.MemoryInstance);
-    defer {
-        mem_inst.ref_count -= 1; // balance the clone's retain
-        allocator.destroy(mem_inst);
-    }
-    mem_inst.* = .{
-        .memory_type = .{ .limits = .{ .min = 1 }, .is_shared = true },
-        .data = mem_data,
-        .current_pages = 1,
-        .max_pages = 4,
-    };
+    const mem_inst = try types.MemoryInstance.createShared(.{
+        .limits = .{ .min = 1, .max = 4 },
+        .is_shared = true,
+    }, allocator);
+    defer mem_inst.release(allocator);
+    mem_inst.data[0] = 42;
 
     var mem_ptrs = [_]*types.MemoryInstance{mem_inst};
     var globals = [_]*types.GlobalInstance{};
@@ -332,7 +322,7 @@ test "ModuleInstance: cloneForThread shares memory" {
     try std.testing.expectEqual(@as(u8, 99), parent.memories[0].data[1]);
 
     // Verify ref count was incremented
-    try std.testing.expectEqual(@as(u32, 2), mem_inst.ref_count);
+    try std.testing.expectEqual(@as(u32, 2), mem_inst.shared_control.?.referenceCount());
 
     allocator.destroy(parent);
 }
@@ -383,29 +373,6 @@ test "AuxStackPool: stack addresses are correct" {
     try std.testing.expect(s3 == 4096 + 1 * 1024);
 }
 
-test "WaiterQueue: notify with no waiters" {
-    const allocator = std.testing.allocator;
-    var wq = try allocator.create(types.WaiterQueue);
-    defer wq.deinit(allocator);
-    wq.* = .{};
-
-    // Notify on empty queue should return 0
-    const woken = wq.notify(0, 10);
-    try std.testing.expectEqual(@as(u32, 0), woken);
-}
-
-test "WaiterQueue: wait with immediate timeout" {
-    const allocator = std.testing.allocator;
-    var wq = try allocator.create(types.WaiterQueue);
-    defer wq.deinit(allocator);
-    wq.* = .{};
-
-    // Wait with 0 timeout should return 2 (timed out) quickly
-    const result = wq.wait(100, 0, allocator);
-    // 0 timeout = immediate timeout or woken (could be either depending on timing)
-    try std.testing.expect(result == 0 or result == 2);
-}
-
 // ── Integration tests ───────────────────────────────────────────────────────
 // These tests exercise the full thread lifecycle: spawn → execute → join.
 // Each builds a WasmModule with an exported wasi_thread_start function,
@@ -453,7 +420,7 @@ fn buildThreadTestModule(
         .index = 0,
     };
     const memories = try allocator.alloc(types.MemoryType, 1);
-    memories[0] = .{ .limits = .{ .min = 1 }, .is_shared = true };
+    memories[0] = .{ .limits = .{ .min = 1, .max = 4 }, .is_shared = true };
 
     module.* = .{
         .types = func_types,
@@ -463,15 +430,10 @@ fn buildThreadTestModule(
     };
 
     // Create shared memory instance
-    const mem_data = try allocator.alloc(u8, 65536);
-    @memset(mem_data, 0);
-    const mem_inst = try allocator.create(types.MemoryInstance);
-    mem_inst.* = .{
-        .memory_type = .{ .limits = .{ .min = 1 }, .is_shared = true },
-        .data = mem_data,
-        .current_pages = 1,
-        .max_pages = 4,
-    };
+    const mem_inst = try types.MemoryInstance.createShared(.{
+        .limits = .{ .min = 1, .max = 4 },
+        .is_shared = true,
+    }, allocator);
     var mem_ptrs = try allocator.alloc(*types.MemoryInstance, 1);
     mem_ptrs[0] = mem_inst;
 


### PR DESCRIPTION
## Summary
- reserve every shared memory at its declared maximum, keep its base immutable, serialize commit/grow, and release/acquire-publish current pages and bytes
- replace the spin waiter queue with a keyed parking lot using Linux futex, macOS ulock, or Windows WaitOnAddress, including exact notify, monotonic timeout, cancellation, and draining shutdown
- add Windows NT reserve/commit, shared-memory AOT metadata round-tripping, backend-neutral runtime APIs, and focused native tests
- keep non-shared allocation behavior compatible; shared instantiation fails instead of falling back to relocating realloc

Opcode load/store/RMW lowering remains out of scope for this foundation.

## Validation
- `zig build test-shared-memory -Dlib_wasi_threads=true -Daot=false -Doptimize=Debug --summary all` (22/22)
- `zig build test-threads-contract -Dlib_wasi_threads=true -Daot=false -Doptimize=Debug --summary all` (11/11)
- `zig build test --summary failures`
- `zig build -Dshared_memory=true -Doptimize=Debug --summary failures`
- cross-compiled parking/reserve paths for x86_64-windows, aarch64-macos, and aarch64-linux
- `git diff --check`

References #616 B1.3.