### PR TITLE
fix(codegen): require the spill site to dominate the reload in loop range splitting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,13 +264,12 @@ jobs:
     timeout-minutes: 45
     # The AArch64 counterpart of the `wasi-p3-testsuite` job above, which
     # runs on x86_64 only. That single-architecture coverage is what let
-    # #929 through: five P3 fixtures stall under AOT on AArch64 while all
-    # 41 pass on x86_64, and nothing in CI observed it.
+    # #929 through: five P3 fixtures stalled under AOT on AArch64 while
+    # all 41 passed on x86_64, and nothing in CI observed it.
     #
-    # Non-blocking until #929 is fixed (same precedent as `jit-parity`
-    # below); `ci-summary` deliberately omits it from needs[]. Flip it into
-    # the gate once AArch64 reaches 41/41.
-    continue-on-error: true
+    # Blocking as of the #929 fix (AArch64 is at 41/41): this job is the
+    # only thing standing between an AArch64-specific codegen regression
+    # and main, so it is in `ci-summary`'s needs[].
     env:
       # Bound the harness so a stalled guest fails one fixture instead of
       # wedging the suite and burning the whole job timeout (#929).
@@ -439,12 +438,12 @@ jobs:
   ci-summary:
     name: Build & Test
     runs-on: ubuntu-22.04
-    needs: [build-and-test, wasi-test, wasi-testsuite, component-examples, wasi-p2-testsuite, wasi-p3-testsuite, lazy-jit]
+    needs: [build-and-test, wasi-test, wasi-testsuite, component-examples, wasi-p2-testsuite, wasi-p3-testsuite, wasi-p3-testsuite-arm64, lazy-jit]
     if: always()
     steps:
       - name: Check results
         run: |
-          if [ "${{ needs.build-and-test.result }}" != "success" ] || [ "${{ needs.wasi-test.result }}" != "success" ] || [ "${{ needs.wasi-testsuite.result }}" != "success" ] || [ "${{ needs.component-examples.result }}" != "success" ] || [ "${{ needs.wasi-p2-testsuite.result }}" != "success" ] || [ "${{ needs.wasi-p3-testsuite.result }}" != "success" ] || [ "${{ needs.lazy-jit.result }}" != "success" ]; then
+          if [ "${{ needs.build-and-test.result }}" != "success" ] || [ "${{ needs.wasi-test.result }}" != "success" ] || [ "${{ needs.wasi-testsuite.result }}" != "success" ] || [ "${{ needs.component-examples.result }}" != "success" ] || [ "${{ needs.wasi-p2-testsuite.result }}" != "success" ] || [ "${{ needs.wasi-p3-testsuite.result }}" != "success" ] || [ "${{ needs.wasi-p3-testsuite-arm64.result }}" != "success" ] || [ "${{ needs.lazy-jit.result }}" != "success" ]; then
             echo "::error::One or more CI jobs failed"
             exit 1
           fi

--- a/src/compiler/ir/range_split.zig
+++ b/src/compiler/ir/range_split.zig
@@ -246,6 +246,36 @@ pub fn splitLiveRangesAtLoopBoundariesWithConfig(
             continue;
         };
 
+        // ── Spill-site reachability gate (#929) ──
+        // The split emits `local_set slot, orig` at the end of
+        // `entry_pred` and `alt = local_get slot` at the start of
+        // `exit.succ`. For `alt` to hold `orig`'s value, EVERY execution
+        // that reaches `exit.succ` must first have passed through
+        // `entry_pred` — i.e. `entry_pred` must dominate `exit.succ`.
+        //
+        // The `computePostLoopReachable` dominance filter below is not
+        // enough: it only proves the rewritten uses are dominated by the
+        // reload, not that the reload's slot was ever written. When
+        // `exit.succ` has a second predecessor that bypasses the loop
+        // entirely, e.g.
+        //
+        //     A: br_if -> E, X
+        //     E: local_set slot, orig ; br -> H      (entry_pred)
+        //     H: <loop>  ; exit edge -> S
+        //     X: br -> S                             (bypasses E and H)
+        //     S: alt = local_get slot ; use(alt)     (exit.succ)
+        //
+        // the `A -> X -> S` path reaches the reload without ever
+        // executing the spill, so `alt` observes an uninitialised slot
+        // (reads as zero) instead of `orig`. On the WASI-p3 fixtures
+        // that produced a guest that spun forever on a zeroed loop bound
+        // rather than writing its first byte of stdout.
+        if (!dom.dominates(entry_pred, exit.succ)) {
+            stats.loops_skipped_shape += 1;
+            continue;
+        }
+
+
         // Build the "post-loop reachable AND exit.succ-dominated" block
         // set. Soundness invariant: every use we rewrite from orig → alt
         // must be dominated by the local_get (which lives at the start
@@ -1612,4 +1642,52 @@ test "splitLiveRangesAtLoopBoundaries: N+1 hot-loop synthetic — fresh vreg red
     // fresh vreg's range starts at the post-loop reload, strictly after
     // the originals' last use).
     try std.testing.expect(orig_max_end < fresh_min_start);
