### PR TITLE
test(perf): add pinned keyvault runtime harness

### DIFF
--- a/.github/skills/aot-perf-profile/SKILL.md
+++ b/.github/skills/aot-perf-profile/SKILL.md
@@ -33,6 +33,29 @@ Do **not** use this skill for:
 - Compile-time cost — that's `WAMR_AOT_CODEGEN_TIMING` / pass-timing, not
   a runtime `perf record`.
 
+## Pinned keyvault harness (preferred)
+
+For #798 comparisons, use `scripts/bench_keyvault.py` and a completed
+`tests/benchmarks/keyvault/manifest.example.json` rather than assembling
+commands ad hoc. The harness validates full source revisions and SHA-256 values
+for every binary/input/mounted tree, precompiles both runtimes outside measured
+execution, requires at least five measured runs, and rejects response-byte or
+generated-file drift. It also records host/tool/input identity and the
+Wasmtime-time/WAMR-time ratio:
+
+```sh
+python3 scripts/bench_keyvault.py \
+  --manifest /path/to/keyvault.lock.json \
+  --work-dir "$PWD/zig-out/keyvault-798" \
+  --warmups 2 --runs 7
+```
+
+Add `--profile` to capture and attribute a WAMR perf run. In that mode missing
+perf/objdump, inadequate permissions or sample count, and insufficient
+attribution coverage are hard failures; the harness never silently falls back
+to an unprofiled success. See `tests/benchmarks/keyvault/README.md` for the
+lockfile and equivalence contract.
+
 ## Environment
 
 This VM is **Microsoft Azure Linux 3 (`azurelinux`, `azl3`)**, x86_64.
@@ -161,12 +184,17 @@ python3 $SKILL/aot_jit_attr.py --perf wamr.perf --cwasm comp.4.cwasm
 
 # Add --func <N> to classify the hot function's instruction mix:
 python3 $SKILL/aot_jit_attr.py --perf wamr.perf --cwasm comp.4.cwasm --func 6145
