### PR TITLE
bench: pin reproducible CoreMark baseline

### DIFF
--- a/.github/workflows/coremark-aarch64.yml
+++ b/.github/workflows/coremark-aarch64.yml
@@ -24,6 +24,7 @@ on:
       - src/runtime/**
       - tests/benchmarks/coremark/**
       - scripts/bench_coremark.py
+      - scripts/test_bench_coremark.py
       - .github/workflows/coremark-aarch64.yml
 
 concurrency:
@@ -54,6 +55,9 @@ jobs:
       - name: Configure Zig caches
         uses: ./.github/actions/zig-cache
 
+      - name: Test CoreMark harness
+        run: python3 -m unittest scripts/test_bench_coremark.py
+
       - name: Resolve refs
         id: refs
         env:
@@ -82,6 +86,7 @@ jobs:
           python3 scripts/bench_coremark.py \
             --baseline "$BASELINE" \
             --target   "$TARGET" \
+            --profile  ci \
             --runs     "$RUNS" \
             --min-delta-pct=-5.0 \
             --out      coremark-table.md \

--- a/.github/workflows/coremark-x86_64.yml
+++ b/.github/workflows/coremark-x86_64.yml
@@ -24,6 +24,7 @@ on:
       - src/runtime/**
       - tests/benchmarks/coremark/**
       - scripts/bench_coremark.py
+      - scripts/test_bench_coremark.py
       - .github/workflows/coremark-x86_64.yml
 
 concurrency:
@@ -55,6 +56,9 @@ jobs:
       - name: Configure Zig caches
         uses: ./.github/actions/zig-cache
 
+      - name: Test CoreMark harness
+        run: python3 -m unittest scripts/test_bench_coremark.py
+
       - name: Resolve refs
         id: refs
         env:
@@ -85,6 +89,7 @@ jobs:
           python3 scripts/bench_coremark.py \
             --baseline "$BASELINE" \
             --target   "$TARGET" \
+            --profile  ci \
             --runs     "$RUNS" \
             --min-delta-pct=-5.0 \
             --out      coremark-table.md \

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ wasm-spec-temp/
 *.aot
 
 # Benchmark artifacts
+.bench-coremark/
 tests/benchmarks/coremark/coremark/
 tests/benchmarks/**/*.wasm
 tests/benchmarks/**/*.aot

--- a/scripts/bench_coremark.py
+++ b/scripts/bench_coremark.py
@@ -1,60 +1,73 @@
 #!/usr/bin/env python3
-"""Compare CoreMark AOT iter/s between two git refs.
+"""Run a reproducible CoreMark comparison across WAMR refs and Wasmtime.
 
-Builds `wamr` + `wamrc` at each ref in a throwaway worktree, AOT-compiles the
-CoreMark .wasm via `tests/benchmarks/coremark`, runs it N times, and prints a
-markdown table with mean / min / max iter/s and delta %.
-
-Intended for use both locally and from `.github/workflows/coremark-aarch64.yml`.
-Requires the CoreMark sources at `tests/benchmarks/coremark/coremark/` (cloned
-on first invocation).
+The default ``authoritative`` profile discards two warmups and records ten
+measured runs.  The tracked CoreMark wasm fixture is used directly, so results
+do not depend on whichever EEMBC/CoreMark commit happens to be upstream.
 
 Usage
 -----
-    scripts/bench_coremark.py --baseline origin/main --target HEAD --runs 3
-    scripts/bench_coremark.py --baseline origin/main --target HEAD --emit github
+    scripts/bench_coremark.py --baseline origin/main --target HEAD
+    scripts/bench_coremark.py --wasmtime-baseline auto --wasmtime /path/to/wasmtime
+    scripts/bench_coremark.py --profile ci --min-delta-pct=-5
     scripts/bench_coremark.py --optimize both
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import platform
 import re
+import shutil
 import statistics
 import subprocess
 import sys
-import tempfile
+import tarfile
+import urllib.request
+import uuid
+from dataclasses import dataclass
 from pathlib import Path
 
 from bench_optimize import OPTIMIZE_CHOICES, fmt_ratio, optimize_slug, parse_optimize_modes
 
 ITER_PATTERN = re.compile(r"Iterations/Sec\s*:\s*([0-9]+(?:\.[0-9]+)?)")
+VALIDATION_TEXT = "Correct operation validated."
+DEFAULT_FIXTURE = Path("tests/benchmarks/coremark/coremark_wasi.wasm")
+DEFAULT_FIXTURE_SHA256 = "f4b7591296ead10264e0f101f355bdf848865c31329325594e66fbabefec235b"
+PINNED_WASMTIME_VERSION = "44.0.1"
+PROFILE_COUNTS = {
+    "authoritative": (2, 10),
+    "ci": (0, 3),
+}
+PINNED_WASMTIME_ASSETS = {
+    ("linux", "x86_64"): (
+        "wasmtime-v44.0.1-x86_64-linux.tar.xz",
+        "afd58715f105e3a7f454169daed22168c5736ec5f225fb04c4ac62c54c9508a3",
+        "47e59a672f6a35ad071e3fbe7c0c541dcaea77b085d7aada4fd1a9ac77a0d601",
+    ),
+    ("linux", "aarch64"): (
+        "wasmtime-v44.0.1-aarch64-linux.tar.xz",
+        "9ec1e606c541099a7e8266865494e190a6f928abb3a2fb7bb4195fd2e8499d2b",
+        "ad27d96d24d193ff32665a59552699e3f5355baeaf7220fb4cd88f023694e93d",
+    ),
+}
 
-# Signature of the known x86_64 native AOT-run flake from issue #406:
-# `wamr run` traps with `out of bounds memory access (..., local_func[N]+0x0, ...)`
-# at the very first byte of a local function (or with a synthetic `[-1]`
-# function index). PR #696 added an optional `"<name>"` annotation between
-# the bracketed funcidx and the offset (e.g. `local_func[0] "__wasm_call_ctors"+0x0`),
-# so the pattern accepts an optional quoted name. The trap is non-deterministic
-# on shared GitHub-hosted x86_64 runners — it has been observed firing on
-# baseline `main` after a clean run of the same binary, proving it's not
-# introduced by any single change. Real coremark regressions would trap
-# deeper inside a function (non-zero offset), so a `+0x0` offset is the
-# discriminator. Retry this failure mode up to `_TRAP_RETRY_MAX` times
-# before treating it as a real regression. Bumped from 3 → 5 because
-# CI run https://github.com/cataggar/wamr/actions/runs/26850322663 (on
-# PR #763) exhausted the 3-retry budget when the flake fired 4 times
-# in a row on a single CoreMark slot — the underlying #406 cause
-# remains unfixed, so a temporary larger retry window keeps CI green
-# without hiding a real regression (real codegen bugs trap deeper
-# inside a function and don't match `+0x0`).
+# Signature of the known x86_64 native AOT-run flake from issue #406.
 _TRAP_FLAKE_PATTERN = re.compile(
     r'wasm trap: out of bounds memory access.*local_func\[-?\d+\](?:\s+"[^"]*")?\+0x0',
     re.IGNORECASE,
 )
 _TRAP_RETRY_MAX = 5
