### PR TITLE
fix(cli): graceful, portable SIGINT/SIGTERM shutdown for `wamr serve` (#918)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -782,6 +782,36 @@ pub fn build(b: *std.Build) void {
         }
     }
 
+    // #918 regression: `wamr serve` must shut down cleanly (exit 0) on
+    // SIGINT/SIGTERM rather than dying from the signal (macOS
+    // `Popen(-2)`) or wedging in `accept` until force-killed (Linux). A
+    // small driver (tests/component-http-shutdown/driver.zig) spawns
+    // `wamr serve --addr=127.0.0.1:0 http-service.wasm`, scrapes the
+    // kernel-assigned port from stdout, confirms one `GET / -> 200`
+    // request, then sends SIGINT and requires a *bounded, clean* exit 0.
+    //
+    // Gated on `jit` (the `-Djit=true` CI jobs build the in-process JIT
+    // needed to compile the ~3 MB P3 component in one process) and
+    // `aot_trampoline_pool_target` (its WASI imports need the host-import
+    // trampoline pool, unsupported on Windows / macOS-aarch64, same as
+    // `jit_component_smoke`). Also Linux-only because the driver drives
+    // the child with raw Linux `kill`/socket syscalls.
+    if (jit and aot_trampoline_pool_target and target.result.os.tag == .linux) {
+        const http_shutdown_driver = b.addExecutable(.{
+            .name = "component-http-shutdown-driver",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("tests/component-http-shutdown/driver.zig"),
+                .target = b.graph.host,
+                .optimize = .Debug,
+            }),
+        });
+        const run_http_shutdown = b.addRunArtifact(http_shutdown_driver);
+        run_http_shutdown.addFileArg(exe.getEmittedBin());
+        run_http_shutdown.addFileArg(b.path("tests/wasi-testsuite/tests/rust/testsuite/wasm32-wasip3/http-service.wasm"));
+        run_http_shutdown.expectExitCode(0);
+        test_step.dependOn(&run_http_shutdown.step);
+    }
+
     // #760 regression: AOT `wasi:cli/exit.exit` must terminate the host
     // process with the requested discriminant rather than returning the
     // post-#714 sentinel through the canon-lower(aot) trampoline. Two

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -1713,6 +1713,99 @@ pub const PendingHttpFetchShared = struct {
     waker: ?Waker = null,
 };
 
