### PR TITLE
fix(wasi): restore wasm32 host build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,14 +115,13 @@ jobs:
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
 
       - name: Build for wasm32-wasi
-        continue-on-error: true
         run: zig build -Doptimize=ReleaseSafe -Dtarget=wasm32-wasi -Dstrip=true
 
       - name: Run wamr via wasmtime
         run: |
           wasmtime --version
-          # Smoke test: run the wasm binary with --help or similar
-          wasmtime zig-out/bin/wamr.wasm -- --version || echo "wamr.wasm executed (exit code: $?)"
+          test "$(wasmtime zig-out/bin/wamr.wasm -- --version)" = "wamr dev"
+          test "$(wasmtime --dir . zig-out/bin/wamr.wasm -- run tests/coldstart/hello_stdout.wasm)" = "hello from jit"
 
   wasi-testsuite:
     name: Build & Test (wasi-testsuite)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: [self-hosted, Linux, X64]
+          - os: ubuntu-22.04
             name: linux-x64
             shell: bash
-          - os: [self-hosted, Linux, ARM64]
+          - os: ubuntu-24.04-arm
             name: linux-arm64
             shell: bash
           - os: windows-latest
@@ -259,7 +259,7 @@ jobs:
 
   wasi-p3-testsuite-arm64:
     name: Build & Test (wasi-p3-testsuite-arm64)
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     # The AArch64 counterpart of the `wasi-p3-testsuite` job above, which
     # runs on x86_64 only. That single-architecture coverage is what let
@@ -372,9 +372,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: [self-hosted, Linux, X64]
+          - os: ubuntu-22.04
             name: linux-x64
-          - os: [self-hosted, Linux, ARM64]
+          - os: ubuntu-24.04-arm
             name: linux-arm64
     # Keep this focused on the unit/regression tests that exercise the
     # lazy-JIT implementation. The full in-process JIT conformance suites

--- a/.github/workflows/coldstart-aarch64.yml
+++ b/.github/workflows/coldstart-aarch64.yml
@@ -1,6 +1,6 @@
 name: Cold-start (aarch64)
 
-# Per-PR cold-start latency comparison on the self-hosted aarch64 runner.
+# Per-PR cold-start latency comparison on a hosted aarch64 runner.
 # Runs `scripts/bench_coldstart.py` against the PR base, posts a sticky
 # delta table, and fails the job if the wamr CLI's median cold-start time
 # regresses by more than --regression-ratio (default 1.5×).
@@ -17,9 +17,8 @@ name: Cold-start (aarch64)
 #   wasmtime `.cwasm`        ~40 ms
 #   wasmtime `.wasm` (JIT)   ~44 ms
 #
-# Pinned to the self-hosted ARM64 runner: GitHub-hosted x86 noise easily
-# exceeds the ~1 ms wamr signal. Hosted runners are unsuitable for this
-# gate.
+# Keep the benchmark on ARM64 and measure both refs in the same hosted job.
+# The 1.5x regression threshold absorbs host variance around the ~1 ms signal.
 
 on:
   workflow_dispatch:
@@ -58,13 +57,8 @@ on:
       - .github/workflows/coldstart-aarch64.yml
 
 concurrency:
-  # Per-ref so successive pushes to the *same* PR cancel earlier runs,
-  # but unrelated PRs queue at the self-hosted runner instead of
-  # silently cancelling each other (a global group key here would make
-  # every new PR discard the previous PR's still-queued run, surfacing
-  # as a `cancelled` ✗ check). The single-slot self-hosted aarch64
-  # runner already serialises cross-PR runs, avoiding the core
-  # contention the author originally guarded against.
+  # Per-ref so successive pushes to the same PR cancel earlier runs while
+  # unrelated hosted-runner comparisons can proceed independently.
   group: coldstart-aarch64-${{ github.ref }}
   cancel-in-progress: true
 
@@ -74,7 +68,7 @@ permissions:
 
 jobs:
   coldstart:
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/coremark-aarch64.yml
+++ b/.github/workflows/coremark-aarch64.yml
@@ -1,6 +1,6 @@
 name: CoreMark (aarch64)
 
-# Per-PR CoreMark comparison on the self-hosted aarch64 runner.
+# Per-PR CoreMark comparison on a hosted aarch64 runner.
 # Runs `scripts/bench_coremark.py` against the PR base, posts a delta table.
 
 on:
