### PR TITLE
wasi:http: detect and act on client disconnect while serving (#616 A8)

### DIFF
--- a/docs/wasi.md
+++ b/docs/wasi.md
@@ -290,6 +290,40 @@ observed after the worker finished.
 Requests with neither a `request-options` budget nor a cancel flag
 still run inline, so the zero-configuration path is unchanged.
 
+#### Client-disconnect handling on the serve path (A8)
+
+`wamr serve` now distinguishes a client hanging up from a server-side
+I/O fault, and reacts to it.
+
+Previously the TCP and TLS output sinks folded *every* write failure
+into a generic I/O error, so a disconnect mid-response was
+indistinguishable from a real fault. The serve loops swallowed the
+error outright, then looped back to read another request that would
+never arrive, and the guest was never told its response had not
+landed.
+
+Now:
+
+* `ECONNRESET` and `EPIPE`/`ENOTCONN` from the socket write — and the
+  equivalent conditions from the TLS record layer — surface as a
+  *closed* stream rather than an error, which the response writers
+  translate into a distinct disconnect condition.
+* Response bodies are written to the socket in 64 KiB slices, so a
+  disconnect is detected within one chunk instead of after the entire
+  transfer has been handed to the socket layer. This also bounds how
+  much of a single guest response the host can queue at once. The
+  bytes on the wire and their framing are unchanged; only the number
+  of `write` calls differs.
+* On disconnect the connection is torn down instead of being kept
+  alive, and any host operations the guest still owns on that
+  instance — an outbound fetch it never awaited, a timer, a socket
+  read — are cancelled, since their results are no longer observable.
+* For Preview 3, the response's transmission future is closed without
+  a ready payload, which is how the guest learns its response was not
+  delivered. The inbound path previously never wrote to that future at
+  all, so a response abandoned mid-flight looked exactly like one
+  delivered in full.
+
 ### Already-shipped 0.3.0 surfaces (section A)
 
 * **Outbound HTTP response headers not surfaced.** `std.http.Client.FetchResult`

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -20700,6 +20700,15 @@ pub const WasiCliAdapter = struct {
         };
     }
 
+    /// Largest slice handed to the client socket in one write.
+    ///
+    /// Bounds how far a response can run past a disconnect before the
+    /// host notices, and bounds the kernel-side queueing a single
+    /// guest response can demand (#616 A8). 64 KiB matches the
+    /// outbound body-chunk size and comfortably exceeds a TLS record,
+    /// so it costs no extra syscalls in the common case.
+    const http_response_chunk_bytes: usize = 64 * 1024;
+
     fn writeAllOutputStream(
         self: *WasiCliAdapter,
         out: *streams.OutputStream,
@@ -20707,7 +20716,36 @@ pub const WasiCliAdapter = struct {
     ) !void {
         switch (out.write(bytes, self.allocator)) {
             .ok => |n| if (n != bytes.len) return error.IoError,
-            .closed, .err => return error.IoError,
+            // `.closed` is the peer hanging up, which is a normal
+            // client behaviour rather than a server fault; callers
+            // must distinguish it so they can abandon the response and
+            // drop keep-alive instead of reporting an error (#616 A8).
+            .closed => return error.HttpClientDisconnected,
+            .err => return error.IoError,
+        }
+    }
+
+    /// Write a response body to the client in bounded slices.
+    ///
+    /// A single `writeAll` of a large body hands everything to the
+    /// socket layer at once, so a client that disappears part-way
+    /// through is only noticed after the whole transfer has been
+    /// attempted. Slicing the write means a disconnect surfaces within
+    /// one chunk, and the host never queues an unbounded amount of a
+    /// guest's response at once (#616 A8).
+    ///
+    /// The wire bytes are identical: this only changes how many
+    /// `write` calls carry them.
+    fn writeHttpBodyChunked(
+        self: *WasiCliAdapter,
+        out: *streams.OutputStream,
+        body: []const u8,
+    ) !void {
+        var offset: usize = 0;
+        while (offset < body.len) {
+            const end = @min(offset + http_response_chunk_bytes, body.len);
+            try self.writeAllOutputStream(out, body[offset..end]);
+            offset = end;
         }
     }
 
@@ -20795,7 +20833,7 @@ pub const WasiCliAdapter = struct {
                 );
                 defer self.allocator.free(trailer);
                 try self.writeAllOutputStream(out, trailer);
-                try self.writeAllOutputStream(out, body);
+                try self.writeHttpBodyChunked(out, body);
             },
         }
     }
