### PR TITLE
threads: make guest-futex group cancellation level-triggered

### DIFF
--- a/docs/design/wasi-threads.md
+++ b/docs/design/wasi-threads.md
@@ -231,6 +231,14 @@ backends claims into the same record:
   installs. The hook raises the manager's interrupt flag and calls
   `MemoryInstance.cancelWaiters`, which cancels every guest `memory.atomic.wait`
   parked in the shared memory's parking lot.
+* That cancellation is **level-triggered**: `ParkingLot.cancelAll` latches a
+  sticky flag before sweeping, and any later attempt to park reports
+  `.cancelled` instead of blocking. Waking only the queued waiters would be a
+  check-then-act race — a thread that passes the caller-side guard below and
+  is then descheduled until after the sweep would enqueue behind it. With an
+  infinite guest timeout nothing would ever free it, because the last sweep
+  runs as the final sibling exits and `terminateAndJoin` may never be entered
+  (the embedder thread itself can be the one parking).
 
 Siblings leave guest code through four interruption points:
 
@@ -241,8 +249,9 @@ Siblings leave guest code through four interruption points:
 | `poll_oneoff`, blocking stdin reads | bounded 20 ms slices, then `error.Trap` | same slices, then `terminateAotThread` |
 | `sched_yield` | dispatch-loop poll | explicit check in the host bridge |
 
-The pre-park guard matters as much as the cancel sweep: a thread that starts
-waiting after the sweep has already run would otherwise park forever.
+The pre-park guards are a cheap fast path, not the correctness argument: the
+latch inside the parking lot is what makes a wait entered after the sweep
+safe, since the guard and the enqueue cannot be made atomic from outside.
 
 The AOT loop-header poll is what makes compiled guest code interruptible at
 all — without it a child running `(loop (br 0))` cannot be stopped, and