+
+
+@dataclass(frozen=True)
+class EngineResult:
+    engine: str
+    version: str
+    optimize: str
+    values: list[float]
 
 
 def run(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> str:
@@ -68,11 +81,6 @@ def run(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> str
             capture_output=True,
         )
     except subprocess.CalledProcessError as exc:
-        # The default str() on CalledProcessError omits the captured output,
-        # which makes CI failures of `zig build run-aot` (and similar) opaque.
-        # Surface stdout + stderr verbatim before re-raising so the actual
-        # error (e.g. a wasm trap printed by the underlying tool) is visible
-        # in the workflow log.
         sys.stderr.write(
             f"\n[harness] command failed (exit {exc.returncode}): "
             f"{' '.join(str(c) for c in cmd)}\n"
@@ -80,13 +88,11 @@ def run(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> str
         if cwd is not None:
             sys.stderr.write(f"[harness]   cwd: {cwd}\n")
         if exc.stdout:
-            sys.stderr.write("[harness] --- stdout ---\n")
-            sys.stderr.write(exc.stdout)
+            sys.stderr.write(f"[harness] --- stdout ---\n{exc.stdout}")
             if not exc.stdout.endswith("\n"):
                 sys.stderr.write("\n")
         if exc.stderr:
-            sys.stderr.write("[harness] --- stderr ---\n")
-            sys.stderr.write(exc.stderr)
+            sys.stderr.write(f"[harness] --- stderr ---\n{exc.stderr}")
             if not exc.stderr.endswith("\n"):
                 sys.stderr.write("\n")
         sys.stderr.flush()
@@ -94,40 +100,52 @@ def run(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> str
     return proc.stdout + proc.stderr
 
 
-def ensure_coremark_src(repo: Path) -> None:
-    src = repo / "tests/benchmarks/coremark/coremark"
-    if (src / "core_main.c").exists():
-        return
-    print(f"[harness] cloning CoreMark sources into {src}", file=sys.stderr)
-    run(
-        [
-            "git",
-            "clone",
-            "--depth",
-            "1",
-            "https://github.com/eembc/coremark.git",
-            str(src),
-        ]
-    )
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
-def make_worktree(repo: Path, ref: str, root: Path, label: str) -> Path:
-    """Create a fresh worktree at `ref` under `root` so concurrent builds don't fight."""
+def resolve_fixture(repo: Path, fixture_arg: Path) -> tuple[Path, str]:
+    fixture = fixture_arg if fixture_arg.is_absolute() else repo / fixture_arg
+    fixture = fixture.resolve()
+    if not fixture.is_file():
+        raise FileNotFoundError(f"CoreMark fixture not found: {fixture}")
+    digest = sha256_file(fixture)
+    default_fixture = (repo / DEFAULT_FIXTURE).resolve()
+    if fixture == default_fixture and digest != DEFAULT_FIXTURE_SHA256:
+        raise RuntimeError(
+            "tracked CoreMark fixture checksum mismatch: "
+            f"expected {DEFAULT_FIXTURE_SHA256}, got {digest}"
+        )
+    return fixture, digest
+
+
+def parse_coremark_output(output: str, engine: str) -> float:
+    if VALIDATION_TEXT not in output or re.search(r"(?m)^.*ERROR!", output):
+        raise RuntimeError(
+            f"{engine} did not produce a CRC-validated CoreMark result:\n{output}"
+        )
+    matches = ITER_PATTERN.findall(output)
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"{engine} produced {len(matches)} Iterations/Sec values; expected one:\n"
+            f"{output}"
+        )
+    return float(matches[0])
+
+
+def make_worktree(repo: Path, ref: str, root: Path, label: str) -> tuple[Path, str]:
     sha = run(["git", "rev-parse", ref], cwd=repo).strip()
     wt = root / f"{label}-{sha[:12]}"
-    if wt.exists():
-        run(["git", "worktree", "remove", "--force", str(wt)], cwd=repo)
     run(["git", "worktree", "add", "--detach", str(wt), sha], cwd=repo)
-    return wt
+    return wt, sha
 
 
 def worktree_env(wt: Path) -> dict:
-    """Return an environment that keeps Zig caches isolated per worktree."""
     env = os.environ.copy()
-    # setup-zig exports both cache dirs to the checkout's .zig-cache. That is
-    # unsafe for this script because it builds multiple git worktrees in
-    # sequence; the target ref can otherwise reuse baseline build artifacts.
-    # Keep each ref's local and global Zig caches independent.
     env.pop("ZIG_LOCAL_CACHE_DIR", None)
     global_cache = wt / ".zig-global-cache"
     global_cache.mkdir(exist_ok=True)
@@ -135,67 +153,228 @@ def worktree_env(wt: Path) -> dict:
     return env
 
 
-def build_and_run(wt: Path, runs: int, coremark_src: Path, optimize: str) -> list[float]:
-    """Build wamr + AOT-compile + run CoreMark `runs` times, return iter/s list."""
-    env = worktree_env(wt)
-    # Each worktree owns its own .zig-cache (already on /work for our runner).
-    print(f"[harness] building {wt.name} ({optimize})", file=sys.stderr)
-    run(["zig", "build", f"-Doptimize={optimize}"], cwd=wt, env=env)
-
-    cm = wt / "tests/benchmarks/coremark"
-    # Symlink CoreMark sources from the canonical location to avoid re-cloning
-    # per worktree.  Worktrees only contain tracked files; CoreMark sources
-    # are external and not tracked.
-    src_link = cm / "coremark"
-    if not src_link.exists():
-        src_link.symlink_to(coremark_src, target_is_directory=True)
-
-    print(f"[harness] AOT-compiling CoreMark in {wt.name}", file=sys.stderr)
-    run(["zig", "build", "aot"], cwd=cm, env=env)
-
-    results: list[float] = []
-    for i in range(runs):
-        out = _run_aot_with_retry(cm, env, run_idx=i, runs_total=runs)
-        m = ITER_PATTERN.search(out)
-        if not m:
-            raise RuntimeError(
-                f"could not parse Iterations/Sec from CoreMark output:\n{out}"
-            )
-        val = float(m.group(1))
-        print(f"[harness]   run {i + 1}/{runs}: {val:.1f} iter/s", file=sys.stderr)
-        results.append(val)
-    return results
-
-
-def _run_aot_with_retry(cm: Path, env: dict, run_idx: int, runs_total: int) -> str:
-    """Wrap `zig build run-aot` so the issue-#406 x86_64 trap flake doesn't
-    fail the gate on the first incidence. Real failures still propagate
-    after `_TRAP_RETRY_MAX` retries."""
+def _run_wamr_with_retry(
+    cmd: list[str],
+    cwd: Path,
+    env: dict,
+    sample_idx: int,
+    samples_total: int,
+) -> str:
     last_exc = None
     for attempt in range(1 + _TRAP_RETRY_MAX):
         try:
-            return run(["zig", "build", "run-aot"], cwd=cm, env=env)
+            return run(cmd, cwd=cwd, env=env)
         except subprocess.CalledProcessError as exc:
-            stderr = exc.stderr or ""
-            if not _TRAP_FLAKE_PATTERN.search(stderr):
-                # Not the known x86_64 trap flake — let it propagate.
+            failure_output = (exc.stdout or "") + (exc.stderr or "")
+            if not _TRAP_FLAKE_PATTERN.search(failure_output):
                 raise
             if attempt == _TRAP_RETRY_MAX:
                 last_exc = exc
                 break
             print(
-                f"[harness]   run {run_idx + 1}/{runs_total}: x86_64 AOT trap flake "
-                f"(issue #406) — retry {attempt + 1}/{_TRAP_RETRY_MAX}",
+                f"[harness]   sample {sample_idx + 1}/{samples_total}: x86_64 "
+                f"AOT trap flake (issue #406) — retry "
+                f"{attempt + 1}/{_TRAP_RETRY_MAX}",
                 file=sys.stderr,
             )
-    # Re-raise the last exception so the original stderr + diagnostic
-    # formatting from `run()` are visible.
     assert last_exc is not None
     raise last_exc
 
 
-def fmt_stats(values: list[float]) -> tuple[float, float, float]:
-    return statistics.fmean(values), min(values), max(values)
+def measure_command(
+    *,
+    engine: str,
+    cmd: list[str],
+    cwd: Path,
+    env: dict,
+    warmups: int,
+    runs: int,
+    retry_wamr_flake: bool = False,
+) -> list[float]:
+    values: list[float] = []
+    total = warmups + runs
+    for i in range(total):
+        if retry_wamr_flake:
+            output = _run_wamr_with_retry(cmd, cwd, env, i, total)
+        else:
+            output = run(cmd, cwd=cwd, env=env)
+        value = parse_coremark_output(output, engine)
+        if i < warmups:
+            print(
+                f"[harness]   {engine} warmup {i + 1}/{warmups}: "
+                f"{value:.1f} iter/s (discarded)",
+                file=sys.stderr,
+            )
+        else:
+            measured_idx = i - warmups + 1
+            print(
+                f"[harness]   {engine} run {measured_idx}/{runs}: "
+                f"{value:.1f} iter/s",
+                file=sys.stderr,
+            )
+            values.append(value)
+    return values
+
+
+def build_and_run_wamr(
+    wt: Path,
+    ref: str,
+    sha: str,
+    fixture: Path,
+    optimize: str,
+    warmups: int,
+    runs: int,
+) -> EngineResult:
+    env = worktree_env(wt)
+    print(f"[harness] building WAMR {ref} ({sha[:12]}, {optimize})", file=sys.stderr)
+    run(["zig", "build", f"-Doptimize={optimize}"], cwd=wt, env=env)
+
+    wamrc = wt / "zig-out/bin/wamrc"
+    wamr = wt / "zig-out/bin/wamr"
+    cwasm = wt / ".bench-coremark.cwasm"
+    print(f"[harness] AOT-compiling tracked fixture with WAMR {ref}", file=sys.stderr)
+    run(
+        [str(wamrc), "compile", str(fixture), "-o", str(cwasm)],
+        cwd=wt,
+        env=env,
+    )
+    values = measure_command(
+        engine=f"WAMR {ref}",
+        cmd=[str(wamr), "run", str(cwasm)],
+        cwd=wt,
+        env=env,
+        warmups=warmups,
+        runs=runs,
+        retry_wamr_flake=True,
+    )
+    return EngineResult("WAMR", f"{ref} ({sha[:12]})", optimize, values)
+
+
+def normalize_arch() -> str:
+    arch = platform.machine().lower()
+    return {
+        "amd64": "x86_64",
+        "x64": "x86_64",
+        "arm64": "aarch64",
+    }.get(arch, arch)
+
+
+def wasmtime_version(path: Path) -> str:
+    output = run([str(path), "--version"]).strip()
+    match = re.search(r"\bwasmtime\s+v?([0-9]+\.[0-9]+\.[0-9]+)\b", output)
+    if not match:
+        raise RuntimeError(f"could not parse Wasmtime version from: {output!r}")
+    return match.group(1)
+
+
+def validate_pinned_wasmtime(path: Path) -> str:
+    version = wasmtime_version(path)
+    if version != PINNED_WASMTIME_VERSION:
+        raise RuntimeError(
+            f"historical Wasmtime baseline must be {PINNED_WASMTIME_VERSION}; "
+            f"{path} reports {version}"
+        )
+    return version
+
+
+def install_pinned_wasmtime(repo: Path, cache_arg: Path | None) -> Path:
+    key = (platform.system().lower(), normalize_arch())
+    asset = PINNED_WASMTIME_ASSETS.get(key)
+    if asset is None:
+        supported = ", ".join(f"{os_name}/{arch}" for os_name, arch in PINNED_WASMTIME_ASSETS)
+        raise RuntimeError(
+            f"automatic Wasmtime installation is unsupported on {key[0]}/{key[1]}; "
+            f"supported: {supported}. Pass --wasmtime-baseline PATH instead."
+        )
+    asset_name, expected_archive_sha, expected_binary_sha = asset
+    cache = (
+        cache_arg.expanduser().resolve()
+        if cache_arg is not None
+        else repo / ".bench-coremark/tools"
+    )
+    install_dir = cache / f"wasmtime-v{PINNED_WASMTIME_VERSION}-{key[1]}-{key[0]}"
+    binary = install_dir / "wasmtime"
+    if binary.is_file():
+        actual_binary_sha = sha256_file(binary)
+        if actual_binary_sha != expected_binary_sha:
+            raise RuntimeError(
+                f"cached Wasmtime binary checksum mismatch: expected "
+                f"{expected_binary_sha}, got {actual_binary_sha}"
+            )
+        validate_pinned_wasmtime(binary)
+        return binary
+
+    cache.mkdir(parents=True, exist_ok=True)
+    archive = cache / asset_name
+    url = (
+        "https://github.com/bytecodealliance/wasmtime/releases/download/"
+        f"v{PINNED_WASMTIME_VERSION}/{asset_name}"
+    )
+    print(f"[harness] downloading pinned Wasmtime {PINNED_WASMTIME_VERSION}", file=sys.stderr)
+    urllib.request.urlretrieve(url, archive)
+    actual_sha = sha256_file(archive)
+    if actual_sha != expected_archive_sha:
+        archive.unlink(missing_ok=True)
+        raise RuntimeError(
+            "Wasmtime archive checksum mismatch: expected "
+            f"{expected_archive_sha}, got {actual_sha}"
+        )
+
+    install_dir.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive, "r:xz") as tar:
+        members = [
+            member
+            for member in tar.getmembers()
+            if member.isfile() and Path(member.name).name == "wasmtime"
+        ]
+        if len(members) != 1:
+            raise RuntimeError(
+                f"expected one wasmtime binary in {archive}, found {len(members)}"
+            )
+        source = tar.extractfile(members[0])
+        if source is None:
+            raise RuntimeError(f"could not extract wasmtime from {archive}")
+        with binary.open("wb") as destination:
+            shutil.copyfileobj(source, destination)
+    binary.chmod(0o755)
+    archive.unlink()
+    actual_binary_sha = sha256_file(binary)
+    if actual_binary_sha != expected_binary_sha:
+        binary.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"Wasmtime binary checksum mismatch: expected {expected_binary_sha}, "
+            f"got {actual_binary_sha}"
+        )
+    validate_pinned_wasmtime(binary)
+    return binary
+
+
+def measure_wasmtime(
+    path: Path,
+    label: str,
+    version: str,
+    fixture: Path,
+    warmups: int,
+    runs: int,
+) -> EngineResult:
+    values = measure_command(
+        engine=label,
+        cmd=[str(path), "run", str(fixture)],
+        cwd=fixture.parent,
+        env=os.environ.copy(),
+        warmups=warmups,
+        runs=runs,
+    )
+    return EngineResult(label, f"{version} ({path})", "default JIT", values)
+
+
+def fmt_stats(values: list[float]) -> tuple[float, float, float, float]:
+    return (
+        statistics.fmean(values),
+        statistics.median(values),
+        min(values),
+        max(values),
+    )
 
 
 def compute_delta_pct(baseline_vals: list[float], target_vals: list[float]) -> float:
@@ -203,13 +382,6 @@ def compute_delta_pct(baseline_vals: list[float], target_vals: list[float]) -> f
 
 
 def host_cpu_model() -> str:
-    """Best-effort friendly CPU model name.
-
-    `lscpu` exposes a friendly core name for ARM (e.g. `Neoverse-N2`) where
-    `/proc/cpuinfo` only carries the raw implementer/part IDs, so try it
-    first; fall back to the x86-style `model name` line, then to
-    `platform.processor()`.
-    """
     try:
         out = subprocess.run(
             ["lscpu"], capture_output=True, text=True, timeout=5
@@ -231,173 +403,361 @@ def host_cpu_model() -> str:
                         return val
     except Exception:
         pass
-    proc = platform.processor()
-    return proc if proc else "unknown CPU"
+    return platform.processor() or "unknown CPU"
 
 
 def host_info() -> str:
-    """One-line markdown describing the machine the benchmark ran on, so the
-    report is self-documenting about arch / vCPU count / CPU model (and the
-    CI runner when present)."""
     arch = platform.machine() or "unknown-arch"
     ncpu = os.cpu_count()
-    ncpu_str = str(ncpu) if ncpu else "?"
-    model = host_cpu_model()
-    parts = [f"arch `{arch}`", f"{ncpu_str} vCPU", f"`{model}`"]
+    parts = [f"arch `{arch}`", f"{ncpu or '?'} vCPU", f"`{host_cpu_model()}`"]
     runner = os.environ.get("RUNNER_NAME")
     if runner:
         parts.append(f"runner `{runner}`")
     return "_Host: " + " · ".join(parts) + "_"
 
 
+def format_samples(values: list[float]) -> str:
+    return ", ".join(f"{value:.1f}" for value in values)
+
+
 def render_table(
-    baseline_ref: str,
-    baseline_vals: list[float],
-    target_ref: str,
-    target_vals: list[float],
-    optimize: str = "ReleaseFast",
+    results: list[EngineResult],
+    *,
+    profile: str,
+    warmups: int,
+    runs: int,
+    fixture: Path,
+    fixture_sha: str,
 ) -> str:
-    bm, bmin, bmax = fmt_stats(baseline_vals)
-    tm, tmin, tmax = fmt_stats(target_vals)
-    delta_pct = compute_delta_pct(baseline_vals, target_vals)
+    baseline, target = results[0], results[1]
+    delta_pct = compute_delta_pct(baseline.values, target.values)
     sign = "+" if delta_pct >= 0 else ""
     lines = [
-        "### CoreMark AOT comparison" if optimize == "ReleaseFast" else f"### CoreMark AOT comparison ({optimize})",
+        "### CoreMark cross-engine comparison",
         "",
-        f"| Ref | Mean iter/s | Min | Max | Runs |",
-        f"|---|---:|---:|---:|---:|",
-        f"| `{baseline_ref}` (baseline) | {bm:.1f} | {bmin:.1f} | {bmax:.1f} | {len(baseline_vals)} |",
-        f"| `{target_ref}` (target) | {tm:.1f} | {tmin:.1f} | {tmax:.1f} | {len(target_vals)} |",
-        f"| **Δ** | **{sign}{delta_pct:.2f}%** | | | |",
+        f"- Measurement profile: `{profile}` ({warmups} warmups discarded, "
+        f"{runs} measured runs per engine)",
+        f"- Fixture: `{fixture}` (`sha256:{fixture_sha}`)",
+        f"- WAMR optimize mode: `{target.optimize}`; Wasmtime mode: `default JIT`",
         "",
-        host_info(),
+        "| Engine | Version / ref | Optimize mode | Mean iter/s | Median | Range | Samples (iter/s) |",
+        "|---|---|---|---:|---:|---:|---|",
     ]
+    for result in results:
+        mean, median, minimum, maximum = fmt_stats(result.values)
+        lines.append(
+            f"| {result.engine} | `{result.version}` | `{result.optimize}` | "
+            f"{mean:.1f} | {median:.1f} | {minimum:.1f}–{maximum:.1f} | "
+            f"{format_samples(result.values)} |"
+        )
+    lines.extend(
+        [
+            "",
+            f"**WAMR target vs baseline:** {sign}{delta_pct:.2f}%",
+        ]
+    )
+    wasmtime_results = results[2:]
+    if wasmtime_results:
+        lines.extend(
+            [
+                "",
+                "| Same-host ratio | Mean iter/s ratio |",
+                "|---|---:|",
+            ]
+        )
+        target_mean = statistics.fmean(target.values)
+        for result in wasmtime_results:
+            ratio = target_mean / statistics.fmean(result.values)
+            lines.append(f"| WAMR target / {result.engine} `{result.version}` | {ratio:.3f}× |")
+    lines.extend(["", host_info()])
     return "\n".join(lines)
-
-
-def fmt_iter_stats(values: list[float] | None) -> tuple[str, str, str]:
-    if values is None:
-        return "failed", "failed", "0"
-    mean, min_val, max_val = fmt_stats(values)
-    return f"{mean:.1f}", f"{min_val:.1f}..{max_val:.1f}", str(len(values))
 
 
 def render_optimize_table(
     target_ref: str,
     results: dict[str, list[float] | None],
+    *,
+    profile: str,
+    warmups: int,
+    runs: int,
+    fixture: Path,
+    fixture_sha: str,
 ) -> str:
-    fast_vals = results["ReleaseFast"]
-    safe_vals = results["ReleaseSafe"]
-    fast_mean, fast_range, fast_runs = fmt_iter_stats(fast_vals)
-    safe_mean, safe_range, safe_runs = fmt_iter_stats(safe_vals)
-    ratio = "—"
-    if fast_vals is not None and safe_vals is not None:
-        ratio = fmt_ratio(statistics.fmean(safe_vals), statistics.fmean(fast_vals))
     lines = [
         "### CoreMark AOT optimize-mode comparison",
         "",
-        "| Ref | ReleaseFast mean iter/s | ReleaseSafe mean iter/s | Safe/Fast iter/s | ReleaseFast min..max | ReleaseSafe min..max | Runs |",
-        "|---|---:|---:|---:|---:|---:|---:|",
-        f"| `{target_ref}` (target) | {fast_mean} | {safe_mean} | {ratio} | "
-        f"{fast_range} | {safe_range} | {fast_runs}/{safe_runs} |",
+        f"- Measurement profile: `{profile}` ({warmups} warmups discarded, "
+        f"{runs} measured runs per mode)",
+        f"- Fixture: `{fixture}` (`sha256:{fixture_sha}`)",
+        "",
+        "| Ref | Mode | Mean iter/s | Median | Range | Samples (iter/s) |",
+        "|---|---|---:|---:|---:|---|",
     ]
-    if fast_vals is None or safe_vals is None:
-        lines.append("")
-        lines.append("At least one optimize mode failed before producing a CoreMark timing; see raw harness output above.")
-    lines.append("")
-    lines.append(host_info())
+    for mode in ("ReleaseFast", "ReleaseSafe"):
+        values = results[mode]
+        if values is None:
+            lines.append(f"| `{target_ref}` | `{mode}` | failed | failed | failed | failed |")
+            continue
+        mean, median, minimum, maximum = fmt_stats(values)
+        lines.append(
+            f"| `{target_ref}` | `{mode}` | {mean:.1f} | {median:.1f} | "
+            f"{minimum:.1f}–{maximum:.1f} | {format_samples(values)} |"
+        )
+    fast_vals = results["ReleaseFast"]
+    safe_vals = results["ReleaseSafe"]
+    if fast_vals is not None and safe_vals is not None:
+        lines.extend(
+            [
+                "",
+                "**ReleaseSafe / ReleaseFast:** "
+                + fmt_ratio(statistics.fmean(safe_vals), statistics.fmean(fast_vals)),
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "At least one optimize mode failed before producing complete timings.",
+            ]
+        )
+    lines.extend(["", host_info()])
     return "\n".join(lines)
 
 
+def resolve_counts(
+    profile: str, warmups_arg: int | None, runs_arg: int | None
+) -> tuple[int, int]:
+    default_warmups, default_runs = PROFILE_COUNTS[profile]
+    warmups = default_warmups if warmups_arg is None else warmups_arg
+    runs = default_runs if runs_arg is None else runs_arg
+    if warmups < 0:
+        raise ValueError("--warmups must be non-negative")
+    if runs <= 0:
+        raise ValueError("--runs must be greater than zero")
+    return warmups, runs
+
+
+def profile_label(
+    profile: str, warmups_arg: int | None, runs_arg: int | None
+) -> str:
+    defaults = PROFILE_COUNTS[profile]
+    resolved = resolve_counts(profile, warmups_arg, runs_arg)
+    return profile if resolved == defaults else f"{profile} (overridden)"
+
+
 def main() -> int:
-    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    p.add_argument("--baseline", default="origin/main", help="git ref for the baseline")
-    p.add_argument("--target", default="HEAD", help="git ref for the target")
-    p.add_argument("--runs", type=int, default=3, help="runs per ref (default 3)")
+    p = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--baseline", default="origin/main", help="WAMR baseline git ref")
+    p.add_argument("--target", default="HEAD", help="WAMR target git ref")
+    p.add_argument(
+        "--profile",
+        choices=PROFILE_COUNTS,
+        default="authoritative",
+        help="measurement profile (default: authoritative = 2 warmups + 10 runs; ci = 0 + 3)",
+    )
+    p.add_argument("--warmups", type=int, default=None, help="override discarded warmups")
+    p.add_argument("--runs", type=int, default=None, help="override measured runs")
+    p.add_argument(
+        "--fixture",
+        type=Path,
+        default=DEFAULT_FIXTURE,
+        help=f"CoreMark wasm fixture (default: {DEFAULT_FIXTURE})",
+    )
     p.add_argument(
         "--repo",
         type=Path,
         default=Path(__file__).resolve().parents[1],
-        help="path to wamr repo (default: parent of scripts/)",
+        help="path to wamr repo",
     )
-    p.add_argument(
-        "--out",
-        type=Path,
-        default=None,
-        help="if given, write the markdown table here as well",
-    )
+    p.add_argument("--out", type=Path, default=None, help="write markdown report here")
     p.add_argument(
         "--emit",
         choices=["markdown", "github"],
         default="markdown",
-        help="`github` also appends to $GITHUB_STEP_SUMMARY when present",
+        help="`github` also appends to $GITHUB_STEP_SUMMARY",
     )
     p.add_argument(
         "--optimize",
         choices=OPTIMIZE_CHOICES,
         default="ReleaseFast",
-        help="Zig optimize mode for wamr builds (default: ReleaseFast); `both` compares ReleaseFast vs ReleaseSafe for --target only",
+        help="WAMR Zig optimize mode; `both` compares target ReleaseFast vs ReleaseSafe",
+    )
+    p.add_argument(
+        "--wasmtime-baseline",
+        default=None,
+        metavar="PATH|auto",
+        help=f"historical pinned Wasmtime {PINNED_WASMTIME_VERSION}; `auto` downloads a checksum-verified binary",
+    )
+    p.add_argument(
+        "--wasmtime",
+        type=Path,
+        default=None,
+        help="caller-selected/current Wasmtime binary; its exact version is reported",
+    )
+    p.add_argument(
+        "--wasmtime-cache",
+        type=Path,
+        default=None,
+        help="cache for --wasmtime-baseline auto (default: .bench-coremark/tools)",
     )
     p.add_argument(
         "--min-delta-pct",
         type=float,
         default=None,
-        help="fail if target mean is below baseline by more than this percent delta",
+        help="fail if WAMR target mean is below WAMR baseline by more than this delta",
     )
     args = p.parse_args()
 
-    repo = args.repo
-    ensure_coremark_src(repo)
-    coremark_src = repo / "tests/benchmarks/coremark/coremark"
+    try:
+        warmups, runs = resolve_counts(args.profile, args.warmups, args.runs)
+    except ValueError as exc:
+        p.error(str(exc))
+    effective_profile = profile_label(args.profile, args.warmups, args.runs)
+    if args.optimize == "both" and (args.wasmtime_baseline or args.wasmtime):
+        p.error("Wasmtime comparisons require a single --optimize mode")
 
-    # Prefer the runner's own scratch dir (writable, already on the NVMe mount
-    # under self-hosted runners). Fall back to /work only if writable — the
-    # azure-nvme convention places /work on local disk but the runner user
-    # may not own its root. Otherwise let tempfile pick the system default.
-    runner_temp = os.environ.get("RUNNER_TEMP")
-    if runner_temp and os.access(runner_temp, os.W_OK):
-        tmp_root: str | None = runner_temp
-    elif os.access("/work", os.W_OK):
-        tmp_root = "/work"
-    else:
-        tmp_root = None
+    repo = args.repo.resolve()
+    fixture, fixture_sha = resolve_fixture(repo, args.fixture)
+    work_root = repo / ".bench-coremark" / f"run-{uuid.uuid4().hex}"
+    work_root.mkdir(parents=True)
     optimize_modes = parse_optimize_modes(args.optimize)
-    with tempfile.TemporaryDirectory(prefix="bench-coremark-", dir=tmp_root) as tmp:
-        root = Path(tmp)
-        try:
-            if args.optimize == "both":
-                results: dict[str, list[float] | None] = {}
-                for optimize in optimize_modes:
-                    wt_t = make_worktree(repo, args.target, root, f"target-{optimize_slug(optimize)}")
-                    try:
-                        results[optimize] = build_and_run(wt_t, args.runs, coremark_src, optimize)
-                    except Exception as exc:
-                        print(f"[harness] {optimize} failed before producing complete CoreMark timings: {exc}", file=sys.stderr)
-                        results[optimize] = None
-                table = render_optimize_table(args.target, results)
-                baseline_vals: list[float] | None = None
-                target_vals = results["ReleaseFast"] or []
-            else:
-                only = optimize_modes[0]
-                wt_b = make_worktree(repo, args.baseline, root, "wt")
-                wt_t = make_worktree(repo, args.target, root, "wt-target")
-                baseline_vals = build_and_run(wt_b, args.runs, coremark_src, only)
-                target_vals = build_and_run(wt_t, args.runs, coremark_src, only)
-                table = render_table(args.baseline, baseline_vals, args.target, target_vals, only)
-        finally:
-            # Clean up worktrees so the parent repo isn't left with stale refs.
-            run(["git", "worktree", "prune"], cwd=repo)
-    print(table)
+    baseline_vals: list[float] | None = None
+    target_vals: list[float] = []
+    optimize_failed = False
 
+    try:
+        if args.optimize == "both":
+            mode_results: dict[str, list[float] | None] = {}
+            for optimize in optimize_modes:
+                wt, sha = make_worktree(
+                    repo, args.target, work_root, f"target-{optimize_slug(optimize)}"
+                )
+                try:
+                    result = build_and_run_wamr(
+                        wt, args.target, sha, fixture, optimize, warmups, runs
+                    )
+                    mode_results[optimize] = result.values
+                except Exception as exc:
+                    print(
+                        f"[harness] {optimize} failed before producing complete "
+                        f"CoreMark timings: {exc}",
+                        file=sys.stderr,
+                    )
+                    mode_results[optimize] = None
+                    optimize_failed = True
+            table = render_optimize_table(
+                args.target,
+                mode_results,
+                profile=effective_profile,
+                warmups=warmups,
+                runs=runs,
+                fixture=fixture,
+                fixture_sha=fixture_sha,
+            )
+            target_vals = mode_results["ReleaseFast"] or []
+        else:
+            optimize = optimize_modes[0]
+            baseline_wt, baseline_sha = make_worktree(
+                repo, args.baseline, work_root, "baseline"
+            )
+            target_wt, target_sha = make_worktree(repo, args.target, work_root, "target")
+            baseline_result = build_and_run_wamr(
+                baseline_wt,
+                args.baseline,
+                baseline_sha,
+                fixture,
+                optimize,
+                warmups,
+                runs,
+            )
+            target_result = build_and_run_wamr(
+                target_wt,
+                args.target,
+                target_sha,
+                fixture,
+                optimize,
+                warmups,
+                runs,
+            )
+            results = [baseline_result, target_result]
+            baseline_vals = baseline_result.values
+            target_vals = target_result.values
+
+            measured_paths: dict[Path, EngineResult] = {}
+            if args.wasmtime_baseline:
+                baseline_path = (
+                    install_pinned_wasmtime(repo, args.wasmtime_cache)
+                    if args.wasmtime_baseline == "auto"
+                    else Path(args.wasmtime_baseline).expanduser().resolve()
+                )
+                if not baseline_path.is_file():
+                    raise FileNotFoundError(
+                        f"historical Wasmtime binary not found: {baseline_path}"
+                    )
+                version = validate_pinned_wasmtime(baseline_path)
+                result = measure_wasmtime(
+                    baseline_path,
+                    "Wasmtime historical pin",
+                    version,
+                    fixture,
+                    warmups,
+                    runs,
+                )
+                results.append(result)
+                measured_paths[baseline_path.resolve()] = result
+
+            if args.wasmtime:
+                current_path = args.wasmtime.expanduser().resolve()
+                if not current_path.is_file():
+                    raise FileNotFoundError(
+                        f"caller-selected Wasmtime binary not found: {current_path}"
+                    )
+                version = wasmtime_version(current_path)
+                cached = measured_paths.get(current_path)
+                if cached is None:
+                    current_result = measure_wasmtime(
+                        current_path,
+                        "Wasmtime caller-selected",
+                        version,
+                        fixture,
+                        warmups,
+                        runs,
+                    )
+                else:
+                    current_result = EngineResult(
+                        "Wasmtime caller-selected",
+                        cached.version,
+                        cached.optimize,
+                        cached.values,
+                    )
+                results.append(current_result)
+
+            table = render_table(
+                results,
+                profile=effective_profile,
+                warmups=warmups,
+                runs=runs,
+                fixture=fixture,
+                fixture_sha=fixture_sha,
+            )
+    finally:
+        shutil.rmtree(work_root, ignore_errors=True)
+        run(["git", "worktree", "prune"], cwd=repo)
+
+    print(table)
     if args.out:
         args.out.write_text(table + "\n")
-
     if args.emit == "github":
         summary = os.environ.get("GITHUB_STEP_SUMMARY")
         if summary:
             with open(summary, "a") as fh:
                 fh.write(table + "\n")
 
+    if optimize_failed:
+        return 1
     if args.min_delta_pct is not None and baseline_vals is not None:
         delta_pct = compute_delta_pct(baseline_vals, target_vals)
         if delta_pct < args.min_delta_pct:
@@ -407,9 +767,8 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
-
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/scripts/test_bench_coremark.py
+++ b/scripts/test_bench_coremark.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_coremark
+
+
+VALID_OUTPUT = """\
+Iterations/Sec   : 12345.5
+[0]crcfinal      : 0x33ff
+Correct operation validated. See README.md for run and reporting rules.
+"""
+
+
+class BenchCoremarkTests(unittest.TestCase):
+    def test_tracked_fixture_checksum_is_pinned(self):
+        repo = Path(__file__).resolve().parents[1]
+        fixture, digest = bench_coremark.resolve_fixture(
+            repo, bench_coremark.DEFAULT_FIXTURE
+        )
+        self.assertEqual(
+            fixture, (repo / bench_coremark.DEFAULT_FIXTURE).resolve()
+        )
+        self.assertEqual(digest, bench_coremark.DEFAULT_FIXTURE_SHA256)
+
+    def test_parse_requires_crc_validation(self):
+        self.assertEqual(
+            bench_coremark.parse_coremark_output(VALID_OUTPUT, "test"), 12345.5
+        )
+        with self.assertRaisesRegex(RuntimeError, "CRC-validated"):
+            bench_coremark.parse_coremark_output(
+                "Iterations/Sec : 12345.5\nERROR! bad crc\n", "test"
+            )
+        with self.assertRaisesRegex(RuntimeError, "CRC-validated"):
+            bench_coremark.parse_coremark_output(
+                "Iterations/Sec : 12345.5\n", "test"
+            )
+
+    def test_parse_rejects_ambiguous_throughput(self):
+        with self.assertRaisesRegex(RuntimeError, "2 Iterations/Sec"):
+            bench_coremark.parse_coremark_output(
+                VALID_OUTPUT + "Iterations/Sec : 1\n", "test"
+            )
+
+    def test_profile_defaults_and_overrides(self):
+        self.assertEqual(
+            bench_coremark.resolve_counts("authoritative", None, None), (2, 10)
+        )
+        self.assertEqual(bench_coremark.resolve_counts("ci", None, None), (0, 3))
+        self.assertEqual(
+            bench_coremark.resolve_counts("ci", 1, 4), (1, 4)
+        )
+        with self.assertRaises(ValueError):
+            bench_coremark.resolve_counts("authoritative", -1, 10)
+        with self.assertRaises(ValueError):
+            bench_coremark.resolve_counts("authoritative", 2, 0)
+        self.assertEqual(
+            bench_coremark.profile_label("authoritative", None, None),
+            "authoritative",
+        )
+        self.assertEqual(
+            bench_coremark.profile_label("authoritative", None, 3),
+            "authoritative (overridden)",
+        )
+
+    @mock.patch.object(bench_coremark, "host_info", return_value="_Host: test_")
+    def test_report_distinguishes_wasmtime_versions_and_lists_samples(self, _):
+        results = [
+            bench_coremark.EngineResult(
+                "WAMR", "origin/main (aaaa)", "ReleaseFast", [50.0, 52.0]
+            ),
+            bench_coremark.EngineResult(
+                "WAMR", "HEAD (bbbb)", "ReleaseFast", [60.0, 62.0]
+            ),
+            bench_coremark.EngineResult(
+                "Wasmtime historical pin",
+                "44.0.1 (/pinned/wasmtime)",
+                "default JIT",
+                [100.0, 102.0],
+            ),
+            bench_coremark.EngineResult(
+                "Wasmtime caller-selected",
+                "48.0.1 (/current/wasmtime)",
+                "default JIT",
+                [120.0, 122.0],
+            ),
+        ]
+        report = bench_coremark.render_table(
+            results,
+            profile="authoritative",
+            warmups=2,
+            runs=2,
+            fixture=Path("coremark.wasm"),
+            fixture_sha="abc",
+        )
+        self.assertIn("Median", report)
+        self.assertIn("50.0, 52.0", report)
+        self.assertIn("44.0.1 (/pinned/wasmtime)", report)
+        self.assertIn("48.0.1 (/current/wasmtime)", report)
+        self.assertIn("WAMR target / Wasmtime historical pin", report)
+        self.assertIn("WAMR target / Wasmtime caller-selected", report)
+
+    @mock.patch.object(
+        bench_coremark, "run", return_value="wasmtime 44.0.1 (abcdef)"
+    )
+    def test_pinned_wasmtime_version_is_enforced(self, _):
+        self.assertEqual(
+            bench_coremark.validate_pinned_wasmtime(Path("/bin/wasmtime")),
+            "44.0.1",
+        )
+        with mock.patch.object(
+            bench_coremark, "run", return_value="wasmtime 48.0.1 (abcdef)"
+        ):
+            with self.assertRaisesRegex(RuntimeError, "must be 44.0.1"):
+                bench_coremark.validate_pinned_wasmtime(Path("/bin/wasmtime"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmarks/coremark/README.md
+++ b/tests/benchmarks/coremark/README.md
@@ -9,11 +9,18 @@ builds and runs CoreMark using Zig's cross-compiler for both native and wasm32-w
    ```
    zig build
    ```
-2. Clone the CoreMark source:
+2. Clone the CoreMark source at the pinned revision used for reproducible
+   source rebuilds:
    ```
    cd tests/benchmarks/coremark
    git clone https://github.com/eembc/coremark.git
+   git -C coremark checkout cfa9ab377835911f23d9b0831c7be302ed1f58de
    ```
+
+The comparison harness does not rebuild from this checkout. It always uses the
+tracked canonical fixture `coremark_wasi.wasm`
+(`sha256:f4b7591296ead10264e0f101f355bdf848865c31329325594e66fbabefec235b`)
+and verifies that checksum before running, eliminating upstream-source drift.
 
 ## Building
 
@@ -30,6 +37,38 @@ zig build run-aot                  # run AOT benchmark via wamr
 zig build run-interp               # run interpreter benchmark via wamr
 zig build bench                    # run all three
 ```
+
+## Reproducible cross-engine comparison
+
+From the repository root:
+
+```
+python3 scripts/bench_coremark.py \
+  --baseline origin/main \
+  --target HEAD \
+  --wasmtime-baseline auto \
+  --wasmtime /path/to/current/wasmtime
+```
+
+The authoritative defaults are two discarded warmups and ten measured runs
+per engine. Reports include architecture, CPU model, optimize mode, exact git
+refs and Wasmtime versions, fixture checksum, every measured sample,
+mean/median/range, and same-host WAMR/Wasmtime ratios. Every sample must contain
+CoreMark's `Correct operation validated.` CRC result; command failures, CRC
+errors, missing results, and ambiguous output fail the run.
+
+`--wasmtime-baseline auto` downloads Wasmtime 44.0.1 (the latest Wasmtime
+release line available before #393's 2026-05-07 reference measurement), the
+pinned historical baseline for future comparisons, and verifies the official
+release archive checksum. Pass
+`--wasmtime /path/to/wasmtime` separately for a caller-selected or current
+binary; the report keeps the two versions in distinct rows. Automatic download
+supports Linux x86_64 and aarch64; other hosts can pass an explicit 44.0.1
+binary.
+
+PR CI deliberately uses `--profile ci` (zero warmups, three measured runs) to
+keep the regression gate affordable. Use the default `--profile authoritative`
+for publishable cross-engine numbers.
 
 ## Options
 
@@ -90,4 +129,3 @@ first 80 lines of `llvm-objdump -d` on the precompiled `.cwasm`. The `perf`
 path requires `kernel.perf_event_paranoid <= 2`; bump it once with
 `sudo sysctl -w kernel.perf_event_paranoid=1`. The wamr `coremark-profile`
 step does **not** depend on `perf_event_paranoid` (it only uses POSIX SIGPROF).
-


### PR DESCRIPTION
## Summary

- make `scripts/bench_coremark.py` use the tracked, checksum-verified CoreMark wasm fixture instead of cloning an unpinned upstream checkout
- add authoritative measurement defaults (2 discarded warmups, 10 measured runs) while keeping PR gates explicitly on the affordable `ci` profile (0 + 3)
- compare WAMR refs with a checksum-verified historical Wasmtime 44.0.1 pin and/or a caller-selected Wasmtime binary, reporting each version separately
- report host architecture/CPU, optimize mode, fixture hash, every sample, mean/median/range, ref delta, and same-host WAMR/Wasmtime ratios
- require CoreMark CRC validation for every warmup and measured run; command failures, CRC errors, missing output, and ambiguous output fail loudly
- pin the optional CoreMark source checkout used by the standalone build documentation and add focused harness tests

## Reproducibility and compatibility

The canonical default fixture is tracked at `tests/benchmarks/coremark/coremark_wasi.wasm` and must match `sha256:f4b7591296ead10264e0f101f355bdf848865c31329325594e66fbabefec235b`. `--wasmtime-baseline auto` installs Wasmtime 44.0.1 from official x86_64/aarch64 Linux archives and verifies both archive and extracted-binary hashes. `--wasmtime PATH` remains a separate row with its detected exact version, so historical and current results are not conflated.

Existing ref-vs-ref CI behavior remains available and explicitly uses `--profile ci`; the default local/publishable mode is `--profile authoritative`. Existing optimize-mode and regression-threshold options remain supported.

## Validation

- `python3 -m unittest scripts/test_bench_coremark.py` — 6 passed
- `python3 -m py_compile scripts/bench_coremark.py scripts/test_bench_coremark.py` — passed
- `git diff --check` — passed
- one-sample WAMR ref-vs-ref smoke (`--profile ci --warmups 0 --runs 1`) — passed with CRC validation
- one-sample cross-engine smoke with `--wasmtime-baseline auto` — passed; verified Wasmtime 44.0.1 download/checksums, CRC validation, version-separated report, and ratio output

Refs #393
