### PR TITLE
chore: bump wabt to v3.0.0-dev.20

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .wabt = .{
-            .url = "https://github.com/cataggar/wabt/archive/refs/tags/v3.0.0-dev.17.tar.gz",
-            .hash = "wabt-0.1.0-eK3F5r75KgC-IV8s0vXgTt3diu4fAj470vequlC0ZVir",
+            .url = "https://github.com/cataggar/wabt/archive/refs/tags/v3.0.0-dev.20.tar.gz",
+            .hash = "wabt-3.0.0-eK3F5jwAMgCximrV2_PSNt4VLZtXJ2JWBC1lAMYDtjSr",
         },
         .tls = .{
             .url = "https://github.com/cataggar/tls.zig/archive/2621e411af81c8b4d8fa5aaae08b9b183a80bb46.tar.gz",


### PR DESCRIPTION
Bumps the `wabt` dependency from `v3.0.0-dev.17` to `v3.0.0-dev.20`.

## Why

wabt `v3.0.0-dev.20` [removes its WebAssembly interpreter and the `wabt spec run` subcommand](https://github.com/cataggar/wabt/pull/346) (−9,716 lines). That removal is the fix for [GHSA-hv37-vjx6-rm9j](https://github.com/cataggar/wabt/security/advisories/GHSA-hv37-vjx6-rm9j) — an unbounded tail-call argument buffer that was only reachable through `spec run`.

wabt is a toolkit, not a runtime. Its interpreter existed solely to self-check the spec testsuite, which is now wamr's job as of #919.

## Impact on wamr: none

wamr consumes exactly two things from wabt, both untouched by the removal:

- 12 pure-text helpers plus the `Command` and `SExpr` types from `wast_runner.zig` (used by `json_from_wast.zig` and the spec runner).
- The `wabt spec to-json` CLI verb.

## Verification

Locally, against the new pin:

- `zig build -Doptimize=ReleaseSafe` — clean.
- `zig build spec-testsuite` — `257 files, 65135 passing assertions (baseline 65135)` / `no drift`.