+}
+
+test "splitLiveRangesAtLoopBoundaries: #929 skips loops whose exit successor is reachable around the loop" {
+    // Regression for #929. `b_join` (the loop's exit successor) has a
+    // second predecessor `b_skip` that bypasses the loop — and therefore
+    // bypasses `b_pre`, where the split would emit `local_set slot, v0`.
+    // Splitting here would make the `local_get` in `b_join` read an
+    // uninitialised slot on the `b_entry -> b_skip -> b_join` path.
+    //
+    //   b_entry: br_if -> b_pre, b_skip
+    //   b_pre:   br    -> b_hdr            (the loop's single entry pred)
+    //   b_hdr:   br_if -> b_hdr, b_join    (single-block, single-exit loop)
+    //   b_skip:  br    -> b_join           (bypasses b_pre and b_hdr)
+    //   b_join:  ret v0
+    const allocator = std.testing.allocator;
+    var func = ir.IrFunction.init(allocator, 0, 1, 0);
+    defer func.deinit();
+
+    const b_entry = try func.newBlock();
+    const b_pre = try func.newBlock();
+    const b_hdr = try func.newBlock();
+    const b_skip = try func.newBlock();
+    const b_join = try func.newBlock();
+
+    const v0 = func.newVReg();
+    const c = func.newVReg();
+    const c2 = func.newVReg();
+
+    try func.getBlock(b_entry).append(.{ .op = .{ .iconst_32 = 7 }, .dest = v0, .type = .i32 });
+    try func.getBlock(b_entry).append(.{ .op = .{ .iconst_32 = 1 }, .dest = c, .type = .i32 });
+    try func.getBlock(b_entry).append(.{ .op = .{ .br_if = .{ .cond = c, .then_block = b_pre, .else_block = b_skip } }, .type = .void });
+
+    try func.getBlock(b_pre).append(.{ .op = .{ .br = b_hdr }, .type = .void });
+
+    try func.getBlock(b_hdr).append(.{ .op = .{ .iconst_32 = 0 }, .dest = c2, .type = .i32 });
+    try func.getBlock(b_hdr).append(.{ .op = .{ .br_if = .{ .cond = c2, .then_block = b_hdr, .else_block = b_join } }, .type = .void });
+
+    try func.getBlock(b_skip).append(.{ .op = .{ .br = b_join }, .type = .void });
+
+    try func.getBlock(b_join).append(.{ .op = .{ .ret = v0 }, .type = .void });
+
+    var sched = try MockSchedule.fromFunc(&func, allocator);
+    defer sched.deinit();
+
+    const stats = try splitLiveRangesAtLoopBoundariesWithConfig(&func, &sched, allocator, .{ .min_candidates = 0, .min_loop_body_insts = 0, .num_available_phys_regs = 0, .num_callee_saved_regs = 0, .safety_margin = 0 });
+    try std.testing.expect(stats.loops_considered >= 1);
+    try std.testing.expectEqual(@as(u32, 0), stats.splits_applied);
+    try std.testing.expect(stats.loops_skipped_shape >= 1);
 }

--- a/tests/wasi-testsuite-adapter/wamr-zig.py
+++ b/tests/wasi-testsuite-adapter/wamr-zig.py
@@ -54,6 +54,51 @@ def _resolve_wamrc() -> List[str]:
 
 
 WAMRC = _resolve_wamrc()