--- a/src/platform/parking_lot.zig
+++ b/src/platform/parking_lot.zig
@@ -71,6 +71,14 @@ const Bucket = struct {
 /// `deinit` first prevents new waits, then wakes every queued waiter and
 /// waits until all active `wait32`/`wait64` calls have returned. The object
 /// may therefore be embedded in another refcounted control block.
+///
+/// Group cancellation (`cancelAll`) is *level*-triggered: it latches a sticky
+/// flag before sweeping the buckets, and every later attempt to park reports
+/// `.cancelled` instead of blocking. Waking only the queued waiters would be
+/// a check-then-act race — a thread that passes its caller-side "is the group
+/// terminating?" guard, then loses the CPU until after the sweep, would
+/// enqueue behind it and (with an infinite timeout) never be woken again,
+/// because nothing sweeps a second time once every sibling has stopped.
 pub const ParkingLot = struct {
     const bucket_count = 64;
     const closing_bit: u32 = 1 << 31;
@@ -78,6 +86,9 @@ pub const ParkingLot = struct {
 
     buckets: [bucket_count]Bucket = @splat(.{}),
     lifecycle: std.atomic.Value(u32) = .init(0),
+    /// Latched by `cancelAll`. Kept out of `lifecycle` so the active-count
+    /// and closing protocol `enter`/`leave`/`deinit` rely on is untouched.
+    cancelled: std.atomic.Value(u32) = .init(0),
 
     pub fn init() ParkingLot {
         return .{};
@@ -135,6 +146,14 @@ pub const ParkingLot = struct {
         if (timeout_ns == 0) {
             bucket.mutex.unlock();
             return .timed_out;
+        }
+        // Checked under the same bucket lock the sweep takes, and only on the
+        // path that would actually block: whichever of the two acquires the
+        // lock first, the waiter is either seen by the sweep or observes the
+        // latch here. Non-blocking outcomes above are unaffected.
+        if (self.cancelled.load(.acquire) != 0) {
+            bucket.mutex.unlock();
+            return .cancelled;
         }
         waiter.next = bucket.head;
         bucket.head = &waiter;
@@ -232,11 +251,19 @@ pub const ParkingLot = struct {
         }
     }
 
-    /// Cancel all waiters. This is the group-cancellation primitive.
+    /// Cancel all waiters and latch the lot as cancelled. This is the
+    /// group-cancellation primitive: after it returns, no thread can park
+    /// here again, so callers need not re-sweep to catch late arrivals.
+    ///
+    /// The latch is published *before* the sweep. A parking thread reads it
+    /// while holding the bucket lock, so it either enqueued before this
+    /// bucket was swept (and is woken below) or observes the latch and
+    /// refuses to park.
     pub fn cancelAll(self: *ParkingLot) BackendError!u32 {
         if (comptime !parking_supported) {
             return error.Unsupported;
         }
+        self.cancelled.store(1, .release);
         var total: u32 = 0;
         for (0..bucket_count) |i| {
             const bucket = &self.buckets[i];
@@ -273,6 +300,11 @@ pub const ParkingLot = struct {
             woken += 1;
         }
         return woken;
+    }
+
+    /// True once `cancelAll` has latched this lot. Diagnostics and tests.
+    pub fn isCancelled(self: *const ParkingLot) bool {
+        return self.cancelled.load(.acquire) != 0;
     }
 
     /// Number of currently queued waiters for a key. Intended for
@@ -570,6 +602,157 @@ fn waitUntilQueued(lot: *ParkingLot, address: *const anyopaque, count: u32) !voi
         platform.usleep(50);
     }
 }
+
+/// Drives one `wait32(-1)` on its own thread and reports when it returned.
+/// The infinite timeout is the point of these tests: only cancellation can
+/// end the wait, so a regression would block forever. `awaitFinished` gives
+/// the harness a bounded escape hatch that turns that into a test failure
+/// instead of a hung CI job.
+const LateWaiterCtx = struct {
+    lot: *ParkingLot,
+    word: *align(4) u32,
+    expected: u32 = 7,
+    /// Set once this thread has read its (still negative) guard.
+    guard_passed: std.atomic.Value(bool) = .init(false),
+    /// Released by the harness once the sweep it must lose to is done.
+    release: *std.atomic.Value(bool),
+    guard_was_clear: bool = false,
+    result: WaitResult = .not_equal,
+    finished: std.atomic.Value(bool) = .init(false),
+
+    fn run(self: *LateWaiterCtx) void {
+        // Stand in for the caller-side "is the group terminating?" guard in
+        // the interpreter and AOT `memory.atomic.wait` paths: read here,
+        // before the harness cancels, so this thread commits to parking on
+        // a stale answer.
+        self.guard_was_clear = !self.lot.isCancelled();
+        self.guard_passed.store(true, .release);
+        while (!self.release.load(.acquire)) std.atomic.spinLoopHint();
+        self.result = self.lot.wait32(self.word, self.expected, -1) catch .closed;
+        self.finished.store(true, .release);
+    }
+
+    fn awaitGuard(self: *LateWaiterCtx) void {
+        while (!self.guard_passed.load(.acquire)) std.atomic.spinLoopHint();
+    }
+
+    fn awaitFinished(self: *LateWaiterCtx, timeout_ns: u64) bool {
+        const deadline = monotonicNowNs() +| timeout_ns;
+        while (!self.finished.load(.acquire)) {
+            if (monotonicNowNs() >= deadline) return false;
+            platform.usleep(200);
+        }
+        return true;
+    }
+};
+
+test "ParkingLot: a wait that loses the race with cancelAll is still cancelled" {
+    if (comptime !parking_supported) return error.SkipZigTest;
+    var lot = ParkingLot.init();
+    defer lot.deinit();
+    var word: u32 align(4) = 7;
+    var release = std.atomic.Value(bool).init(false);
+    var ctx = LateWaiterCtx{ .lot = &lot, .word = &word, .release = &release };
+
+    const thread = try std.Thread.spawn(.{}, LateWaiterCtx.run, .{&ctx});
+    // Force the reported interleaving: the waiter has already passed its
+    // guard, then the last sibling sweeps an empty queue and exits, and only
+    // afterwards does the waiter try to park.
+    ctx.awaitGuard();
+    try std.testing.expectEqual(@as(u32, 0), try lot.cancelAll());
+    release.store(true, .release);
+
+    const finished = ctx.awaitFinished(5 * std.time.ns_per_s);
+    if (!finished) {
+        // Edge-triggered regression: the waiter is queued and only another
+        // sweep can free it. Release it so the test fails instead of hanging.
+        _ = lot.cancelAll() catch {};
+    }
+    thread.join();
+    try std.testing.expect(ctx.guard_was_clear);
+    try std.testing.expect(finished);
+    try std.testing.expectEqual(WaitResult.cancelled, ctx.result);
+}
+
+/// Run one infinite-timeout wait on a helper thread and require it to come
+/// back cancelled. Never blocks the test thread: if the wait parks anyway
+/// (the pre-fix behaviour) the helper is released by a second sweep and the
+/// assertion fails, so a regression cannot hang CI.
+fn expectCancelledWait(lot: *ParkingLot, word: *align(4) u32, expected: u32) !void {
+    var release = std.atomic.Value(bool).init(true);
+    var ctx = LateWaiterCtx{ .lot = lot, .word = word, .release = &release };
+    ctx.expected = expected;
+    const thread = try std.Thread.spawn(.{}, LateWaiterCtx.run, .{&ctx});
+    const finished = ctx.awaitFinished(5 * std.time.ns_per_s);
+    if (!finished) _ = lot.cancelAll() catch {};
+    thread.join();
+    try std.testing.expect(finished);
+    try std.testing.expectEqual(WaitResult.cancelled, ctx.result);
+}
+
+test "ParkingLot: cancellation latches so later waits never park" {
+    if (comptime !parking_supported) return error.SkipZigTest;
+    var lot = ParkingLot.init();
+    defer lot.deinit();
+    var word: u32 align(4) = 7;
+
+    try std.testing.expect(!lot.isCancelled());
+    _ = try lot.cancelAll();
+    try std.testing.expect(lot.isCancelled());
+
+    // Infinite timeout after the sweep: only the level-triggered latch can
+    // end these waits.
+    try expectCancelledWait(&lot, &word, 7);
+    try expectCancelledWait(&lot, &word, 7);
+    try std.testing.expectEqual(@as(u32, 0), lot.waiterCount(&word));
+
+    // Non-blocking results still take precedence: a cancelled lot does not
+    // rewrite a value mismatch or a zero timeout, so neither can block.
+    try std.testing.expectEqual(WaitResult.not_equal, try lot.wait32(&word, 9, -1));
+    try std.testing.expectEqual(WaitResult.timed_out, try lot.wait32(&word, 7, 0));
+}
+
+test "ParkingLot: a 64-bit wait entered after cancellation is cancelled too" {
+    if (comptime !parking_supported or @bitSizeOf(usize) < 64)
+        return error.SkipZigTest;
+    var lot = ParkingLot.init();
+    defer lot.deinit();
+    var word: u64 align(8) = 11;
+
+    _ = try lot.cancelAll();
+
+    var release = std.atomic.Value(bool).init(true);
+    var ctx = Wait64Ctx{ .lot = &lot, .word = &word, .release = &release };
+    const thread = try std.Thread.spawn(.{}, Wait64Ctx.run, .{&ctx});
+    const finished = ctx.awaitFinished(5 * std.time.ns_per_s);
+    if (!finished) _ = lot.cancelAll() catch {};
+    thread.join();
+    try std.testing.expect(finished);
+    try std.testing.expectEqual(WaitResult.cancelled, ctx.result);
+}
+
+const Wait64Ctx = struct {
+    lot: *ParkingLot,
+    word: *align(8) u64,
+    release: *std.atomic.Value(bool),
+    result: WaitResult = .not_equal,
+    finished: std.atomic.Value(bool) = .init(false),
+
+    fn run(self: *Wait64Ctx) void {
+        while (!self.release.load(.acquire)) std.atomic.spinLoopHint();
+        self.result = self.lot.wait64(self.word, 11, -1) catch .closed;
+        self.finished.store(true, .release);
+    }
+
+    fn awaitFinished(self: *Wait64Ctx, timeout_ns: u64) bool {
+        const deadline = monotonicNowNs() +| timeout_ns;
+        while (!self.finished.load(.acquire)) {
+            if (monotonicNowNs() >= deadline) return false;
+            platform.usleep(200);
+        }
+        return true;
+    }
+};
 
 test "ParkingLot: wait mismatch does not enqueue" {
     var lot = ParkingLot.init();

--- a/src/wasi/thread_manager.zig
+++ b/src/wasi/thread_manager.zig
@@ -10,6 +10,7 @@ const ExecEnv = @import("../runtime/common/exec_env.zig").ExecEnv;
 const execution_context = @import("../runtime/common/execution_context.zig");
 const termination = @import("../runtime/common/termination.zig");
 const platform = @import("../platform/platform.zig");
+const parking_lot = @import("../platform/parking_lot.zig");
 const config = @import("config");
 
 /// Simple spinlock mutex (Zig 0.16 moved std.Thread.Mutex behind Io).
@@ -2310,4 +2311,93 @@ test "group termination: the cancel broadcast reaches compiled code on every int
         .broadcast = Probe.broadcast,
     });
     try std.testing.expect(late.calls >= 1);
+}
+
+/// Parks the calling thread on the group's shared memory with an infinite
+/// timeout, on its own thread so the harness keeps a bounded escape hatch.
+const EmbedderParkCtx = struct {
+    memory: *types.MemoryInstance,
+    offset: usize,
+    result: types.MemoryInstance.SharedWaitError!parking_lot.WaitResult = .not_equal,
+    finished: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    fn run(self: *EmbedderParkCtx) void {
+        self.result = self.memory.wait32(self.offset, 0, -1);
+        self.finished.store(true, .release);
+    }
+
+    fn awaitFinished(self: *EmbedderParkCtx, timeout_ns: u64) bool {
+        const deadline = monotonicNowNs() +| timeout_ns;
+        while (!self.finished.load(.acquire)) {
+            if (monotonicNowNs() >= deadline) return false;
+            platform.usleep(200);
+        }
+        return true;
+    }
+};
+
+test "group termination: the embedder parking after the last sweep is still cancelled" {
+    // The reported #955 hang: the embedder thread checks `isTerminating()`,
+    // a child claims the terminal outcome and exits (running the last sweep
+    // over an empty queue), and only then does the embedder park with an
+    // infinite timeout. Nothing sweeps again — `terminateAndJoin` is never
+    // even entered — so the wait must be refused rather than woken.
+    try requireThreadLifecycle();
+    const allocator = std.testing.allocator;
+    const ctx = try buildThreadTestModule(&nop_thread_code, allocator);
+    defer cleanupThreadTest(ctx, allocator);
+
+    var state = termination.State{};
+    var manager = ThreadManager.init(allocator);
+    defer manager.deinit();
+    manager.bindTermination(&state);
+    try manager.prepareSharedMemory(ctx.mem_inst, null);
+    ctx.inst.thread_manager = &manager;
+
+    // A child that completes on its own; its `threadEntry` outcome plus the
+    // claim below produce the only two sweeps in the run.
+    _ = try manager.spawnThread(ctx.inst, 0);
+    try waitForCompleted(&manager, 1);
+    _ = state.claimExit(0);
+    try std.testing.expect(manager.isTerminating());
+
+    var park = EmbedderParkCtx{ .memory = ctx.mem_inst, .offset = 16 };
+    const thread = try std.Thread.spawn(.{}, EmbedderParkCtx.run, .{&park});
+    const finished = park.awaitFinished(5 * std.time.ns_per_s);
+    if (!finished) _ = ctx.mem_inst.cancelWaiters() catch 0;
+    thread.join();
+
+    try std.testing.expect(finished);
+    try std.testing.expectEqual(
+        parking_lot.WaitResult.cancelled,
+        try park.result,
+    );
+    _ = manager.terminateAndJoin(default_termination_timeout_ns);
+}
+
+test "group termination: an interpreter child that parks after termination traps" {
+    // Same shape as the embedder case but through the real interpreter
+    // `memory.atomic.wait32` path with an infinite timeout: the group is
+    // already terminated when the child reaches its wait, so the child must
+    // trap out instead of parking behind the sweep.
+    try requireThreadLifecycle();
+    const allocator = std.testing.allocator;
+    const ctx = try buildThreadTestModule(&futex_wait_thread_code, allocator);
+    defer cleanupThreadTest(ctx, allocator);
+
+    var state = termination.State{};
+    var manager = ThreadManager.init(allocator);
+    defer manager.deinit();
+    manager.bindTermination(&state);
+    try manager.prepareSharedMemory(ctx.mem_inst, null);
+    ctx.inst.thread_manager = &manager;
+
+    _ = state.claimExit(3);
+    try std.testing.expect(ctx.mem_inst.shared_control.?.parking_lot.isCancelled());
+
+    const tid = try manager.spawnThread(ctx.inst, 0);
+    const started_ns = monotonicNowNs();
+    try std.testing.expectEqual(ThreadOutcome.trapped, try manager.joinOne(tid));
+    try std.testing.expect(monotonicNowNs() - started_ns < std.time.ns_per_s);
+    try std.testing.expectEqual(@as(?u32, 3), state.exitCode());
 }


### PR DESCRIPTION
Fixes a Medium-severity hang found by review of merged #955 (`6932c612`): the
pre-park guard against group termination is a TOCTOU, and a thread that parks
inside the window is never woken.

## The race

`ThreadManager.interrupt()` → `MemoryInstance.cancelWaiters()` →
`ParkingLot.cancelAll()` walked only the *currently queued* waiters and left no
sticky state. The guest-side guard is check-then-act:

```zig
if (tm.isTerminating()) return error.ThreadCancelled;   // (1) reads false
const result = mem.wait32(addr, expected, -1);          // (2) enqueues
```

1. embedder checks `isTerminating()` → false
2. child `proc_exit(0)` → `claimExit` → `interrupt()` → `cancelAll()` over an
   empty queue
3. child `threadEntry` → `signalTrap()` → `interrupt()` → `cancelAll()` over an
   empty queue; child exits
4. embedder enqueues and `osWait(..., null)` parks forever

`terminateAndJoin`'s 200 µs re-arm cannot help: the parked thread *is* the
embedder that would have called it, so it is never entered and the 2 s bound is
never reached. `git grep -n cancelWaiters` still shows one caller, so nothing
re-sweeps.

## Fix — option (a), latched rather than generation-compared

`ParkingLot.cancelAll` now stores a sticky `cancelled` flag **before** sweeping,
and `waitValue` checks it **while holding the same bucket lock the sweep takes**,
on the path that would otherwise block:

```zig
if (timeout_ns == 0) { ...; return .timed_out; }
if (self.cancelled.load(.acquire) != 0) { bucket.mutex.unlock(); return .cancelled; }
waiter.next = bucket.head; bucket.head = &waiter;
```

Whichever side takes the bucket lock first, the waiter is either seen by the
sweep or observes the latch: the store is released before the sweep, and the
waiter's lock acquire synchronizes-with the sweep's unlock.

**Why not option (b)** (a `should_abort` predicate passed into `waitValue`): it
would have to be threaded through `MemoryInstance.wait32/64` and
`Control.wait32/64` and every backend call site — including
`src/runtime/aot/runtime.zig` and `src/runtime/common/types.zig`, which another
agent is editing right now. The latch closes the same window in one file with no
signature changes. It is also strictly stronger than a naive generation snapshot
taken inside `waitValue`: that would still park forever when the sweep happened
*before* `waitValue` was entered, which is exactly the reported sequence.

Both backends inherit the fix because both reach the same lot
(`memory.atomic.wait{32,64}` → `MemoryInstance` → `Control` → `ParkingLot`), and
both already map `.cancelled` to a thread unwind (interpreter
`error.ThreadCancelled`; AOT `terminateAotThread`). The existing caller-side
guards stay as a cheap fast path. Non-blocking outcomes (`not_equal`,
zero-timeout `timed_out`) are deliberately checked first, so nothing that could
not block changes behaviour. `deinit`'s active-count/closing protocol is
untouched — the latch is a separate word, not a bit stolen from `lifecycle`.

## Regressions added

All of them are structured so a regression **fails within seconds instead of
hanging CI**: every infinite-timeout wait runs on a helper thread, the harness
waits with a deadline, and on expiry it issues a second sweep to release the
(wrongly) queued waiter before asserting.

* `ParkingLot: a wait that loses the race with cancelAll is still cancelled` —
  forces the exact interleaving with two gates: the waiter reads its guard
  (asserted clear), the harness then sweeps an *empty* queue, and only then is
  the waiter released to park. Infinite timeout.
* `ParkingLot: cancellation latches so later waits never park` — waits entered
  after the sweep, plus assertions that `not_equal` and zero-timeout results are
  unchanged.
* `ParkingLot: a 64-bit wait entered after cancellation is cancelled too` —
  `wait64` parity.
* `group termination: the embedder parking after the last sweep is still
  cancelled` — the reported sequence end to end through the real
  `ThreadManager` + `MemoryInstance`: child completes, terminal outcome is
  claimed, embedder then parks with `-1`.
* `group termination: an interpreter child that parks after termination traps` —
  the real interpreter `memory.atomic.wait32` path with `-1`, joined under a
  1 s assertion.

Verified as genuine detectors: with the latch check disabled, the parking-lot
suite fails 3 tests and the thread-lifecycle suite fails the embedder test, all
in bounded time (`rc=1`, no hang). With the fix, 5× repeats of both suites pass.

## Validation

`test-shared-memory`, `test-thread-lifecycle` (interp + AOT), `test-wasi-threads`,
`test-aot-threads`, and full `zig build test` in default,
`-Dlib_wasi_threads=true -Daot=false`, and `-Dlib_wasi_threads=true -Dinterp=false`
— all pass. Files touched: `src/platform/parking_lot.zig`,
`src/wasi/thread_manager.zig`, `docs/design/wasi-threads.md` (no codegen, no
`types.zig`, no `aot/runtime.zig`, no `wasi_cli_adapter.zig`).
