### PR TITLE
fix(testsuite): bound harness-side blocking operations and gate P3 on AArch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,49 @@ jobs:
       - name: Run unfiltered WASI Preview 3 conformance contract
         run: zig build wasi-p3-testsuite-unfiltered -Doptimize=ReleaseSafe
 
+  wasi-p3-testsuite-arm64:
+    name: Build & Test (wasi-p3-testsuite-arm64)
+    runs-on: [self-hosted, Linux, ARM64]
+    timeout-minutes: 45
+    # The AArch64 counterpart of the `wasi-p3-testsuite` job above, which
+    # runs on x86_64 only. That single-architecture coverage is what let
+    # #929 through: five P3 fixtures stall under AOT on AArch64 while all
+    # 41 pass on x86_64, and nothing in CI observed it.
+    #
+    # Non-blocking until #929 is fixed (same precedent as `jit-parity`
+    # below); `ci-summary` deliberately omits it from needs[]. Flip it into
+    # the gate once AArch64 reaches 41/41.
+    continue-on-error: true
+    env:
+      # Bound the harness so a stalled guest fails one fixture instead of
+      # wedging the suite and burning the whole job timeout (#929).
+      WAMR_TESTSUITE_TIMEOUT: "30"
+      WAMR_TESTSUITE_OP_TIMEOUT: "30"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Configure Zig caches
+        uses: ./.github/actions/zig-cache
+
+      - name: Install wasi-testsuite runner deps
+        run: |
+          python3 -m pip install --user --break-system-packages \
+            -r tests/wasi-testsuite/test-runner/requirements.txt
+
+      - name: Build wamr (ReleaseSafe)
+        run: zig build -Doptimize=ReleaseSafe
+
+      - name: Run unfiltered WASI Preview 3 conformance contract
+        run: zig build wasi-p3-testsuite-unfiltered -Doptimize=ReleaseSafe
+
   jit-parity:
     name: Build & Test (jit-parity)
     runs-on: ubuntu-22.04

