### PR TITLE
perf(x86_64): fold compound base+index*scale+disp into single LEA (#543)

### DIFF
--- a/src/compiler/bench_codegen.zig
+++ b/src/compiler/bench_codegen.zig
@@ -357,6 +357,31 @@ fn bodyAddIntoLoad(func: *ir.IrFunction, block: *ir.BasicBlock) void {
     block.append(.{ .op = .{ .ret = loaded } }) catch unreachable;
 }
 
+/// Compound address `base + index*4 + 16` fed by two opaque memory loads.
+/// `foldCompoundLea` collapses the `shl` + inner `add` + outer `add` chain
+/// into a single `lea` (#543). The base/index come from loads rather than
+/// constants because `constantFold` would otherwise collapse the whole
+/// expression before the LEA fold could fire.
+fn bodyLeaCompound(func: *ir.IrFunction, block: *ir.BasicBlock) void {
+    const mem = func.newVReg();
+    const base = func.newVReg();
+    const index = func.newVReg();
+    const two = func.newVReg();
+    const shifted = func.newVReg();
+    const inner = func.newVReg();
+    const c16 = func.newVReg();
+    const result = func.newVReg();
+    block.append(.{ .op = .{ .iconst_32 = 0x1000 }, .dest = mem, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .load = .{ .base = mem, .offset = 0, .size = 4 } }, .dest = base, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .load = .{ .base = mem, .offset = 4, .size = 4 } }, .dest = index, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = two, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .shl = .{ .lhs = index, .rhs = two } }, .dest = shifted, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .add = .{ .lhs = base, .rhs = shifted } }, .dest = inner, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .iconst_32 = 16 }, .dest = c16, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .add = .{ .lhs = inner, .rhs = c16 } }, .dest = result, .type = .i32 }) catch unreachable;
+    block.append(.{ .op = .{ .ret = result } }) catch unreachable;
+}
+
 // ── Branch benchmark bodies ───────────────────────────────────────────
 
 /// compare + br_if diamond — exercises Jcc fusion and branch layout.
@@ -423,7 +448,16 @@ fn bodyBrTable(func: *ir.IrFunction, block: *ir.BasicBlock) void {
     const t3 = func.newBlock() catch unreachable;
 
     block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = idx, .type = .i32 }) catch unreachable;
-    const targets = &[_]ir.BlockId{ t0, t1, t2, t3 };
+    // `br_table.targets` must outlive this function: codegen reads it long
+    // after `bodyBrTable` returns, and IR does not copy or free it (see the
+    // "leaked by IR" note on the br_table compile test). A `&[_]…{…}` array
+    // literal would dangle here, so allocate a slice that survives (leaked;
+    // acceptable in a short-lived benchmark process).
+    const targets = func.allocator.alloc(ir.BlockId, 4) catch unreachable;
+    targets[0] = t0;
+    targets[1] = t1;
+    targets[2] = t2;
+    targets[3] = t3;
     block.append(.{ .op = .{ .br_table = .{ .index = idx, .targets = targets, .default = t0 } } }) catch unreachable;
 
     func.getBlock(t0).append(.{ .op = .{ .iconst_32 = 10 }, .dest = r0, .type = .i32 }) catch unreachable;
@@ -913,6 +947,7 @@ pub fn main() !void {
         .{ .name = "3× load same base (hoisted)", .body = &bodyConsecutiveLoads },
         .{ .name = "div_u by const 7 (magic mul)", .body = &bodyDivByConst },
         .{ .name = "add base,const → load offset", .body = &bodyAddIntoLoad },
+        .{ .name = "base+index*4+16 → lea (#543)", .body = &bodyLeaCompound },
         .{ .name = "chained br_if same cond", .body = &bodyChainedBrIfSameCond },
         .{ .name = "4× load + sum (bounds elide)", .body = &bodyLoadStoreMulti },
         .{ .name = "reg pressure (12 live vals)", .body = &bodyRegPressure },

--- a/src/compiler/codegen/aarch64/compile.zig
+++ b/src/compiler/codegen/aarch64/compile.zig
@@ -3278,6 +3278,38 @@ fn compileInst(
 
         // ── Linear memory load/store ─────────────────────────────────
         .load => |ld| try emitLoad(code, inst, ld, reg_map),
+
+        // ── Compound address (base + index*scale + disp) ─────────────
+        // The x86-64 `foldCompoundLea` pass is the only producer of `.lea`
+        // and it is gated to the x86-64 pipeline, so this arm is not
+        // reached in practice; it is provided so the op is lowered
+        // correctly should it ever appear on AArch64 (there is no single
+        // AArch64 addressing-compute instruction, so it expands to
+        // lsl + add [+ add disp]).
+        .lea => |l| {
+            const dest = inst.dest orelse return;
+            const scale_log2: u6 = switch (l.scale) {
+                1 => 0,
+                2 => 1,
+                4 => 2,
+                8 => 3,
+                else => unreachable,
+            };
+            const idx = try useInto(code, reg_map, l.index, RegMap.tmp0);
+            if (scale_log2 != 0) {
+                try code.lslImm(RegMap.tmp0, idx, scale_log2);
+            } else if (idx != RegMap.tmp0) {
+                try code.addImm(RegMap.tmp0, idx, 0);
+            }
+            const base = try useInto(code, reg_map, l.base, RegMap.tmp1);
+            const info = try destBegin(reg_map, dest, RegMap.tmp0);
+            try code.addRegReg(info.reg, base, RegMap.tmp0);
+            if (l.disp != 0) {
+                try code.movImm64(RegMap.tmp1, @bitCast(@as(i64, l.disp)));
+                try code.addRegReg(info.reg, info.reg, RegMap.tmp1);
+            }
+            try destCommit(code, reg_map, info);
+        },
         .store => |st| try emitStore(code, st, reg_map),
 
         .ret => |maybe_val| {

--- a/src/compiler/codegen/x86_64/compile.zig
+++ b/src/compiler/codegen/x86_64/compile.zig
@@ -983,6 +983,11 @@ fn compileInst(
             try stack.push(code, .rax);
         },
 
+        // `.lea` is produced only by the x86-64 `foldCompoundLea` pass,
+        // whose output is lowered by the register-allocating path
+        // (`compileInstRA`). This legacy stack-machine path never sees it.
+        .lea => return error.UnimplementedOp,
+
         // ── Memory store ──────────────────────────────────────────────
         .store => |st| {
             try stack.pop(code, .rcx); // value
@@ -3278,6 +3283,36 @@ fn compileInstRA(
                     .xor => try code.xorRegReg(dr, rhs_reg),
                     else => unreachable,
                 }
+                try writeDefTyped(code, alloc_result, dest, dr, inst.type);
+            }
+        },
+
+        // ── Fused address computation (LEA) ───────────────────────────
+        // dest = base + index*scale + disp, emitted as a single flag-free
+        // LEA (#543). Produced only by the `foldCompoundLea` peephole,
+        // which guarantees base/index are live here (they are the op's
+        // operands) and scale ∈ {1,2,4,8}. base→r11, index→r10 are
+        // non-allocatable scratches, so a spilled operand loaded into a
+        // scratch never clobbers the other operand's register.
+        .lea => |l| {
+            const dest = inst.dest orelse return;
+            const dr = destReg(alloc_result, dest);
+            const base_reg = try useVReg(code, alloc_result, l.base, .r11);
+            const index_reg = try useVReg(code, alloc_result, l.index, .r10);
+            const scale_log2: u2 = switch (l.scale) {
+                1 => 0,
+                2 => 1,
+                4 => 2,
+                8 => 3,
+                else => unreachable,
+            };
+            if (inst.type == .i32) {
+                // 32-bit LEA truncates+zero-extends — exactly i32 wrapping,
+                // no trailing zero-extend needed (#393/#543).
+                try code.leaRegBaseIndexScaleDisp32(dr, base_reg, index_reg, scale_log2, l.disp);
+                try writeDef(code, alloc_result, dest, dr);
+            } else {
+                try code.leaRegBaseIndexScaleDisp64(dr, base_reg, index_reg, scale_log2, l.disp);
                 try writeDefTyped(code, alloc_result, dest, dr, inst.type);
             }
         },
@@ -6969,6 +7004,35 @@ test "compileFunctionRA: add of two non-constant values emits LEA" {
     try std.testing.expect(containsBytes(code, &.{0x8D}));
     // ADD reg,reg (opcode 01) must NOT appear — the LEA replaced it.
     // Check no standalone 01 in a REX+01 pattern. Just verify 0x8D is present.
+    try std.testing.expectEqual(@as(u8, 0xC3), code[code.len - 1]);
+}
+
+test "compileFunctionRA: .lea op emits a single LEA (0x8D) with disp" {
+    // Directly lower a `.lea` IR op (as produced by foldCompoundLea) and
+    // confirm codegen emits the LEA opcode. base/index come from local_get
+    // so they are real registers.
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 2, 3, 0);
+    defer func.deinit();
+
+    const block_id = try func.newBlock();
+    const block = func.getBlock(block_id);
+    const v0 = func.newVReg();
+    const v1 = func.newVReg();
+    const v2 = func.newVReg();
+    try block.append(.{ .op = .{ .local_get = 0 }, .dest = v0, .type = .i32 });
+    try block.append(.{ .op = .{ .local_get = 1 }, .dest = v1, .type = .i32 });
+    try block.append(.{ .op = .{ .lea = .{ .base = v0, .index = v1, .scale = 4, .disp = 16 } }, .dest = v2, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = v2 } });
+
+    const compile_result = try compileFunctionRA(&func, 0, allocator);
+    const code = compile_result.code;
+    defer allocator.free(compile_result.call_patches);
+    defer allocator.free(code);
+
+    // LEA opcode present, and the disp8 = 16 (0x10) byte appears.
+    try std.testing.expect(containsBytes(code, &.{0x8D}));
+    try std.testing.expect(containsBytes(code, &.{0x10}));
     try std.testing.expectEqual(@as(u8, 0xC3), code[code.len - 1]);
 }
 