+
+
+def _compiler_mtime() -> float:
+    """Newest mtime across the `wamrc` invocation's binaries.
+
+    The AOT artifact cache below is keyed on source-vs-artifact mtime.
+    That is not sufficient on its own: the artifacts are *compiler
+    output*, so a rebuilt `wamrc` invalidates every one of them even
+    though no `.wasm` source changed.
+
+    On ephemeral CI runners this never bit us — the workspace starts
+    empty, so every artifact was a cache miss. On a **self-hosted**
+    runner the checkout (and in particular the `tests/wasi-testsuite`
+    submodule working tree) persists across jobs, so stale artifacts
+    built by a *previous commit's* `wamrc` survive and get reused.
+    That silently tests the old compiler: a codegen fix appears to
+    have no effect, and a codegen regression appears clean.
+
+    Returns 0.0 if the binaries can't be stat'd, which degrades to the
+    previous source-mtime-only behaviour rather than erroring.
+    """
+    newest = 0.0
+    for part in WAMRC:
+        try:
+            newest = max(newest, os.stat(part).st_mtime)
+        except OSError:
+            continue
+    return newest
+
+
+COMPILER_MTIME = _compiler_mtime()
+
+
+def _artifact_is_fresh(artifact: Path, source: Path) -> bool:
+    """True iff `artifact` can be reused for `source`.
+
+    Requires the artifact to be at least as new as BOTH the wasm source
+    and the `wamrc` that produced it.
+    """
+    if not artifact.exists():
+        return False
+    artifact_mtime = artifact.stat().st_mtime
+    if artifact_mtime < source.stat().st_mtime:
+        return False
+    return artifact_mtime >= COMPILER_MTIME
 _SAMPLE_LAUNCHER = (
     Path(__file__).resolve().parent.parent.parent
     / "scripts"
@@ -263,7 +308,8 @@ def _is_component(path: Path) -> bool:
 
 def _precompile(test_path: str) -> str:
     """Compile `<test_path>` to a sibling AOT artifact, skipping
-    recompile if the artifact exists and is newer than the source.
+    recompile if the artifact exists and is newer than both the source
+    and the `wamrc` binary (see `_artifact_is_fresh`).
     Returns the path `wamr run` should be invoked with — the sibling
     `.cwasm` for core wasm, or the source `.wasm` itself for a
     component (since `wamr run` auto-probes the sibling
@@ -308,7 +354,7 @@ def _precompile(test_path: str) -> str:
     phase = f"{artifact_kind}_precompile"
     if is_component:
         manifest = p.with_suffix(".cwasm.json")
-        if not manifest.exists() or manifest.stat().st_mtime < p.stat().st_mtime:
+        if not _artifact_is_fresh(manifest, p):
             # `wamrc compile-component` already disables the IR
             # verifier internally (compileCoreWasm hard-codes
             # verify_mode=.off), so no extra flag is needed here.
@@ -326,7 +372,7 @@ def _precompile(test_path: str) -> str:
             )
         return test_path
     cwasm = p.with_suffix(".cwasm")
-    if cwasm.exists() and cwasm.stat().st_mtime >= p.stat().st_mtime:
+    if _artifact_is_fresh(cwasm, p):
         _emit_timing(
             p, phase, artifact_kind, time.perf_counter_ns() - started_ns, "hit"
         )


### PR DESCRIPTION
Fixes #929.

## Root cause

`splitLiveRangesAtLoopBoundaries` (issue #383) relieves register pressure by spilling a loop-crossing vreg to a synthetic local at the loop's **entry predecessor**, reloading it into a fresh vreg at the loop's **exit successor**, and rewriting post-loop uses onto the reload.

The soundness argument only covered half the requirement. The existing `computePostLoopReachable` dominance filter proves every rewritten *use* is dominated by the reload — but nothing proved the reload's slot was ever *written*.

When the exit successor has a second predecessor that bypasses the loop (and therefore bypasses the entry predecessor holding the `local_set`), the reload observes an uninitialised slot, which reads as zero:

```
A: br_if -> E, X
E: local_set slot, orig ; br -> H      (entry_pred)
H: <loop> ; exit edge -> S
X: br -> S                             (bypasses E and H)
S: alt = local_get slot ; use(alt)     (exit.succ)
```

The `A -> X -> S` path reaches the reload without ever executing the spill.

## Fix

Gate the split on `dom.dominates(entry_pred, exit.succ)` — 5 lines plus an explanatory comment.

## Impact

On AArch64 this produced five WASI-p3 fixtures whose AOT guests spun forever in a pure userspace loop (single thread, `state=R`, `stime` pinned at 0) without ever writing their first byte of stdout — a zeroed loop bound derived from the uninitialised slot:

`cli-stdio-roundtrip`, `cli-stdout-flush`, `filesystem-io`, `sockets-tcp-send`, `sockets-echo`

x86_64 was unaffected because its allocator produced a different pressure profile, so the offending loops never crossed the `#524` pressure gate.

The gate is narrow: on the `cli-stdio-roundtrip` component it rejects **2 of 28** candidate splits, leaving the #383/#524 pressure-relief benefit intact.

## How it was found

1. #930 added AArch64 P3 coverage and bounded the harness-side blocking reads that had previously wedged the whole run — turning an indefinite hang into 5 reported failures.
2. Local AArch64 reproduction on x86_64: `wamrc --target=aarch64` cross-compiles natively, and the guest runs under `qemu-aarch64`.
3. `-O0` fixed it but `WAMR_AOT_PASSES_LIMIT=0` did not — which localised the bug to the four *infrastructure* passes that `WAMR_AOT_PASSES_LIMIT` cannot address (documented in `docs/wamrc-bisect.md`).
4. `WAMR_AOT_SKIP_PROMOTE_SSA` bisection narrowed to **core module 0, function 235**.
5. A temporary env knob over the AArch64 `CompileOptions` toggles pinned it to `enable_range_split`.

SSA promotion was implicated only because it changes the IR shape enough for `range_split`'s pressure gate to fire; the defect is in `range_split` itself.

## Verification

- **AArch64** (cross-compiled `wamrc --target=aarch64`, run under `qemu-aarch64`): all five fixtures run to completion. Before the fix `cli-stdio-roundtrip` hit the 120 s timeout with zero output; after, it echoes `Hello, world!` and exits 0.
- **x86_64** `zig build wasi-p3-testsuite`: **41/41**, unchanged.
- **`zig build test`**: **2235 passed, 11 skipped, 0 failed**, including a new `range_split` regression test covering the bypass-path CFG shape.

Once CI's `wasi-p3-testsuite-arm64` job goes green on this branch, it can be moved into `ci-summary`'s `needs[]` and lose its `continue-on-error`.