@@ -27,8 +27,7 @@ on:
       - .github/workflows/coremark-aarch64.yml
 
 concurrency:
-  # Serialize on the self-hosted runner: parallel CoreMark invocations would
-  # contend on cores and skew results.
+  # Keep one canonical ARM64 comparison active at a time.
   group: coremark-aarch64
   cancel-in-progress: true
 
@@ -38,7 +37,7 @@ permissions:
 
 jobs:
   coremark:
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ Cross-compilation works out of the box:
 $ zig build -Dtarget=aarch64-linux -Doptimize=ReleaseSafe
 $ zig build -Dtarget=aarch64-macos -Doptimize=ReleaseSafe
 $ zig build -Dtarget=x86_64-windows -Doptimize=ReleaseSafe
+$ zig build -Dtarget=wasm32-wasi -Doptimize=ReleaseSafe
 ```
+
+The `wasm32-wasi` target produces an interpreter-only `wamr.wasm` that can
+run core WebAssembly modules inside a WASI runtime such as Wasmtime. Native
+AOT/JIT execution, `wamrc`, Component Model execution, `serve`, shared
+memory, and host threads are intentionally excluded from this target.
 
 ## Running tests
 

--- a/build.zig
+++ b/build.zig
@@ -23,6 +23,8 @@ pub fn build(b: *std.Build) void {
     // these arches so cross-compiled release builds for e.g. riscv64 don't
     // try to compile or run the AOT execution path.
     const target_arch = target.result.cpu.arch;
+    const is_wasm_wasi_host = target.result.os.tag == .wasi and
+        (target_arch == .wasm32 or target_arch == .wasm64);
     const aot_executable_target = switch (target_arch) {
         .x86_64, .aarch64 => true,
         else => false,
@@ -56,7 +58,7 @@ pub fn build(b: *std.Build) void {
     const interp = b.option(bool, "interp", "Enable interpreter") orelse true;
     options.addOption(bool, "interp", interp);
 
-    const aot = b.option(bool, "aot", "Enable AOT support") orelse true;
+    const aot = b.option(bool, "aot", "Enable AOT support") orelse !is_wasm_wasi_host;
     options.addOption(bool, "aot", aot);
 
     const fast_interp = b.option(bool, "fast_interp", "Enable fast interpreter") orelse true;
@@ -141,6 +143,19 @@ pub fn build(b: *std.Build) void {
     const component_model = b.option(bool, "component_model", "Enable Component Model") orelse false;
     options.addOption(bool, "component_model", component_model);
 
+    if (is_wasm_wasi_host) {
+        if (!interp)
+            std.debug.panic("wasm32-wasi host builds require the interpreter", .{});
+        if (aot)
+            std.debug.panic("wasm32-wasi host builds do not support the native AOT runtime", .{});
+        if (jit or fast_jit or wamr_compiler)
+            std.debug.panic("wasm32-wasi host builds do not support native code generation", .{});
+        if (component_model)
+            std.debug.panic("wasm32-wasi host builds do not support Component Model execution", .{});
+        if (lib_pthread or lib_wasi_threads or thread_mgr or shared_memory)
+            std.debug.panic("wasm32-wasi host builds do not support host threads or shared memory", .{});
+    }
+
     const threads_inputs = threads_feature.Inputs{
         .enabled = lib_wasi_threads,
         .pointer_bits = target.result.ptrBitWidth(),
@@ -184,6 +199,31 @@ pub fn build(b: *std.Build) void {
     ) orelse true;
 
     const config_module = options.createModule();
+
+    // A WebAssembly host cannot execute the native code produced by WAMR's
+    // AOT backends. Build a deliberately reduced, interpreter-only CLI and
+    // keep native-only dependencies out of the module graph entirely.
+    if (is_wasm_wasi_host) {
+        const wasm_host_module = b.createModule(.{
+            .root_source_file = b.path("src/main_wasm_host.zig"),
+            .target = target,
+            .optimize = optimize,
+            .strip = if (strip) true else null,
+            .stack_protector = if (stack_protector) true else null,
+            .link_libc = if (link_libc) true else null,
+        });
+        wasm_host_module.addImport("config", config_module);
+
+        const wasm_host_exe = b.addExecutable(.{
+            .name = "wamr-exe",
+            .root_module = wasm_host_module,
+        });
+        const install_wasm_host = b.addInstallArtifact(wasm_host_exe, .{
+            .dest_sub_path = b.fmt("wamr{s}", .{target.result.exeFileExt()}),
+        });
+        b.getInstallStep().dependOn(&install_wasm_host.step);
+        return;
+    }
 
     const stable_resources_test_step = b.step(
         "test-stable-resources",

--- a/src/main_wasm_host.zig
+++ b/src/main_wasm_host.zig
@@ -1,0 +1,300 @@
+const std = @import("std");
+const build_config = @import("config");
+const types = @import("runtime/common/types.zig");
+const loader = @import("runtime/interpreter/loader.zig");
+const instance = @import("runtime/interpreter/instance.zig");
+const interp = @import("runtime/interpreter/interp.zig");
+const ExecEnv = @import("runtime/common/exec_env.zig").ExecEnv;
+const WasiCtx = @import("wasi/wasi.zig").WasiCtx;
+
+const default_stack_size: u32 = 64 * 1024;
+
+const MapDir = struct {
+    host_path: []const u8,
+    guest_name: []const u8,
+};
+
+pub fn main(init: std.process.Init) !u8 {
+    const allocator = init.gpa;
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    const cli_args = if (args.len > 1 and std.mem.eql(u8, args[1], "--"))
+        args[2..]
+    else
+        args[1..];
+
+    if (cli_args.len == 0) {
+        std.debug.print("error: missing subcommand - try `wamr help`\n", .{});
+        return 2;
+    }
+    if (std.mem.eql(u8, cli_args[0], "--version") or std.mem.eql(u8, cli_args[0], "version")) {
+        if (cli_args.len != 1) {
+            std.debug.print("error: version takes no arguments\n", .{});
+            return 2;
+        }
+        writeStdout(init.io, "wamr " ++ build_config.version ++ "\n");
+        return 0;
+    }
+    if (std.mem.eql(u8, cli_args[0], "help")) {
+        writeStdout(init.io, top_usage);
+        return 0;
+    }
+    if (std.mem.eql(u8, cli_args[0], "run")) {
+        return runCore(init, allocator, cli_args[1..]);
+    }
+
+    std.debug.print(
+        "error: unsupported subcommand '{s}' in the wasm32-wasi interpreter build\n",
+        .{cli_args[0]},
+    );
+    return 2;
+}
+
+fn runCore(
+    init: std.process.Init,
+    allocator: std.mem.Allocator,
+    run_args: []const []const u8,
+) !u8 {
+    if (run_args.len == 1 and std.mem.eql(u8, run_args[0], "help")) {
+        writeStdout(init.io, run_usage);
+        return 0;
+    }
+
+    var stack_size = default_stack_size;
+    var wasm_path: ?[]const u8 = null;
+    var wasm_args: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer wasm_args.deinit(allocator);
+    var env_flags: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer env_flags.deinit(allocator);
+    var map_dirs: std.ArrayListUnmanaged(MapDir) = .empty;
+    defer map_dirs.deinit(allocator);
+    var past_options = false;
+
+    var i: usize = 0;
+    while (i < run_args.len) : (i += 1) {
+        const arg = run_args[i];
+        if (!past_options and arg.len > 0 and arg[0] == '-') {
+            if (std.mem.eql(u8, arg, "--")) {
+                past_options = true;
+            } else if (std.mem.startsWith(u8, arg, "--stack-size=")) {
+                const value = arg["--stack-size=".len..];
+                stack_size = std.fmt.parseInt(u32, value, 10) catch {
+                    std.debug.print("error: invalid --stack-size value '{s}'\n", .{value});
+                    return 2;
+                };
+                if (stack_size == 0) {
+                    std.debug.print("error: --stack-size must be greater than zero\n", .{});
+                    return 2;
+                }
+            } else if (std.mem.eql(u8, arg, "--env") or std.mem.startsWith(u8, arg, "--env=")) {
+                const spec = if (std.mem.eql(u8, arg, "--env")) blk: {
+                    i += 1;
+                    if (i >= run_args.len) {
+                        std.debug.print("error: --env requires KEY=VALUE\n", .{});
+                        return 2;
+                    }
+                    break :blk run_args[i];
+                } else arg["--env=".len..];
+                if (std.mem.indexOfScalar(u8, spec, '=') == null) {
+                    std.debug.print("error: --env value '{s}' is missing '='\n", .{spec});
+                    return 2;
+                }
+                try env_flags.append(allocator, spec);
+            } else if (std.mem.eql(u8, arg, "--map-dir") or std.mem.startsWith(u8, arg, "--map-dir=")) {
+                const spec = if (std.mem.eql(u8, arg, "--map-dir")) blk: {
+                    i += 1;
+                    if (i >= run_args.len) {
+                        std.debug.print("error: --map-dir requires HOST::GUEST\n", .{});
+                        return 2;
+                    }
+                    break :blk run_args[i];
+                } else arg["--map-dir=".len..];
+                const mapping = parseMapDir(spec) catch {
+                    std.debug.print(
+                        "error: --map-dir value '{s}' must be HOST::GUEST\n",
+                        .{spec},
+                    );
+                    return 2;
+                };
+                try map_dirs.append(allocator, mapping);
+            } else {
+                std.debug.print("error: unknown option '{s}' - try `wamr run help`\n", .{arg});
+                return 2;
+            }
+        } else if (wasm_path == null) {
+            wasm_path = arg;
+            past_options = true;
+        } else {
+            try wasm_args.append(allocator, arg);
+        }
+    }
+
+    const path = wasm_path orelse {
+        std.debug.print("error: missing core wasm file\n", .{});
+        return 2;
+    };
+
+    const cwd = std.Io.Dir.cwd();
+    const wasm_data = cwd.readFileAlloc(
+        init.io,
+        path,
+        allocator,
+        @enumFromInt(256 * 1024 * 1024),
+    ) catch |err| {
+        std.debug.print("error: cannot read '{s}': {s}\n", .{ path, @errorName(err) });
+        return 1;
+    };
+    defer allocator.free(wasm_data);
+
+    if (wasm_data.len >= 4 and
+        std.mem.readInt(u32, wasm_data[0..4], .little) == types.aot_magic)
+    {
+        std.debug.print("error: AOT modules cannot execute inside a wasm32-wasi host\n", .{});
+        return 2;
+    }
+    if (wasm_data.len >= 8 and
+        std.mem.readInt(u32, wasm_data[0..4], .little) == types.wasm_magic and
+        std.mem.readInt(u32, wasm_data[4..8], .little) == types.component_version)
+    {
+        std.debug.print("error: Component Model execution is not supported by this wasm32-wasi build\n", .{});
+        return 2;
+    }
+
+    return executeCore(
+        init.io,
+        allocator,
+        wasm_data,
+        path,
+        wasm_args.items,
+        env_flags.items,
+        map_dirs.items,
+        stack_size,
+    );
+}
+
+fn executeCore(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    wasm_data: []const u8,
+    wasm_path: []const u8,
+    wasm_args: []const []const u8,
+    env_flags: []const []const u8,
+    map_dirs: []const MapDir,
+    stack_size: u32,
+) u8 {
+    var module_arena = std.heap.ArenaAllocator.init(allocator);
+    defer module_arena.deinit();
+
+    const module = loader.load(wasm_data, module_arena.allocator()) catch |err| {
+        std.debug.print("error: failed to load core module: {s}\n", .{@errorName(err)});
+        return 1;
+    };
+    const module_inst = instance.instantiate(&module, allocator) catch |err| {
+        std.debug.print("error: failed to instantiate core module: {s}\n", .{@errorName(err)});
+        return 1;
+    };
+    defer instance.destroy(module_inst);
+
+    const wasi_start = module.findExport("_start", .function);
+    const start_func = wasi_start orelse module.findExport("main", .function) orelse {
+        std.debug.print("error: no _start or main function exported\n", .{});
+        return 1;
+    };
+    const is_main = wasi_start == null;
+    const func_type = module.getFuncType(start_func.index) orelse {
+        std.debug.print("error: entry point has no function type\n", .{});
+        return 1;
+    };
+    if (func_type.params.len != 0) {
+        std.debug.print("error: entry point parameters are not supported; use a WASI _start export\n", .{});
+        return 1;
+    }
+    if ((!is_main and func_type.results.len != 0) or
+        (is_main and (func_type.results.len > 1 or
+            (func_type.results.len == 1 and func_type.results[0] != .i32))))
+    {
+        std.debug.print("error: unsupported entry point result signature\n", .{});
+        return 1;
+    }
+
+    var env = ExecEnv.create(module_inst, stack_size, allocator) catch |err| {
+        std.debug.print("error: failed to create execution environment: {s}\n", .{@errorName(err)});
+        return 1;
+    };
+    defer env.destroy();
+
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    argv.append(allocator, wasm_path) catch return 1;
+    for (wasm_args) |arg| argv.append(allocator, arg) catch return 1;
+
+    const wasi_ctx = WasiCtx.init(allocator, io) catch |err| {
+        std.debug.print("error: failed to create WASI context: {s}\n", .{@errorName(err)});
+        return 1;
+    };
+    defer wasi_ctx.deinit();
+    wasi_ctx.setArgs(argv.items);
+    wasi_ctx.setEnv(env_flags);
+
+    for (map_dirs) |mapping| {
+        _ = wasi_ctx.openMappedDir(mapping.host_path, mapping.guest_name) catch |err| {
+            std.debug.print(
+                "error: cannot pre-open '{s}' as '{s}': {s}\n",
+                .{ mapping.host_path, mapping.guest_name, @errorName(err) },
+            );
+            return 1;
+        };
+    }
+    env.wasi_ctx = @ptrCast(wasi_ctx);
+
+    interp.executeFunction(env, start_func.index) catch |err| {
+        if (wasi_ctx.exit_code) |code| return @truncate(code);
+        std.debug.print("error: execution trapped: {s}\n", .{@errorName(err)});
+        return 1;
+    };
+    if (wasi_ctx.exit_code) |code| return @truncate(code);
+    if (is_main and func_type.results.len == 1) {
+        const code = env.popI32() catch return 1;
+        return @truncate(@as(u32, @bitCast(code)));
+    }
+    return 0;
+}
+
+fn parseMapDir(spec: []const u8) !MapDir {
+    const separator = std.mem.indexOf(u8, spec, "::") orelse
+        return error.MissingSeparator;
+    if (separator == 0 or separator + 2 == spec.len)
+        return error.MissingSeparator;
+    return .{
+        .host_path = spec[0..separator],
+        .guest_name = spec[separator + 2 ..],
+    };
+}
+
+fn writeStdout(io: std.Io, text: []const u8) void {
+    var stdout_file = std.Io.File.stdout();
+    stdout_file.writeStreamingAll(io, text) catch {};
+}
+
+const top_usage =
+    \\wamr - WebAssembly Micro Runtime (wasm32-wasi interpreter build)
+    \\
+    \\Usage: wamr <subcommand> [args...]
+    \\
+    \\Subcommands:
+    \\  run       Interpret a core .wasm module
+    \\  version   Print version and exit
+    \\  help      Print this help
+    \\
+    \\AOT, JIT, Component Model, serve, and host threads are unavailable.
+    \\
+;
+
+const run_usage =
+    \\Usage: wamr run [options] <file.wasm> [args...]
+    \\
+    \\Options:
+    \\  --stack-size=<bytes>     Interpreter stack size (default: 65536)
+    \\  --env KEY=VALUE          Set a WASI environment variable (repeatable)
+    \\  --map-dir HOST::GUEST    Pre-open HOST as GUEST (repeatable)
+    \\
+;

--- a/src/platform/parking_lot.zig
+++ b/src/platform/parking_lot.zig
@@ -12,6 +12,7 @@ const platform = @import("platform.zig");
 const is_linux = builtin.os.tag == .linux;
 const is_macos = builtin.os.tag == .macos;
 const is_windows = builtin.os.tag == .windows;
+const parking_supported = !builtin.single_threaded and (is_linux or is_macos or is_windows);
 
 pub const WaitResult = enum(u32) {
     notified = 0,
@@ -88,7 +89,11 @@ pub const ParkingLot = struct {
         expected: u32,
         timeout_ns: i64,
     ) BackendError!WaitResult {
-        return self.waitValue(u32, address, expected, timeout_ns);
+        if (comptime parking_supported) {
+            return self.waitValue(u32, address, expected, timeout_ns);
+        } else {
+            return error.Unsupported;
+        }
     }
 
     pub fn wait64(
@@ -97,7 +102,11 @@ pub const ParkingLot = struct {
         expected: u64,
         timeout_ns: i64,
     ) BackendError!WaitResult {
-        return self.waitValue(u64, address, expected, timeout_ns);
+        if (comptime parking_supported and @bitSizeOf(usize) >= 64) {
+            return self.waitValue(u64, address, expected, timeout_ns);
+        } else {
+            return error.Unsupported;
+        }
     }
 
     fn waitValue(
@@ -206,17 +215,28 @@ pub const ParkingLot = struct {
 
     /// Wake up to `count` waiters at exactly `address`.
     pub fn notify(self: *ParkingLot, address: *const anyopaque, count: u32) BackendError!u32 {
-        if (count == 0) return 0;
-        return self.wakeKey(@intFromPtr(address), count, .notified);
+        if (comptime parking_supported) {
+            if (count == 0) return 0;
+            return self.wakeKey(@intFromPtr(address), count, .notified);
+        } else {
+            return error.Unsupported;
+        }
     }
 
     /// Cancel every waiter at exactly `address`.
     pub fn cancel(self: *ParkingLot, address: *const anyopaque) BackendError!u32 {
-        return self.wakeKey(@intFromPtr(address), std.math.maxInt(u32), .cancelled);
+        if (comptime parking_supported) {
+            return self.wakeKey(@intFromPtr(address), std.math.maxInt(u32), .cancelled);
+        } else {
+            return error.Unsupported;
+        }
     }
 
     /// Cancel all waiters. This is the group-cancellation primitive.
     pub fn cancelAll(self: *ParkingLot) BackendError!u32 {
+        if (comptime !parking_supported) {
+            return error.Unsupported;
+        }
         var total: u32 = 0;
         for (0..bucket_count) |i| {
             const bucket = &self.buckets[i];
@@ -258,6 +278,9 @@ pub const ParkingLot = struct {
     /// Number of currently queued waiters for a key. Intended for
     /// diagnostics and deterministic native tests.
     pub fn waiterCount(self: *ParkingLot, address: *const anyopaque) u32 {
+        if (comptime !parking_supported) {
+            return 0;
+        }
         const key = @intFromPtr(address);
         const bucket = self.bucketFor(key);
         bucket.mutex.lock();
@@ -274,6 +297,9 @@ pub const ParkingLot = struct {
     /// Wake all waiters and wait for their stack-allocated queue nodes to
     /// leave the parking lot.
     pub fn deinit(self: *ParkingLot) void {
+        if (comptime !parking_supported) {
+            return;
+        }
         _ = self.lifecycle.fetchOr(closing_bit, .acq_rel);
         self.closeAll();
 

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -15,6 +15,8 @@ const builtin = @import("builtin");
 const is_windows = builtin.os.tag == .windows;
 const is_linux = builtin.os.tag == .linux;
 const is_macos = builtin.os.tag == .macos;
+const supports_posix_mmap = !is_windows and builtin.os.tag != .wasi;
+const supports_posix_time = !is_windows and builtin.os.tag != .wasi;
 const page_size = std.heap.page_size_min;
 
 // ── Windows NT API imports ──────────────────────────────────────────────
@@ -57,28 +59,31 @@ pub const MapFlags = packed struct {
 pub fn mmap(hint: ?[*]u8, size: usize, prot: MemProt, flags: MapFlags) ?[*]u8 {
     if (size == 0) return null;
 
-    if (is_windows) {
+    if (comptime is_windows) {
         return mmapWindows(hint, size, prot, flags);
-    } else {
+    } else if (comptime supports_posix_mmap) {
         return mmapPosix(hint, size, prot, flags);
     }
+    return null;
 }
 
 /// Unmap previously mapped memory.
 pub fn munmap(addr: [*]u8, size: usize) void {
-    if (is_windows) {
+    if (comptime is_windows) {
         munmapWindows(addr);
-    } else {
+    } else if (comptime supports_posix_mmap) {
         munmapPosix(addr, size);
     }
 }
 
 /// Change protection on mapped memory.
 pub fn mprotect(addr: [*]u8, size: usize, prot: MemProt) !void {
-    if (is_windows) {
+    if (comptime is_windows) {
         try mprotectWindows(addr, size, prot);
-    } else {
+    } else if (comptime supports_posix_mmap) {
         try mprotectPosix(addr, size, prot);
+    } else {
+        return error.Unsupported;
     }
 }
 
@@ -261,7 +266,7 @@ fn mprotectPosix(addr: [*]u8, size: usize, prot: MemProt) !void {
 /// True on platforms where `reserveAddressSpace` + `commitPages` are
 /// supported. POSIX uses an anonymous `PROT_NONE` mapping followed by
 /// `mprotect`; Windows uses one NT reserve followed by in-place commits.
-pub const supports_reserved_memory: bool = true;
+pub const supports_reserved_memory: bool = is_windows or supports_posix_mmap;
 
 /// Reserve `size` bytes of virtual address space, no physical pages
 /// backed. Returns the base pointer or null on failure. Free with
@@ -445,9 +450,9 @@ fn threadGetStackBoundaryMacos() ?[*]u8 {
 
 /// Sleep for the specified number of microseconds.
 pub fn usleep(us: u64) void {
-    if (is_windows) {
+    if (comptime is_windows) {
         usleepWindows(us);
-    } else {
+    } else if (comptime supports_posix_time) {
         usleepPosix(us);
     }
 }
@@ -513,11 +518,12 @@ var portable_fence_slot: u32 = 0;
 
 /// Monotonic time since boot in microseconds.
 pub fn timeGetBootUs() u64 {
-    if (is_windows) {
+    if (comptime is_windows) {
         return timeGetBootUsWindows();
-    } else {
+    } else if (comptime supports_posix_time) {
         return timeGetBootUsPosix();
     }
+    return 0;
 }
 
 fn timeGetBootUsWindows() u64 {
@@ -549,11 +555,12 @@ fn timeGetBootUsPosix() u64 {
 /// Current thread CPU time in microseconds (best-effort).
 /// Falls back to monotonic time when per-thread CPU time is unavailable.
 pub fn timeThreadCputimeUs() u64 {
-    if (is_windows) {
+    if (comptime is_windows) {
         return timeThreadCputimeWindows();
-    } else {
+    } else if (comptime supports_posix_time) {
         return timeThreadCputimePosix();
     }
+    return 0;
 }
 
 fn timeThreadCputimeWindows() u64 {

--- a/src/runtime/common/types.zig
+++ b/src/runtime/common/types.zig
@@ -494,6 +494,10 @@ pub const MemoryInstance = struct {
     reserved_size: usize = 0,
 
     pub const page_size: u32 = 65536;
+    pub const max_addressable_pages: u32 = @intCast(@min(
+        @as(u64, 65536),
+        @as(u64, std.math.maxInt(usize) / @as(usize, page_size)),
+    ));
 
     /// Page size of the host platform — used for mmap/mprotect alignment.
     /// Distinct from `page_size` above (the wasm linear-memory page = 64 KiB)
@@ -501,6 +505,11 @@ pub const MemoryInstance = struct {
     /// aarch64. wasm pages are always a multiple of any reasonable host page,
     /// so the OS calls never see sub-page slack.
     pub const page_size_min: u29 = std.heap.page_size_min;
+
+    pub fn byteSizeForPages(pages: u32) ?usize {
+        if (pages > max_addressable_pages) return null;
+        return std.math.mul(usize, @intCast(pages), page_size) catch null;
+    }
 
     /// Allocate a `MemoryInstance` with **stable-address backing** when the
     /// host supports it. The memory's `data.ptr` is pinned to a virtual
@@ -523,11 +532,11 @@ pub const MemoryInstance = struct {
         if (mem_type.is_shared) return null;
         if (!platform.supports_reserved_memory) return null;
         if (cap_pages == 0) return null;
-        const reserved_size: usize = @as(usize, cap_pages) * page_size;
+        const reserved_size = byteSizeForPages(cap_pages) orelse return null;
         const base = platform.reserveAddressSpace(reserved_size) orelse return null;
         errdefer platform.releaseAddressSpace(base, reserved_size);
 
-        const initial_size: usize = @as(usize, initial_pages) * page_size;
+        const initial_size = byteSizeForPages(initial_pages) orelse return null;
         if (initial_size > 0) {
             platform.commitPages(base, initial_size) catch {
                 platform.releaseAddressSpace(base, reserved_size);
@@ -561,7 +570,7 @@ pub const MemoryInstance = struct {
     ) shared_memory.CreateError!*MemoryInstance {
         if (!mem_type.is_shared) return error.InvalidLimits;
         const max_u64 = mem_type.limits.max orelse return error.InvalidLimits;
-        if (mem_type.limits.min > max_u64 or max_u64 > 65536)
+        if (mem_type.limits.min > max_u64 or max_u64 > max_addressable_pages)
             return error.InvalidLimits;
         const initial_pages: u32 = @intCast(mem_type.limits.min);
         const max_pages: u32 = @intCast(max_u64);
@@ -615,8 +624,7 @@ pub const MemoryInstance = struct {
         if (self.memory_type.limits.max) |max| {
             if (new_pages > max) return error.MemoryGrowFailed;
         }
-        if (new_pages > 65536) return error.MemoryGrowFailed;
-        const new_size = @as(usize, new_pages) * page_size;
+        const new_size = byteSizeForPages(new_pages) orelse return error.MemoryGrowFailed;
         const old_size = self.data.len;
         if (old_size < new_size) {
             if (self.reserved_base) |base| {
@@ -1081,6 +1089,15 @@ test "MemoryInstance: createReserved keeps data.ptr stable across grow" {
     // Growing past the cap fails.
     try std.testing.expectError(error.MemoryGrowFailed, mem.grow(1, allocator));
     try std.testing.expectEqual(@as(u32, 8), mem.current_pages);
+}
+
+test "MemoryInstance: page sizing respects host pointer width" {
+    const expected_max: u32 = if (@bitSizeOf(usize) == 32) 65535 else 65536;
+    try std.testing.expectEqual(expected_max, MemoryInstance.max_addressable_pages);
+    try std.testing.expect(MemoryInstance.byteSizeForPages(expected_max) != null);
+    if (expected_max < 65536) {
+        try std.testing.expect(MemoryInstance.byteSizeForPages(expected_max + 1) == null);
+    }
 }
 
 test "MemoryInstance: shared control keeps base stable and lifetime refcounted" {

--- a/src/runtime/interpreter/instance.zig
+++ b/src/runtime/interpreter/instance.zig
@@ -392,9 +392,15 @@ fn allocateMemories(module: *const types.WasmModule, allocator: std.mem.Allocato
             continue;
         }
 
-        const min_pages: u32 = @intCast(@min(mem_type.limits.min, 65536));
-        const max_pages: u32 = @intCast(@min(mem_type.limits.max orelse 65536, 65536));
-        const initial_size = @as(usize, min_pages) * types.MemoryInstance.page_size;
+        if (mem_type.limits.min > types.MemoryInstance.max_addressable_pages)
+            return error.MemoryAllocationFailed;
+        const min_pages: u32 = @intCast(mem_type.limits.min);
+        const max_pages: u32 = @intCast(@min(
+            mem_type.limits.max orelse 65536,
+            types.MemoryInstance.max_addressable_pages,
+        ));
+        const initial_size = types.MemoryInstance.byteSizeForPages(min_pages) orelse
+            return error.MemoryAllocationFailed;
 
         const data = allocator.alloc(u8, initial_size) catch
             return error.MemoryAllocationFailed;


### PR DESCRIPTION
## Summary

- build `wasm32-wasi` as an interpreter-only host profile
- add a reduced CLI for core WebAssembly execution under a WASI runtime
- gate unsupported AOT/JIT, components, threads, parking, and mmap paths
- make linear-memory sizing safe for 32-bit `usize`
- make the WASI CI gate fail on build or hosted-runtime regressions
- move blocking Linux correctness and ARM64 benchmark jobs off unavailable self-hosted runners

## Validation

- `zig build -Doptimize=ReleaseSafe -Dtarget=wasm32-wasi -Dstrip=true`
- `wasmtime zig-out/bin/wamr.wasm -- --version`
- `wasmtime --dir . zig-out/bin/wamr.wasm -- run tests/coldstart/hello_stdout.wasm`
- `zig build -Doptimize=ReleaseSafe`
- `zig build test`

Closes #935
Closes #936