### PR TITLE
fix(filesystem): reject dot components in rename-at (#616 D3)

### DIFF
--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -9727,15 +9727,26 @@ pub const WasiCliAdapter = struct {
         return null;
     }
 
-    /// Whether `path` would make Linux `unlinkat(AT_REMOVEDIR)` (or
-    /// the Zig stdlib's `dirDeleteDirPosix`) return `EINVAL` — i.e.
-    /// the path's last component is `.` or `..`. Both the kernel and
-    /// Zig stdlib treat this as a "programmer bug" and panic in debug
-    /// builds; the 0.3 filesystem-mkdir-rmdir fixture explicitly tests
-    /// `rmdir(".")` and expects `Err(ErrorCode::Invalid | Access)`.
-    /// Detect early so the guest gets a clean `.invalid` rather than a
-    /// host trap. Empty path is left to the kernel (NoEntry).
-    fn rmdirPathIsInvalid(path: []const u8) bool {
+    /// Whether `path`'s last component is `.` or `..`, which POSIX
+    /// specifies as `EINVAL` for both `rmdir` and `rename`.
+    ///
+    /// For `rmdir`, Linux `unlinkat(AT_REMOVEDIR)` (and the Zig stdlib's
+    /// `dirDeleteDirPosix`) return `EINVAL`; both the kernel and Zig
+    /// stdlib treat this as a "programmer bug" and panic in debug
+    /// builds, and the 0.3 filesystem-mkdir-rmdir fixture explicitly
+    /// tests `rmdir(".")` expecting `Err(ErrorCode::Invalid | Access)`.
+    ///
+    /// For `rename`, hosts disagree: Linux reports `EBUSY` for
+    /// `rename(".", ...)`, but macOS reports `EINVAL`, which is absent
+    /// from Zig's `RenameError` set and so collapses to
+    /// `error.Unexpected` — surfacing to the guest as a misleading
+    /// `.io`. That is why filesystem-rename passed on Linux but failed
+    /// natively on macOS ARM64 (#616 D3).
+    ///
+    /// Detect early so every host agrees and the guest gets a clean
+    /// `.invalid` rather than a host trap. Empty path is left to the
+    /// kernel (NoEntry).
+    fn pathLastComponentIsDot(path: []const u8) bool {
         if (path.len == 0) return false;
         // Drop trailing slashes — `rmdir("foo/")` should behave like
         // `rmdir("foo")` for the trailing-`.` check below.
@@ -11130,7 +11141,7 @@ pub const WasiCliAdapter = struct {
         // panics on as a "programmer bug". Guard explicitly so the
         // guest sees `Err(ErrorCode::Invalid)` per `filesystem-mkdir-rmdir`
         // (line 73-75 `Err(Invalid | Access)`). (#571.)
-        if (rmdirPathIsInvalid(path_bytes)) {
+        if (pathLastComponentIsDot(path_bytes)) {
             results[0] = try fsResultErr(allocator, .invalid);
             return;
         }
@@ -11228,6 +11239,16 @@ pub const WasiCliAdapter = struct {
         }
         if (checkPathSymlinks(new_dir, new_path_bytes, false)) |code| {
             results[0] = try fsResultErr(allocator, code);
+            return;
+        }
+
+        // POSIX `EINVAL`: renaming to or from a path whose final
+        // component is `.` or `..`. Hosts disagree on the reported
+        // errno, so normalize before hitting the syscall. (#616 D3.)
+        if (pathLastComponentIsDot(old_path_bytes) or
+            pathLastComponentIsDot(new_path_bytes))
+        {
+            results[0] = try fsResultErr(allocator, .invalid);
             return;
         }
 
@@ -29169,6 +29190,95 @@ test "filesystem #476: rename-at within a single preopen" {
     try WasiCliAdapter.fsDescriptorStatAt(&adapter, &ci, &stat_new, &stat_new_r, testing.allocator);
     defer stat_new_r[0].deinit(testing.allocator);
     try testing.expect(stat_new_r[0].result_val.is_ok);
+}
+
+test "filesystem #616: rename-at rejects dot components uniformly across hosts" {
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const io = std.Io.Threaded.global_single_threaded.io();
+    try tmp.dir.writeFile(io, .{ .sub_path = "a.txt", .data = "data" });
+
+    const handle = try adapter.pushFsDescriptor(.{ .preopen = .{
+        .dir = tmp.dir,
+        .flags = .{ .read = true, .write = true, .mutate_directory = true },
+    } });
+    defer adapter.fs_descriptor_table.items[handle] = null;
+
+    var ci: ComponentInstance = undefined;
+    try ci.enableTestMem(testing.allocator, 8192);
+    defer ci.disableTestMem();
+
+    // The 0.3 filesystem-rename fixture runs `mv . q.txt` and accepts
+    // `Busy | Invalid | Access`. Linux reports `EBUSY`, but macOS reports
+    // `EINVAL`, which is absent from Zig's `RenameError` and collapsed to
+    // `error.Unexpected` — the guest saw `.io` and the fixture failed only
+    // on native macOS ARM64.
+    for ([_][2][]const u8{
+        .{ ".", "q.txt" },
+        .{ "a.txt", "." },
+        .{ "./", "q.txt" },
+    }) |pair| {
+        const old_path = try testMakeListVal(&ci, testing.allocator, pair[0]);
+        const new_path = try testMakeListVal(&ci, testing.allocator, pair[1]);
+        var args = [_]InterfaceValue{
+            .{ .handle = handle },
+            .{ .string = old_path.list },
+            .{ .handle = handle },
+            .{ .string = new_path.list },
+        };
+        var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+        try WasiCliAdapter.fsDescriptorRenameAt(&adapter, &ci, &args, &results, testing.allocator);
+        defer results[0].deinit(testing.allocator);
+        try testing.expect(!results[0].result_val.is_ok);
+        try testing.expectEqual(
+            @intFromEnum(FsErrorCode.invalid),
+            results[0].result_val.payload.?.variant_val.discriminant,
+        );
+    }
+
+    // `..` is rejected earlier by the sandbox check as `not-permitted`,
+    // which the same fixture asserts for `mv a.txt ../q.txt`. Keep that
+    // precedence intact rather than reclassifying it as `.invalid`.
+    for ([_][2][]const u8{
+        .{ "..", "q.txt" },
+        .{ "a.txt", "../q.txt" },
+    }) |pair| {
+        const old_path = try testMakeListVal(&ci, testing.allocator, pair[0]);
+        const new_path = try testMakeListVal(&ci, testing.allocator, pair[1]);
+        var args = [_]InterfaceValue{
+            .{ .handle = handle },
+            .{ .string = old_path.list },
+            .{ .handle = handle },
+            .{ .string = new_path.list },
+        };
+        var results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+        try WasiCliAdapter.fsDescriptorRenameAt(&adapter, &ci, &args, &results, testing.allocator);
+        defer results[0].deinit(testing.allocator);
+        try testing.expect(!results[0].result_val.is_ok);
+        try testing.expectEqual(
+            @intFromEnum(FsErrorCode.not_permitted),
+            results[0].result_val.payload.?.variant_val.discriminant,
+        );
+    }
+
+    // A rename with no dot component still succeeds.
+    const ok_old = try testMakeListVal(&ci, testing.allocator, "a.txt");
+    const ok_new = try testMakeListVal(&ci, testing.allocator, "b.txt");
+    var ok_args = [_]InterfaceValue{
+        .{ .handle = handle },
+        .{ .string = ok_old.list },
+        .{ .handle = handle },
+        .{ .string = ok_new.list },
+    };
+    var ok_results: [1]InterfaceValue = .{.{ .u32 = 0 }};
+    try WasiCliAdapter.fsDescriptorRenameAt(&adapter, &ci, &ok_args, &ok_results, testing.allocator);
+    defer ok_results[0].deinit(testing.allocator);
+    try testing.expect(ok_results[0].result_val.is_ok);
 }
 
 test "filesystem #476: rename-at across two distinct descriptor handles" {


### PR DESCRIPTION
## Summary

The D3 profiling run at `cc0700c8` ([run 31320869277](https://github.com/cataggar/wamr/actions/runs/31320869277)) — the first to retain evidence after #926 — shows native macOS ARM64 JIT at **40/41**, with one deterministic failure reproduced in **all 15 samples**:

```
filesystem-rename: mv . q.txt: unexpected error ErrorCode::Io
```

This is real progress on the July baseline of 33/41, and `filesystem-rename` is now the *only* remaining native-macOS JIT failure.

## Root cause

The fixture runs `mv(".", "q.txt")` and accepts `Busy | Invalid | Access`. POSIX specifies `EINVAL` when a path's final component is dot or dot-dot, but hosts disagree on what they actually report:

| Host | errno | Zig error | `mapFsError` | Result |
|---|---|---|---|---|
| Linux | `EBUSY` | `error.FileBusy` | `.busy` | passes |
| macOS | `EINVAL` | *(absent from `RenameError`)* → `error.Unexpected` | `else` → `.io` | **fails** |

`RenameError` has no `EINVAL` member, so on macOS the error collapses to `error.Unexpected` and the guest sees a misleading `.io`. This is why the fixture passed the Linux CI gate but failed only on native macOS ARM64.

## Fix

Reject the case in the adapter before reaching the syscall so every host agrees, reusing the check already written for `rmdir(".")` and generalizing its name from `rmdirPathIsInvalid` to `pathLastComponentIsDot`.

`..` keeps its existing precedence: `validateSandboxPath` rejects it as `.not-permitted` first, which is exactly what the same fixture asserts for `mv a.txt ../q.txt`. Only dot is reclassified — the new test pins both behaviors so the precedence cannot silently change.

`rename-at`'s P3 entry point delegates to the same handler, so Preview 2 and Preview 3 are both covered.

## Validation

- `zig build test -Doptimize=Debug` — **101/101 steps, 4618/4642 tests passed** (24 skipped, 0 failed)
- `zig build wasi-p3-testsuite -Doptimize=ReleaseSafe` — **41/41** on Linux, no regression
- New regression test covers dot rejection on both the old and new path, `..` retaining `.not-permitted`, and an ordinary rename still succeeding

Refs #616 (D3).