+
+# Machine-readable output + a minimum useful sample gate:
+python3 $SKILL/aot_jit_attr.py --perf wamr.perf --cwasm comp.4.cwasm \
+  --func 6145 --min-samples 5000 --json-out attribution.json
 ```
 
 It prints: total samples, % of run in this core, top functions by
 self-samples, and for `--func` the class breakdown (spill reloads /
 frame stores / reg-reg mov / ALU / bounds-check / linear-mem / dispatch /
-call) plus the 20 hottest instructions. Cross-validate: the static
+call) plus the 20 hottest instructions. JSON output also records total and
+attributed samples plus attribution coverage. Cross-validate: the static
 frame-load count for the hot fn should ≈ its `spill_ld` from Step 3.
 
 If size-matching picks the wrong mapping (multiple equal-size cores),

--- a/.github/skills/aot-perf-profile/aot_jit_attr.py
+++ b/.github/skills/aot-perf-profile/aot_jit_attr.py
@@ -15,7 +15,8 @@ Usage:
 
 Requires: perf, objdump, python3. x86_64 only for --func classification.
 """
-import argparse, bisect, json, re, struct, subprocess, sys, tempfile, os
+import argparse, bisect, json, re, struct, subprocess, sys, os
+from pathlib import Path
 
 AOT_MAGIC = 0x746F6100  # "\0aot"
 AOT_VERSION = 7
@@ -25,7 +26,7 @@ SEC_FUNCTION = 3
 
 def parse_cwasm(path):
     """Return (func_offsets:list[int], text_size:int, text_fileoff:int)."""
-    f = open(path, "rb").read()
+    f = Path(path).read_bytes()
     magic, ver = struct.unpack_from("<II", f, 0)
     if magic != AOT_MAGIC:
         sys.exit(f"{path}: bad magic {magic:#x} (not a .cwasm)")
@@ -119,22 +120,34 @@ def main():
     ap.add_argument("--func", type=int, default=None, help="classify this local_func's instr mix")
     ap.add_argument("--top", type=int, default=20)
     ap.add_argument("--base", default=None, help="override text mmap base (hex)")
+    ap.add_argument("--json-out", default=None,
+                    help="write machine-readable attribution summary")
+    ap.add_argument("--min-samples", type=int, default=0,
+                    help="fail unless perf contains at least this many self samples")
+    ap.add_argument("--require-size-match", action="store_true",
+                    help="fail instead of guessing when the text mmap is not unique")
     a = ap.parse_args()
 
     offs, tsize, tfileoff, fbytes = parse_cwasm(a.cwasm)
     cnt, total = addr_counts(a.perf)
     if total == 0:
         sys.exit("no samples in perf data")
+    if total < a.min_samples:
+        sys.exit(f"perf data has only {total} self samples; "
+                 f"--min-samples requires at least {a.min_samples}")
 
     if a.base:
         base = int(a.base, 16)
     else:
         # pick the anon exec mapping whose size matches this core's text (page-rounded)
         maps = jit_exec_mmaps(a.perf)
-        base = None
-        for b, s in maps:
-            if abs(s - tsize) <= 0x2000:
-                base = b; break
+        matches = [(b, s) for b, s in maps if abs(s - tsize) <= 0x2000]
+        if a.require_size_match and len(matches) != 1:
+            sys.exit(
+                f"expected one anonymous executable mmap matching text_size={tsize}, "
+                f"found {len(matches)}; pass --base explicitly"
+            )
+        base = matches[0][0] if matches else None
         if base is None and maps:
             base = maps[0][0]
             print(f"warning: no mmap size match for text_size={tsize}; using largest "
@@ -153,26 +166,53 @@ def main():
             perfunc[fi] = perfunc.get(fi, 0) + c
     print(f"samples in this core: {in_core} ({100*in_core/total:.1f}% of run)\n")
     print(f"=== top {a.top} functions by self samples ===")
+    top_functions = []
     for fi, c in sorted(perfunc.items(), key=lambda x: -x[1])[:a.top]:
         fend = offs[fi + 1] if fi + 1 < len(offs) else tsize
+        top_functions.append({
+            "local_func": fi,
+            "samples": c,
+            "percent_of_run": 100 * c / total,
+            "code_bytes": fend - offs[fi],
+        })
         print(f"  local_func={fi:<6} samples={c:<6} ({100*c/total:.2f}% of run)  "
               f"code_bytes={fend-offs[fi]}")
 
+    report = {
+        "schema_version": 1,
+        "perf": str(Path(a.perf).resolve()),
+        "cwasm": str(Path(a.cwasm).resolve()),
+        "text_base": base,
+        "text_size": tsize,
+        "function_count": len(offs),
+        "total_samples": total,
+        "attributed_samples": in_core,
+        "attribution_coverage_pct": 100 * in_core / total,
+        "top_functions": top_functions,
+    }
+
     if a.func is None:
+        if a.json_out:
+            Path(a.json_out).write_text(
+                json.dumps(report, indent=2, sort_keys=True) + "\n",
+                encoding="UTF-8",
+            )
         return
     fi = a.func
     if fi < 0 or fi >= len(offs):
         sys.exit(f"--func {fi} out of range (0..{len(offs)-1})")
     s = offs[fi]; e = offs[fi + 1] if fi + 1 < len(offs) else tsize
     fnbase = base + s
-    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tf:
-        tf.write(fbytes[tfileoff + s:tfileoff + e]); tmp = tf.name
+    scratch = Path(a.perf).resolve().parent
+    tmp = scratch / f".aot-jit-attr-{os.getpid()}-{fi}.bin"
+    tmp.write_bytes(fbytes[tfileoff + s:tfileoff + e])
     try:
         asm = subprocess.run(
             ["objdump", "-D", "-b", "binary", "-m", "i386:x86-64", "-M", "intel",
-             "--adjust-vma=0x%x" % fnbase, tmp], capture_output=True, text=True).stdout
+             "--adjust-vma=0x%x" % fnbase, str(tmp)],
+            capture_output=True, text=True).stdout
     finally:
-        os.remove(tmp)
+        tmp.unlink(missing_ok=True)
     ipat = re.compile(r"^\s*([0-9a-f]+):\s+(?:[0-9a-f]{2} )+\s*(.*)$")
     fn_total = 0
     byclass = {}
@@ -211,6 +251,34 @@ def main():
     print(f"\n=== top 20 hottest instructions in local_func={fi} ===")
     for c, addr, txt in sorted(hot, reverse=True)[:20]:
         print(f"  {c:>5} ({100*c/total:.2f}%)  {addr:x}: {txt}")
+    report["classified_function"] = {
+        "local_func": fi,
+        "samples": fn_total,
+        "percent_of_run": 100 * fn_total / total,
+        "classes": {
+            group: {
+                "samples": sum(byclass.get(key, 0) for key in keys),
+                "percent_of_run": (
+                    100 * sum(byclass.get(key, 0) for key in keys) / total
+                ),
+            }
+            for group, keys in groups.items()
+        },
+        "hottest_instructions": [
+            {
+                "samples": count,
+                "percent_of_run": 100 * count / total,
+                "address": address,
+                "instruction": text,
+            }
+            for count, address, text in sorted(hot, reverse=True)[:20]
+        ],
+    }
+    if a.json_out:
+        Path(a.json_out).write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="UTF-8",
+        )
 
 
 if __name__ == "__main__":

--- a/.github/skills/aot-perf-profile/run_wamr_keyvault.sh
+++ b/.github/skills/aot-perf-profile/run_wamr_keyvault.sh
@@ -14,7 +14,7 @@ ASZ="${ASZ:-$HOME/azure-sdk-for-zig}"
 WASM="${WASM:-$ASZ/codegen/cli/zig-out/bin/codegen-cli.composed.wasm}"
 PREOPENS="${PREOPENS:-$ASZ/codegen/tcgc-component/dist/stdlib-preopens.txt}"
 SPEC="${SPEC:-$HOME/azure-rest-api-specs/specification/keyvault/data-plane/Secrets}"
-OUT="${OUT:-/tmp/keyvault-out}"
+OUT="${OUT:?set OUT to a dedicated output directory}"
 MANIFEST="${MANIFEST:-}"   # optional --precompiled-manifest (else sibling auto-probe)
 
 mkdir -p "$OUT"

--- a/build.zig
+++ b/build.zig
@@ -675,10 +675,15 @@ pub fn build(b: *std.Build) void {
     });
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 
+    const keyvault_harness_tests = b.addSystemCommand(&.{
+        "python3",
+        "tests/test_bench_keyvault.py",
+    });
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_exe_unit_tests.step);
     test_step.dependOn(stable_resources_test_step);
+    test_step.dependOn(&keyvault_harness_tests.step);
 
     const artifact_consumer_test = b.addSystemCommand(&.{ b.graph.zig_exe, "build" });
     artifact_consumer_test.setCwd(b.path("tests/artifact-consumer"));

--- a/scripts/bench_keyvault.py
+++ b/scripts/bench_keyvault.py
@@ -1,0 +1,1092 @@
+#!/usr/bin/env python3
+"""Pinned dual-runtime keyvault/SpiderMonkey-TCGC benchmark harness.
+
+The harness never downloads or builds third-party inputs.  A manifest must
+identify every binary, checkout, file, and mounted tree by exact revision or
+SHA-256.  Both runtimes are precompiled before warmups and measured execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+MIN_MEASURED_RUNS = 5
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+TCGC_BYTES_RE = re.compile(r"got\s+(\d+)\s+bytes\s+back\s+from\s+tcgc\.compile")
+
+
+class HarnessError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Tool:
+    name: str
+    path: Path
+    sha256: str
+    version: str
+
+
+@dataclass(frozen=True)
+class Mount:
+    host: Path
+    guest: str
+    sha256_tree: str
+
+
+@dataclass(frozen=True)
+class Config:
+    manifest_path: Path
+    tools: dict[str, Tool]
+    sources: list[dict[str, Any]]
+    component: Path
+    component_sha256: str
+    preopens_file: Path
+    preopens_sha256: str
+    mounts: list[Mount]
+    package_name: str
+    guest_env: dict[str, str]
+    expected_response_bytes: int
+    perf: dict[str, Any]
+
+
+def _require_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise HarnessError(f"{label} must be a JSON object")
+    return value
+
+
+def _require_list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list) or not value:
+        raise HarnessError(f"{label} must be a non-empty JSON array")
+    return value
+
+
+def _require_string(obj: dict[str, Any], key: str, label: str) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value:
+        raise HarnessError(f"{label}.{key} must be a non-empty string")
+    return value
+
+
+def _require_sha(value: str, label: str) -> str:
+    value = value.lower()
+    if not SHA256_RE.fullmatch(value) or value == "0" * 64:
+        raise HarnessError(f"{label} must be a non-zero, lowercase SHA-256")
+    return value
+
+
+def _resolve(base: Path, value: str) -> Path:
+    path = Path(value).expanduser()
+    return path.resolve() if path.is_absolute() else (base / path).resolve()
+
+
+def load_manifest(path: Path) -> Config:
+    try:
+        raw = json.loads(path.read_text(encoding="UTF-8"))
+    except FileNotFoundError as exc:
+        raise HarnessError(f"manifest not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise HarnessError(f"invalid JSON in {path}: {exc}") from exc
+    root = _require_object(raw, "manifest")
+    if root.get("schema_version") != SCHEMA_VERSION:
+        raise HarnessError(
+            f"schema_version must be {SCHEMA_VERSION}, got {root.get('schema_version')!r}"
+        )
+    base = path.resolve().parent
+
+    tools_raw = _require_object(root.get("tools"), "tools")
+    tools: dict[str, Tool] = {}
+    for name in ("wamr", "wamrc", "wasmtime"):
+        item = _require_object(tools_raw.get(name), f"tools.{name}")
+        tools[name] = Tool(
+            name=name,
+            path=_resolve(base, _require_string(item, "path", f"tools.{name}")),
+            sha256=_require_sha(
+                _require_string(item, "sha256", f"tools.{name}"),
+                f"tools.{name}.sha256",
+            ),
+            version=_require_string(item, "version", f"tools.{name}"),
+        )
+
+    sources = _require_list(root.get("sources"), "sources")
+    normalized_sources: list[dict[str, Any]] = []
+    for index, value in enumerate(sources):
+        item = _require_object(value, f"sources[{index}]")
+        revision = _require_string(item, "revision", f"sources[{index}]").lower()
+        if not REVISION_RE.fullmatch(revision):
+            raise HarnessError(
+                f"sources[{index}].revision must be a full 40-character commit SHA"
+            )
+        normalized_sources.append(
+            {
+                "name": _require_string(item, "name", f"sources[{index}]"),
+                "path": _resolve(
+                    base, _require_string(item, "path", f"sources[{index}]")
+                ),
+                "revision": revision,
+            }
+        )
+
+    workload = _require_object(root.get("workload"), "workload")
+    component = _require_object(workload.get("component"), "workload.component")
+    preopens = _require_object(
+        workload.get("preopens_file"), "workload.preopens_file"
+    )
+    mounts_raw = _require_list(workload.get("mounts"), "workload.mounts")
+    mounts: list[Mount] = []
+    guests: set[str] = set()
+    for index, value in enumerate(mounts_raw):
+        item = _require_object(value, f"workload.mounts[{index}]")
+        guest = _require_string(item, "guest", f"workload.mounts[{index}]")
+        if not guest.startswith("/") or guest in guests:
+            raise HarnessError(
+                f"workload.mounts[{index}].guest must be a unique absolute guest path"
+            )
+        guests.add(guest)
+        mounts.append(
+            Mount(
+                host=_resolve(
+                    base,
+                    _require_string(item, "path", f"workload.mounts[{index}]"),
+                ),
+                guest=guest,
+                sha256_tree=_require_sha(
+                    _require_string(
+                        item, "sha256_tree", f"workload.mounts[{index}]"
+                    ),
+                    f"workload.mounts[{index}].sha256_tree",
+                ),
+            )
+        )
+    if "/spec" not in guests:
+        raise HarnessError("workload.mounts must include the input spec tree at /spec")
+
+    expected_response_bytes = workload.get("expected_tcgc_response_bytes")
+    if not isinstance(expected_response_bytes, int) or expected_response_bytes <= 0:
+        raise HarnessError(
+            "workload.expected_tcgc_response_bytes must be a positive integer"
+        )
+    guest_env_raw = _require_object(workload.get("env"), "workload.env")
+    guest_env: dict[str, str] = {}
+    for key, value in guest_env_raw.items():
+        if (
+            not isinstance(key, str)
+            or not key
+            or "=" in key
+            or not isinstance(value, str)
+        ):
+            raise HarnessError(
+                "workload.env must map non-empty names without '=' to string values"
+            )
+        guest_env[key] = value
+    if "WAMR_KEYVAULT_HARNESS" in guest_env:
+        raise HarnessError("workload.env reserves WAMR_KEYVAULT_HARNESS")
+
+    perf = _require_object(root.get("perf"), "perf")
+    core_index = perf.get("core_index")
+    hot_func = perf.get("hot_func")
+    min_samples = perf.get("min_samples")
+    min_coverage_pct = perf.get("min_attribution_coverage_pct")
+    base = perf.get("base")
+    if not isinstance(core_index, int) or core_index < 0:
+        raise HarnessError("perf.core_index must be a non-negative integer")
+    if hot_func is not None and (not isinstance(hot_func, int) or hot_func < 0):
+        raise HarnessError("perf.hot_func must be null or a non-negative integer")
+    if not isinstance(min_samples, int) or min_samples < 1000:
+        raise HarnessError("perf.min_samples must be an integer >= 1000")
+    if not isinstance(min_coverage_pct, (int, float)) or not (
+        0 < float(min_coverage_pct) <= 100
+    ):
+        raise HarnessError(
+            "perf.min_attribution_coverage_pct must be in the range (0, 100]"
+        )
+    if base is not None and (
+        not isinstance(base, str) or re.fullmatch(r"0x[0-9a-fA-F]+", base) is None
+    ):
+        raise HarnessError("perf.base must be null or a hexadecimal address")
+
+    return Config(
+        manifest_path=path.resolve(),
+        tools=tools,
+        sources=normalized_sources,
+        component=_resolve(
+            base, _require_string(component, "path", "workload.component")
+        ),
+        component_sha256=_require_sha(
+            _require_string(component, "sha256", "workload.component"),
+            "workload.component.sha256",
+        ),
+        preopens_file=_resolve(
+            base, _require_string(preopens, "path", "workload.preopens_file")
+        ),
+        preopens_sha256=_require_sha(
+            _require_string(preopens, "sha256", "workload.preopens_file"),
+            "workload.preopens_file.sha256",
+        ),
+        mounts=mounts,
+        package_name=_require_string(workload, "package_name", "workload"),
+        guest_env=guest_env,
+        expected_response_bytes=expected_response_bytes,
+        perf={
+            "core_index": core_index,
+            "hot_func": hot_func,
+            "min_samples": min_samples,
+            "min_attribution_coverage_pct": float(min_coverage_pct),
+            "base": base,
+        },
+    )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def tree_snapshot(path: Path) -> dict[str, Any]:
+    if not path.is_dir():
+        raise HarnessError(f"tree input is not a directory: {path}")
+    entries: list[dict[str, Any]] = []
+    for item in sorted(path.rglob("*"), key=lambda p: p.relative_to(path).as_posix()):
+        rel = item.relative_to(path).as_posix()
+        if item.is_symlink():
+            raise HarnessError(f"symlinks are not allowed in hashed trees: {item}")
+        if item.is_dir():
+            continue
+        if not item.is_file():
+            raise HarnessError(f"unsupported non-file tree entry: {item}")
+        entries.append(
+            {"path": rel, "size": item.stat().st_size, "sha256": sha256_file(item)}
+        )
+    canonical = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode()
+    return {
+        "sha256": hashlib.sha256(canonical).hexdigest(),
+        "file_count": len(entries),
+        "total_bytes": sum(item["size"] for item in entries),
+        "files": entries,
+    }
+
+
+def parse_preopens(path: Path) -> list[tuple[Path, str]]:
+    result: list[tuple[Path, str]] = []
+    for line_number, raw in enumerate(
+        path.read_text(encoding="UTF-8").splitlines(), start=1
+    ):
+        line = raw.strip()
+        if not line:
+            continue
+        if "=" not in line:
+            raise HarnessError(
+                f"{path}:{line_number}: expected HOST=GUEST preopen mapping"
+            )
+        host, guest = line.split("=", 1)
+        if not host or not guest.startswith("/"):
+            raise HarnessError(
+                f"{path}:{line_number}: expected non-empty HOST and absolute GUEST"
+            )
+        host_path = Path(host).expanduser()
+        if not host_path.is_absolute():
+            host_path = path.parent / host_path
+        result.append((host_path.resolve(), guest))
+    if not result:
+        raise HarnessError(f"preopens file has no mappings: {path}")
+    return result
+
+
+def command_version(tool: Tool) -> str:
+    version_arg = "--version" if tool.name == "wasmtime" else "version"
+    proc = subprocess.run(
+        [str(tool.path), version_arg],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=15,
+        env=controlled_host_env(),
+    )
+    output = (proc.stdout + proc.stderr).strip()
+    if proc.returncode != 0:
+        raise HarnessError(
+            f"{tool.name} --version failed with exit {proc.returncode}: {output}"
+        )
+    if tool.version not in output:
+        raise HarnessError(
+            f"{tool.name} version mismatch: expected output containing "
+            f"{tool.version!r}, got {output!r}"
+        )
+    return output
+
+
+def validate_config(config: Config) -> dict[str, Any]:
+    tool_report: dict[str, Any] = {}
+    for tool in config.tools.values():
+        if not tool.path.is_file():
+            raise HarnessError(
+                f"required {tool.name} binary is absent: {tool.path}; "
+                "install/build the pinned version and update the manifest path"
+            )
+        if not os.access(tool.path, os.X_OK):
+            raise HarnessError(f"required {tool.name} binary is not executable: {tool.path}")
+        actual = sha256_file(tool.path)
+        if actual != tool.sha256:
+            raise HarnessError(
+                f"{tool.name} SHA-256 mismatch for {tool.path}: "
+                f"expected {tool.sha256}, got {actual}"
+            )
+        tool_report[tool.name] = {
+            "path": str(tool.path),
+            "sha256": actual,
+            "version": command_version(tool),
+        }
+
+    source_report = []
+    for source in config.sources:
+        path = source["path"]
+        if not (path / ".git").exists() and not (
+            subprocess.run(
+                ["git", "-C", str(path), "rev-parse", "--git-dir"],
+                capture_output=True,
+                check=False,
+            ).returncode
+            == 0
+        ):
+            raise HarnessError(f"source checkout is absent or not a git tree: {path}")
+        proc = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        actual = proc.stdout.strip().lower()
+        if proc.returncode != 0 or actual != source["revision"]:
+            raise HarnessError(
+                f"source revision mismatch for {source['name']} at {path}: "
+                f"expected {source['revision']}, got {actual or proc.stderr.strip()}"
+            )
+        dirty = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(path),
+                "status",
+                "--porcelain",
+                "--untracked-files=no",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if dirty.returncode != 0 or dirty.stdout.strip():
+            raise HarnessError(
+                f"source checkout has tracked modifications: {source['name']} at {path}"
+            )
+        source_report.append(
+            {"name": source["name"], "path": str(path), "revision": actual}
+        )
+
+    for path, expected, label in (
+        (config.component, config.component_sha256, "component"),
+        (config.preopens_file, config.preopens_sha256, "preopens file"),
+    ):
+        if not path.is_file():
+            raise HarnessError(f"required {label} is absent: {path}")
+        actual = sha256_file(path)
+        if actual != expected:
+            raise HarnessError(
+                f"{label} SHA-256 mismatch for {path}: expected {expected}, got {actual}"
+            )
+
+    mount_report = []
+    configured = {(mount.host, mount.guest): mount for mount in config.mounts}
+    file_mappings = parse_preopens(config.preopens_file)
+    configured_stdlib = {
+        (mount.host, mount.guest)
+        for mount in config.mounts
+        if mount.guest not in ("/spec", "/out")
+    }
+    if set(file_mappings) != configured_stdlib:
+        missing = set(file_mappings) - configured_stdlib
+        extra = configured_stdlib - set(file_mappings)
+        raise HarnessError(
+            "preopens file and workload.mounts differ; "
+            f"unconfigured={sorted(map(str, missing))}, extra={sorted(map(str, extra))}"
+        )
+    for key, mount in configured.items():
+        snapshot = tree_snapshot(mount.host)
+        if snapshot["sha256"] != mount.sha256_tree:
+            raise HarnessError(
+                f"tree SHA-256 mismatch for mount {mount.host}::{mount.guest}: "
+                f"expected {mount.sha256_tree}, got {snapshot['sha256']}"
+            )
+        mount_report.append(
+            {
+                "path": str(mount.host),
+                "guest": mount.guest,
+                "sha256_tree": snapshot["sha256"],
+                "file_count": snapshot["file_count"],
+                "total_bytes": snapshot["total_bytes"],
+            }
+        )
+    return {
+        "tools": tool_report,
+        "sources": source_report,
+        "inputs": {
+            "component": {
+                "path": str(config.component),
+                "sha256": config.component_sha256,
+                "size": config.component.stat().st_size,
+            },
+            "preopens_file": {
+                "path": str(config.preopens_file),
+                "sha256": config.preopens_sha256,
+            },
+            "mounts": mount_report,
+            "package_name": config.package_name,
+            "guest_env": config.guest_env,
+            "expected_tcgc_response_bytes": config.expected_response_bytes,
+        },
+    }
+
+
+def precompile_commands(
+    config: Config, artifact_dir: Path
+) -> tuple[list[str], list[str], Path, Path]:
+    wamr_manifest = artifact_dir / "keyvault.cwasm.json"
+    wasmtime_cwasm = artifact_dir / "keyvault.wasmtime.cwasm"
+    wamr = [
+        str(config.tools["wamrc"].path),
+        "compile-component",
+        "--target=x86_64",
+        str(config.component),
+        "-o",
+        str(wamr_manifest),
+    ]
+    wasmtime = [
+        str(config.tools["wasmtime"].path),
+        "compile",
+        "-W",
+        "max-memory-size=4294967296",
+        "-O",
+        "opt-level=2",
+        str(config.component),
+        "-o",
+        str(wasmtime_cwasm),
+    ]
+    return wamr, wasmtime, wamr_manifest, wasmtime_cwasm
+
+
+def runtime_command(
+    config: Config,
+    runtime: str,
+    output_dir: Path,
+    wamr_manifest: Path,
+    wasmtime_cwasm: Path,
+) -> list[str]:
+    if runtime == "wamr":
+        command = [
+            str(config.tools["wamr"].path),
+            "run",
+            "--precompiled-manifest",
+            str(wamr_manifest),
+        ]
+        for key, value in sorted(
+            {"WAMR_KEYVAULT_HARNESS": "1", **config.guest_env}.items()
+        ):
+            command += ["--env", f"{key}={value}"]
+        for mount in config.mounts:
+            command += ["--map-dir", f"{mount.host}::{mount.guest}"]
+        command += ["--map-dir", f"{output_dir.resolve()}::/out"]
+        command += [
+            str(config.component),
+            "/spec",
+            "/out",
+            "--package-name",
+            config.package_name,
+        ]
+        return command
+    if runtime == "wasmtime":
+        command = [
+            str(config.tools["wasmtime"].path),
+            "run",
+            "--allow-precompiled",
+            "-S",
+            "http",
+            "-W",
+            "max-memory-size=4294967296",
+        ]
+        for key, value in sorted(
+            {"WAMR_KEYVAULT_HARNESS": "1", **config.guest_env}.items()
+        ):
+            command += ["--env", f"{key}={value}"]
+        for mount in config.mounts:
+            command += ["--dir", f"{mount.host}::{mount.guest}"]
+        command += ["--dir", f"{output_dir.resolve()}::/out"]
+        command += [
+            str(wasmtime_cwasm),
+            "/spec",
+            "/out",
+            "--package-name",
+            config.package_name,
+        ]
+        return command
+    raise HarnessError(f"unknown runtime: {runtime}")
+
+
+def parse_tcgc_response_bytes(output: str) -> int:
+    matches = TCGC_BYTES_RE.findall(output)
+    if len(matches) != 1:
+        raise HarnessError(
+            "expected exactly one 'got N bytes back from tcgc.compile' marker, "
+            f"found {len(matches)}"
+        )
+    return int(matches[0])
+
+
+def parse_timing_samples(records: list[dict[str, Any]], runtime: str) -> list[float]:
+    samples = [
+        record.get("elapsed_seconds")
+        for record in records
+        if record.get("runtime") == runtime and record.get("phase") == "measure"
+    ]
+    if any(not isinstance(value, (int, float)) or value <= 0 for value in samples):
+        raise HarnessError(f"{runtime} has an invalid measured timing sample")
+    if len(samples) < MIN_MEASURED_RUNS:
+        raise HarnessError(
+            f"{runtime} has {len(samples)} measured runs; "
+            f"at least {MIN_MEASURED_RUNS} are required"
+        )
+    return [float(value) for value in samples]
+
+
+def controlled_host_env() -> dict[str, str]:
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "LANG": "C",
+        "LC_ALL": "C",
+        "TZ": "UTC",
+    }
+    if "HOME" in os.environ:
+        env["HOME"] = os.environ["HOME"]
+    return env
+
+
+def _run_checked(command: list[str], *, timeout: float, label: str) -> subprocess.CompletedProcess[str]:
+    try:
+        proc = subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+            env=controlled_host_env(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise HarnessError(f"{label} exceeded timeout of {timeout:g}s") from exc
+    if proc.returncode != 0:
+        raise HarnessError(
+            f"{label} failed with exit {proc.returncode}\n"
+            f"command: {' '.join(command)}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    return proc
+
+
+def precompile(config: Config, artifact_dir: Path, timeout: float) -> tuple[Path, Path, dict[str, Any]]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    wamr_cmd, wasmtime_cmd, wamr_manifest, wasmtime_cwasm = precompile_commands(
+        config, artifact_dir
+    )
+    for old in artifact_dir.iterdir():
+        if old.is_dir():
+            shutil.rmtree(old)
+        else:
+            old.unlink()
+    start = time.perf_counter_ns()
+    _run_checked(wamr_cmd, timeout=timeout, label="WAMR precompile")
+    wamr_seconds = (time.perf_counter_ns() - start) / 1e9
+    start = time.perf_counter_ns()
+    _run_checked(wasmtime_cmd, timeout=timeout, label="Wasmtime precompile")
+    wasmtime_seconds = (time.perf_counter_ns() - start) / 1e9
+    if not wamr_manifest.is_file() or not wasmtime_cwasm.is_file():
+        raise HarnessError("precompile completed without producing both artifacts")
+    artifacts = []
+    for item in sorted(artifact_dir.iterdir()):
+        if item.is_file():
+            artifacts.append(
+                {
+                    "path": str(item),
+                    "size": item.stat().st_size,
+                    "sha256": sha256_file(item),
+                }
+            )
+    return wamr_manifest, wasmtime_cwasm, {
+        "excluded_from_measurement": True,
+        "wamr_seconds": wamr_seconds,
+        "wasmtime_seconds": wasmtime_seconds,
+        "commands": {"wamr": wamr_cmd, "wasmtime": wasmtime_cmd},
+        "artifacts": artifacts,
+    }
+
+
+def run_one(
+    config: Config,
+    runtime: str,
+    phase: str,
+    index: int,
+    output_root: Path,
+    wamr_manifest: Path,
+    wasmtime_cwasm: Path,
+    timeout: float,
+) -> dict[str, Any]:
+    output_dir = output_root / runtime / f"{phase}-{index:02d}"
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True)
+    command = runtime_command(
+        config, runtime, output_dir, wamr_manifest, wasmtime_cwasm
+    )
+    start = time.perf_counter_ns()
+    proc = _run_checked(
+        command, timeout=timeout, label=f"{runtime} {phase} run {index}"
+    )
+    elapsed = (time.perf_counter_ns() - start) / 1e9
+    combined = proc.stdout + "\n" + proc.stderr
+    response_bytes = parse_tcgc_response_bytes(combined)
+    if response_bytes != config.expected_response_bytes:
+        raise HarnessError(
+            f"{runtime} {phase} run {index} returned {response_bytes} bytes from "
+            f"tcgc.compile; manifest requires {config.expected_response_bytes}"
+        )
+    snapshot = tree_snapshot(output_dir)
+    return {
+        "runtime": runtime,
+        "phase": phase,
+        "index": index,
+        "elapsed_seconds": elapsed,
+        "tcgc_response_bytes": response_bytes,
+        "output": {
+            "sha256_tree": snapshot["sha256"],
+            "file_count": snapshot["file_count"],
+            "total_bytes": snapshot["total_bytes"],
+            "files": snapshot["files"],
+        },
+        "command": command,
+    }
+
+
+def verify_equivalence(records: list[dict[str, Any]]) -> dict[str, Any]:
+    if not records:
+        raise HarnessError("no runtime records were produced")
+    expected_bytes = records[0]["tcgc_response_bytes"]
+    expected_output = records[0]["output"]
+    for record in records[1:]:
+        if record["tcgc_response_bytes"] != expected_bytes:
+            raise HarnessError(
+                "tcgc response-size drift: "
+                f"expected {expected_bytes}, got {record['tcgc_response_bytes']} "
+                f"for {record['runtime']} {record['phase']} {record['index']}"
+            )
+        if record["output"] != expected_output:
+            raise HarnessError(
+                "generated output mismatch: exact paths, sizes, or SHA-256 values "
+                f"differ for {record['runtime']} {record['phase']} {record['index']}"
+            )
+    return {
+        "tcgc_response_bytes": expected_bytes,
+        "output_sha256_tree": expected_output["sha256_tree"],
+        "file_count": expected_output["file_count"],
+        "total_bytes": expected_output["total_bytes"],
+        "deterministic_across_all_runs": True,
+        "cross_runtime_exact_match": True,
+    }
+
+
+def sample_stats(values: list[float]) -> dict[str, Any]:
+    return {
+        "samples_seconds": values,
+        "mean_seconds": statistics.fmean(values),
+        "median_seconds": statistics.median(values),
+        "min_seconds": min(values),
+        "max_seconds": max(values),
+        "range_seconds": max(values) - min(values),
+        "runs": len(values),
+    }
+
+
+def host_report() -> dict[str, Any]:
+    cpu = "unknown"
+    try:
+        out = subprocess.run(
+            ["lscpu"], text=True, capture_output=True, check=False, timeout=5
+        ).stdout
+        for line in out.splitlines():
+            if line.lower().startswith("model name:"):
+                cpu = line.split(":", 1)[1].strip()
+                break
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return {
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "cpu": cpu,
+        "logical_cpus": os.cpu_count(),
+        "python": platform.python_version(),
+    }
+
+
+def run_perf(
+    config: Config,
+    work_dir: Path,
+    wamr_manifest: Path,
+    wasmtime_cwasm: Path,
+    timeout: float,
+    reference_output: dict[str, Any],
+) -> dict[str, Any]:
+    if platform.system() != "Linux" or platform.machine() != "x86_64":
+        raise HarnessError("--profile requires Linux x86_64")
+    for name in ("perf", "objdump"):
+        if shutil.which(name) is None:
+            raise HarnessError(
+                f"--profile explicitly selected, but required tool {name!r} is absent"
+            )
+    paranoid = Path("/proc/sys/kernel/perf_event_paranoid")
+    if paranoid.is_file():
+        value = int(paranoid.read_text().strip())
+        if value > 2:
+            raise HarnessError(
+                "--profile explicitly selected, but kernel.perf_event_paranoid "
+                f"is {value}; set it to <= 2"
+            )
+
+    perf_dir = work_dir / "perf"
+    output_dir = perf_dir / "output"
+    shutil.rmtree(perf_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True)
+    runtime = runtime_command(
+        config, "wamr", output_dir, wamr_manifest, wasmtime_cwasm
+    )
+    perf_data = perf_dir / "wamr.perf.data"
+    command = [
+        "perf",
+        "record",
+        "-g",
+        "--call-graph=dwarf",
+        "-F",
+        "999",
+        "-e",
+        "cycles:u",
+        "-o",
+        str(perf_data),
+        "--",
+        *runtime,
+    ]
+    proc = _run_checked(command, timeout=timeout, label="WAMR perf capture")
+    response_bytes = parse_tcgc_response_bytes(proc.stdout + "\n" + proc.stderr)
+    snapshot = tree_snapshot(output_dir)
+    current = {
+        "sha256_tree": snapshot["sha256"],
+        "file_count": snapshot["file_count"],
+        "total_bytes": snapshot["total_bytes"],
+        "files": snapshot["files"],
+    }
+    if response_bytes != config.expected_response_bytes or current != reference_output:
+        raise HarnessError("profiled WAMR run was not semantically equivalent")
+
+    core = perf_dir.parent / "artifacts" / f"keyvault.{config.perf['core_index']}.cwasm"
+    if not core.is_file():
+        raise HarnessError(
+            f"configured perf core artifact is absent: {core}; "
+            "check perf.core_index and the WAMR manifest"
+        )
+    attr_json = perf_dir / "attribution.json"
+    helper = Path(__file__).resolve().parents[1] / ".github/skills/aot-perf-profile/aot_jit_attr.py"
+    attr_command = [
+        sys.executable,
+        str(helper),
+        "--perf",
+        str(perf_data),
+        "--cwasm",
+        str(core),
+        "--json-out",
+        str(attr_json),
+        "--min-samples",
+        str(config.perf["min_samples"]),
+        "--require-size-match",
+    ]
+    if config.perf["base"] is not None:
+        attr_command.remove("--require-size-match")
+        attr_command += ["--base", config.perf["base"]]
+    if config.perf["hot_func"] is not None:
+        attr_command += ["--func", str(config.perf["hot_func"])]
+    _run_checked(attr_command, timeout=timeout, label="perf attribution")
+    attribution = json.loads(attr_json.read_text(encoding="UTF-8"))
+    coverage = attribution["attribution_coverage_pct"]
+    if coverage < config.perf["min_attribution_coverage_pct"]:
+        raise HarnessError(
+            f"perf attribution coverage {coverage:.2f}% is below manifest minimum "
+            f"{config.perf['min_attribution_coverage_pct']:.2f}%"
+        )
+    return {
+        "selected": True,
+        "command": command,
+        "perf_data": str(perf_data),
+        "attribution": attribution,
+        "attribution_command": attr_command,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    timing = report["timing"]
+    wamr = timing["wamr"]
+    wasmtime = timing["wasmtime"]
+    host = report["host"]
+    lines = [
+        "# Keyvault SpiderMonkey/TCGC AOT benchmark",
+        "",
+        f"- Host: `{host['system']} {host['release']}` · `{host['machine']}` · "
+        f"{host['logical_cpus']} CPUs · `{host['cpu']}`",
+        f"- Manifest: `{report['manifest']}`",
+        f"- Warmups: {report['plan']['warmups']} per runtime",
+        f"- Authoritative measured runs: {report['plan']['runs']} per runtime",
+        "- Compilation: precompiled once per runtime and excluded from measured execution",
+        "",
+        "| Runtime | Samples (s) | Mean | Median | Min | Max | Range |",
+        "|---|---|---:|---:|---:|---:|---:|",
+        f"| WAMR | {', '.join(f'{v:.3f}' for v in wamr['samples_seconds'])} | "
+        f"{wamr['mean_seconds']:.3f} | {wamr['median_seconds']:.3f} | "
+        f"{wamr['min_seconds']:.3f} | {wamr['max_seconds']:.3f} | "
+        f"{wamr['range_seconds']:.3f} |",
+        f"| Wasmtime | {', '.join(f'{v:.3f}' for v in wasmtime['samples_seconds'])} | "
+        f"{wasmtime['mean_seconds']:.3f} | {wasmtime['median_seconds']:.3f} | "
+        f"{wasmtime['min_seconds']:.3f} | {wasmtime['max_seconds']:.3f} | "
+        f"{wasmtime['range_seconds']:.3f} |",
+        "",
+        f"**Wasmtime-time/WAMR-time ratio: "
+        f"{timing['wasmtime_time_over_wamr_time']:.4f}×**",
+        "",
+        "## Semantic equivalence",
+        "",
+        f"- `tcgc.compile` bytes: {report['equivalence']['tcgc_response_bytes']}",
+        f"- Generated files: {report['equivalence']['file_count']} "
+        f"({report['equivalence']['total_bytes']} bytes)",
+        f"- Output tree SHA-256: `{report['equivalence']['output_sha256_tree']}`",
+        "- Every warmup/measured output and both runtimes matched exactly by path, size, and SHA-256.",
+        "",
+        "## Exact tools and inputs",
+        "",
+    ]
+    for name, tool in report["validation"]["tools"].items():
+        lines.append(
+            f"- {name}: `{tool['version']}` · SHA-256 `{tool['sha256']}` · `{tool['path']}`"
+        )
+    lines.append(
+        f"- component: SHA-256 `{report['validation']['inputs']['component']['sha256']}` · "
+        f"{report['validation']['inputs']['component']['size']} bytes"
+    )
+    lines.append(
+        "- preopens file: SHA-256 "
+        f"`{report['validation']['inputs']['preopens_file']['sha256']}` · "
+        f"`{report['validation']['inputs']['preopens_file']['path']}`"
+    )
+    for mount in report["validation"]["inputs"]["mounts"]:
+        lines.append(
+            f"- mount `{mount['guest']}`: tree SHA-256 `{mount['sha256_tree']}` · "
+            f"{mount['file_count']} files / {mount['total_bytes']} bytes · "
+            f"`{mount['path']}`"
+        )
+    for source in report["validation"]["sources"]:
+        lines.append(
+            f"- source {source['name']}: `{source['revision']}` · `{source['path']}`"
+        )
+    if report["perf"]["selected"]:
+        attr = report["perf"]["attribution"]
+        lines += [
+            "",
+            "## Perf attribution",
+            "",
+            f"- Total self samples: {attr['total_samples']}",
+            f"- Samples attributed to configured core: {attr['attributed_samples']}",
+            f"- Attribution coverage: {attr['attribution_coverage_pct']:.2f}%",
+            f"- `perf.data`: `{report['perf']['perf_data']}`",
+        ]
+    else:
+        lines += [
+            "",
+            "## Perf attribution",
+            "",
+            "- Not selected. Re-run with `--profile`; missing/unsupported perf is a hard error in that mode.",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def execute(args: argparse.Namespace) -> dict[str, Any]:
+    if args.runs < MIN_MEASURED_RUNS:
+        raise HarnessError(
+            f"--runs must be >= {MIN_MEASURED_RUNS} for an authoritative result"
+        )
+    if args.warmups < 0:
+        raise HarnessError("--warmups must be >= 0")
+    if platform.system() != "Linux" or platform.machine() != "x86_64":
+        raise HarnessError(
+            "the pinned #798 timing cohort requires Linux x86_64"
+        )
+    config = load_manifest(args.manifest)
+    validation = validate_config(config)
+    work_dir = args.work_dir.resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+    wamr_manifest, wasmtime_cwasm, compile_report = precompile(
+        config, work_dir / "artifacts", args.compile_timeout
+    )
+    records: list[dict[str, Any]] = []
+    for index in range(1, args.warmups + 1):
+        for runtime in ("wamr", "wasmtime"):
+            records.append(
+                run_one(
+                    config,
+                    runtime,
+                    "warmup",
+                    index,
+                    work_dir / "outputs",
+                    wamr_manifest,
+                    wasmtime_cwasm,
+                    args.run_timeout,
+                )
+            )
+    for index in range(1, args.runs + 1):
+        order = ("wamr", "wasmtime") if index % 2 else ("wasmtime", "wamr")
+        for runtime in order:
+            record = run_one(
+                config,
+                runtime,
+                "measure",
+                index,
+                work_dir / "outputs",
+                wamr_manifest,
+                wasmtime_cwasm,
+                args.run_timeout,
+            )
+            records.append(record)
+            print(
+                f"[keyvault] {runtime} measured {index}/{args.runs}: "
+                f"{record['elapsed_seconds']:.3f}s",
+                file=sys.stderr,
+            )
+    equivalence = verify_equivalence(records)
+    wamr_samples = parse_timing_samples(records, "wamr")
+    wasmtime_samples = parse_timing_samples(records, "wasmtime")
+    timing = {
+        "wamr": sample_stats(wamr_samples),
+        "wasmtime": sample_stats(wasmtime_samples),
+        "wasmtime_time_over_wamr_time": (
+            statistics.fmean(wasmtime_samples) / statistics.fmean(wamr_samples)
+        ),
+    }
+    measured_reference = next(
+        record["output"] for record in records if record["phase"] == "measure"
+    )
+    perf_report = (
+        run_perf(
+            config,
+            work_dir,
+            wamr_manifest,
+            wasmtime_cwasm,
+            args.run_timeout,
+            measured_reference,
+        )
+        if args.profile
+        else {"selected": False}
+    )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "keyvault-tcgc-aot-benchmark",
+        "manifest": str(config.manifest_path),
+        "host": host_report(),
+        "plan": {
+            "warmups": args.warmups,
+            "runs": args.runs,
+            "compile_timeout_seconds": args.compile_timeout,
+            "run_timeout_seconds": args.run_timeout,
+        },
+        "validation": validation,
+        "precompile": compile_report,
+        "records": records,
+        "equivalence": equivalence,
+        "timing": timing,
+        "perf": perf_report,
+    }
+    args.report_json.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="UTF-8"
+    )
+    args.report_markdown.write_text(render_markdown(report), encoding="UTF-8")
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--work-dir", type=Path)
+    parser.add_argument(
+        "--hash",
+        type=Path,
+        help="print the harness SHA-256 for a file or directory, then exit",
+    )
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument("--compile-timeout", type=float, default=1800)
+    parser.add_argument("--run-timeout", type=float, default=600)
+    parser.add_argument("--profile", action="store_true")
+    parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument("--report-json", type=Path, default=Path("keyvault-report.json"))
+    parser.add_argument(
+        "--report-markdown", type=Path, default=Path("keyvault-report.md")
+    )
+    args = parser.parse_args()
+    try:
+        if args.hash:
+            path = args.hash.resolve()
+            if path.is_file():
+                print(json.dumps({"path": str(path), "sha256": sha256_file(path)}))
+            elif path.is_dir():
+                print(json.dumps(tree_snapshot(path), indent=2, sort_keys=True))
+            else:
+                raise HarnessError(f"path to hash is absent: {path}")
+            return 0
+        if args.manifest is None:
+            raise HarnessError("--manifest is required unless --hash is used")
+        if not args.validate_only and args.work_dir is None:
+            raise HarnessError("--work-dir is required for benchmark execution")
+        config = load_manifest(args.manifest)
+        if args.validate_only:
+            print(json.dumps(validate_config(config), indent=2, sort_keys=True))
+            return 0
+        args.report_json = args.report_json.resolve()
+        args.report_markdown = args.report_markdown.resolve()
+        args.report_json.parent.mkdir(parents=True, exist_ok=True)
+        args.report_markdown.parent.mkdir(parents=True, exist_ok=True)
+        report = execute(args)
+        print(render_markdown(report), end="")
+        return 0
+    except (HarnessError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmarks/keyvault/README.md
+++ b/tests/benchmarks/keyvault/README.md
@@ -1,0 +1,116 @@
+# Keyvault SpiderMonkey/TCGC AOT harness
+
+`scripts/bench_keyvault.py` compares precompiled WAMR and Wasmtime execution
+of the keyvault codegen workload from #798. It is deliberately an orchestrator,
+not an installer: it never clones repositories, downloads runtimes, installs
+`perf`, builds the component, or guesses a floating version.
+
+## Reproduction contract
+
+Create a local manifest from `manifest.example.json`. Every placeholder must be
+replaced with:
+
+- full 40-character revisions for the WAMR, azure-sdk-for-zig, and
+  azure-rest-api-specs checkouts used to produce the workload;
+- SHA-256 values for `wamr`, `wamrc`, Wasmtime, the composed component, and the
+  generated `stdlib-preopens.txt`;
+- the harness tree SHA-256 for `/spec` and every stdlib preopen;
+- the complete guest environment (an empty object means no workload-specific
+  variables);
+- the exact expected `got N bytes back from tcgc.compile` byte count.
+
+The example records the known #743 component identity
+`fe08b02f...d9da8c92` and SDK revision
+`19e06fc47073bcb9a6c461e3a0bf5298dc49cc60`. It is not a runnable lockfile:
+machine-specific paths, locally built tool hashes, stdlib tree hashes, and the
+exact spec cohort still need to be supplied. Do not substitute current branch
+tips and call the result the #798 baseline.
+
+Compute hashes with the harness's canonical algorithm:
+
+```bash
+python3 scripts/bench_keyvault.py --hash /path/to/file
+python3 scripts/bench_keyvault.py --hash /path/to/tree
+```
+
+Directory hashes cover the sorted relative path, exact size, and SHA-256 of
+every regular file. Symlinks are rejected. The `preopens_file` mappings must
+exactly match all configured mounts except `/spec`; the output mount `/out` is
+created separately for every run.
+
+Validate prerequisites without compiling or executing:
+
+```bash
+python3 scripts/bench_keyvault.py \
+  --manifest /path/to/keyvault.lock.json \
+  --validate-only
+```
+
+Validation is intentionally strict. Missing binaries/checkouts, shortened or
+wrong revisions, tracked source modifications, placeholder hashes, changed
+inputs, malformed preopens, or a tool whose version output does not contain the
+pinned version are hard errors with the expected and actual identities.
+
+## Authoritative timing
+
+The harness currently targets the Linux x86_64 #798 cohort. Build WAMR
+`ReleaseFast`, obtain a pinned Wasmtime binary (the repository CI currently
+uses `v46.0.1`), build the component and TCGC stdlib, and prepare the pinned
+spec checkout before invoking it:
+
+```bash
+python3 scripts/bench_keyvault.py \
+  --manifest /path/to/keyvault.lock.json \
+  --work-dir "$PWD/zig-out/keyvault-798" \
+  --warmups 2 \
+  --runs 7 \
+  --report-json "$PWD/zig-out/keyvault-798/report.json" \
+  --report-markdown "$PWD/zig-out/keyvault-798/report.md"
+```
+
+`--runs` cannot be less than five. WAMR `compile-component` and Wasmtime
+`compile` happen once, before warmups, and their durations are reported but
+excluded from measured execution. Measured runs alternate WAMR-first and
+Wasmtime-first ordering. The host subprocess environment is reduced to
+`PATH`, `HOME`, `LANG=C`, `LC_ALL=C`, and `TZ=UTC`, preventing ambient WAMR or
+Wasmtime tuning variables from changing the cohort. Both guests receive only
+the manifest environment plus a fixed harness marker, which also prevents the
+WAMR component CLI from inheriting the caller's environment. The report
+includes:
+
+- host/kernel/CPU details;
+- exact tool versions, binary/input hashes, and source revisions;
+- every timing sample plus mean, median, minimum, maximum, and range;
+- the requested **Wasmtime-time/WAMR-time** ratio;
+- every generated path, size, and SHA-256 plus a canonical tree hash.
+
+Every warmup and measured run must emit exactly one TCGC byte marker, equal the
+manifest's pinned value, and generate an identical output tree. Consequently,
+the historical 58187-vs-58188 response-size drift is a failure even if the
+generated files happen to match.
+
+No report is produced if validation, execution, or equivalence fails. In
+particular, absent external workload assets cannot produce a success-shaped or
+fabricated baseline.
+
+## Perf capture and attribution
+
+Perf is opt-in, never an automatic fallback:
+
+```bash
+python3 scripts/bench_keyvault.py \
+  --manifest /path/to/keyvault.lock.json \
+  --work-dir "$PWD/zig-out/keyvault-798" \
+  --warmups 2 --runs 7 --profile
+```
+
+`--profile` requires Linux x86_64, `perf`, `objdump`, sampling permissions, the
+configured WAMR core index, at least `perf.min_samples`, and at least
+`perf.min_attribution_coverage_pct`. Any unmet requirement fails the command.
+The profiled run is checked against the same response byte count and generated
+output tree before `aot_jit_attr.py` maps self samples to `local_func` indices.
+The JSON/Markdown reports record total samples, attributed samples, coverage,
+top functions, and (when `hot_func` is configured) instruction-class data.
+
+For Azure Linux setup and interpretation details, see
+`.github/skills/aot-perf-profile/SKILL.md`.

--- a/tests/benchmarks/keyvault/manifest.example.json
+++ b/tests/benchmarks/keyvault/manifest.example.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "tools": {
+    "wamr": {
+      "path": "/absolute/path/to/wamr/zig-out/bin/wamr",
+      "sha256": "<64-character-sha256>",
+      "version": "wamr dev"
+    },
+    "wamrc": {
+      "path": "/absolute/path/to/wamr/zig-out/bin/wamrc",
+      "sha256": "<64-character-sha256>",
+      "version": "wamrc dev"
+    },
+    "wasmtime": {
+      "path": "/absolute/path/to/wasmtime",
+      "sha256": "<64-character-sha256>",
+      "version": "wasmtime 46.0.1"
+    }
+  },
+  "sources": [
+    {
+      "name": "wamr",
+      "path": "/absolute/path/to/wamr",
+      "revision": "<full-40-character-commit-sha>"
+    },
+    {
+      "name": "azure-sdk-for-zig",
+      "path": "/absolute/path/to/azure-sdk-for-zig",
+      "revision": "19e06fc47073bcb9a6c461e3a0bf5298dc49cc60"
+    },
+    {
+      "name": "azure-rest-api-specs",
+      "path": "/absolute/path/to/azure-rest-api-specs",
+      "revision": "<full-40-character-commit-sha>"
+    }
+  ],
+  "workload": {
+    "component": {
+      "path": "/absolute/path/to/codegen-cli.composed.wasm",
+      "sha256": "fe08b02fa85209855850ba1ea72bc3ab554cec961fdee005cacb6348d9da8c92"
+    },
+    "preopens_file": {
+      "path": "/absolute/path/to/stdlib-preopens.txt",
+      "sha256": "<64-character-sha256>"
+    },
+    "mounts": [
+      {
+        "path": "/absolute/path/to/azure-rest-api-specs/specification/keyvault/data-plane/Secrets",
+        "guest": "/spec",
+        "sha256_tree": "<64-character-tree-sha256>"
+      },
+      {
+        "path": "/absolute/path/from/stdlib-preopens.txt",
+        "guest": "/the-exact-guest-path-from-stdlib-preopens.txt",
+        "sha256_tree": "<64-character-tree-sha256>"
+      }
+    ],
+    "package_name": "keyvault-secrets",
+    "env": {},
+    "expected_tcgc_response_bytes": 58187
+  },
+  "perf": {
+    "core_index": 4,
+    "hot_func": 6145,
+    "min_samples": 5000,
+    "min_attribution_coverage_pct": 50.0,
+    "base": null
+  }
+}

--- a/tests/benchmarks/keyvault/manifest.schema.json
+++ b/tests/benchmarks/keyvault/manifest.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cataggar/wamr/tests/benchmarks/keyvault/manifest.schema.json",
+  "title": "Pinned keyvault/TCGC benchmark manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "tools", "sources", "workload", "perf"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "tools": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wamr", "wamrc", "wasmtime"],
+      "properties": {
+        "wamr": { "$ref": "#/$defs/tool" },
+        "wamrc": { "$ref": "#/$defs/tool" },
+        "wasmtime": { "$ref": "#/$defs/tool" }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/source" }
+    },
+    "workload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "component",
+        "preopens_file",
+        "mounts",
+        "package_name",
+        "env",
+        "expected_tcgc_response_bytes"
+      ],
+      "properties": {
+        "component": { "$ref": "#/$defs/file" },
+        "preopens_file": { "$ref": "#/$defs/file" },
+        "mounts": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "guest", "sha256_tree"],
+            "properties": {
+              "path": { "type": "string", "minLength": 1 },
+              "guest": { "type": "string", "pattern": "^/" },
+              "sha256_tree": { "$ref": "#/$defs/sha256" }
+            }
+          }
+        },
+        "package_name": { "type": "string", "minLength": 1 },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "propertyNames": {
+            "minLength": 1,
+            "not": { "pattern": "=" }
+          }
+        },
+        "expected_tcgc_response_bytes": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "perf": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "core_index",
+        "hot_func",
+        "min_samples",
+        "min_attribution_coverage_pct",
+        "base"
+      ],
+      "properties": {
+        "core_index": { "type": "integer", "minimum": 0 },
+        "hot_func": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "min_samples": { "type": "integer", "minimum": 1000 },
+        "min_attribution_coverage_pct": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 100
+        },
+        "base": {
+          "oneOf": [
+            { "type": "string", "pattern": "^0x[0-9a-fA-F]+$" },
+            { "type": "null" }
+          ]
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "version"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "version": { "type": "string", "minLength": 1 }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "path", "revision"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "revision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_bench_keyvault.py
+++ b/tests/test_bench_keyvault.py
@@ -8,6 +8,7 @@ import contextlib
 import importlib.util
 import io
 import json
+import platform
 import shutil
 import stat
 import struct
@@ -149,7 +150,7 @@ class KeyvaultHarnessTest(unittest.TestCase):
         config = bench.load_manifest(self.manifest)
         with mock.patch.object(
             bench, "command_version", return_value="pinned-tool-1.0"
-        ):
+        ), mock.patch.object(bench.os, "access", return_value=True):
             report = bench.validate_config(config)
         self.assertEqual(report["inputs"]["component"]["size"], len(self.component.read_bytes()))
         self.assertEqual(len(report["sources"]), 2)
@@ -160,7 +161,7 @@ class KeyvaultHarnessTest(unittest.TestCase):
             bench.HarnessError, "tracked modifications|tree SHA-256 mismatch"
         ), mock.patch.object(
             bench, "command_version", return_value="pinned-tool-1.0"
-        ):
+        ), mock.patch.object(bench.os, "access", return_value=True):
             bench.validate_config(config)
 
     def test_manifest_rejects_placeholders_and_short_revisions(self) -> None:
@@ -324,7 +325,10 @@ class KeyvaultHarnessTest(unittest.TestCase):
         self.assertEqual(report["attributed_samples"], 10)
         self.assertEqual(report["attribution_coverage_pct"], 100)
 
-    @unittest.skipIf(sys.platform == "win32", "controlled runner uses POSIX shell")
+    @unittest.skipUnless(
+        sys.platform.startswith("linux") and platform.machine() == "x86_64",
+        "controlled timing cohort requires Linux x86_64",
+    )
     def test_controlled_end_to_end_smoke(self) -> None:
         self.tool.write_text(
             "#!/bin/sh\n"

--- a/tests/test_bench_keyvault.py
+++ b/tests/test_bench_keyvault.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Controlled tests for the pinned keyvault/TCGC benchmark harness."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib.util
+import io
+import json
+import shutil
+import stat
+import struct
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import bench_keyvault as bench  # noqa: E402
+
+
+def _load_attr_module():
+    path = ROOT / ".github" / "skills" / "aot-perf-profile" / "aot_jit_attr.py"
+    spec = importlib.util.spec_from_file_location("aot_jit_attr_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class KeyvaultHarnessTest(unittest.TestCase):
+    scratch = ROOT / "zig-out" / "keyvault-harness-unit"
+
+    def setUp(self) -> None:
+        shutil.rmtree(self.scratch, ignore_errors=True)
+        self.scratch.mkdir(parents=True)
+        self.sdk = self.scratch / "sdk"
+        self.spec_repo = self.scratch / "spec-repo"
+        self.component = self.sdk / "component.wasm"
+        self.preopens = self.sdk / "stdlib-preopens.txt"
+        self.stdlib = self.sdk / "stdlib"
+        self.spec = self.spec_repo / "Secrets"
+        self.stdlib.mkdir(parents=True)
+        self.spec.mkdir(parents=True)
+        self.component.write_bytes(b"\0asm controlled component")
+        (self.stdlib / "lib.tsp").write_text("model Library {}\n", encoding="UTF-8")
+        (self.spec / "main.tsp").write_text("model Secret {}\n", encoding="UTF-8")
+        self.preopens.write_text(
+            f"{self.stdlib.resolve()}=/stdlib\n", encoding="UTF-8"
+        )
+        self.tool = self.scratch / "fake-tool"
+        self.tool.write_text("#!/bin/sh\necho pinned-tool-1.0\n", encoding="UTF-8")
+        self.tool.chmod(self.tool.stat().st_mode | stat.S_IXUSR)
+        self.sdk_revision = self._init_repo(self.sdk)
+        self.spec_revision = self._init_repo(self.spec_repo)
+        self.manifest = self.scratch / "manifest.json"
+        self.manifest.write_text(
+            json.dumps(self._manifest_document(), indent=2), encoding="UTF-8"
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.scratch, ignore_errors=True)
+
+    def _init_repo(self, path: Path) -> str:
+        subprocess.run(["git", "init", "-q", str(path)], check=True)
+        subprocess.run(
+            ["git", "-C", str(path), "config", "user.email", "test@example.invalid"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(path), "config", "user.name", "Harness Test"],
+            check=True,
+        )
+        subprocess.run(["git", "-C", str(path), "add", "."], check=True)
+        subprocess.run(
+            ["git", "-C", str(path), "commit", "-qm", "fixture"], check=True
+        )
+        return subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+    def _manifest_document(self) -> dict:
+        tool_sha = bench.sha256_file(self.tool)
+        return {
+            "schema_version": 1,
+            "tools": {
+                name: {
+                    "path": str(self.tool),
+                    "sha256": tool_sha,
+                    "version": "pinned-tool-1.0",
+                }
+                for name in ("wamr", "wamrc", "wasmtime")
+            },
+            "sources": [
+                {
+                    "name": "azure-sdk-for-zig",
+                    "path": str(self.sdk),
+                    "revision": self.sdk_revision,
+                },
+                {
+                    "name": "azure-rest-api-specs",
+                    "path": str(self.spec_repo),
+                    "revision": self.spec_revision,
+                },
+            ],
+            "workload": {
+                "component": {
+                    "path": str(self.component),
+                    "sha256": bench.sha256_file(self.component),
+                },
+                "preopens_file": {
+                    "path": str(self.preopens),
+                    "sha256": bench.sha256_file(self.preopens),
+                },
+                "mounts": [
+                    {
+                        "path": str(self.spec),
+                        "guest": "/spec",
+                        "sha256_tree": bench.tree_snapshot(self.spec)["sha256"],
+                    },
+                    {
+                        "path": str(self.stdlib),
+                        "guest": "/stdlib",
+                        "sha256_tree": bench.tree_snapshot(self.stdlib)["sha256"],
+                    },
+                ],
+                "package_name": "keyvault-secrets",
+                "env": {},
+                "expected_tcgc_response_bytes": 58187,
+            },
+            "perf": {
+                "core_index": 4,
+                "hot_func": 6145,
+                "min_samples": 5000,
+                "min_attribution_coverage_pct": 50,
+                "base": None,
+            },
+        }
+
+    def test_manifest_validation_checks_hashes_revisions_and_preopens(self) -> None:
+        config = bench.load_manifest(self.manifest)
+        with mock.patch.object(
+            bench, "command_version", return_value="pinned-tool-1.0"
+        ):
+            report = bench.validate_config(config)
+        self.assertEqual(report["inputs"]["component"]["size"], len(self.component.read_bytes()))
+        self.assertEqual(len(report["sources"]), 2)
+        self.assertEqual(report["inputs"]["mounts"][1]["file_count"], 1)
+
+        (self.stdlib / "lib.tsp").write_text("changed\n", encoding="UTF-8")
+        with self.assertRaisesRegex(
+            bench.HarnessError, "tracked modifications|tree SHA-256 mismatch"
+        ), mock.patch.object(
+            bench, "command_version", return_value="pinned-tool-1.0"
+        ):
+            bench.validate_config(config)
+
+    def test_manifest_rejects_placeholders_and_short_revisions(self) -> None:
+        document = self._manifest_document()
+        document["tools"]["wamr"]["sha256"] = "0" * 64
+        document["sources"][0]["revision"] = "19e06fc47"
+        self.manifest.write_text(json.dumps(document), encoding="UTF-8")
+        with self.assertRaisesRegex(bench.HarnessError, "non-zero"):
+            bench.load_manifest(self.manifest)
+
+        document["tools"]["wamr"]["sha256"] = bench.sha256_file(self.tool)
+        self.manifest.write_text(json.dumps(document), encoding="UTF-8")
+        with self.assertRaisesRegex(bench.HarnessError, "40-character"):
+            bench.load_manifest(self.manifest)
+
+    def test_checked_in_schema_and_example_track_parser_version(self) -> None:
+        directory = ROOT / "tests" / "benchmarks" / "keyvault"
+        schema = json.loads(
+            (directory / "manifest.schema.json").read_text(encoding="UTF-8")
+        )
+        example = json.loads(
+            (directory / "manifest.example.json").read_text(encoding="UTF-8")
+        )
+        self.assertEqual(schema["properties"]["schema_version"]["const"], 1)
+        self.assertEqual(example["schema_version"], bench.SCHEMA_VERSION)
+        self.assertEqual(
+            example["workload"]["component"]["sha256"],
+            "fe08b02fa85209855850ba1ea72bc3ab554cec961fdee005cacb6348d9da8c92",
+        )
+
+    def test_command_construction_precompiles_then_runs_artifacts(self) -> None:
+        config = bench.load_manifest(self.manifest)
+        artifacts = self.scratch / "artifacts"
+        wamr_compile, wasmtime_compile, wamr_manifest, wasmtime_cwasm = (
+            bench.precompile_commands(config, artifacts)
+        )
+        self.assertEqual(
+            wamr_compile[1:4],
+            ["compile-component", "--target=x86_64", str(self.component)],
+        )
+        self.assertIn("max-memory-size=4294967296", wasmtime_compile)
+        self.assertEqual(wasmtime_compile[-2:], ["-o", str(wasmtime_cwasm)])
+
+        out = self.scratch / "out"
+        wamr_run = bench.runtime_command(
+            config, "wamr", out, wamr_manifest, wasmtime_cwasm
+        )
+        wasmtime_run = bench.runtime_command(
+            config, "wasmtime", out, wamr_manifest, wasmtime_cwasm
+        )
+        self.assertIn("--precompiled-manifest", wamr_run)
+        self.assertIn(str(wamr_manifest), wamr_run)
+        self.assertIn("WAMR_KEYVAULT_HARNESS=1", wamr_run)
+        self.assertIn("--allow-precompiled", wasmtime_run)
+        self.assertIn(str(wasmtime_cwasm), wasmtime_run)
+        self.assertIn("WAMR_KEYVAULT_HARNESS=1", wasmtime_run)
+        self.assertNotIn("compile-component", wamr_run)
+        self.assertNotIn("compile", wasmtime_run)
+
+    def test_timing_and_tcgc_output_parsing(self) -> None:
+        self.assertEqual(
+            bench.parse_tcgc_response_bytes(
+                "calling tcgc.compile...\ngot 58187 bytes back from tcgc.compile\n"
+            ),
+            58187,
+        )
+        with self.assertRaisesRegex(bench.HarnessError, "exactly one"):
+            bench.parse_tcgc_response_bytes("no response marker")
+        records = [
+            {
+                "runtime": "wamr",
+                "phase": "measure",
+                "elapsed_seconds": value,
+            }
+            for value in (5.1, 5.2, 5.3, 5.4, 5.5)
+        ]
+        self.assertEqual(bench.parse_timing_samples(records, "wamr")[2], 5.3)
+        with self.assertRaisesRegex(bench.HarnessError, "at least 5"):
+            bench.parse_timing_samples(records[:4], "wamr")
+
+    def test_equivalence_detects_58187_58188_and_file_hash_drift(self) -> None:
+        output = {
+            "sha256_tree": "a" * 64,
+            "file_count": 1,
+            "total_bytes": 4,
+            "files": [{"path": "a.zig", "size": 4, "sha256": "b" * 64}],
+        }
+        base = {
+            "runtime": "wamr",
+            "phase": "measure",
+            "index": 1,
+            "tcgc_response_bytes": 58187,
+            "output": output,
+        }
+        drift = dict(base, runtime="wasmtime", tcgc_response_bytes=58188)
+        with self.assertRaisesRegex(bench.HarnessError, "response-size drift"):
+            bench.verify_equivalence([base, drift])
+
+        changed_output = dict(output, total_bytes=5)
+        drift = dict(base, runtime="wasmtime", output=changed_output)
+        with self.assertRaisesRegex(bench.HarnessError, "generated output mismatch"):
+            bench.verify_equivalence([base, drift])
+
+    def test_missing_prerequisite_is_actionable(self) -> None:
+        config = bench.load_manifest(self.manifest)
+        self.tool.unlink()
+        with self.assertRaisesRegex(
+            bench.HarnessError, "required wamr binary is absent"
+        ):
+            bench.validate_config(config)
+
+    def test_profile_mode_never_falls_back_when_unsupported(self) -> None:
+        config = bench.load_manifest(self.manifest)
+        with mock.patch.object(bench.platform, "system", return_value="Darwin"):
+            with self.assertRaisesRegex(bench.HarnessError, "requires Linux x86_64"):
+                bench.run_perf(
+                    config,
+                    self.scratch,
+                    self.scratch / "manifest.cwasm.json",
+                    self.scratch / "wasmtime.cwasm",
+                    10,
+                    {},
+                )
+
+    def test_attribution_json_reports_sample_coverage(self) -> None:
+        attr = _load_attr_module()
+        cwasm = self.scratch / "core.cwasm"
+        text = b"\x90" * 8
+        functions = struct.pack("<III", 1, 0, 0)
+        cwasm.write_bytes(
+            struct.pack("<II", attr.AOT_MAGIC, attr.AOT_VERSION)
+            + struct.pack("<II", attr.SEC_TEXT, len(text))
+            + text
+            + struct.pack("<II", attr.SEC_FUNCTION, len(functions))
+            + functions
+        )
+        perf = self.scratch / "perf.data"
+        perf.write_bytes(b"controlled")
+        output = self.scratch / "attribution.json"
+        base = 0x100000
+        argv = [
+            "aot_jit_attr.py",
+            "--perf",
+            str(perf),
+            "--cwasm",
+            str(cwasm),
+            "--json-out",
+            str(output),
+            "--min-samples",
+            "5",
+            "--require-size-match",
+        ]
+        with mock.patch.object(attr, "addr_counts", return_value=({base: 10}, 10)), (
+            mock.patch.object(attr, "jit_exec_mmaps", return_value=[(base, 8)])
+        ), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(
+            io.StringIO()
+        ):
+            attr.main()
+        report = json.loads(output.read_text(encoding="UTF-8"))
+        self.assertEqual(report["total_samples"], 10)
+        self.assertEqual(report["attributed_samples"], 10)
+        self.assertEqual(report["attribution_coverage_pct"], 100)
+
+    @unittest.skipIf(sys.platform == "win32", "controlled runner uses POSIX shell")
+    def test_controlled_end_to_end_smoke(self) -> None:
+        self.tool.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            "case \"${1:-}\" in\n"
+            "  version|--version) echo pinned-tool-1.0; exit 0 ;;\n"
+            "  compile-component)\n"
+            "    while [ \"$#\" -gt 0 ]; do\n"
+            "      if [ \"$1\" = -o ]; then shift; out=\"$1\"; break; fi\n"
+            "      shift\n"
+            "    done\n"
+            "    printf '{\"modules\":[]}' > \"$out\"\n"
+            "    stem=${out%.cwasm.json}\n"
+            "    printf core > \"${stem}.4.cwasm\"\n"
+            "    exit 0 ;;\n"
+            "  compile)\n"
+            "    while [ \"$#\" -gt 0 ]; do\n"
+            "      if [ \"$1\" = -o ]; then shift; out=\"$1\"; break; fi\n"
+            "      shift\n"
+            "    done\n"
+            "    printf wasmtime > \"$out\"\n"
+            "    exit 0 ;;\n"
+            "  run)\n"
+            "    out=''\n"
+            "    while [ \"$#\" -gt 0 ]; do\n"
+            "      case \"$1\" in\n"
+            "        *::/out) out=${1%::/out} ;;\n"
+            "      esac\n"
+            "      shift\n"
+            "    done\n"
+            "    mkdir -p \"$out\"\n"
+            "    printf 'pub const generated = true;\\n' > \"$out/generated.zig\"\n"
+            "    echo 'got 58187 bytes back from tcgc.compile'\n"
+            "    exit 0 ;;\n"
+            "esac\n"
+            "exit 3\n",
+            encoding="UTF-8",
+        )
+        self.tool.chmod(self.tool.stat().st_mode | stat.S_IXUSR)
+        document = self._manifest_document()
+        current_sha = bench.sha256_file(self.tool)
+        for tool in document["tools"].values():
+            tool["sha256"] = current_sha
+        self.manifest.write_text(json.dumps(document), encoding="UTF-8")
+        report_json = self.scratch / "report.json"
+        report_markdown = self.scratch / "report.md"
+        with contextlib.redirect_stderr(io.StringIO()):
+            report = bench.execute(
+                argparse.Namespace(
+                    manifest=self.manifest,
+                    work_dir=self.scratch / "work",
+                    warmups=1,
+                    runs=5,
+                    compile_timeout=10.0,
+                    run_timeout=10.0,
+                    profile=False,
+                    report_json=report_json,
+                    report_markdown=report_markdown,
+                )
+            )
+        self.assertEqual(report["timing"]["wamr"]["runs"], 5)
+        self.assertEqual(report["timing"]["wasmtime"]["runs"], 5)
+        self.assertTrue(report["equivalence"]["cross_runtime_exact_match"])
+        self.assertTrue(report_json.is_file())
+        self.assertIn(
+            "Wasmtime-time/WAMR-time ratio", report_markdown.read_text()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_keyvault.py
+++ b/tests/test_bench_keyvault.py
@@ -35,11 +35,12 @@ def _load_attr_module():
 
 
 class KeyvaultHarnessTest(unittest.TestCase):
-    scratch = ROOT / "zig-out" / "keyvault-harness-unit"
+    scratch_root = ROOT / "zig-out"
 
     def setUp(self) -> None:
+        self.scratch = self.scratch_root / f"keyvault-harness-{self._testMethodName}"
         shutil.rmtree(self.scratch, ignore_errors=True)
-        self.scratch.mkdir(parents=True)
+        self.scratch.mkdir(parents=True, exist_ok=True)
         self.sdk = self.scratch / "sdk"
         self.spec_repo = self.scratch / "spec-repo"
         self.component = self.sdk / "component.wasm"


### PR DESCRIPTION
## Summary
- Add a manifest-driven WAMR/Wasmtime keyvault SpiderMonkey-TCGC timing harness.
- Pin and validate full source revisions plus SHA-256 identities for tools, component, preopens, spec, and stdlib trees.
- Precompile both runtimes outside measurement, require explicit warmups and at least five alternating measured runs, and report host/tool/input identity, samples/statistics, and the Wasmtime-time/WAMR-time ratio.
- Require exact TCGC response bytes and generated path/size/SHA-256 equivalence across every run, catching the known 58187-vs-58188 drift.
- Add opt-in fail-closed perf capture with minimum samples, unambiguous mmap attribution, coverage gates, and JSON output.

## Prerequisites
The harness intentionally does not download or build external assets. A local lock manifest must point at already-prepared WAMR, Wasmtime, azure-sdk-for-zig, azure-rest-api-specs, the composed component, preopens, and mounted trees with exact revisions/hashes. Missing or changed prerequisites fail with actionable errors.

## Validation
- Python compile checks for the harness, tests, and attribution helper.
- 10 Python tests, including a controlled end-to-end smoke test.
- Zig formatting and git diff checks.
- Full zig build test suite.

The external component/spec assets, Wasmtime, and perf are absent on this host, so no authoritative workload baseline was produced or fabricated.

Refs #798