--- a/src/compiler/codegen/x86_64/emit.zig
+++ b/src/compiler/codegen/x86_64/emit.zig
@@ -552,23 +552,7 @@ pub const CodeBuffer = struct {
     /// a `mov dst, base` compared to the mov+add sequence.
     /// Precondition: index must not be RSP (SIB encodes rsp as "no index").
     pub fn leaRegBaseIndex64(self: *CodeBuffer, dst: Reg, base: Reg, index: Reg) !void {
-        std.debug.assert(index != .rsp);
-        // REX.W + R (dst) + X (index) + B (base).
-        const rex_byte: u8 = 0x48 |
-            (@as(u8, @intFromEnum(dst) >> 3) << 2) |
-            (@as(u8, @intFromEnum(index) >> 3) << 1) |
-            (@as(u8, @intFromEnum(base) >> 3));
-        try self.emitByte(rex_byte);
-        try self.emitByte(0x8D); // LEA
-        // If base.low3 == 5 (rbp/r13), mod=00 would mean RIP-relative, so use
-        // mod=01 with disp8=0 to encode a plain [base + index] form.
-        const needs_disp8 = base.low3() == 5;
-        const mod: u2 = if (needs_disp8) 0b01 else 0b00;
-        try self.modrm(mod, dst.low3(), 0b100); // rm=100 → SIB follows
-        // SIB: scale=00, index=index.low3, base=base.low3
-        const sib: u8 = (@as(u8, 0) << 6) | (@as(u8, index.low3()) << 3) | @as(u8, base.low3());
-        try self.emitByte(sib);
-        if (needs_disp8) try self.emitByte(0x00);
+        try self.leaRegBaseIndexScaleDisp64(dst, base, index, 0, 0);
     }
 
     /// LEA r32, [base + index] (32-bit operand size). The address is computed
@@ -576,19 +560,58 @@ pub const CodeBuffer = struct {
     /// since add-mod-2^32 depends only on the low 32 bits of each operand,
     /// this is exactly Wasm `i32.add` (#393), with no separate zero-extend.
     pub fn leaRegBaseIndex32(self: *CodeBuffer, dst: Reg, base: Reg, index: Reg) !void {
+        try self.leaRegBaseIndexScaleDisp32(dst, base, index, 0, 0);
+    }
+
+    /// LEA dst, [base + index*scale + disp] — 64-bit compound address
+    /// computation folded into a single flag-free instruction (#543).
+    /// `scale_log2` is the SIB scale exponent (0/1/2/3 → scale 1/2/4/8);
+    /// `disp` is a signed 32-bit displacement. Precondition: index != RSP.
+    pub fn leaRegBaseIndexScaleDisp64(self: *CodeBuffer, dst: Reg, base: Reg, index: Reg, scale_log2: u2, disp: i32) !void {
+        std.debug.assert(index != .rsp);
+        const rex_byte: u8 = 0x48 |
+            (@as(u8, @intFromEnum(dst) >> 3) << 2) |
+            (@as(u8, @intFromEnum(index) >> 3) << 1) |
+            (@as(u8, @intFromEnum(base) >> 3));
+        try self.emitByte(rex_byte);
+        try self.emitSibLeaBody(dst, base, index, scale_log2, disp);
+    }
+
+    /// LEA r32, [base + index*scale + disp] (32-bit operand size). See the
+    /// 64-bit variant; the 32-bit form truncates+zero-extends the address,
+    /// which is exactly Wasm i32 wrapping arithmetic (#393/#543).
+    pub fn leaRegBaseIndexScaleDisp32(self: *CodeBuffer, dst: Reg, base: Reg, index: Reg, scale_log2: u2, disp: i32) !void {
         std.debug.assert(index != .rsp);
         const rex_byte: u8 = 0x40 |
             (@as(u8, @intFromEnum(dst) >> 3) << 2) |
             (@as(u8, @intFromEnum(index) >> 3) << 1) |
             (@as(u8, @intFromEnum(base) >> 3));
         if (rex_byte != 0x40) try self.emitByte(rex_byte);
+        try self.emitSibLeaBody(dst, base, index, scale_log2, disp);
+    }
+
+    /// Shared opcode + ModRM/SIB + displacement encoding for the scaled LEA
+    /// forms. The caller has already emitted any REX prefix.
+    fn emitSibLeaBody(self: *CodeBuffer, dst: Reg, base: Reg, index: Reg, scale_log2: u2, disp: i32) !void {
         try self.emitByte(0x8D); // LEA
-        const needs_disp8 = base.low3() == 5;
-        const mod: u2 = if (needs_disp8) 0b01 else 0b00;
+        // base.low3 == 5 (rbp/r13) cannot use mod=00 (that encodes a
+        // disp32-only form with no base), so force at least a disp8=0.
+        const base_is_bp = base.low3() == 5;
+        const mod: u2 = if (disp == 0 and !base_is_bp)
+            0b00
+        else if (disp >= -128 and disp <= 127)
+            0b01
+        else
+            0b10;
         try self.modrm(mod, dst.low3(), 0b100); // rm=100 → SIB follows
-        const sib: u8 = (@as(u8, 0) << 6) | (@as(u8, index.low3()) << 3) | @as(u8, base.low3());
+        const sib: u8 = (@as(u8, scale_log2) << 6) | (@as(u8, index.low3()) << 3) | @as(u8, base.low3());
         try self.emitByte(sib);
-        if (needs_disp8) try self.emitByte(0x00);
+        switch (mod) {
+            0b00 => {},
+            0b01 => try self.emitByte(@bitCast(@as(i8, @intCast(disp)))),
+            0b10 => try self.emitI32(disp),
+            else => unreachable,
+        }
     }
 
     /// ADD reg, imm32 (64-bit).
@@ -1784,6 +1807,65 @@ test "leaRegBaseIndex64 rax, r8, r9" {
     // Opcode 0x8D. ModR/M mod=00, reg=0, rm=100 → 0x04.
     // SIB scale=0, index=r9.low3=1, base=r8.low3=0 → 00_001_000 = 0x08.
     try hexEqual(buf.getCode(), &.{ 0x4B, 0x8D, 0x04, 0x08 });
+}
+
+test "leaRegBaseIndexScaleDisp64 rdx, [rsi + rdi*4]" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.leaRegBaseIndexScaleDisp64(.rdx, .rsi, .rdi, 2, 0);
+    // REX.W 0x48. 0x8D. mod=00 reg=rdx=2 rm=100 → 0x14.
+    // SIB scale=2(→*4) index=rdi=7 base=rsi=6 → 10_111_110 = 0xBE.
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x8D, 0x14, 0xBE });
+}
+
+test "leaRegBaseIndexScaleDisp64 rdx, [rsi + rdi*2 + 16] (disp8)" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.leaRegBaseIndexScaleDisp64(.rdx, .rsi, .rdi, 1, 16);
+    // mod=01 (disp8) → 0x54. SIB scale=1(→*2) → 01_111_110 = 0x7E. disp8=0x10.
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x8D, 0x54, 0x7E, 0x10 });
+}
+
+test "leaRegBaseIndexScaleDisp64 rdx, [rsi + rdi*8 + 0x1000] (disp32)" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.leaRegBaseIndexScaleDisp64(.rdx, .rsi, .rdi, 3, 0x1000);
+    // mod=10 (disp32) → 0x94. SIB scale=3(→*8) → 11_111_110 = 0xFE.
+    // disp32 little-endian: 00 10 00 00.
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x8D, 0x94, 0xFE, 0x00, 0x10, 0x00, 0x00 });
+}
+
+test "leaRegBaseIndexScaleDisp64 base rbp forces disp8=0" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.leaRegBaseIndexScaleDisp64(.rdx, .rbp, .rdi, 2, 0);
+    // base rbp (low3=5) can't use mod=00 → mod=01 with disp8=0.
+    // modrm 01_010_100 = 0x54. SIB 10_111_101 = 0xBD. disp8 = 0x00.
+    try hexEqual(buf.getCode(), &.{ 0x48, 0x8D, 0x54, 0xBD, 0x00 });
+}
+
+test "leaRegBaseIndexScaleDisp64 index r12 is a valid index (REX.X)" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.leaRegBaseIndexScaleDisp64(.rdx, .rsi, .r12, 2, 0);
+    // REX.W + REX.X(index=r12) = 0x4A. SIB index=r12.low3=4 → 10_100_110 = 0xA6.
+    try hexEqual(buf.getCode(), &.{ 0x4A, 0x8D, 0x14, 0xA6 });
+}
+
+test "leaRegBaseIndexScaleDisp32 rdx, [rsi + rdi*4] (no REX)" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.leaRegBaseIndexScaleDisp32(.rdx, .rsi, .rdi, 2, 0);
+    // 32-bit form, no register needs REX → REX omitted.
+    try hexEqual(buf.getCode(), &.{ 0x8D, 0x14, 0xBE });
+}
+
+test "leaRegBaseIndexScaleDisp32 r8d, [rsi + rdi*4] (REX.R only)" {
+    var buf = CodeBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+    try buf.leaRegBaseIndexScaleDisp32(.r8, .rsi, .rdi, 2, 0);
+    // REX.R for r8 dst → 0x44. modrm reg=r8.low3=0 → 0x04.
+    try hexEqual(buf.getCode(), &.{ 0x44, 0x8D, 0x04, 0xBE });
 }
 
 