@@ -22432,6 +22470,27 @@ pub const WasiCliAdapter = struct {
     /// response (when the body length is unknown pre-write). Trailers
     /// supplied via the guest's `future<option<trailers>>` are lifted
     /// into the chunked trailer block. (#570 / #583 A5)
+    /// Settle a response's transmission future as failed (#616 A8).
+    ///
+    /// In `wasi:http@0.3` the response carries a transmission future
+    /// so the guest can learn whether its response actually reached
+    /// the client. Until now the inbound serve path never wrote to it:
+    /// a response abandoned mid-flight looked identical to one
+    /// delivered in full. Closing it without a ready payload gives the
+    /// guest the failure signal the WIT promises.
+    fn failHttpResponseTransmission(
+        self: *WasiCliAdapter,
+        ci: *ComponentInstance,
+        response_handle: u32,
+    ) void {
+        const response = self.lookupHttpResponseP3(response_handle) orelse return;
+        const tx = ci.futures.getPtr(response.transmission_future_handle) orelse return;
+        tx.state = .closed;
+        tx.write_closed = true;
+        if (tx.waitable_set) |ws| if (tx.read_waitable_idx) |idx|
+            ws.setReady(idx, self.allocator, executor_root.STATUS_STARTED_CANCELLED);
+    }
+
     pub fn writeHttpResponseP3FromHandle(
         self: *WasiCliAdapter,
         out: *streams.OutputStream,
@@ -22545,7 +22604,7 @@ pub const WasiCliAdapter = struct {
                 const size_line = try std.fmt.allocPrint(self.allocator, "{x}\r\n", .{body.len});
                 defer self.allocator.free(size_line);
                 try self.writeAllOutputStream(out, size_line);
-                try self.writeAllOutputStream(out, body);
+                try self.writeHttpBodyChunked(out, body);
                 try self.writeAllOutputStream(out, "\r\n");
             }
             try self.writeAllOutputStream(out, "0\r\n");
@@ -22571,7 +22630,7 @@ pub const WasiCliAdapter = struct {
             );
             defer self.allocator.free(trailer);
             try self.writeAllOutputStream(out, trailer);
-            try self.writeAllOutputStream(out, body);
+            try self.writeHttpBodyChunked(out, body);
         }
     }
 
@@ -22776,7 +22835,32 @@ pub const WasiCliAdapter = struct {
                 return;
             }
 
-            self.writeHttpResponseP3FromHandle(output, ci, outcome.payload, parsed.keep_alive) catch {};
+            // A client that hangs up mid-response is reported
+            // distinctly from a server-side I/O fault (#616 A8). There
+            // is nothing left to say on this connection and no basis
+            // for keeping it alive, so tear down rather than looping
+            // back to read a request that will never arrive.
+            var disconnected = false;
+            self.writeHttpResponseP3FromHandle(
+                output,
+                ci,
+                outcome.payload,
+                parsed.keep_alive,
+            ) catch |err| {
+                disconnected = err == error.HttpClientDisconnected;
+            };
+            if (disconnected) {
+                self.failHttpResponseTransmission(ci, outcome.payload);
+                // The handler has returned, but it may have left host
+                // operations running on this instance — an outbound
+                // fetch it never awaited, a timer, a socket read. With
+                // the client gone their results are unobservable, so
+                // release them instead of letting them run to
+                // completion.
+                cancelAllPendingAsyncOps(self, ci, null, self.allocator);
+                self.cleanupHttpResourcesAllVersions();
+                return;
+            }
 
             // Per-request resource tables are owned by the handler
             // dispatch — reset them so the next round-trip starts
@@ -26336,7 +26420,14 @@ fn serveOneHttpConnection(
         return;
     };
 
-    adapter.writeHttpResponseFromOutparam(&output, outparam_handle) catch {};
+    // P2 serves one request per connection, so a disconnect has no
+    // keep-alive to suppress — but the guest may still own host
+    // operations whose results can no longer be observed (#616 A8).
+    adapter.writeHttpResponseFromOutparam(&output, outparam_handle) catch |err| {
+        if (err == error.HttpClientDisconnected) {
+            WasiCliAdapter.cancelAllPendingAsyncOps(adapter, inst, null, adapter.allocator);
+        }
+    };
 }
 
 /// P3 (`@0.3.x`) variant of `serveOneHttpConnection`. Dispatches