--- a/docs/wasi.md
+++ b/docs/wasi.md
@@ -379,6 +379,32 @@ diagnostics along with it. `WAMR_COMPILE_TIMEOUT=<seconds>` bounds a single
 $ WAMR_COMPILE_TIMEOUT=120 zig build wasi-p3-testsuite
 ```
 
+### `WAMR_TESTSUITE_OP_TIMEOUT`
+
+`WAMR_TESTSUITE_TIMEOUT` bounds only `do_wait`'s `Popen.wait`. Fixtures that
+declare an `operations` list (`sockets-echo`, `cli-stdio-roundtrip`, …) also
+perform blocking work on the *harness* side, none of which upstream bounds:
+`do_connect` does an unbounded `readline()` on the guest's stdout to discover
+`host:port`, and `do_read` / `do_send` / `do_recv` block on a pipe or socket
+with no timeout.
+
+A guest that starts but never produces its expected output therefore parks the
+harness forever, so **one wedged fixture hangs the entire suite** instead of
+failing a single test. That is exactly how five AArch64 AOT fixtures consumed
+900 s profiling samples while reporting nothing at all
+([#929](https://github.com/cataggar/wamr/issues/929)).
+
+Each blocking operation now runs under a watchdog that kills the guest process
+when the deadline expires. Killing the guest is what actually unblocks the
+harness: its stdout hits EOF and its sockets are closed by the kernel, so
+upstream's existing error paths turn the stall into an ordinary failure with a
+precise message. `WAMR_TESTSUITE_OP_TIMEOUT=<seconds>` sets the budget;
+unset, it inherits `WAMR_TESTSUITE_TIMEOUT`, falling back to 60 s.
+
+```console
+$ WAMR_TESTSUITE_OP_TIMEOUT=30 zig build wasi-p3-testsuite
+```
+
 ### Outbound HTTPS in unit tests
 
 Off by default so CI stays hermetic:

--- a/tests/wasi-testsuite-runner-patch/wasi_test_runner.py
+++ b/tests/wasi-testsuite-runner-patch/wasi_test_runner.py
@@ -6,14 +6,19 @@ launcher makes the vendored package importable and delegates to its entry
 point. When `WAMR_PROFILE_TIMINGS` is set, it also records process execution
 time after adapter-side precompilation. The hook is entirely opt-in and does
 not wrap the guest process or alter its streams/argv.
+
+It also installs unconditional deadlines on the upstream runner's
+harness-side blocking operations (see `_install_operation_deadlines`).
 """
 
 import json
 import os
+import socket
 import sys
+import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 _THIS_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _THIS_DIR.parent.parent
@@ -90,6 +95,133 @@ def _install_profile_hooks() -> None:
 
 
 _install_profile_hooks()
+
+
+# ── Harness-side operation deadlines (#929) ───────────────────────────
+#
+# The upstream runner's `operations` fixtures perform blocking work on the
+# *harness* side: `do_connect` does an unbounded `readline()` on the guest's
+# stdout to discover `host:port`, and `do_read`/`do_send`/`do_recv` block on
+# a pipe or socket with no timeout. The adapter's `WAMR_TESTSUITE_TIMEOUT`
+# bounds only `do_wait`'s `Popen.wait`, so none of those are covered.
+#
+# The practical consequence (#929) is severe: a guest that starts but never
+# reaches its first `println!` leaves the harness parked in `readline()`
+# forever. One wedged fixture then hangs the entire suite instead of failing
+# a single test, which is how `sockets-echo` consumed 900s samples on ARM64
+# AOT while reporting nothing at all.
+#
+# Rather than reimplement upstream's stream handling, each blocking op is
+# wrapped in a watchdog that kills the guest process when the deadline
+# expires. Killing the guest is what actually unblocks the harness: its
+# stdout hits EOF (so `readline`/`read` return promptly) and its sockets are
+# closed by the kernel (so `recv` returns empty and `send` raises EPIPE).
+# Upstream's existing error paths then turn that into an ordinary failure.
+_DEFAULT_OPERATION_DEADLINE_SECONDS = 60.0
+
+
+def _operation_deadline_seconds(runner: Any) -> float:
+    """Seconds any single harness-side blocking operation may take.
+
+    `WAMR_TESTSUITE_OP_TIMEOUT` wins when set. Otherwise the adapter's
+    guest-wait budget is reused, so callers that already tighten
+    `WAMR_TESTSUITE_TIMEOUT` (the profiling workflow uses 30s/120s) get
+    proportionally tight operation deadlines for free.
+    """
+    raw = os.getenv("WAMR_TESTSUITE_OP_TIMEOUT")
+    if raw:
+        try:
+            explicit = float(raw)
+        except ValueError:
+            explicit = 0.0
+        if explicit > 0:
+            return explicit
+        print(
+            f"warning: ignoring invalid WAMR_TESTSUITE_OP_TIMEOUT={raw!r}",
+            file=sys.stderr,
+        )
+    try:
+        inherited = float(runner._runtime.get_timeout_seconds())
+    except Exception:  # pylint: disable=broad-except
+        inherited = 0.0
+    if inherited > 0:
+        return inherited
+    return _DEFAULT_OPERATION_DEADLINE_SECONDS
+
+
+def _kill_guest(runner: Any) -> None:
+    proc = getattr(runner, "_proc", None)
+    if proc is None or proc.poll() is not None:
+        return
+    try:
+        proc.kill()
+    except OSError:
+        pass
+
+
+def _bounded(runner: Any, label: str, call: Callable[[], None]) -> bool:
+    """Run `call`, killing the guest if it outlives the deadline.
+
+    Returns True when the deadline fired. The timer thread only kills the
+    guest; it never touches runner state, so the failure is always recorded
+    from this (the main) thread after `call` unblocks and returns.
+    """
+    seconds = _operation_deadline_seconds(runner)
+    fired = threading.Event()
+
+    def on_deadline() -> None:
+        fired.set()
+        _kill_guest(runner)
+
+    timer = threading.Timer(seconds, on_deadline)
+    timer.daemon = True
+    timer.start()
+    try:
+        call()
+    finally:
+        timer.cancel()
+
+    if fired.is_set():
+        runner.fail_unexpected(
+            f"{label} exceeded the {seconds:g}s harness operation deadline; "
+            "the guest process was killed to unblock the suite "
+            "(WAMR_TESTSUITE_OP_TIMEOUT)"
+        )
+        return True
+    return False
+
+
+def _install_operation_deadlines() -> None:
+    runner_cls = _suite_runner.TestCaseRunner
+
+    def bound_method(name: str) -> None:
+        original = getattr(runner_cls, name)
+
+        def wrapper(self: Any, op: Any) -> None:
+            _bounded(self, f"{name}({op})", lambda: original(self, op))
+
+        wrapper.__name__ = name
+        setattr(runner_cls, name, wrapper)
+
+    for method in ("do_read", "do_connect", "do_send", "do_recv"):
+        bound_method(method)
+
+    # Belt-and-braces for the socket ops: an explicit socket timeout makes
+    # `send`/`recv` fail on their own even in the case where the guest
+    # process has already exited but a peer socket somehow stays open.
+    original_add_socket = runner_cls.add_socket
+
+    def add_socket(self: Any, name: str, sock: socket.socket) -> None:
+        try:
+            sock.settimeout(_operation_deadline_seconds(self))
+        except OSError:
+            pass
+        original_add_socket(self, name, sock)
+
+    runner_cls.add_socket = add_socket
+
+
+_install_operation_deadlines()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the second half of #929 and closes the CI coverage gap that let the first half through.

## The wedge

Upstream's wasi-testsuite runner performs blocking work on the **harness** side for any fixture declaring an `operations` list, and none of it is bounded:

| operation | blocks on | bounded by |
|---|---|---|
| `do_connect` | `readline()` on guest stdout to discover `host:port` | — |
| `do_read` | `read(n)` on a guest pipe | — |
| `do_send` / `do_recv` | socket with no `settimeout` | — |
| `do_wait` | `Popen.wait` | `WAMR_TESTSUITE_TIMEOUT` |

Only the last row was covered. A guest that starts but never produces its expected output parks the harness forever, so **one wedged fixture hangs the entire suite** rather than failing a single test.

That is precisely how five AArch64 AOT fixtures consumed whole 900 s D3 profiling samples while reporting nothing — the runs looked like slow compilation when they were actually stalls with no diagnosis attached.

## The fix

Each blocking operation runs under a watchdog that kills the guest when the deadline expires. Rather than reimplementing upstream's stream handling, this leans on what killing the guest already does: stdout hits EOF so `readline`/`read` return promptly, and the kernel closes its sockets so `recv`/`send` fail. Upstream's existing error paths then report an ordinary failure.

The timer thread only kills the process — it never touches runner state — so the failure is always recorded from the main thread after the call unblocks.

`WAMR_TESTSUITE_OP_TIMEOUT` sets the budget. Unset, it inherits the adapter's guest-wait budget, so callers that already tighten `WAMR_TESTSUITE_TIMEOUT` (the profiling workflow uses 30s/120s) get proportionally tight operation deadlines for free.

## Coverage gap

`wasi-p3-testsuite` runs on `ubuntu-22.04` only. That single-architecture coverage is why #929 sat undetected: 41/41 pass on x86_64 while five fixtures fail on AArch64. This adds `wasi-p3-testsuite-arm64` on the self-hosted runner, **non-blocking** until #929 is fixed (matching the `jit-parity` precedent; `ci-summary` omits it from `needs[]`). Flip it into the gate once AArch64 reaches 41/41.

## Verification

On the self-hosted AArch64 runner ([run 31337316462](https://github.com/cataggar/wamr/actions/runs/31337316462)), the P3 AOT suite went from **wedging indefinitely** to **completing in ~5 minutes** with a precise per-fixture diagnosis:

```
Test cli-stdio-roundtrip failed
  [Expectation mismatch] Read(id='stdout', payload='Hello, world!') stdout failed: expected Hello, world!, got
  [Unexpected] do_read(...) exceeded the 30s harness operation deadline; the guest
               process was killed to unblock the suite (WAMR_TESTSUITE_OP_TIMEOUT)
```

That diagnosis is what made the #929 root cause reachable at all.

- x86_64 `zig build wasi-p3-testsuite` → **41/41** with deadlines active, so the watchdog is inert when nothing stalls.
- Synthetic wedged-guest fixture: exit 124 with zero output before, clean 1/1 failure in 5 s after.

Refs #929, #616 D3