--- a/src/compiler/ir/analysis.zig
+++ b/src/compiler/ir/analysis.zig
@@ -730,6 +730,11 @@ fn addInstUses(live: *std.AutoHashMap(ir.VReg, void), inst: ir.Inst) void {
             live.put(bin.rhs, {}) catch {};
         },
 
+        .lea => |l| {
+            live.put(l.base, {}) catch {};
+            live.put(l.index, {}) catch {};
+        },
+
         .v128_bitwise => |bin| {
             live.put(bin.lhs, {}) catch {};
             live.put(bin.rhs, {}) catch {};
@@ -1351,6 +1356,11 @@ fn updateLastUse(last_use: *std.AutoHashMap(ir.VReg, u32), inst: ir.Inst, pos: u
         => |bin| {
             last_use.put(bin.lhs, pos) catch {};
             last_use.put(bin.rhs, pos) catch {};
+        },
+
+        .lea => |l| {
+            last_use.put(l.base, pos) catch {};
+            last_use.put(l.index, pos) catch {};
         },
 
         .v128_bitwise => |bin| {

--- a/src/compiler/ir/interp.zig
+++ b/src/compiler/ir/interp.zig
@@ -306,6 +306,14 @@ fn execInst(machine: *Machine, inst: ir.Inst) !?Outcome {
             };
             if (inst.dest) |d| try machine.setVReg(d, .{ .ty = if (inst.op == .eqz) .i32 else inst.type, .bits = bits });
         },
+        .lea => |l| {
+            const base = try machine.getVReg(l.base);
+            const index = try machine.getVReg(l.index);
+            // base + index*scale + disp, computed in 64 bits and wrapped to
+            // the result width by `setVReg`/`normalized`.
+            const addr = base.asI64() +% index.asI64() *% @as(i64, l.scale) +% @as(i64, l.disp);
+            if (inst.dest) |d| try machine.setVReg(d, .{ .ty = inst.type, .bits = @bitCast(addr) });
+        },
         .select => |sel| {
             const cond = try machine.getVReg(sel.cond);
             const chosen = if (cond.bits != 0) try machine.getVReg(sel.if_true) else try machine.getVReg(sel.if_false);

--- a/src/compiler/ir/ir.zig
+++ b/src/compiler/ir/ir.zig
@@ -170,6 +170,12 @@ pub const Inst = struct {
         rotl: BinOp,
         rotr: BinOp,
 
+        // Fused address computation: dest = base + index*scale + disp.
+        // Produced by the x86-64 `foldCompoundLea` peephole (#543) so the
+        // register allocator sees base/index as coincident operands of a
+        // single instruction (correct liveness) and codegen emits one LEA.
+        lea: Lea,
+
         // Unary
         clz: VReg,
         ctz: VReg,
@@ -401,6 +407,18 @@ pub const Inst = struct {
     pub const BinOp = struct {
         lhs: VReg,
         rhs: VReg,
+    };
+
+    /// Operands of a fused `lea` (x86-64 address-generation) instruction.
+    /// Computes `base + index * scale + disp`. `scale` must be 1, 2, 4, or
+    /// 8 (the legal x86-64 SIB scales); `disp` is a signed 32-bit
+    /// displacement. The result wraps to `type`'s width (i32/i64), matching
+    /// a chain of wasm `add`/`shl` with the same operands.
+    pub const Lea = struct {
+        base: VReg,
+        index: VReg,
+        scale: u8,
+        disp: i32,
     };
 
     pub const AtomicRmwOp = enum { add, sub, @"and", @"or", xor, xchg };

--- a/src/compiler/ir/passes.zig
+++ b/src/compiler/ir/passes.zig
@@ -948,6 +948,10 @@ fn getUsedVRegs(inst: ir.Inst) BoundedVRegList {
         .local_set => |ls| list.append(ls.val),
         .global_set => |gs| list.append(gs.val),
         .load => |ld| list.append(ld.base),
+        .lea => |l| {
+            list.append(l.base);
+            list.append(l.index);
+        },
         .v128_load => |ld| list.append(ld.base),
         .v128_load_splat => |ld| list.append(ld.base),
         .v128_load_zero => |ld| list.append(ld.base),
@@ -1589,6 +1593,10 @@ pub fn replaceInInst(inst: *ir.Inst, old: ir.VReg, new: ir.VReg) void {
         .load => |*ld| if (ld.base == old) {
             ld.base = new;
         },
+        .lea => |*l| {
+            if (l.base == old) l.base = new;
+            if (l.index == old) l.index = new;
+        },
         .v128_load => |*ld| if (ld.base == old) {
             ld.base = new;
         },
@@ -2228,6 +2236,203 @@ pub fn strengthReduceMulShiftAdd(func: *ir.IrFunction, allocator: std.mem.Alloca
                 },
                 else => {},
             }
+        }
+    }
+    return changed;
+}
+
+// ── Compound-address LEA folding (x86-64) ───────────────────────────────────
+
+const LeaShlInfo = struct { idx: ir.VReg, scale: u8 };
+
+/// If `v` is defined in this block by a single-use `shl(idx, k)` with
+/// `k ∈ {1,2,3}` and a non-constant `idx`, return the equivalent LEA
+/// index/scale. `k == 0` is rejected: scale-1 with no displacement is a
+/// plain `add`, already handled by the backend's #393 base+index fusion,
+/// and folding it here would only churn the IR.
+fn matchLeaShl(
+    block: *ir.BasicBlock,
+    defs: *const std.AutoHashMap(ir.VReg, usize),
+    constants: *const std.AutoHashMap(ir.VReg, i64),
+    use_counts: *const VRegUseCounts,
+    v: ir.VReg,
+) ?LeaShlInfo {
+    const di = defs.get(v) orelse return null;
+    switch (block.instructions.items[di].op) {
+        .shl => |bin| {
+            const k = constants.get(bin.rhs) orelse return null;
+            if (k < 1 or k > 3) return null;
+            if ((use_counts.get(v) orelse 0) != 1) return null;
+            if (constants.get(bin.lhs) != null) return null;
+            return .{ .idx = bin.lhs, .scale = @as(u8, 1) << @intCast(k) };
+        },
+        else => return null,
+    }
+}
+
+fn fitsSignedI32(c: i64) bool {
+    return c >= std.math.minInt(i32) and c <= std.math.maxInt(i32);
+}
+
+/// Fold compound address computation `base + index*scale + disp` into a
+/// single `lea` IR op, mirroring the x86-64 `LEA` addressing mode
+/// (`[base + index*scale + disp]`, scale ∈ {1,2,4,8}, disp signed 32-bit).
+///
+/// Two shapes are matched, per straight-line block:
+///
+///   Case B (with displacement):
+///     add(add(base, shl(idx, k)), C)  →  lea(base, idx, 1<<k, C)
+///     add(add(base, S),          C)  →  lea(base, S,   1,    C)
+///   Case A (scale only):
+///     add(x, shl(idx, k))            →  lea(x, idx, 1<<k, 0)
+///
+/// with `k ∈ {1,2,3}` (scale 2/4/8) and `C` a constant that fits a
+/// signed 32-bit displacement. Case B is matched first so the combined
+/// displacement form always wins over folding the inner add on its own.
+///
+/// Safety:
+///   * `LEA` does not set flags, but wasm has no flag-dependent
+///     arithmetic sequences (comparisons are explicit value-producing
+///     ops), so replacing `add`/`shl` chains with a flag-free `lea`
+///     never changes observable semantics.
+///   * `add`, `shl` and `lea` all wrap identically mod 2^32 / 2^64, and
+///     a 32-bit `lea` zero-extends into the full register — exactly the
+///     i32 wasm wrapping semantics (#393). i64 folds still require the
+///     displacement to fit signed 32-bit.
+///   * base/index are kept as operands of the new `lea`, so the register
+///     allocator (which runs after this pass) sees the correct coincident
+///     liveness — this is why the fold is done at the IR level rather than
+///     opportunistically at codegen time.
+///
+/// Only fires when the consumed intermediates (`shl`, inner `add`) are
+/// single-use so the subsequent dead-code pass can remove them, making
+/// every fold a strict instruction-count win. base/index must be
+/// non-constant (a `LEA` base/index is a register).
+pub fn foldCompoundLea(func: *ir.IrFunction, allocator: std.mem.Allocator) !bool {
+    var changed = false;
+    var constants = std.AutoHashMap(ir.VReg, i64).init(allocator);
+    defer constants.deinit();
+    var defs = std.AutoHashMap(ir.VReg, usize).init(allocator);
+    defer defs.deinit();
+    var use_counts = try buildVRegUseCounts(func, allocator);
+    defer use_counts.deinit();
+    var consumed = std.AutoHashMap(ir.VReg, void).init(allocator);
+    defer consumed.deinit();
+
+    for (func.blocks.items) |*block| {
+        constants.clearRetainingCapacity();
+        defs.clearRetainingCapacity();
+        consumed.clearRetainingCapacity();
+
+        // Pass B (with maps built lazily top-down): the inner add and the
+        // shl always precede the outer add, so `defs`/`constants` are
+        // populated by the time we reach the outer add. Rewrites are done
+        // in place (no index shifts, dest unchanged), so the maps stay
+        // valid across mutations.
+        var i: usize = 0;
+        while (i < block.instructions.items.len) : (i += 1) {
+            const inst = block.instructions.items[i];
+            if (inst.dest) |d| {
+                switch (inst.op) {
+                    .iconst_32 => |v| try constants.put(d, v),
+                    .iconst_64 => |v| try constants.put(d, v),
+                    else => {},
+                }
+                try defs.put(d, i);
+            }
+
+            const bin = switch (inst.op) {
+                .add => |b| b,
+                else => continue,
+            };
+            const dest = inst.dest orelse continue;
+            if (inst.type != .i32 and inst.type != .i64) continue;
+
+            // Outer add(P, C): identify the constant operand C and the
+            // non-constant intermediate P = add(base, S).
+            var p_vreg: ir.VReg = undefined;
+            var disp: i64 = undefined;
+            if (constants.get(bin.rhs)) |c| {
+                p_vreg = bin.lhs;
+                disp = c;
+            } else if (constants.get(bin.lhs)) |c| {
+                p_vreg = bin.rhs;
+                disp = c;
+            } else continue;
+            if (!fitsSignedI32(disp)) continue;
+            if (constants.get(p_vreg) != null) continue;
+            if ((use_counts.get(p_vreg) orelse 0) != 1) continue;
+
+            const p_di = defs.get(p_vreg) orelse continue;
+            const p_bin = switch (block.instructions.items[p_di].op) {
+                .add => |b| b,
+                else => continue,
+            };
+
+            // Choose (base, index, scale): prefer a foldable shl on either
+            // operand of the inner add; otherwise fall back to scale-1.
+            var base: ir.VReg = undefined;
+            var index: ir.VReg = undefined;
+            var scale: u8 = 1;
+            if (matchLeaShl(block, &defs, &constants, &use_counts, p_bin.rhs)) |s| {
+                base = p_bin.lhs;
+                index = s.idx;
+                scale = s.scale;
+            } else if (matchLeaShl(block, &defs, &constants, &use_counts, p_bin.lhs)) |s| {
+                base = p_bin.rhs;
+                index = s.idx;
+                scale = s.scale;
+            } else {
+                base = p_bin.lhs;
+                index = p_bin.rhs;
+                scale = 1;
+            }
+            if (constants.get(base) != null or constants.get(index) != null) continue;
+
+            block.instructions.items[i].op = .{ .lea = .{
+                .base = base,
+                .index = index,
+                .scale = scale,
+                .disp = @intCast(disp),
+            } };
+            block.instructions.items[i].dest = dest;
+            try consumed.put(p_vreg, {}); // inner add is now dead
+            changed = true;
+        }
+
+        // Pass A (scale only): fold add(x, shl(idx, k)) that was not already
+        // absorbed into a Case B displacement fold. Skip the inner adds
+        // consumed above — they are dead and awaiting DCE.
+        i = 0;
+        while (i < block.instructions.items.len) : (i += 1) {
+            const inst = block.instructions.items[i];
+            const bin = switch (inst.op) {
+                .add => |b| b,
+                else => continue,
+            };
+            const dest = inst.dest orelse continue;
+            if (inst.type != .i32 and inst.type != .i64) continue;
+            if (consumed.contains(dest)) continue;
+
+            var base: ir.VReg = undefined;
+            var info: LeaShlInfo = undefined;
+            if (matchLeaShl(block, &defs, &constants, &use_counts, bin.rhs)) |s| {
+                base = bin.lhs;
+                info = s;
+            } else if (matchLeaShl(block, &defs, &constants, &use_counts, bin.lhs)) |s| {
+                base = bin.rhs;
+                info = s;
+            } else continue;
+            if (constants.get(base) != null) continue;
+
+            block.instructions.items[i].op = .{ .lea = .{
+                .base = base,
+                .index = info.idx,
+                .scale = info.scale,
+                .disp = 0,
+            } };
+            block.instructions.items[i].dest = dest;
+            changed = true;
         }
     }
     return changed;
@@ -3820,6 +4025,7 @@ const pass_name_registry = [_]PassNameEntry{
     .{ .fn_ptr = &algebraicSimplify, .name = "algebraicSimplify" },
     .{ .fn_ptr = &strengthReduceMul, .name = "strengthReduceMul" },
     .{ .fn_ptr = &strengthReduceMulShiftAdd, .name = "strengthReduceMulShiftAdd" },
+    .{ .fn_ptr = &foldCompoundLea, .name = "foldCompoundLea" },
     .{ .fn_ptr = &strengthReduceDivRem, .name = "strengthReduceDivRem" },
     .{ .fn_ptr = &foldConstantBranches, .name = "foldConstantBranches" },
     .{ .fn_ptr = &foldInverseCompareEqz, .name = "foldInverseCompareEqz" },
@@ -6365,6 +6571,10 @@ fn shiftVRegsInInst(inst: *ir.Inst, offset: ir.VReg) void {
         .local_set => |*ls| ls.val += offset,
         .global_set => |*gs| gs.val += offset,
         .load => |*ld| ld.base += offset,
+        .lea => |*l| {
+            l.base += offset;
+            l.index += offset;
+        },
         .v128_load => |*ld| ld.base += offset,
         .v128_load_splat => |*ld| ld.base += offset,
         .v128_load_zero => |*ld| ld.base += offset,
@@ -8924,6 +9134,7 @@ const x86_64_default_passes: []const PassFn = &.{
     @import("forward_redundant_loads.zig").forwardRedundantLoads,
     &@import("forward_redundant_loads_dominator.zig").forwardRedundantLoadsDominator,
     &deadStoreElimination,
+    &foldCompoundLea,
     &deadCodeAndLocalSetCleanup,
     &hoistLoopBoundsChecks,
     &elideRedundantBoundsChecks,
@@ -8961,8 +9172,8 @@ const x86_64_default_passes_no_iv: []const PassFn = &.{
     &strengthReduceMulShiftAdd,  &strengthReduceDivRem,             &foldConstantBranches,       &foldInverseCompareEqz,
     &foldBranchOnEqz,            &threadChainedConditionalBranches, &tailDuplicateSmallJoins,    &foldSelectOnEqz,
     &foldSignExtendingLoad,      &foldFloatUnaryIdempotents,        &foldWrapOfExtend,           &globalValueNumbering,
-    &hoistLoopInvariantCode,     &unrollSmallFixedLoops,            &deadCodeAndLocalSetCleanup, &hoistLoopBoundsChecks,
-    &elideRedundantBoundsChecks, &foldLoadStoreOffset,
+    &hoistLoopInvariantCode,     &unrollSmallFixedLoops,            &foldCompoundLea,            &deadCodeAndLocalSetCleanup,
+    &hoistLoopBoundsChecks,      &elideRedundantBoundsChecks,       &foldLoadStoreOffset,
 };
 
 const x86_64_default_passes_no_unroll: []const PassFn = &.{
@@ -8970,8 +9181,8 @@ const x86_64_default_passes_no_unroll: []const PassFn = &.{
     &strengthReduceMulShiftAdd,       &strengthReduceDivRem,             &foldConstantBranches,       &foldInverseCompareEqz,
     &foldBranchOnEqz,                 &threadChainedConditionalBranches, &tailDuplicateSmallJoins,    &foldSelectOnEqz,
     &foldSignExtendingLoad,           &foldFloatUnaryIdempotents,        &foldWrapOfExtend,           &globalValueNumbering,
-    &inductionVariableSimplification, &hoistLoopInvariantCode,           &deadCodeAndLocalSetCleanup, &hoistLoopBoundsChecks,
-    &elideRedundantBoundsChecks,      &foldLoadStoreOffset,
+    &inductionVariableSimplification, &hoistLoopInvariantCode,           &foldCompoundLea,            &deadCodeAndLocalSetCleanup,
+    &hoistLoopBoundsChecks,           &elideRedundantBoundsChecks,       &foldLoadStoreOffset,
 };
 
 const x86_64_default_passes_no_iv_no_unroll: []const PassFn = &.{
@@ -8979,8 +9190,8 @@ const x86_64_default_passes_no_iv_no_unroll: []const PassFn = &.{
     &strengthReduceMulShiftAdd, &strengthReduceDivRem,             &foldConstantBranches,    &foldInverseCompareEqz,
     &foldBranchOnEqz,           &threadChainedConditionalBranches, &tailDuplicateSmallJoins, &foldSelectOnEqz,
     &foldSignExtendingLoad,     &foldFloatUnaryIdempotents,        &foldWrapOfExtend,        &globalValueNumbering,
-    &hoistLoopInvariantCode,    &deadCodeAndLocalSetCleanup,       &hoistLoopBoundsChecks,   &elideRedundantBoundsChecks,
-    &foldLoadStoreOffset,
+    &hoistLoopInvariantCode,    &foldCompoundLea,                  &deadCodeAndLocalSetCleanup, &hoistLoopBoundsChecks,
+    &elideRedundantBoundsChecks, &foldLoadStoreOffset,
 };
 
 pub fn defaultPassesForTarget(target: TargetArch) []const PassFn {
@@ -9061,6 +9272,7 @@ const x86_64_jit_fast_passes: []const PassFn = &.{
     &foldSignExtendingLoad,
     &foldFloatUnaryIdempotents,
     &foldWrapOfExtend,
+    &foldCompoundLea,
     &deadCodeAndLocalSetCleanup,
     &foldLoadStoreOffset,
 };
@@ -14065,6 +14277,230 @@ test "strengthReduceMulShiftAdd: pipeline composition with strengthReduceMul" {
     for (block.instructions.items) |inst| {
         try std.testing.expect(inst.op != .mul);
     }
+}
+
+// ── foldCompoundLea (#543) ──────────────────────────────────────────────────
+
+/// Helper: find the single `.lea` instruction in a block, or null.
+fn findLea(block: *const ir.BasicBlock) ?ir.Inst.Lea {
+    for (block.instructions.items) |inst| {
+        if (inst.op == .lea) return inst.op.lea;
+    }
+    return null;
+}
+
+test "foldCompoundLea: add(add(base, shl(idx,2)), 16) -> lea(base, idx, 4, 16)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 2, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    var block = &func.blocks.items[b0];
+
+    // base/idx are non-constant (unwritten params) so the fold's
+    // "operand must be a register" precondition holds.
+    const base = func.newVReg();
+    const idx = func.newVReg();
+    const two = func.newVReg();
+    const shifted = func.newVReg();
+    const inner = func.newVReg();
+    const c16 = func.newVReg();
+    const result = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = two, .type = .i32 });
+    try block.append(.{ .op = .{ .shl = .{ .lhs = idx, .rhs = two } }, .dest = shifted, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = base, .rhs = shifted } }, .dest = inner, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 16 }, .dest = c16, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = inner, .rhs = c16 } }, .dest = result, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = result } });
+
+    const changed = try foldCompoundLea(&func, allocator);
+    try std.testing.expect(changed);
+    const lea = findLea(block) orelse return error.NoLea;
+    try std.testing.expectEqual(base, lea.base);
+    try std.testing.expectEqual(idx, lea.index);
+    try std.testing.expectEqual(@as(u8, 4), lea.scale);
+    try std.testing.expectEqual(@as(i32, 16), lea.disp);
+    // The rewrite keeps dest/type of the outer add.
+    try std.testing.expectEqual(result, block.instructions.items[4].dest.?);
+}
+
+test "foldCompoundLea: add(x, shl(idx,3)) -> lea(x, idx, 8, 0) (scale only)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 2, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    var block = &func.blocks.items[b0];
+
+    const x = func.newVReg();
+    const idx = func.newVReg();
+    const three = func.newVReg();
+    const shifted = func.newVReg();
+    const result = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 3 }, .dest = three, .type = .i32 });
+    try block.append(.{ .op = .{ .shl = .{ .lhs = idx, .rhs = three } }, .dest = shifted, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = x, .rhs = shifted } }, .dest = result, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = result } });
+
+    const changed = try foldCompoundLea(&func, allocator);
+    try std.testing.expect(changed);
+    const lea = findLea(block) orelse return error.NoLea;
+    try std.testing.expectEqual(x, lea.base);
+    try std.testing.expectEqual(idx, lea.index);
+    try std.testing.expectEqual(@as(u8, 8), lea.scale);
+    try std.testing.expectEqual(@as(i32, 0), lea.disp);
+}
+
+test "foldCompoundLea: add(add(base, other), 8) -> lea(base, other, 1, 8) (scale 1)" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 2, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    var block = &func.blocks.items[b0];
+
+    const base = func.newVReg();
+    const other = func.newVReg();
+    const inner = func.newVReg();
+    const c8 = func.newVReg();
+    const result = func.newVReg();
+    try block.append(.{ .op = .{ .add = .{ .lhs = base, .rhs = other } }, .dest = inner, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 8 }, .dest = c8, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = inner, .rhs = c8 } }, .dest = result, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = result } });
+
+    const changed = try foldCompoundLea(&func, allocator);
+    try std.testing.expect(changed);
+    const lea = findLea(block) orelse return error.NoLea;
+    try std.testing.expectEqual(base, lea.base);
+    try std.testing.expectEqual(other, lea.index);
+    try std.testing.expectEqual(@as(u8, 1), lea.scale);
+    try std.testing.expectEqual(@as(i32, 8), lea.disp);
+}
+
+test "foldCompoundLea: illegal scale (shl by 4) is NOT folded" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 2, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    var block = &func.blocks.items[b0];
+
+    const x = func.newVReg();
+    const idx = func.newVReg();
+    const four = func.newVReg();
+    const shifted = func.newVReg();
+    const result = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 4 }, .dest = four, .type = .i32 });
+    try block.append(.{ .op = .{ .shl = .{ .lhs = idx, .rhs = four } }, .dest = shifted, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = x, .rhs = shifted } }, .dest = result, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = result } });
+
+    const changed = try foldCompoundLea(&func, allocator);
+    try std.testing.expect(!changed);
+    try std.testing.expect(findLea(block) == null);
+}
+
+test "foldCompoundLea: oversized i64 displacement is NOT folded" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 2, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    var block = &func.blocks.items[b0];
+
+    // Inner add has no shl so Case A can't fold it either; the only
+    // candidate fold is the outer disp, which must be rejected because
+    // 2^32 does not fit a signed 32-bit displacement.
+    const base = func.newVReg();
+    const other = func.newVReg();
+    const inner = func.newVReg();
+    const cbig = func.newVReg();
+    const result = func.newVReg();
+    try block.append(.{ .op = .{ .add = .{ .lhs = base, .rhs = other } }, .dest = inner, .type = .i64 });
+    try block.append(.{ .op = .{ .iconst_64 = 0x1_0000_0000 }, .dest = cbig, .type = .i64 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = inner, .rhs = cbig } }, .dest = result, .type = .i64 });
+    try block.append(.{ .op = .{ .ret = result } });
+
+    const changed = try foldCompoundLea(&func, allocator);
+    try std.testing.expect(!changed);
+    try std.testing.expect(findLea(block) == null);
+}
+
+test "foldCompoundLea: multi-use inner add blocks the displacement fold" {
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 2, 1, 0);
+    defer func.deinit();
+    const b0 = try func.newBlock();
+    var block = &func.blocks.items[b0];
+
+    // `inner` is consumed by both the outer add and a second add, so the
+    // outer disp fold is unsafe (it would leave `inner` alive). No shl is
+    // present, so no scale-only fold applies either → nothing folds.
+    const base = func.newVReg();
+    const other = func.newVReg();
+    const inner = func.newVReg();
+    const c16 = func.newVReg();
+    const result = func.newVReg();
+    const other_use = func.newVReg();
+    try block.append(.{ .op = .{ .add = .{ .lhs = base, .rhs = other } }, .dest = inner, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 16 }, .dest = c16, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = inner, .rhs = c16 } }, .dest = result, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = inner, .rhs = base } }, .dest = other_use, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = result } });
+
+    const changed = try foldCompoundLea(&func, allocator);
+    try std.testing.expect(!changed);
+    try std.testing.expect(findLea(block) == null);
+}
+
+test "foldCompoundLea: end-to-end via pipeline removes dead shl/add" {
+    // Build base/idx from opaque loads so constantFold cannot collapse the
+    // expression, then run the full x86-64 pass pipeline and confirm the
+    // chain is folded to a single lea with the intermediates DCE'd.
+    const allocator = std.testing.allocator;
+    var module = ir.IrModule.init(allocator);
+    defer module.deinit();
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    const b0 = try func.newBlock();
+    var block = &func.blocks.items[b0];
+
+    const mem = func.newVReg();
+    const base = func.newVReg();
+    const idx = func.newVReg();
+    const two = func.newVReg();
+    const shifted = func.newVReg();
+    const inner = func.newVReg();
+    const c16 = func.newVReg();
+    const result = func.newVReg();
+    try block.append(.{ .op = .{ .iconst_32 = 0x1000 }, .dest = mem, .type = .i32 });
+    try block.append(.{ .op = .{ .load = .{ .base = mem, .offset = 0, .size = 4 } }, .dest = base, .type = .i32 });
+    try block.append(.{ .op = .{ .load = .{ .base = mem, .offset = 4, .size = 4 } }, .dest = idx, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 2 }, .dest = two, .type = .i32 });
+    try block.append(.{ .op = .{ .shl = .{ .lhs = idx, .rhs = two } }, .dest = shifted, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = base, .rhs = shifted } }, .dest = inner, .type = .i32 });
+    try block.append(.{ .op = .{ .iconst_32 = 16 }, .dest = c16, .type = .i32 });
+    try block.append(.{ .op = .{ .add = .{ .lhs = inner, .rhs = c16 } }, .dest = result, .type = .i32 });
+    try block.append(.{ .op = .{ .ret = result } });
+
+    _ = try module.addFunction(func);
+    _ = try runPasses(&module, defaultPassesForTarget(.x86_64), allocator);
+
+    var lea_count: usize = 0;
+    var shl_count: usize = 0;
+    var found: ?ir.Inst.Lea = null;
+    for (module.functions.items[0].blocks.items) |*bl| {
+        for (bl.instructions.items) |inst| {
+            switch (inst.op) {
+                .lea => {
+                    lea_count += 1;
+                    found = inst.op.lea;
+                },
+                .shl => shl_count += 1,
+                else => {},
+            }
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 1), lea_count);
+    try std.testing.expectEqual(@as(usize, 0), shl_count); // dead shl removed
+    const lea = found orelse return error.NoLea;
+    try std.testing.expectEqual(@as(u8, 4), lea.scale);
+    try std.testing.expectEqual(@as(i32, 16), lea.disp);
 }
 
 test "strengthReduceDivRem: div_u by 5 uses reciprocal multiply" {

--- a/src/compiler/ir/print.zig
+++ b/src/compiler/ir/print.zig
@@ -146,6 +146,8 @@ fn formatPayload(op: ir.Inst.Op, w: *std.Io.Writer) Error!void {
         .f_ge,
         => |bin| try w.print(" v{d}, v{d}", .{ bin.lhs, bin.rhs }),
 
+        .lea => |l| try w.print(" base=v{d}, index=v{d}, scale={d}, disp={d}", .{ l.base, l.index, l.scale, l.disp }),
+
         // Scalar unary ops (single VReg payload)
         .clz,
         .ctz,

--- a/src/compiler/ir/range_split.zig
+++ b/src/compiler/ir/range_split.zig
@@ -894,6 +894,10 @@ pub fn forEachUseInst(
         .ret => |maybe_v| if (maybe_v) |v| try visit(context, v),
         .ret_multi => |vregs| for (vregs) |v| try visit(context, v),
         .load => |ld| try visit(context, ld.base),
+        .lea => |l| {
+            try visit(context, l.base);
+            try visit(context, l.index);
+        },
         .store => |st| {
             try visit(context, st.base);
             try visit(context, st.val);

--- a/src/compiler/ir/verifier.zig
+++ b/src/compiler/ir/verifier.zig
@@ -411,6 +411,10 @@ pub fn forEachOperand(
         .global_set => |gs| cb(ctx, gs.val),
 
         .load => |ld| cb(ctx, ld.base),
+        .lea => |l| {
+            cb(ctx, l.base);
+            cb(ctx, l.index);
+        },
         .v128_load => |ld| cb(ctx, ld.base),
         .v128_load_splat => |ld| cb(ctx, ld.base),
         .v128_load_zero => |ld| cb(ctx, ld.base),
@@ -1115,6 +1119,11 @@ fn checkOneInst(ctx: OperandCheckCtx, inst: ir.Inst) VerifyError!void {
 
         // Loads: `base` is the linear-memory pointer, always i32 in wasm32.
         .load => |ld| try ctx.expect(ld.base, .i32, "base"),
+        // Fused LEA: base/index share the op's integer width (i32/i64).
+        .lea => |l| {
+            try ctx.expect(l.base, inst.type, "base");
+            try ctx.expect(l.index, inst.type, "index");
+        },
         .v128_load => |ld| try ctx.expect(ld.base, .i32, "base"),
         .v128_load_splat => |ld| try ctx.expect(ld.base, .i32, "base"),
         .v128_load_zero => |ld| try ctx.expect(ld.base, .i32, "base"),


### PR DESCRIPTION
## Summary

Implements the peephole from #543: fold compound address computation `base + index*scale + disp` — currently lowered as a `shl`/`add`/`add` chain — into a single flag-free x86-64 `LEA`.

The fold is done as a new **IR-level pass** (`foldCompoundLea`), not a codegen-time rewrite. Register allocation runs up front and may coalesce the `shl`'s input register with its output (`idx` dies at the `shl`), so `idx` is not guaranteed live at the `add`. Rewriting before regalloc makes `base`/`index` coincident operands of one `lea` instruction, giving correct liveness; codegen then emits a single `LEA`. This extends the #393 LEA-fusion lineage rather than duplicating it (the existing `leaRegBaseIndex{32,64}` helpers now delegate to a general scaled+disp emitter).

### Transformation (per straight-line block)
```
add(add(base, shl(idx, k)), C) -> lea(base, idx, 1<<k, C)   (k ∈ 1..3)
add(add(base, S),          C) -> lea(base, S,   1,    C)
add(x, shl(idx, k))           -> lea(x, idx, 1<<k, 0)       (k ∈ 1..3)
```

### Safety conditions
- **Flags:** `LEA` doesn't set flags, but wasm has no flag-dependent arithmetic sequences (comparisons are explicit value ops), so replacing add/shl chains with a flag-free LEA never changes semantics.
- **Wrapping:** `add`/`shl`/`lea` wrap identically mod 2³²/2⁶⁴; a 32-bit `LEA` truncates+zero-extends, exactly matching i32 wasm semantics (#393). i64 folds still require the displacement to fit signed 32-bit.
- **Legality:** only legal SIB scales (1/2/4/8) and signed-32-bit displacements fold; base/index must be non-constant registers.
- **Win guarantee:** only fires when consumed intermediates (`shl`, inner `add`) are single-use, so DCE removes them and each fold is a strict instruction-count win.

Pass is **x86_64-only**, registered before `deadCodeAndLocalSetCleanup` in the four x86_64 default pass lists + the x86_64 jit-fast list. The new `lea` IR op is wired through interp, verifier, liveness/range-split, printing, and both x86_64 and (defensive) aarch64 codegen.

### Tests
- Byte-exact emit tests for scaled+disp `LEA`: scale 2/4/8, disp 0/i8/i32, base `rbp`/`r13` (forced disp8=0), index `r12` (REX.X), 32-bit no-REX and REX.R forms.
- Pass unit tests: positive folds (scale+disp, scale-only, scale-1+disp) and negatives (illegal scale shl-by-4, oversized i64 disp, multi-use intermediate), plus an end-to-end pipeline test asserting a single `lea` with the dead `shl` DCE'd.
- Codegen test asserting the `.lea` op emits `0x8D` with the displacement.

`zig build` and `zig build test` pass.

### Measured (codegen-bench, `base+index*4+16` body, after default passes)
| | code bytes | codegen ticks/op |
|---|---|---|
| before | 123 | ~1.33M |
| after | 101 | ~1.02M |

~18% smaller generated code for the compound-address pattern (bench measures compile cost + generated code size, not runtime of generated code).

### ⚠️ Pre-existing codegen-bench SEGV (fixed here)
The baseline pasted in #543 ends in `SIGSEGV`. Root cause is a **harness bug** in `bodyBrTable`: `targets` was `&[_]BlockId{...}`, a pointer to a stack-local array that dangles after the builder returns; codegen later reads freed memory → garbage block IDs → crash. It **reproduces on unmodified `main`** and is unrelated to this change. Fixed here (heap-allocate `targets`) because the bench is the acceptance tool for this issue. May warrant its own tracking issue.

Refs #543 (partial step toward the CoreMark AOT perf goal in #393; does not fully close #543).