@@ -42755,6 +42846,145 @@ test "wasi:http@0.3 (#570): writeHttpResponseP3FromHandle emits status line + he
     // One non-zero chunk + the terminating 0-chunk with no trailers.
     try testing.expect(std.mem.indexOf(u8, written, "\r\n4\r\nhey\n\r\n") != null);
     try testing.expect(std.mem.endsWith(u8, written, "0\r\n\r\n"));
+}
+
+test "wasi:http #616 A8: a client disconnect is reported distinctly from an I/O fault" {
+    // Before A8 the socket sinks folded every write failure into
+    // `.err = .io_error`, so a client hanging up mid-response was
+    // indistinguishable from a genuine server fault. Callers therefore
+    // could not decide whether to keep the connection alive, and every
+    // disconnect looked like a 500-class problem.
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+    var ci = p3HttpTestCi(testing.allocator);
+    defer p3HttpTestCiDeinit(&ci);
+
+    const fields = try testing.allocator.create(HttpFields);
+    fields.* = .{};
+    const fields_handle = try adapter.pushHttpFields(fields);
+
+    const body_handle = ci.allocAsyncHandle();
+    var body: async_mod.AsyncStream = .{ .elem_type_idx = 0 };
+    try body.buffer.appendSlice(testing.allocator, "hey\n");
+    body.write_closed = true;
+    try ci.streams.put(testing.allocator, body_handle, body);
+
+    const trailers_h = ci.allocAsyncHandle();
+    try ci.futures.put(testing.allocator, trailers_h, .{
+        .elem_type_idx = 0,
+        .state = .ready,
+        .write_closed = true,
+    });
+    const tx_h = ci.allocAsyncHandle();
+    try ci.futures.put(testing.allocator, tx_h, .{
+        .elem_type_idx = 0,
+        .state = .ready,
+        .write_closed = true,
+    });
+
+    const resp = try testing.allocator.create(HttpResponseP3);
+    resp.* = .{
+        .status = 200,
+        .headers_handle = fields_handle,
+        .body_stream_handle = body_handle,
+        .trailers_future_handle = trailers_h,
+        .transmission_future_handle = tx_h,
+    };
+    const resp_handle = try adapter.pushHttpResponseP3(resp);
+
+    // A `.closed` sink is exactly what a departed peer looks like from
+    // the writer's point of view.
+    var out: streams.OutputStream = .{ .sink = .closed };
+    try testing.expectError(
+        error.HttpClientDisconnected,
+        adapter.writeHttpResponseP3FromHandle(&out, &ci, resp_handle, true),
+    );
+
+    // And the guest learns that its response never landed.
+    adapter.failHttpResponseTransmission(&ci, resp_handle);
+    const tx = ci.futures.getPtr(tx_h).?;
+    try testing.expectEqual(async_mod.Future.State.closed, tx.state);
+    try testing.expect(tx.write_closed);
+}
+
+test "wasi:http #616 A8: the P2 response writer also reports disconnect distinctly" {
+    // Same guarantee on the Preview 2 path, which has its own writer.
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    const fields = try testing.allocator.create(HttpFields);
+    fields.* = .{};
+    const fields_handle = try adapter.pushHttpFields(fields);
+
+    const response = try testing.allocator.create(OutgoingResponse);
+    response.* = .{ .status = 200, .headers_handle = fields_handle };
+    const response_handle = try adapter.pushOutgoingResponse(response);
+
+    const outparam = try testing.allocator.create(ResponseOutparam);
+    outparam.* = .{ .state = .{ .response = response_handle } };
+    const outparam_handle = try adapter.pushResponseOutparam(outparam);
+
+    var out: streams.OutputStream = .{ .sink = .closed };
+    try testing.expectError(
+        error.HttpClientDisconnected,
+        adapter.writeHttpResponseFromOutparam(&out, outparam_handle),
+    );
+}
+
+test "wasi:http #616 A8: chunking a large body does not change the bytes on the wire" {
+    // The body is now written in bounded slices so a disconnect is
+    // caught within one chunk instead of after the whole transfer.
+    // That must be purely an issue of how many `write` calls carry the
+    // bytes — the bytes themselves, and the framing around them, are
+    // unchanged. This body is deliberately larger than the chunk size
+    // and not a multiple of it, so it exercises the final short slice.
+    const testing = std.testing;
+    var adapter = WasiCliAdapter.init(testing.allocator);
+    defer adapter.deinit();
+
+    const size = WasiCliAdapter.http_response_chunk_bytes * 2 + 12345;
+    const payload = try testing.allocator.alloc(u8, size);
+    defer testing.allocator.free(payload);
+    for (payload, 0..) |*b, i| b.* = @truncate(i * 31 + 7);
+
+    var chunked = streams.OutputStream.toBuffer();
+    defer chunked.deinit(testing.allocator);
+    try adapter.writeHttpBodyChunked(&chunked, payload);
+    try testing.expectEqualSlices(u8, payload, chunked.getBufferContents());
+
+    // An empty body must emit nothing at all rather than a stray
+    // zero-length write.
+    var empty = streams.OutputStream.toBuffer();
+    defer empty.deinit(testing.allocator);
+    try adapter.writeHttpBodyChunked(&empty, "");
+    try testing.expectEqual(@as(usize, 0), empty.getBufferContents().len);
+
+    // A departed peer is reported from the very first slice.
+    var closed: streams.OutputStream = .{ .sink = .closed };
+    try testing.expectError(
+        error.HttpClientDisconnected,
+        adapter.writeHttpBodyChunked(&closed, payload),
+    );
+}
+
+test "wasi:http #616 A8: peer-teardown errors classify as disconnect, faults do not" {
+    const testing = std.testing;
+    // The socket sinks route writes through this predicate, so a
+    // misclassification here would either mask real I/O faults as
+    // clean hangups or resurrect the old behaviour of treating every
+    // hangup as a server error.
+    try testing.expect(streams.isPeerDisconnectError(error.ConnectionResetByPeer));
+    try testing.expect(streams.isPeerDisconnectError(error.SocketUnconnected));
+    try testing.expect(streams.isPeerDisconnectError(error.BrokenPipe));
+    try testing.expect(streams.isPeerDisconnectError(error.NotOpenForWriting));
+    try testing.expect(streams.isPeerDisconnectError(error.EndOfStream));
+
+    try testing.expect(!streams.isPeerDisconnectError(error.SystemResources));
+    try testing.expect(!streams.isPeerDisconnectError(error.NetworkDown));
+    try testing.expect(!streams.isPeerDisconnectError(error.AccessDenied));
+    try testing.expect(!streams.isPeerDisconnectError(error.OutOfMemory));
 }
 
 test "wasi:http@0.3 (#570): writeHttpResponseP3FromHandle handles 404 + empty body" {

--- a/src/wasi/preview2/streams.zig
+++ b/src/wasi/preview2/streams.zig
@@ -140,6 +140,28 @@ pub const InputStream = struct {
 // ── wasi:io/streams — output-stream ─────────────────────────────────────────
 
 /// An output stream resource — a writable byte sink.
+/// True for the errors a socket write produces when the peer has gone
+/// away, as opposed to a genuine I/O fault (#616 A8).
+///
+/// Taken through `anyerror` deliberately: the TLS connection's write
+/// path has an inferred error set that varies with the underlying
+/// stream type, so naming the variants directly there would not
+/// compile. Every name below is a real socket-teardown condition:
+/// `netWrite` maps ECONNRESET to `ConnectionResetByPeer` and both
+/// EPIPE and ENOTCONN to `SocketUnconnected`, while `BrokenPipe` and
+/// `EndOfStream` can surface from file-like and TLS record paths.
+pub fn isPeerDisconnectError(err: anyerror) bool {
+    return switch (err) {
+        error.ConnectionResetByPeer,
+        error.SocketUnconnected,
+        error.BrokenPipe,
+        error.NotOpenForWriting,
+        error.EndOfStream,
+        => true,
+        else => false,
+    };
+}
+
 pub const OutputStream = struct {
     sink: Sink,
 
@@ -219,15 +241,33 @@ pub const OutputStream = struct {
                 if (data.len == 0) return .{ .ok = 0 };
                 const io = std.Io.Threaded.global_single_threaded.io();
                 const slices = [_][]const u8{data};
-                _ = io.vtable.netWrite(io.userdata, fd, &.{}, &slices, 1) catch
-                    return .{ .err = .io_error };
+                _ = io.vtable.netWrite(io.userdata, fd, &.{}, &slices, 1) catch |err| return switch (err) {
+                    // The peer went away. This is not an I/O fault: it
+                    // is the ordinary way a client abandons a request,
+                    // and callers must be able to tell the two apart so
+                    // they can stop writing and drop keep-alive rather
+                    // than reporting a server error (#616 A8).
+                    //
+                    // `netWrite` maps ECONNRESET to `ConnectionResetByPeer`
+                    // and both EPIPE and ENOTCONN to `SocketUnconnected`.
+                    error.ConnectionResetByPeer,
+                    error.SocketUnconnected,
+                    => .{ .closed = {} },
+                    else => .{ .err = .io_error },
+                };
                 return .{ .ok = data.len };
             },
             .tls => |conn| {
-                // `writeAll` encrypts `data` into one or more TLS records and
-                // flushes them to the underlying socket. Any failure (record
-                // overflow, socket error) maps to `.io_error`.
-                conn.writeAll(data) catch return .{ .err = .io_error };
+                // `writeAll` encrypts `data` into one or more TLS records
+                // and flushes them to the underlying socket. A peer that
+                // disappears mid-response surfaces here as the same
+                // socket-level errors as the plain path, so it must reach
+                // callers as `.closed` too (#616 A8); anything else is a
+                // genuine fault (record overflow, encryption failure).
+                conn.writeAll(data) catch |err| return if (isPeerDisconnectError(err))
+                    .{ .closed = {} }
+                else
+                    .{ .err = .io_error };
                 return .{ .ok = data.len };
             },
             .closed => return .{ .closed = {} },


### PR DESCRIPTION
Implements the disconnect-detection and bounded-transmission half of **A8** in the #616 WASI hardening cycle.

## The problem

`streams.OutputStream`'s `tcp_stream` and `tls` sinks mapped **every** write failure to `.err = .io_error`:

```zig
_ = io.vtable.netWrite(io.userdata, fd, &.{}, &slices, 1) catch
    return .{ .err = .io_error };
```

So a client hanging up mid-response was indistinguishable from a genuine server fault. Both serve loops then discarded the error entirely — `writeHttpResponseP3FromHandle(...) catch {}` — with four consequences:

1. The P3 keep-alive loop went back to read another request that would never arrive.
2. Keep-alive was not dropped on a connection that no longer existed.
3. Host operations the guest still owned (an outbound fetch it never awaited, a timer, a socket read) kept running for a result nobody could observe.
4. The response's transmission future was **never written on the inbound path at all**, so a response abandoned mid-flight looked exactly like one delivered in full.

## The fix

**Classify peer teardown.** ECONNRESET, and EPIPE/ENOTCONN — which `netWrite` reports as `SocketUnconnected` — now yield `.closed` rather than `.err`, which `writeAllOutputStream` turns into `error.HttpClientDisconnected`. Genuine faults still produce `error.IoError`.

The TLS sink routes through the same `isPeerDisconnectError` predicate taken over `anyerror`. That indirection is deliberate: the TLS connection's write path has an **inferred** error set that varies with the underlying stream type, so naming the variants directly there does not compile.

**Bound transmission.** Response bodies go to the socket in 64 KiB slices. A single `writeAll` hands everything to the socket layer at once, so a departed client is only noticed after the whole transfer has been attempted; slicing bounds detection to one chunk and bounds how much of a single guest response the host can queue. 64 KiB matches the outbound body-chunk size and comfortably exceeds a TLS record, so it costs no extra syscalls in the common case. **The bytes on the wire and their framing are unchanged** — only the number of `write` calls differs, and there is a test asserting exactly that.

**Act on it.** On disconnect: tear the connection down rather than keeping it alive, cancel the instance's pending host async operations, and (P3) close the response's transmission future without a ready payload so the guest learns the response did not land.

## Scope note

The remaining part of A8's scope statement — streaming the guest's body to the socket *concurrently with guest execution*, rather than after the handler returns — is not addressed here. Today the guest fills its `stream<u8>` completely before the handler returns, so the body is already fully materialised in `ci.streams[handle].buffer` by the time the writer runs. Interleaving those would mean driving guest execution and socket writes together, which is a much deeper change to the dispatch model and belongs in its own PR. Everything in this one is independently correct and independently valuable.

## Verification

- `zig build test` — **2245 passed, 11 skipped, 0 failed**
- `zig build wasi-p3-testsuite` — **41/41**, including `http-service`, which exercises the serve and keep-alive paths end to end
- Four new tests: P3 writer reports disconnect distinctly and the transmission future is closed; P2 writer likewise; a >2-chunk body round-trips byte-identically while an empty body emits nothing and a closed peer is caught on the first slice; and the error-classification predicate accepts the five teardown conditions while rejecting `SystemResources`, `NetworkDown`, `AccessDenied` and `OutOfMemory`.

The `.closed` sink variant turns out to be an exact simulator for a departed peer, so these tests need no socket.

Docs: new "Client-disconnect handling on the serve path (A8)" section in `docs/wasi.md`.

Refs #616