+/// `wamr serve` graceful-shutdown state (#918). Set by the async-signal-safe
+/// SIGINT/SIGTERM handler and observed by the accept loop in
+/// `serveLoadedHttpComponent`. `http_shutdown_requested` is the source of
+/// truth; `http_shutdown_wake_fd` is the write end of a self-pipe the
+/// handler pokes to wake a `poll()` parked on the listener. Process-global
+/// because a process serves at most one long-lived listener at a time; the
+/// finite-`max_requests` unit-test path never installs the handler, so it
+/// leaves these untouched.
+var http_shutdown_requested: std.atomic.Value(bool) = .init(false);
+var http_shutdown_wake_fd: std.atomic.Value(i32) = .init(-1);
+
+/// The self-pipe waker the accept loop parks on and the signal handler
+/// pokes. Owned by the arm/disarm pair below; the loop borrows its
+/// `read_fd`. Process-global for the same single-listener reason as the
+/// flag above. Only touched on the main (control-flow) path — never
+/// inside the signal handler, which reads `http_shutdown_wake_fd` instead.
+var http_shutdown_waker: ?Waker = null;
+var http_shutdown_armed: bool = false;
+
+/// Block SIGINT/SIGTERM on the calling (main) thread. Call this as early
+/// as possible — *before* the multi-second component decode + JIT compile
+/// — so a signal that races startup is held **pending** instead of being
+/// lost. A blocked signal becomes pending even when its disposition is
+/// `SIG_IGN` (the accept loop's process inherits `SIG_IGN` for SIGINT from
+/// a background shell, and Zig's startup momentarily resets the
+/// disposition via a `system(3)`-style helper); `armHttpShutdown` later
+/// installs the real handler and unblocks, at which point the pending
+/// signal is delivered to it. This is what makes the task's
+/// `sleep 1; kill -INT` startup-race reproduction exit cleanly (#918).
+/// A no-op on Windows (the `switch` keeps the POSIX arm out of the
+/// Windows build).
+pub fn blockHttpShutdownSignals() void {
+    switch (builtin.os.tag) {
+        .windows => return,
+        else => setHttpShutdownSignalMask(std.posix.SIG.BLOCK),
+    }
+}
+
+/// Unblock SIGINT/SIGTERM on the calling thread, delivering any instance
+/// that went pending while blocked. Called by `armHttpShutdown` *after*
+/// the handler is installed so a startup-race signal fires into the
+/// handler rather than the (possibly `SIG_IGN`) startup disposition.
+fn unblockHttpShutdownSignals() void {
+    switch (builtin.os.tag) {
+        .windows => return,
+        else => setHttpShutdownSignalMask(std.posix.SIG.UNBLOCK),
+    }
+}
+
+fn setHttpShutdownSignalMask(how: u32) void {
+    switch (builtin.os.tag) {
+        .windows => return,
+        else => {
+            var set = std.posix.sigemptyset();
+            std.posix.sigaddset(&set, std.posix.SIG.INT);
+            std.posix.sigaddset(&set, std.posix.SIG.TERM);
+            std.posix.sigprocmask(how, &set, null);
+        },
+    }
+}
+
+/// Arm the portable `wamr serve` SIGINT/SIGTERM graceful-shutdown path.
+/// Creates the self-pipe waker, publishes its write end for the handler,
+/// installs the async-signal-safe handler, and finally unblocks the
+/// signals (see `blockHttpShutdownSignals`). Call this *late* — right
+/// before entering the accept loop, once all of startup's signal
+/// manipulation is done — so the handler installed here survives to
+/// service the shutdown. Idempotent and a no-op on Windows; pair with
+/// `disarmHttpShutdown` on teardown.
+pub fn armHttpShutdown() void {
+    if (comptime builtin.os.tag == .windows) return;
+    if (http_shutdown_armed) return;
+    http_shutdown_armed = true;
+    http_shutdown_requested.store(false, .release);
+    http_shutdown_waker = Waker.init() catch null;
+    if (http_shutdown_waker) |w| http_shutdown_wake_fd.store(w.write_fd, .release);
+    installHttpShutdownHandler();
+    // Deliver any SIGINT/SIGTERM that went pending during startup now that
+    // the real handler is in place.
+    unblockHttpShutdownSignals();
+}
+
+/// Tear down the shutdown waker installed by `armHttpShutdown`. Stops
+/// publishing the write fd before closing it so a late signal can't write
+/// into a closed / reused descriptor. Idempotent; no-op on Windows.
+pub fn disarmHttpShutdown() void {
+    if (comptime builtin.os.tag == .windows) return;
+    http_shutdown_wake_fd.store(-1, .release);
+    if (http_shutdown_waker) |*w| w.deinit();
+    http_shutdown_waker = null;
+    http_shutdown_armed = false;
+}
+
 /// Cross-platform self-pipe waker (#833). A worker thread that settles a
 /// future without owning a pollable fd (outbound HTTP, future-trailers)
 /// uses this so the host's `std.posix.poll`-based block/poll loop has a
