### PR TITLE
fix(interp): make atomic.fence a real barrier (#616 B1.3)

### DIFF
--- a/docs/design/wasi-threads.md
+++ b/docs/design/wasi-threads.md
@@ -1,7 +1,7 @@
 # `wasi:threads` design — multi-threaded interpreter state isolation
 
-Status: **DRAFT** (shared-memory/parking foundation implemented; opcode
-atomicity and production spawning remain incomplete).
+Status: **DRAFT** (shared-memory/parking foundation and atomic opcode
+semantics implemented; production spawning remains incomplete).
 
 Tracking: [#616 B1.3](https://github.com/cataggar/wamr/issues/616).
 
@@ -83,10 +83,18 @@ memory uses NT reserve/commit. These APIs are intentionally independent of
 opcode lowering so the remaining atomic load/store/RMW audit can use them.
 
 The remaining production work follows the ordered plan below: make all
-shared runtime and host resources safe; complete atomic opcode and fence
-behavior; spawn in both interpreter and AOT modes; isolate cancellation and
-per-thread component/WASI context; and pass the end-to-end correctness,
-conformance, and performance gates.
+shared runtime and host resources safe; spawn in both interpreter and AOT
+modes; isolate cancellation and per-thread component/WASI context; and pass
+the end-to-end correctness, conformance, and performance gates.
+
+Atomic opcode and fence behavior is complete on both execution tiers.
+Interpreted atomic loads, stores, RMW and `cmpxchg` are `seq_cst`, bounds-
+and alignment-checked; `wait`/`notify` use the monotonic parking lot; and
+`atomic.fence` emits a real barrier through `platform.memoryFenceSeqCst`
+rather than the no-op it used to be. That last point matters because the AOT
+backends have always emitted `MFENCE` / `DMB ISH` for the same instruction,
+so a no-op in the interpreter was a tier-dependent memory model — the kind of
+divergence that only surfaces as a rare race once threads actually run.
 
 ## Upstream state
 
@@ -324,11 +332,15 @@ already targets.
   thread's `ModuleInstance.memories[]` slot. All `i32.load` /
   `i32.store` already operate on the shared bytes; `i32.atomic.*` etc.
   add the synchronisation. The core-wasm `threads` proposal
-  (atomic loads/stores/RMW/`wait`/`notify`) is already partly wired in
-  `interp.zig:3349` (`atomic_prefix`) — `atomic.fence` is a no-op
-  ("Fence is a no-op for single-threaded execution.") and most RMW
-  opcodes are implemented as **non-atomic** sequences. **This is the
-  single biggest correctness gap to close before Option B is real.**
+  (atomic loads/stores/RMW/`wait`/`notify`) is wired up in
+  `interp.zig` (`atomic_prefix`): loads, stores, RMW and `cmpxchg` all
+  lower to genuine `seq_cst` Zig atomics, `wait`/`notify` go through
+  the [`parking_lot`](../../src/platform/parking_lot.zig) with
+  monotonic deadlines and cancellation wakeups, and `atomic.fence`
+  issues a real barrier via `platform.memoryFenceSeqCst` (`MFENCE` on
+  x86-64, `DMB ISH` on AArch64) — the same instruction the AOT
+  backends emit for the `atomic_fence` IR op. Bounds and alignment are
+  checked on every atomic access.
 * **Globals:** Cloned per thread via `cloneForThread` (today's
   behaviour). When `shared-everything-threads` lands, `shared` globals
   will need atomic access; for now, the Preview-1 model (mutable

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -468,6 +468,47 @@ fn usleepPosix(us: u64) void {
     _ = std.posix.system.nanosleep(&ts, null);
 }
 
+/// Sequentially-consistent full memory barrier.
+///
+/// This is the host-side counterpart of the WebAssembly `atomic.fence`
+/// instruction. It must order *all* prior loads and stores against *all*
+/// subsequent loads and stores, in both the compiler and the hardware.
+///
+/// The emitted instruction deliberately matches what the AOT backends emit
+/// for the `atomic_fence` IR op (`MFENCE` on x86_64, `DMB ISH` on AArch64),
+/// so interpreted and compiled code observe the same memory model. Anything
+/// weaker here would let the interpreter reorder across a fence that AOT
+/// honours, which is exactly the kind of divergence that only shows up as a
+/// rare data race under load.
+///
+/// `@fence` no longer exists as a builtin, so architectures without an
+/// explicit case fall back to a sequentially-consistent read-modify-write on
+/// a dedicated global. A seq-cst RMW carries full fence semantics and cannot
+/// be elided by the optimiser, which makes it a correct (if slightly heavier)
+/// portable lowering.
+pub fn memoryFenceSeqCst() void {
+    switch (builtin.cpu.arch) {
+        .x86_64, .x86 => asm volatile ("mfence" ::: .{ .memory = true }),
+        .aarch64, .aarch64_be => asm volatile ("dmb ish" ::: .{ .memory = true }),
+        else => {
+            if (builtin.single_threaded) {
+                // No other agent can observe memory, so there is nothing to
+                // order. Single-threaded semantics are preserved by the
+                // compiler regardless of how it schedules the surrounding
+                // accesses. Deliberately avoids inline asm so this branch
+                // also compiles for wasm hosts.
+                return;
+            }
+            _ = @atomicRmw(u32, &portable_fence_slot, .Or, 0, .seq_cst);
+        },
+    }
+}
+
+/// Backing location for the portable `memoryFenceSeqCst` lowering. It is only
+/// ever the target of a no-op `or 0`, so its value is always zero; it exists
+/// solely to give the RMW a real, non-escaping-analysable address.
+var portable_fence_slot: u32 = 0;
+
 // ── 3. Time ─────────────────────────────────────────────────────────────
 
 /// Monotonic time since boot in microseconds.
@@ -823,4 +864,92 @@ test "timeGetBootUs returns increasing values" {
     usleep(1_000); // 1 ms
     const t2 = timeGetBootUs();
     try std.testing.expect(t2 > t1);
+}
+
+test "memoryFenceSeqCst is callable and orders a store-buffer litmus test" {
+    memoryFenceSeqCst();
+    if (builtin.single_threaded) return error.SkipZigTest;
+
+    // Classic store-buffer (Dekker) litmus test. Each round, one thread does
+    // `x = 1; fence; read y` while the other does `y = 1; fence; read x`.
+    //
+    // Relaxed atomics are used for the shared accesses precisely because they
+    // forbid *compiler* reordering while still permitting *hardware*
+    // StoreLoad reordering. That isolates the barrier: the only thing that
+    // can stop both threads reading 0 is the fence itself. On x86-64's TSO
+    // model StoreLoad is the single reordering allowed, so a no-op fence
+    // fails this test in practice rather than only in theory.
+    const Shared = struct {
+        x: u32 = 0,
+        y: u32 = 0,
+        r1: u32 = 0,
+        r2: u32 = 0,
+        /// Monotonically increasing arrival counter. Round `k` (0-based)
+        /// releases once it reaches `2 * (k + 1)`. Making it monotonic
+        /// removes any reset race, and — more importantly — lets *both*
+        /// threads spin on the same value so they resume together. An
+        /// asymmetric barrier that releases one side early would mostly
+        /// serialise the two threads and hide the reordering being tested.
+        arrived: u32 = 0,
+        violations: u32 = 0,
+
+        const Self = @This();
+        const rounds: u32 = 20_000;
+
+        /// Wait until both threads have reached round `round`.
+        fn barrier(self: *Self, round: u32) void {
+            _ = @atomicRmw(u32, &self.arrived, .Add, 1, .acq_rel);
+            const release_at = 2 * (round + 1);
+            var spins: u32 = 0;
+            while (@atomicLoad(u32, &self.arrived, .acquire) < release_at) {
+                // Spin first — the whole point is to release both threads
+                // within a few nanoseconds of each other. But an unbounded
+                // spin would livelock on a single-core runner, where the
+                // waiting thread has to be descheduled before the other can
+                // make progress, so fall back to yielding.
+                spins += 1;
+                if (spins < 512) {
+                    std.atomic.spinLoopHint();
+                } else {
+                    std.Thread.yield() catch std.atomic.spinLoopHint();
+                }
+            }
+        }
+
+        fn threadA(self: *Self) void {
+            var round: u32 = 0;
+            while (round < rounds) : (round += 1) {
+                self.barrier(2 * round);
+                @atomicStore(u32, &self.x, 1, .monotonic);
+                memoryFenceSeqCst();
+                self.r1 = @atomicLoad(u32, &self.y, .monotonic);
+                self.barrier(2 * round + 1);
+                // Both threads are past their loads, so this is the only
+                // point at which r1/r2 may be compared, and only one thread
+                // does the comparison and the reset.
+                if (self.r1 == 0 and self.r2 == 0) self.violations += 1;
+                @atomicStore(u32, &self.x, 0, .monotonic);
+                @atomicStore(u32, &self.y, 0, .monotonic);
+            }
+        }
+
+        fn threadB(self: *Self) void {
+            var round: u32 = 0;
+            while (round < rounds) : (round += 1) {
+                self.barrier(2 * round);
+                @atomicStore(u32, &self.y, 1, .monotonic);
+                memoryFenceSeqCst();
+                self.r2 = @atomicLoad(u32, &self.x, .monotonic);
+                self.barrier(2 * round + 1);
+            }
+        }
+    };
+
+    var shared = Shared{};
+    const a = try std.Thread.spawn(.{}, Shared.threadA, .{&shared});
+    const b = try std.Thread.spawn(.{}, Shared.threadB, .{&shared});
+    a.join();
+    b.join();
+
+    try std.testing.expectEqual(@as(u32, 0), shared.violations);
 }

--- a/src/runtime/interpreter/interp.zig
+++ b/src/runtime/interpreter/interp.zig
@@ -65,6 +65,7 @@ inline fn wasmNearestF64(x: f64) f64 {
 const Opcode = @import("opcode.zig").Opcode;
 const simd = @import("simd.zig");
 const leb128 = @import("../../shared/utils/leb128.zig");
+const platform = @import("../../platform/platform.zig");
 
 pub const TrapError = error{
     OutOfFuel,
@@ -3354,8 +3355,12 @@ fn dispatchLoopWithFuel(env: *ExecEnv, code: []const u8, tail_call_target: *u32,
                 switch (sub_op) {
                     0x03 => { // atomic.fence
                         _ = readU32(code, &ip); // reserved byte (must be 0)
-                        // Fence is a no-op for single-threaded execution.
-                        // When multi-threading is implemented, use a proper barrier.
+                        // A sequentially-consistent barrier, matching the
+                        // MFENCE / DMB ISH that the AOT backends emit for the
+                        // `atomic_fence` IR op. The interpreter shares linear
+                        // memory with `wasi:threads` workers, so this must be
+                        // a real barrier and not a no-op.
+                        platform.memoryFenceSeqCst();
                     },
                     // atomic loads
                     0x10 => try atomicLoad(env, code, &ip, u32, u32, 4),   // i32.atomic.load
@@ -4916,8 +4921,14 @@ test "interp: i32.atomic.rmw.cmpxchg success" {
     try testing.expectEqual(@as(i32, 10), result);
 }
 
-test "interp: atomic.fence is a no-op" {
-    // fence then return constant — no memory needed
+test "interp: atomic.fence executes a real barrier and does not disturb the stack" {
+    // The fence has no value-level effect, so what this pins down is that it
+    // decodes its reserved byte correctly and leaves the operand stack alone.
+    // The barrier itself is exercised by the store-buffer litmus test on
+    // `platform.memoryFenceSeqCst`, which is what this opcode now lowers to
+    // (previously it was a no-op, diverging from the MFENCE / DMB ISH that
+    // the AOT backends emit for the same instruction).
+    //
     // 77 in signed LEB128 = 0xCD 0x00 (two bytes, since 77 > 63)
     const result = try runCode(&.{
         0xFE, 0x03, 0x00, // atomic.fence reserved=0
@@ -4925,6 +4936,21 @@ test "interp: atomic.fence is a no-op" {
         0x0B,
     });
     try testing.expectEqual(@as(i32, 77), result);
+}
+
+test "interp: atomic.fence orders surrounding atomic memory accesses" {
+    // Store, fence, load-back through the same address. The fence must not
+    // swallow or reorder the store it separates from the load.
+    const result = try runCodeWithMem(&.{
+        0x41, 0x00, // i32.const 0 (addr)
+        0x41, 42, // i32.const 42
+        0xFE, 0x17, 0x02, 0x00, // i32.atomic.store align=2 offset=0
+        0xFE, 0x03, 0x00, // atomic.fence reserved=0
+        0x41, 0x00, // i32.const 0 (addr)
+        0xFE, 0x10, 0x02, 0x00, // i32.atomic.load align=2 offset=0
+        0x0B,
+    });
+    try testing.expectEqual(@as(i32, 42), result);
 }
 
 test "interp: i32.load8_s with 0xFF" {


### PR DESCRIPTION
Part of #616 (B1.3 — atomic opcode and fence behavior).

## The bug

The interpreter decoded `atomic.fence`, discarded the reserved byte, and did nothing:

```zig
0x03 => { // atomic.fence
    _ = readU32(code, &ip); // reserved byte (must be 0)
    // Fence is a no-op for single-threaded execution.
    // When multi-threading is implemented, use a proper barrier.
},
```

That premise no longer holds. The interpreter already executes `memory.atomic.wait32/64` and `memory.atomic.notify` against shared linear memory via `platform/parking_lot.zig`, and every other atomic opcode (`load` / `store` / `rmw` / `cmpxchg`) already lowers to a genuine `seq_cst` operation.

More importantly, **both AOT backends have always emitted a real barrier for the same instruction** — `MFENCE` on x86_64 (`codegen/x86_64/compile.zig`) and `DMB ISH` on AArch64 (`codegen/aarch64/compile.zig`). The memory model a guest observed therefore depended on which execution tier it happened to run on. That is the kind of divergence that never reproduces on demand and instead shows up as a rare data race under load.

## The fix

Add `platform.memoryFenceSeqCst()`, emitting exactly the instruction the corresponding AOT backend emits, and lower the interpreter's `atomic.fence` to it.

`@fence` no longer exists as a builtin in this Zig, so:

- **x86_64 / x86** → `mfence`
- **aarch64 / aarch64_be** → `dmb ish`
- **single-threaded** → returns immediately, and deliberately avoids inline asm so the branch also compiles for wasm hosts
- **anything else** → a `seq_cst` read-modify-write, which carries full fence semantics and cannot be elided by the optimiser

## Verifying the barrier actually works

A memory barrier is easy to "test" without testing anything, so this ships a store-buffer (Dekker) litmus test rather than a smoke test.

Each round, one thread runs `x = 1; fence; read y` while the other runs `y = 1; fence; read x`. Both reading `0` is impossible unless the store was reordered past the load. The shared accesses use **relaxed** atomics on purpose: relaxed forbids *compiler* reordering while still permitting the *hardware* StoreLoad reordering under test, so the fence is the only thing that can make the test pass.

Two details that matter for it to have teeth:

- The barrier between rounds is a **monotonic counter both threads spin on**, so they resume together. An asymmetric barrier releases one side early, serialises the threads, and hides the reordering — the first version of this test used a sense-reversing barrier and detected only 2 violations per run instead of 150-300.
- It falls back to `Thread.yield()` after a bounded spin so it cannot livelock on a single-core runner.

Evidence it is a real regression detector, on this x86-64 host:

| build | result |
|---|---|
| barrier replaced with an empty `asm volatile ("" ::: memory)` | **fails**, 153 / 294 / 199 violations across three runs |
| real barrier | passes, 5/5 runs |
| real barrier, `taskset -c 0` (single core) | passes |

## Also in this change

- Replaces the interpreter test literally named `"interp: atomic.fence is a no-op"`, which asserted the old behaviour, with two tests covering stack discipline and ordering around atomic accesses.
- Corrects `docs/design/wasi-threads.md`, which still described fences as no-ops and most RMW opcodes as "implemented as **non-atomic** sequences" and called that "the single biggest correctness gap". Both claims were stale — the RMW opcodes are already `seq_cst`, and with this change the fence is too.

## Testing

- `zig build test` → **2247 passed / 11 skipped / 0 failed** (both test targets green)
- `zig build wasi-p3-testsuite` → 41/41
- `-Dtarget=wasm32-freestanding` was checked; it fails identically with and without this change (8 pre-existing errors inside Zig's own `std/Io/Threaded.zig` and `std/posix.zig`), so the wasm-safe fallback branch is not the cause.