### PR TITLE
ci: bound and instrument the P3 profiling harness (#616 D3)

### DIFF
--- a/.github/workflows/wasi-p3-macos-profile.yml
+++ b/.github/workflows/wasi-p3-macos-profile.yml
@@ -16,16 +16,25 @@ permissions:
 
 jobs:
   measure:
-    name: Measure (${{ matrix.platform_id }})
+    name: Measure (${{ matrix.platform_id }}, ${{ matrix.mode }})
     strategy:
       fail-fast: false
       matrix:
+        platform_id: [macos-arm64, linux-arm64]
+        mode: [aot, jit]
         include:
           - platform_id: macos-arm64
             runner: macos-14
           - platform_id: linux-arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
+    # AOT and JIT are separate jobs so each mode gets a full budget. Run
+    # 31259495409 was cancelled at this timeout while still inside the AOT
+    # phase on both platforms, leaving the JIT phase unreachable and — because
+    # a job-level timeout cancels the job rather than failing a step — skipping
+    # the `if: always()` upload and destroying every diagnostic. The harness
+    # `--deadline-minutes` below is what actually stops the work, so the upload
+    # and enforcement steps always run. (#616 D3.)
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -51,7 +60,7 @@ jobs:
 
       - name: Record raw host metadata
         env:
-          OUT: wasi-p3-measure-${{ matrix.platform_id }}
+          OUT: wasi-p3-measure-${{ matrix.platform_id }}-${{ matrix.mode }}
         shell: bash
         run: |
           set -euo pipefail
@@ -69,30 +78,47 @@ jobs:
             '^(ImageOS|RUNNER_|ZIG_(GLOBAL|LOCAL)_CACHE_DIR)=' \
             > "$OUT/runner-environment.txt"
 
-      - name: Build ReleaseSafe AOT tools
-        run: zig build -Doptimize=ReleaseSafe
+      - name: Build ReleaseSafe tools
+        run: |
+          if [ '${{ matrix.mode }}' = jit ]; then
+            zig build -Doptimize=ReleaseSafe -Djit=true
+          else
+            zig build -Doptimize=ReleaseSafe
+          fi
 
-      - name: Measure AOT — 5 cold and 10 warm unfiltered suites
-        id: measure-aot
+      - name: Measure ${{ matrix.mode }} — 5 cold and 10 warm unfiltered suites
+        id: measure
         continue-on-error: true
         env:
           WAMR: ${{ github.workspace }}/zig-out/bin/wamr
           WAMRC: ${{ github.workspace }}/zig-out/bin/wamrc
+          # Match `build.zig`'s unfiltered P3 gates. Without this the adapter
+          # falls back to its 5s default, which is far tighter than the gate
+          # these measurements are meant to mirror. JIT recompiles every
+          # fixture in-process with no cross-process cache, so it needs more.
+          WAMR_TESTSUITE_TIMEOUT: ${{ matrix.mode == 'jit' && '120' || '30' }}
+          # Bound adapter-side `wamrc` precompilation, which runs before the
+          # guest process exists and is therefore not covered above.
+          WAMR_COMPILE_TIMEOUT: "600"
         run: |
           python3 scripts/wasi_p3_profile.py run \
-            --mode aot \
+            --mode '${{ matrix.mode }}' \
             --platform-id '${{ matrix.platform_id }}' \
             --cold-samples 5 \
             --warm-samples 10 \
-            --output-dir 'wasi-p3-measure-${{ matrix.platform_id }}/aot'
+            --sample-timeout 900 \
+            --deadline-minutes 300 \
+            --output-dir 'wasi-p3-measure-${{ matrix.platform_id }}-${{ matrix.mode }}/${{ matrix.mode }}'
 
+      # Runs in every job so each uploaded artifact is self-contained and the
+      # aggregate does not depend on artifact ordering to find a report.
       - name: Characterize wasi-microbench without budget enforcement
         id: microbench
         if: always()
         shell: bash
         run: |
           set -euo pipefail
-          OUT='wasi-p3-measure-${{ matrix.platform_id }}/microbench'
+          OUT='wasi-p3-measure-${{ matrix.platform_id }}-${{ matrix.mode }}/microbench'
           mkdir -p "$OUT"
           zig build wasi-microbench -Doptimize=ReleaseSafe -- \
             --samples 10 \
@@ -101,47 +127,25 @@ jobs:
             --json "$OUT/report.json" \
             > "$OUT/report.txt" 2>&1
 
-      - name: Build ReleaseSafe JIT tools
-        id: build-jit
-        if: always()
-        run: zig build -Doptimize=ReleaseSafe -Djit=true
-
-      - name: Measure JIT equivalent — 5 cold and 10 warm unfiltered suites
-        id: measure-jit
-        if: always() && steps.build-jit.outcome == 'success'
-        continue-on-error: true
-        env:
-          WAMR: ${{ github.workspace }}/zig-out/bin/wamr
-          WAMRC: ${{ github.workspace }}/zig-out/bin/wamrc
-        run: |
-          python3 scripts/wasi_p3_profile.py run \
-            --mode jit \
-            --platform-id '${{ matrix.platform_id }}' \
-            --cold-samples 5 \
-            --warm-samples 10 \
-            --output-dir 'wasi-p3-measure-${{ matrix.platform_id }}/jit'
-
       - name: Upload raw measurements and conformance reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: wasi-p3-measure-${{ matrix.platform_id }}
-          path: wasi-p3-measure-${{ matrix.platform_id }}/
+          name: wasi-p3-measure-${{ matrix.platform_id }}-${{ matrix.mode }}
+          path: wasi-p3-measure-${{ matrix.platform_id }}-${{ matrix.mode }}/
           if-no-files-found: error
           retention-days: 90
 
       - name: Enforce successful measurement phases
         if: always()
         env:
-          AOT: ${{ steps.measure-aot.outcome }}
+          MEASURE: ${{ steps.measure.outcome }}
           MICROBENCH: ${{ steps.microbench.outcome }}
-          BUILD_JIT: ${{ steps.build-jit.outcome }}
-          JIT: ${{ steps.measure-jit.outcome }}
         shell: bash
         run: |
           set -euo pipefail
           failed=0
-          for phase in AOT MICROBENCH BUILD_JIT JIT; do
+          for phase in MEASURE MICROBENCH; do
             outcome="${!phase}"
             printf '%s=%s\n' "$phase" "$outcome"
             if [ "$outcome" != success ]; then failed=1; fi

--- a/docs/wasi.md
+++ b/docs/wasi.md
@@ -335,6 +335,20 @@ PR [#585](https://github.com/cataggar/wamr/pull/585)).
 $ WAMR_TESTSUITE_TIMEOUT=30 zig build wasi-testsuite
 ```
 
+### `WAMR_COMPILE_TIMEOUT`
+
+`WAMR_TESTSUITE_TIMEOUT` bounds only the guest process wait. Adapter-side
+`wamrc` precompilation runs *before* that process exists, so a codegen hang
+there is otherwise unbounded — it stalls until the CI job timeout cancels the
+job, which skips the `if: always()` artifact upload and destroys the
+diagnostics along with it. `WAMR_COMPILE_TIMEOUT=<seconds>` bounds a single
+`wamrc` invocation and defaults to 600 s
+([#616](https://github.com/cataggar/wamr/issues/616) D3).
+
+```console
+$ WAMR_COMPILE_TIMEOUT=120 zig build wasi-p3-testsuite
+```
+
 ### Outbound HTTPS in unit tests
 
 Off by default so CI stays hermetic:

--- a/scripts/wasi_p3_profile.py
+++ b/scripts/wasi_p3_profile.py
@@ -8,6 +8,7 @@ import json
 import os
 import platform
 import shlex
+import signal
 import subprocess
 import sys
 import time
@@ -18,6 +19,9 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 EXPECTED_FIXTURES = 41
+# Never start a sample that cannot plausibly finish; anything
+# shorter is guaranteed to be recorded as a timeout.
+_MIN_SAMPLE_BUDGET_S = 120.0
 ROOT = Path(__file__).resolve().parent.parent
 SUITE = (
     ROOT
@@ -213,11 +217,40 @@ def _sample_is_valid(
     return not errors, errors
 
 
+def _terminate_process_tree(proc: "subprocess.Popen[bytes]") -> None:
+    """Kill the runner and every descendant it spawned.
+
+    A timed-out sample usually means `wamrc` or a guest process is
+    wedged. Killing only the direct child would leave those grandchildren
+    running and contending with the samples that follow, so the child is
+    started in its own session and the whole group is signalled.
+    """
+    if proc.poll() is not None:
+        return
+    if os.name != "nt":
+        for signal_number in (signal.SIGTERM, signal.SIGKILL):
+            try:
+                os.killpg(os.getpgid(proc.pid), signal_number)
+            except (ProcessLookupError, PermissionError, OSError):
+                break
+            try:
+                proc.wait(timeout=10)
+                return
+            except subprocess.TimeoutExpired:
+                continue
+    proc.kill()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 def _run_sample(
     mode: str,
     temperature: str,
     index: int,
     output_dir: Path,
+    timeout_s: float | None = None,
 ) -> dict[str, Any]:
     run_id = f"{mode}-{temperature}-{index:02d}"
     raw_dir = output_dir / "raw"
@@ -248,16 +281,23 @@ def _run_sample(
     else:
         env.pop("WAMR_JIT_TESTSUITE", None)
 
+    timed_out = False
     started_ns = time.perf_counter_ns()
     with log.open("w", encoding="UTF-8") as output:
-        proc = subprocess.run(
+        proc = subprocess.Popen(
             [sys.executable, str(UNFILTERED)],
             cwd=ROOT,
             env=env,
             stdout=output,
             stderr=subprocess.STDOUT,
-            check=False,
+            start_new_session=os.name != "nt",
         )
+        try:
+            returncode = proc.wait(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            _terminate_process_tree(proc)
+            returncode = proc.returncode if proc.returncode is not None else -1
     suite_duration_ns = time.perf_counter_ns() - started_ns
 
     counts = (
@@ -266,12 +306,17 @@ def _run_sample(
         else {"fixtures": 0, "executed": 0, "passed": 0, "failed": 0}
     )
     events = parse_jsonl(timing) if timing.is_file() else []
-    valid, errors = _sample_is_valid(
-        mode, temperature, proc.returncode, counts, events
-    )
+    if timed_out:
+        valid = False
+        errors = [f"sample exceeded {timeout_s:g}s and was terminated"]
+    else:
+        valid, errors = _sample_is_valid(
+            mode, temperature, returncode, counts, events
+        )
     print(
         f"{run_id}: valid={valid} passed={counts['passed']}/"
-        f"{EXPECTED_FIXTURES} elapsed={suite_duration_ns / 1e9:.3f}s",
+        f"{EXPECTED_FIXTURES} elapsed={suite_duration_ns / 1e9:.3f}s"
+        f"{' TIMEOUT' if timed_out else ''}",
         flush=True,
     )
     return {
@@ -280,7 +325,8 @@ def _run_sample(
         "index": index,
         "valid": valid,
         "errors": errors,
-        "returncode": proc.returncode,
+        "timed_out": timed_out,
+        "returncode": returncode,
         "suite_duration_ns": suite_duration_ns,
         "counts": counts,
         "events": events,
@@ -293,6 +339,8 @@ def _run_sample(
 def run_collection(args: argparse.Namespace) -> int:
     output_dir = args.output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
+    deadline_s = args.deadline_minutes * 60 if args.deadline_minutes else None
+    started_ns = time.perf_counter_ns()
     document = {
         "schema_version": SCHEMA_VERSION,
         "kind": "wasi-p3-profile-runs",
@@ -301,21 +349,50 @@ def run_collection(args: argparse.Namespace) -> int:
             "cold_samples": args.cold_samples,
             "warm_samples": args.warm_samples,
             "optimize": "ReleaseSafe",
+            "sample_timeout_s": args.sample_timeout,
+            "deadline_minutes": args.deadline_minutes,
         },
+        "planned_samples": args.cold_samples + args.warm_samples,
+        "stopped_early": False,
+        "stop_reason": "",
         "samples": [],
     }
     destination = output_dir / "samples.json"
+
+    def persist() -> None:
+        destination.write_text(json.dumps(document, indent=2) + "\n", encoding="UTF-8")
+
+    persist()
     for temperature, count in (
         ("cold", args.cold_samples),
         ("warm", args.warm_samples),
     ):
         for index in range(1, count + 1):
+            timeout_s = args.sample_timeout
+            if deadline_s is not None:
+                remaining = deadline_s - (time.perf_counter_ns() - started_ns) / 1e9
+                # Stop while there is still time for the caller to upload
+                # what has been collected. A job-level timeout cancels the
+                # workflow run outright, which skips even `if: always()`
+                # upload steps and destroys the evidence. (#616 D3.)
+                if remaining <= _MIN_SAMPLE_BUDGET_S:
+                    document["stopped_early"] = True
+                    document["stop_reason"] = (
+                        f"collection deadline of {args.deadline_minutes}min reached "
+                        f"after {len(document['samples'])} of "
+                        f"{document['planned_samples']} samples"
+                    )
+                    print(f"stopping early: {document['stop_reason']}", flush=True)
+                    persist()
+                    validate_run_document(document)
+                    return 1
+                timeout_s = (
+                    min(timeout_s, remaining) if timeout_s is not None else remaining
+                )
             document["samples"].append(
-                _run_sample(args.mode, temperature, index, output_dir)
+                _run_sample(args.mode, temperature, index, output_dir, timeout_s)
             )
-            destination.write_text(
-                json.dumps(document, indent=2) + "\n", encoding="UTF-8"
-            )
+            persist()
     validate_run_document(document)
     return 0 if all(sample["valid"] for sample in document["samples"]) else 1
 
@@ -386,6 +463,13 @@ def _positive_int(raw: str) -> int:
     return value
 
 
+def _positive_float(raw: str) -> float:
+    value = float(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive number")
+    return value
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -396,6 +480,21 @@ def main() -> int:
     collect.add_argument("--output-dir", type=Path, required=True)
     collect.add_argument("--cold-samples", type=_positive_int, default=5)
     collect.add_argument("--warm-samples", type=_positive_int, default=10)
+    collect.add_argument(
+        "--sample-timeout",
+        type=_positive_float,
+        default=1800.0,
+        help="wall-clock bound in seconds for one unfiltered suite sample",
+    )
+    collect.add_argument(
+        "--deadline-minutes",
+        type=_positive_float,
+        default=None,
+        help=(
+            "stop collecting once this much wall clock has elapsed so the "
+            "caller can still upload partial evidence before any job timeout"
+        ),
+    )
     collect.set_defaults(func=run_collection)
 
     profile = subparsers.add_parser("profile", help="capture selected macOS samples")

--- a/tests/test_wasi_p3_profile.py
+++ b/tests/test_wasi_p3_profile.py
@@ -273,5 +273,102 @@ class ProfileTestCase(unittest.TestCase):
         self.assertIn(("jit", "http-fields", "fixture_execution"), keys)
 
 
+    def test_sample_timeout_terminates_runner_and_its_children(self) -> None:
+        """A wedged sample must be bounded and leave nothing behind.
+
+        Before #616 D3 the runner was invoked without a timeout, so a
+        stuck `wamrc` ran until the CI job timeout cancelled the job,
+        which skipped the `if: always()` upload and destroyed the
+        evidence.
+        """
+        marker = self.scratch / "grandchild-started"
+        stub = self.scratch / "hang.py"
+        stub.write_text(
+            "import subprocess, sys, time\n"
+            "subprocess.Popen([sys.executable, '-c',\n"
+            f"    \"import time; open({str(marker)!r}, 'w').close();\"\n"
+            '    "time.sleep(600)"])\n'
+            "time.sleep(600)\n",
+            encoding="UTF-8",
+        )
+        with mock.patch.object(profile, "UNFILTERED", stub):
+            sample = profile._run_sample(
+                "jit", "warm", 1, self.scratch / "out", timeout_s=5
+            )
+
+        self.assertTrue(sample["timed_out"])
+        self.assertFalse(sample["valid"])
+        self.assertLess(sample["suite_duration_ns"], 60_000_000_000)
+        self.assertIn("exceeded", sample["errors"][0])
+        # The document must still satisfy the schema so partial evidence
+        # can be uploaded and inspected.
+        profile.validate_run_document(
+            {
+                "schema_version": profile.SCHEMA_VERSION,
+                "kind": "wasi-p3-profile-runs",
+                "metadata": {
+                    "mode": "jit",
+                    "platform_id": "test",
+                    "commit": "0" * 40,
+                },
+                "samples": [sample],
+            }
+        )
+        self.assertTrue(marker.exists(), "stub never spawned a grandchild")
+        if os.name != "nt":
+            import subprocess as sp
+
+            survivors = sp.run(
+                ["pgrep", "-f", "time.sleep(600)"],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout.split()
+            self.assertEqual(survivors, [], "descendant processes leaked")
+
+    def test_collection_deadline_stops_early_and_persists_evidence(self) -> None:
+        output_dir = self.scratch / "deadline"
+        args = argparse.Namespace(
+            mode="jit",
+            platform_id="test",
+            output_dir=output_dir,
+            cold_samples=5,
+            warm_samples=10,
+            sample_timeout=900.0,
+            deadline_minutes=0.001,
+        )
+        self.assertEqual(profile.run_collection(args), 1)
+        document = json.loads(
+            (output_dir / "samples.json").read_text(encoding="UTF-8")
+        )
+        self.assertTrue(document["stopped_early"])
+        self.assertIn("deadline", document["stop_reason"])
+        self.assertEqual(document["planned_samples"], 15)
+        self.assertEqual(document["samples"], [])
+
+    def test_compile_timeout_is_bounded_and_configurable(self) -> None:
+        adapter = _load_adapter()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                adapter.get_compile_timeout_seconds(),
+                adapter._DEFAULT_COMPILE_TIMEOUT_SECONDS,
+            )
+        with mock.patch.dict(os.environ, {"WAMR_COMPILE_TIMEOUT": "12"}, clear=True):
+            self.assertEqual(adapter.get_compile_timeout_seconds(), 12.0)
+        with mock.patch.dict(os.environ, {"WAMR_COMPILE_TIMEOUT": "nope"}, clear=True):
+            self.assertEqual(
+                adapter.get_compile_timeout_seconds(),
+                adapter._DEFAULT_COMPILE_TIMEOUT_SECONDS,
+            )
+        with mock.patch.dict(os.environ, {"WAMR_COMPILE_TIMEOUT": "2"}, clear=True):
+            with self.assertRaises(RuntimeError) as caught:
+                adapter._run_compile(
+                    [sys.executable, "-c", "import time; time.sleep(120)"],
+                    Path("fixture.wasm"),
+                    "component_precompile",
+                )
+        self.assertIn("WAMR_COMPILE_TIMEOUT", str(caught.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/wasi-testsuite-adapter/wamr-zig.py
+++ b/tests/wasi-testsuite-adapter/wamr-zig.py
@@ -33,6 +33,7 @@ from typing import Dict, List, Optional, Tuple
 
 WAMR = shlex.split(os.getenv("WAMR", "wamr"))
 _DEFAULT_TIMEOUT_SECONDS = 5.0
+_DEFAULT_COMPILE_TIMEOUT_SECONDS = 600.0
 
 
 def _resolve_wamrc() -> List[str]:
@@ -133,13 +134,47 @@ def _profile_command(cmd: List[str], fixture: Path, phase: str) -> List[str]:
     ]
 
 
+def get_compile_timeout_seconds() -> float:
+    """Wall-clock bound for a single `wamrc` invocation.
+
+    Precompilation runs before the guest process exists, so it is not
+    covered by `WAMR_TESTSUITE_TIMEOUT` (which only bounds the guest
+    wait). An unbounded compile turns a codegen hang into a silent
+    multi-hour stall that outlives the CI job timeout and destroys the
+    diagnostics with it. Override with `WAMR_COMPILE_TIMEOUT`. (#616 D3.)
+    """
+    raw = os.getenv("WAMR_COMPILE_TIMEOUT")
+    if not raw:
+        return _DEFAULT_COMPILE_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw)
+    except ValueError:
+        timeout = 0
+    if timeout <= 0:
+        print(
+            f"warning: ignoring invalid WAMR_COMPILE_TIMEOUT={raw!r}; "
+            f"falling back to {_DEFAULT_COMPILE_TIMEOUT_SECONDS}s",
+            file=sys.stderr,
+        )
+        return _DEFAULT_COMPILE_TIMEOUT_SECONDS
+    return timeout
+
+
 def _run_compile(cmd: List[str], fixture: Path, phase: str) -> None:
     """Run wamrc, optionally attaching macOS's sampling profiler."""
-    subprocess.run(
-        _profile_command(cmd, fixture, phase),
-        check=True,
-        stdout=subprocess.DEVNULL,
-    )
+    timeout = get_compile_timeout_seconds()
+    try:
+        subprocess.run(
+            _profile_command(cmd, fixture, phase),
+            check=True,
+            stdout=subprocess.DEVNULL,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"wamrc {phase} for {fixture.name} exceeded "
+            f"{timeout:g}s (WAMR_COMPILE_TIMEOUT)"
+        ) from exc
 
 
 def get_name() -> str:


### PR DESCRIPTION
## Summary

Re-dispatching the D3 profiling workflow after the #916/#917/#918 fixes produced [run 31259495409](https://github.com/cataggar/wamr/actions/runs/31259495409), which was **cancelled by the 360-minute job timeout while still inside the AOT measurement phase on both ARM64 platforms**. Because a job-level timeout cancels the job rather than failing a step, the `if: always()` upload never ran and **every diagnostic was destroyed** — leaving no way to distinguish a hang from a budget overrun.

Nothing in the chain was bounded:

- `scripts/wasi_p3_profile.py::_run_sample` invoked the unfiltered runner with **no timeout**.
- `tests/wasi-testsuite-adapter/wamr-zig.py::_run_compile` ran `wamrc` with **no timeout**. `WAMR_TESTSUITE_TIMEOUT` bounds only the *guest process wait*, and precompilation happens before that process exists.

Measured locally on a 16-core NVMe x86_64 box, one **cold AOT sample takes ~305s** (warm ~1s) because it recompiles all 41 components. The phase is dominated by the 5 cold samples, and running AOT and JIT sequentially in one job cannot fit both modes' worst case in a single 360-minute budget.

## Changes

- Bound each sample with `--sample-timeout` and kill the entire process group, so a wedged `wamrc` or guest leaves no descendants to contend with later samples.
- Add `--deadline-minutes` so collection stops while there is still time to upload partial evidence, recording `stopped_early` / `stop_reason`.
- Record `timed_out` per sample and keep timed-out samples schema-valid, so partial documents still upload and validate.
- Bound `wamrc` with a new `WAMR_COMPILE_TIMEOUT` (default 600s), documented in `docs/wasi.md`.
- Split AOT and JIT into **separate matrix jobs** so each mode gets a full budget, and emit a microbench report per job so each artifact is self-contained rather than depending on artifact ordering.
- Set `WAMR_TESTSUITE_TIMEOUT` explicitly to match `build.zig`'s unfiltered gates (30s AOT, 120s JIT). The workflow previously inherited the adapter's much tighter **5s default**.

## Contract

Unchanged. The 60-sample 41/41 validity requirement still holds — an early-stopped or timed-out run still fails aggregation, it just does so with its evidence retained. Verified that removing a single sample makes the aggregate reject the run (`warm samples=9, expected=10`).

## Validation

- `python3 -m pytest tests/test_wasi_p3_profile.py -q` — **8 passed** (5 pre-existing + 3 new).
- New regression tests cover the sample timeout (including that descendant processes do not leak), the collection deadline persisting partial evidence, and the `wamrc` compile bound.
- Real end-to-end collection at this revision: `aot-cold-01 valid=True passed=41/41 elapsed=310.072s`, `aot-warm-01/02 valid=True passed=41/41` — happy path unchanged, exit 0.
- Aggregate accepts the new per-mode artifact layout end-to-end (`Validated 60 41/41 suite samples ...; selected 2 profiles`).
- `zig build -Doptimize=ReleaseSafe` succeeds.

This unblocks a re-dispatch of `wasi-p3-macos-profile.yml`: whatever happens next, the run will now terminate gracefully and retain per-sample timings instead of being cancelled with no evidence.

Refs #616 (D3).