@@ -25509,6 +25602,14 @@ pub fn serveHttpComponentBytes(
     options: ServeHttpOptions,
     opts: core_backend.Options,
 ) anyerror!void {
+    // #918: block SIGINT/SIGTERM *before* the component decode below (and
+    // the JIT compile that follows in `serveLoadedHttpComponent`), so a
+    // signal that races startup is held pending rather than lost. The real
+    // handler is installed and the signals unblocked later, right before
+    // the accept loop (`armHttpShutdown`). Only for the long-lived
+    // serve-forever path; the finite-`max_requests` unit-test path never
+    // signals.
+    if (options.max_requests == null) blockHttpShutdownSignals();
     const component_storage = allocator.create(ctypes_root.Component) catch return error.OutOfMemory;
     defer allocator.destroy(component_storage);
     component_storage.* = component_loader.load(data, allocator) catch return error.LoadFailed;
@@ -25522,6 +25623,23 @@ pub fn serveLoadedHttpComponent(
     options: ServeHttpOptions,
     opts: core_backend.Options,
 ) anyerror!void {
+    // #918: portable graceful-shutdown wiring. SIGINT/SIGTERM are blocked
+    // early (in `serveHttpComponentBytes`, before the component decode +
+    // JIT compile) so a signal that races startup is held pending. Block
+    // again here (idempotent) so direct callers of this entry point are
+    // covered too. The real async-signal-safe handler is installed and the
+    // signals unblocked *late* — right before the accept loop, once all of
+    // startup's own signal manipulation is done — by `armHttpShutdown`;
+    // `disarmHttpShutdown` tears the waker down on the normal control-flow
+    // path once the loop unwinds. The handler only sets an atomic flag and
+    // writes one byte to the waker pipe; every teardown step (listener
+    // close, `inst.deinit`, arena / allocator cleanup) runs here, never
+    // inside the handler. Skipped for the finite-`max_requests` unit-test
+    // mode (no signals) and on Windows (no POSIX signal APIs).
+    const serve_forever = options.max_requests == null;
+    if (serve_forever) blockHttpShutdownSignals();
+    defer if (serve_forever) disarmHttpShutdown();
+
     const inst = instance_mod.instantiateWithOptions(
         component,
         allocator,
@@ -25606,20 +25724,45 @@ pub fn serveLoadedHttpComponent(
         stderr_file.writeStreamingAll(io, stderr_line) catch {};
     }
 
-    // Install a SIGINT/SIGTERM handler that exits cleanly with code 0
+    // Install the SIGINT/SIGTERM handler and unblock the signals now, once
+    // the listener is up and all of startup's signal manipulation is done
     // — the wasi-testsuite `http-service` fixture issues
     // `{ "type": "kill", "signal": "SIGINT" }` followed by
-    // `{ "type": "wait" }` (default exit_code 0). Without a handler
-    // the default disposition is process-terminate with a non-zero
-    // signal status, which the runner reports as a failure. Linux
-    // only — the conformance suite isn't run on Windows or macOS in
-    // CI, and the stdlib Sigaction shape differs per-platform. (#570)
-    if (builtin.target.os.tag == .linux) {
-        installHttpShutdownHandler();
-    }
+    // `{ "type": "wait" }` (default exit_code 0). Without a portable
+    // handler the default disposition is process-terminate with a
+    // non-zero signal status (observed as `Popen` `-2` on macOS, #918),
+    // which the runner reports as a failure. `armHttpShutdown` also
+    // unblocks the signals blocked at startup, so a SIGINT that raced the
+    // JIT compile is delivered to the handler right here; the accept loop
+    // below then observes the flag / self-pipe and shuts down cleanly.
+    if (serve_forever) armHttpShutdown();
 
     var served: usize = 0;
     while (options.max_requests == null or served < options.max_requests.?) {
+        // Portable graceful shutdown: block on the listener *and* the
+        // shutdown self-pipe so a SIGINT/SIGTERM wakes `accept` promptly
+        // instead of waiting for the next connection. `std.posix.poll`
+        // retries `EINTR` internally, so a signal delivered to this
+        // thread simply re-enters `poll` and then observes the readable
+        // pipe / atomic flag. Guarded to non-Windows because
+        // `std.posix.poll` is a compile error on Windows (and the waker
+        // is always null there). (#918)
+        if (comptime builtin.os.tag != .windows) {
+            if (http_shutdown_waker) |w| {
+                if (http_shutdown_requested.load(.acquire)) break;
+                var pfds = [_]std.posix.pollfd{
+                    .{ .fd = server.socket.handle, .events = std.posix.POLL.IN, .revents = 0 },
+                    .{ .fd = w.read_fd, .events = std.posix.POLL.IN, .revents = 0 },
+                };
+                _ = std.posix.poll(&pfds, -1) catch break;
+                if (http_shutdown_requested.load(.acquire)) break;
+                if (pfds[1].revents != 0) break;
+                if (pfds[0].revents & (std.posix.POLL.ERR | std.posix.POLL.NVAL) != 0) {
+                    return error.AcceptFailed;
+                }
+                if (pfds[0].revents & std.posix.POLL.IN == 0) continue;
+            }
+        }
         const accepted = server.accept(io) catch return error.AcceptFailed;
         {
             defer accepted.close(io);
@@ -25633,32 +25776,75 @@ pub fn serveLoadedHttpComponent(
     }
 }
 
-/// SIGINT/SIGTERM handler: exit the process with code 0. Used by the
-/// wasi:http/service event loop so a `kill` operation from the
-/// conformance test driver doesn't surface a non-zero exit status to
-/// the runner's `wait` check. `std.process.exit` lowers to
-/// `exit_group` on Linux — async-signal-safe. Linux-only — the
-/// conformance suite isn't run on Windows or macOS in CI, and the
-/// stdlib's Sigaction shape varies across platforms (Linux uses
-/// `u32` mask, BSD uses `[N]c_ulong`). (#570)
-fn httpShutdownSignalHandler(_: std.os.linux.SIG) callconv(.c) void {
-    std.process.exit(0);
+/// SIGINT/SIGTERM handler: request an orderly shutdown of the
+/// `wasi:http/service` accept loop. Async-signal-safe — it only stores
+/// an atomic flag and writes one byte to the shutdown self-pipe so a
+/// `poll()` parked on the accept path wakes immediately. All teardown
+/// (listener close, component `deinit`, allocator cleanup) then runs on
+/// the normal control-flow path once the loop unwinds; nothing unsafe
+/// (allocation, `deinit`, buffered I/O) happens inside the handler.
+/// (#918)
+fn httpShutdownRequest() void {
+    http_shutdown_requested.store(true, .release);
+    const fd = http_shutdown_wake_fd.load(.acquire);
+    if (fd >= 0) {
+        const byte = [_]u8{1};
+        // Best-effort, async-signal-safe wake. Errors (EINTR / EAGAIN /
+        // EPIPE) are ignored — the atomic flag is the source of truth;
+        // the byte only unblocks a `poll()` on the read end.
+        _ = std.posix.system.write(fd, &byte, 1);
+    }
+}
+
+/// Per-platform `callconv(.c)` trampolines into `httpShutdownRequest`.
+/// The signal-handler function-pointer type is `fn (SIG)` where `SIG`
+/// is the platform's signal enum, which differs between the raw Linux
+/// (`std.os.linux.SIG`) and the libc/BSD (`std.posix.SIG`) ABIs — hence
+/// two thin wrappers. Only the one referenced by the active target is
+/// analyzed (lazy analysis), so neither is compiled on Windows. (#918)
+fn httpShutdownSignalHandlerLinux(_: std.os.linux.SIG) callconv(.c) void {
+    httpShutdownRequest();
+}
+
+fn httpShutdownSignalHandlerPosix(_: std.posix.SIG) callconv(.c) void {
+    httpShutdownRequest();
 }
 
 fn installHttpShutdownHandler() void {
-    if (builtin.target.os.tag != .linux) return;
-    const linux = std.os.linux;
-    var act: linux.Sigaction = .{
-        .handler = .{ .handler = httpShutdownSignalHandler },
-        .mask = linux.sigemptyset(),
-        .flags = 0,
-    };
-    // Use the raw linux sigaction syscall: when libc is linked (musl) the
-    // std.posix wrapper expects c.common_linux_Sigaction which has a
-    // different layout than std.os.linux.Sigaction and rejects this struct.
-    // The raw syscall takes linux.Sigaction directly on every linux target.
-    _ = linux.sigaction(linux.SIG.INT, &act, null);
-    _ = linux.sigaction(linux.SIG.TERM, &act, null);
+    switch (builtin.os.tag) {
+        .windows => return,
+        .linux => {
+            // Use the raw linux sigaction syscall: when libc is linked
+            // (musl) the std.posix wrapper expects `c.common_linux_Sigaction`
+            // which has a different layout than `std.os.linux.Sigaction`
+            // and rejects this struct. The raw syscall takes
+            // `linux.Sigaction` directly on every linux target.
+            const linux = std.os.linux;
+            var act: linux.Sigaction = .{
+                .handler = .{ .handler = httpShutdownSignalHandlerLinux },
+                .mask = linux.sigemptyset(),
+                // SA_RESETHAND: a *second* SIGINT (impatient Ctrl-C)
+                // falls through to the default disposition and terminates
+                // the process, so shutdown can never wedge.
+                .flags = linux.SA.RESETHAND,
+            };
+            _ = linux.sigaction(linux.SIG.INT, &act, null);
+            _ = linux.sigaction(linux.SIG.TERM, &act, null);
+        },
+        else => {
+            // macOS / BSD: the libc `sigaction` wrapper matches
+            // `std.posix.Sigaction`'s layout, so use it directly. This is
+            // what fixes the macOS `Popen(-2)` shutdown failure (#918):
+            // previously no handler was installed off-Linux.
+            var act: std.posix.Sigaction = .{
+                .handler = .{ .handler = httpShutdownSignalHandlerPosix },
+                .mask = std.posix.sigemptyset(),
+                .flags = std.posix.SA.RESETHAND,
+            };
+            std.posix.sigaction(std.posix.SIG.INT, &act, null);
+            std.posix.sigaction(std.posix.SIG.TERM, &act, null);
+        },
+    }
 }
 
 fn statusForRequestReadError(err: anyerror) u16 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -524,6 +524,16 @@ fn runServe(init: std.process.Init, allocator: std.mem.Allocator, serve_args: []
         writeStdout(init.io, serve_usage);
         return 0;
     }
+    // #918: block SIGINT/SIGTERM before any of the (potentially
+    // multi-second) startup work below — component read, manifest /
+    // AOT-or-JIT precompile, and instantiation — so a signal that races
+    // startup is held pending on this (single) thread rather than lost to
+    // the inherited `SIG_IGN` disposition. The real async-signal-safe
+    // handler is installed and the signals unblocked later, right before
+    // the accept loop (`serveLoadedHttpComponent` → `armHttpShutdown`), at
+    // which point the pending signal is delivered and shuts the server
+    // down cleanly. No-op on Windows.
+    wamr.wasi_cli_adapter.blockHttpShutdownSignals();
     var wasm_path: ?[]const u8 = null;
     var wasm_args: std.ArrayListUnmanaged([]const u8) = .empty;
     defer wasm_args.deinit(allocator);

--- a/tests/component-http-shutdown/driver.zig
+++ b/tests/component-http-shutdown/driver.zig
@@ -1,0 +1,243 @@
+//! End-to-end SIGINT graceful-shutdown driver for `wamr serve` (#918).
+//!
+//! Spawns `<wamr_exe> serve --addr=127.0.0.1:0 <component.wasm>` as a
+//! subprocess, discovers the kernel-assigned ephemeral port by scraping
+//! the `Listening on 127.0.0.1:<port>` line from the child's stdout,
+//! confirms at least one successful HTTP request (`GET /` -> 200), then
+//! sends `SIGINT` and requires a *bounded, clean* `exit 0`.
+//!
+//! This is the regression net for #918: before the fix `wamr serve`
+//! installed a graceful-shutdown handler only on Linux (so native macOS
+//! died with signal 2 / `Popen(-2)`), and even on Linux a SIGINT that
+//! raced the JIT compile was lost — the process wedged in `accept` until
+//! force-killed. After the fix the SIGINT/SIGTERM handler is portable and
+//! async-signal-safe (it only sets an atomic flag + wakes the accept loop
+//! via a self-pipe), and all teardown runs on the normal control path.
+//!
+//! Mirrors `tests/component-http-smoke/driver.zig` (the serve-loop smoke
+//! driver). Uses the `http-service.wasm` P3 fixture, which serves
+//! `GET / -> 200 "hey\n"`.
+//!
+//! Usage: `component-http-shutdown-driver <wamr_exe> <component.wasm>`
+//!
+//! Exit 0 on success; non-zero (with a message on stderr) otherwise.
+
+const std = @import("std");
+const linux = std.os.linux;
+const builtin = @import("builtin");
+
+const usage = "usage: component-http-shutdown-driver <wamr_exe> <component.wasm>\n";
+
+/// Force-kills the server if it fails to exit within the deadline, so a
+/// regression can never hang the test suite indefinitely.
+const Watchdog = struct {
+    pid: linux.pid_t,
+    done: std.atomic.Value(bool) = .init(false),
+
+    fn run(self: *Watchdog) void {
+        const timeout_ms: usize = 10_000;
+        var waited: usize = 0;
+        while (waited < timeout_ms) : (waited += 50) {
+            if (self.done.load(.acquire)) return;
+            const ts: linux.timespec = .{ .sec = 0, .nsec = 50 * std.time.ns_per_ms };
+            _ = linux.nanosleep(&ts, null);
+        }
+        if (self.done.load(.acquire)) return;
+        std.debug.print("driver: TIMEOUT waiting for clean shutdown; force-killing\n", .{});
+        _ = linux.kill(self.pid, .KILL);
+    }
+
+    fn cancel(self: *Watchdog) void {
+        self.done.store(true, .release);
+    }
+};
+
+pub fn main(init: std.process.Init) !void {
+    if (comptime builtin.os.tag != .linux) {
+        // This driver uses raw Linux syscalls; it is only wired into the
+        // build on Linux (see build.zig). Skip cleanly elsewhere.
+        std.debug.print("component-http-shutdown-driver only runs on Linux; skipping\n", .{});
+        std.process.exit(0);
+    }
+
+    const io = init.io;
+    const allocator = init.gpa;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    if (args.len < 3) {
+        std.debug.print(usage, .{});
+        std.process.exit(2);
+    }
+    const wamr_exe = args[1];
+    const component_path = args[2];
+
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ wamr_exe, "serve", "--addr=127.0.0.1:0", component_path },
+        .stdin = .ignore,
+        .stdout = .pipe,
+        .stderr = .inherit,
+    });
+    var killed = false;
+    defer if (!killed) child.kill(io);
+
+    // Discover the ephemeral port from the child's stdout `Listening on
+    // 127.0.0.1:<port>` line. `read` blocks until the line is produced;
+    // JIT-compiling the ~3 MB component can take a couple of seconds.
+    const out_fd = child.stdout.?.handle;
+    var acc: std.ArrayListUnmanaged(u8) = .empty;
+    defer acc.deinit(allocator);
+    const port: u16 = blk: {
+        var buf: [512]u8 = undefined;
+        while (true) {
+            const rc = linux.read(out_fd, &buf, buf.len);
+            if (linux.errno(rc) != .SUCCESS) {
+                std.debug.print("driver: read(server stdout) failed\n", .{});
+                std.process.exit(1);
+            }
+            const n: isize = @bitCast(rc);
+            if (n <= 0) {
+                std.debug.print("driver: server closed stdout before announcing a port\n", .{});
+                std.process.exit(1);
+            }
+            try acc.appendSlice(allocator, buf[0..@intCast(n)]);
+            if (parseListeningPort(acc.items)) |p| break :blk p;
+            if (acc.items.len > 64 * 1024) {
+                std.debug.print("driver: no `Listening on` line in server stdout\n", .{});
+                std.process.exit(1);
+            }
+        }
+    };
+
+    // ── One successful request: GET / -> 200 "hey\n" ──────────────────
+    {
+        var resp_buf: [4096]u8 = undefined;
+        const resp = sendReceiveOnce(port, "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n", resp_buf[0..]) catch |err| {
+            std.debug.print("driver: request failed: {t}\n", .{err});
+            std.process.exit(1);
+        };
+        assertStatus(resp, 200) catch std.process.exit(1);
+        assertBodyEquals(resp, "hey\n") catch std.process.exit(1);
+    }
+
+    // ── Send SIGINT; require a bounded, clean exit 0 ──────────────────
+    const pid = child.id.?;
+    var wd: Watchdog = .{ .pid = pid };
+    const wd_thread = try std.Thread.spawn(.{}, Watchdog.run, .{&wd});
+
+    _ = linux.kill(pid, .INT);
+
+    const term = child.wait(io) catch |err| {
+        wd.cancel();
+        wd_thread.join();
+        std.debug.print("driver: wait failed: {t}\n", .{err});
+        std.process.exit(1);
+    };
+    killed = true; // `wait` reaped the child; do not `kill` it in `defer`.
+    wd.cancel();
+    wd_thread.join();
+
+    switch (term) {
+        .exited => |code| {
+            if (code != 0) {
+                std.debug.print("driver: serve exited {d} on SIGINT, expected 0\n", .{code});
+                std.process.exit(1);
+            }
+        },
+        else => {
+            std.debug.print("driver: serve did not exit cleanly on SIGINT: {any}\n", .{term});
+            std.process.exit(1);
+        },
+    }
+}
+
+/// Scrape the `Listening on 127.0.0.1:<port>` line the CLI prints once the
+/// listener is bound (only emitted for the ephemeral `:0` bind path).
+fn parseListeningPort(bytes: []const u8) ?u16 {
+    const marker = "Listening on 127.0.0.1:";
+    const idx = std.mem.indexOf(u8, bytes, marker) orelse return null;
+    const rest = bytes[idx + marker.len ..];
+    var end: usize = 0;
+    while (end < rest.len and rest[end] >= '0' and rest[end] <= '9') : (end += 1) {}
+    if (end == 0) return null;
+    // Require the newline so we don't parse a truncated port mid-read.
+    if (end >= rest.len or (rest[end] != '\n' and rest[end] != '\r')) return null;
+    return std.fmt.parseInt(u16, rest[0..end], 10) catch null;
+}
+
+fn tcpConnect(port: u16) !i32 {
+    const dest: linux.sockaddr.in = .{
+        .port = std.mem.nativeToBig(u16, port),
+        .addr = @bitCast([4]u8{ 127, 0, 0, 1 }),
+    };
+    const fd_rc = linux.socket(linux.AF.INET, linux.SOCK.STREAM | linux.SOCK.CLOEXEC, linux.IPPROTO.TCP);
+    if (linux.errno(fd_rc) != .SUCCESS) return error.SocketFailed;
+    const fd: i32 = @intCast(@as(isize, @bitCast(fd_rc)));
+    const rc = linux.connect(fd, @ptrCast(&dest), @sizeOf(@TypeOf(dest)));
+    if (linux.errno(rc) != .SUCCESS) {
+        _ = linux.close(fd);
+        return error.ConnectFailed;
+    }
+    return fd;
+}
+
+fn sendReceiveOnce(
+    port: u16,
+    request: []const u8,
+    resp_buf: []u8,
+) ![]const u8 {
+    const fd = try tcpConnect(port);
+    defer _ = linux.close(fd);
+
+    var sent: usize = 0;
+    while (sent < request.len) {
+        const rc = linux.write(fd, request[sent..].ptr, request.len - sent);
+        if (linux.errno(rc) != .SUCCESS) return error.SendFailed;
+        const n: isize = @bitCast(rc);
+        if (n <= 0) return error.SendFailed;
+        sent += @intCast(n);
+    }
+
+    // Read until the connection closes — wamr serves one response then
+    // closes (per `serveOneHttpConnection`).
+    var total: usize = 0;
+    while (true) {
+        if (total >= resp_buf.len) break;
+        const rc = linux.read(fd, resp_buf[total..].ptr, resp_buf.len - total);
+        if (linux.errno(rc) != .SUCCESS) return error.RecvFailed;
+        const n: isize = @bitCast(rc);
+        if (n == 0) break;
+        if (n < 0) return error.RecvFailed;
+        total += @intCast(n);
+    }
+    return resp_buf[0..total];
+}
+
+fn assertStatus(resp: []const u8, expected: u16) !void {
+    const prefix = "HTTP/1.1 ";
+    if (!std.mem.startsWith(u8, resp, prefix)) {
+        std.debug.print("driver: bad status line — got: {s}\n", .{resp[0..@min(resp.len, 80)]});
+        return error.BadStatusLine;
+    }
+    const after = resp[prefix.len..];
+    var i: usize = 0;
+    while (i < after.len and after[i] >= '0' and after[i] <= '9') : (i += 1) {}
+    if (i == 0) return error.BadStatusLine;
+    const code = std.fmt.parseInt(u16, after[0..i], 10) catch return error.BadStatusLine;
+    if (code != expected) {
+        std.debug.print("driver: expected {d}, got {d} — full status line: {s}\n", .{
+            expected,
+            code,
+            after[0..@min(after.len, 60)],
+        });
+        return error.WrongStatus;
+    }
+}
+
+fn assertBodyEquals(resp: []const u8, expected: []const u8) !void {
+    const sep = "\r\n\r\n";
+    const sep_idx = std.mem.indexOf(u8, resp, sep) orelse return error.MissingHeaderTerminator;
+    const body = resp[sep_idx + sep.len ..];
+    if (!std.mem.eql(u8, body, expected)) {
+        std.debug.print("driver: body mismatch.\n  expected: {s}\n  got:      {s}\n", .{ expected, body });
+        return error.BodyMismatch;
+    }
+}


### PR DESCRIPTION
Fixes #918.

## Root cause
`wamr serve` completed every `http-service` request but died from the signal on shutdown:
- On **macOS** no signal handler was installed at all — the default disposition terminated the process (surfaced as Python `Popen` returning `-2`).
- On **Linux** a SIGINT that raced the multi-second component decode + JIT compile was lost: the handler was installed only *after* that ~13s of startup work, and the inherited `SIG_IGN` disposition (background-shell job control) swallowed the early signal, wedging the process in `accept()` until force-killed.

## Fix — portable, async-signal-safe shutdown
- **Block SIGINT/SIGTERM early** (top of `runServe`, before decode/manifest/JIT) so a startup-race signal is held *pending* (a blocked signal goes pending even under `SIG_IGN`) instead of being lost.
- **Install the handler + unblock late** — right before the accept loop (`armHttpShutdown`) — so the pending signal is delivered cleanly.
- The **handler is async-signal-safe**: it only stores an atomic flag and writes one byte to a self-pipe waker. All teardown (listener close, component `deinit`, allocator cleanup) runs on the normal control-flow path once the loop unwinds.
- The **accept loop now `poll()`s the listener *and* the self-pipe**, so a signal wakes it promptly instead of waiting for the next connection.
- `SA_RESETHAND` lets an impatient second Ctrl-C fall through to the default disposition, so shutdown is always bounded.
- **SIGTERM handled the same as SIGINT.**
- All POSIX signal APIs are behind `switch (builtin.os.tag)` guards so the **Windows build keeps compiling** (verified via `-Dtarget=x86_64-windows`).

## Test
Adds `tests/component-http-shutdown/driver.zig`, a subprocess regression test wired into `test_step` (gated `jit and aot_trampoline_pool_target` and Linux). It starts the server on `127.0.0.1:0`, confirms a `GET / -> 200 "hey\n"` request, sends SIGINT, and requires a bounded clean `exit 0`. Genuine server errors still return nonzero.

## Validation (Linux)
| Check | Result |
| --- | --- |
| `zig build -Doptimize=ReleaseSafe -Djit=true` | exit 0 |
| `zig build -Dtarget=x86_64-windows` | exit 0 (Windows compiles) |
| `zig build test` | exit 0 |
| `zig build test -Djit=true` (runs new #918 test) | exit 0 |
| Task repro snippet (`sleep 1; kill -INT`) **before fix** | 137 (hang → SIGKILL) |
| Task repro snippet **after fix** (3×) | **0** |
| New driver against `http-service.wasm` | exit 0 |
| Genuine errors (bad `--addr`, missing file) | 2 / 1 (nonzero preserved) |

No follow-up expected.