### PR TITLE
bench(keyvault): stop perf.base from shadowing the manifest directory

### DIFF
--- a/scripts/bench_keyvault.py
+++ b/scripts/bench_keyvault.py
@@ -204,7 +204,7 @@ def load_manifest(path: Path) -> Config:
     hot_func = perf.get("hot_func")
     min_samples = perf.get("min_samples")
     min_coverage_pct = perf.get("min_attribution_coverage_pct")
-    base = perf.get("base")
+    perf_base = perf.get("base")
     if not isinstance(core_index, int) or core_index < 0:
         raise HarnessError("perf.core_index must be a non-negative integer")
     if hot_func is not None and (not isinstance(hot_func, int) or hot_func < 0):
@@ -217,8 +217,9 @@ def load_manifest(path: Path) -> Config:
         raise HarnessError(
             "perf.min_attribution_coverage_pct must be in the range (0, 100]"
         )
-    if base is not None and (
-        not isinstance(base, str) or re.fullmatch(r"0x[0-9a-fA-F]+", base) is None
+    if perf_base is not None and (
+        not isinstance(perf_base, str)
+        or re.fullmatch(r"0x[0-9a-fA-F]+", perf_base) is None
     ):
         raise HarnessError("perf.base must be null or a hexadecimal address")
 
@@ -249,7 +250,7 @@ def load_manifest(path: Path) -> Config:
             "hot_func": hot_func,
             "min_samples": min_samples,
             "min_attribution_coverage_pct": float(min_coverage_pct),
-            "base": base,
+            "base": perf_base,
         },
     )
 

--- a/tests/test_bench_keyvault.py
+++ b/tests/test_bench_keyvault.py
@@ -178,6 +178,27 @@ class KeyvaultHarnessTest(unittest.TestCase):
         with self.assertRaisesRegex(bench.HarnessError, "40-character"):
             bench.load_manifest(self.manifest)
 
+    def test_relative_paths_resolve_against_manifest_directory(self) -> None:
+        document = self._manifest_document()
+        manifest_dir = self.manifest.parent.resolve()
+        document["workload"]["component"]["path"] = str(
+            self.component.resolve().relative_to(manifest_dir)
+        )
+        document["workload"]["preopens_file"]["path"] = str(
+            self.preopens.resolve().relative_to(manifest_dir)
+        )
+        document["workload"]["mounts"][0]["path"] = str(
+            self.spec.resolve().relative_to(manifest_dir)
+        )
+        document["perf"]["base"] = "0x400000"
+        self.manifest.write_text(json.dumps(document), encoding="UTF-8")
+
+        config = bench.load_manifest(self.manifest)
+        self.assertEqual(config.component, self.component.resolve())
+        self.assertEqual(config.preopens_file, self.preopens.resolve())
+        self.assertEqual(config.mounts[0].host, self.spec.resolve())
+        self.assertEqual(config.perf["base"], "0x400000")
+
     def test_checked_in_schema_and_example_track_parser_version(self) -> None:
         directory = ROOT / "tests" / "benchmarks" / "keyvault"
         schema = json.loads(


### PR DESCRIPTION
Fixes #960

## Root cause

In `scripts/bench_keyvault.py`, `load_manifest` binds `base = path.resolve().parent` (the manifest directory) and uses it via `_resolve(base, ...)`. Line 207 then rebound the same name with `base = perf.get("base")` (a hex address string or `None`). The `workload.component.path` and `workload.preopens_file.path` resolutions happen *after* that line, so relative paths were resolved against the perf base:

- `perf.base = null` -> unhandled `TypeError: unsupported operand type(s) for /: 'NoneType' and 'PosixPath'`
- `perf.base = "0x400000"` -> silently resolved under a bogus `0x400000/` directory

`tools`, `sources[]` and `workload.mounts[]` are resolved before line 207 and were unaffected, and the checked-in example manifest uses absolute paths, so the defect was latent.

## Fix

Renamed the shadowing local to `perf_base` (validation and the emitted `perf["base"]` updated accordingly); `base` now unambiguously stays the manifest directory.

## Audit

Scanned every `_resolve` call site and every repeated local assignment in the file (AST scan). No other manifest-relative path is resolved against a wrong or rebound base, and no other `perf.*`/manifest key shadows an outer local. `parse_preopens` correctly resolves relative host paths against the preopens file's own directory.

## Regression evidence

New test `test_relative_paths_resolve_against_manifest_directory` builds a manifest with relative `component`, `preopens_file` and mount paths plus `perf.base = "0x400000"`.

Before the fix (source change stashed, test applied):

```
AssertionError: PosixPath(.../fix-960-keyvault/0x400000/sdk/component.wasm) !=
                PosixPath(.../zig-out/keyvault-harness-.../sdk/component.wasm)
FAILED (failures=1)
```

After the fix: `tests/test_bench_keyvault.py` 11/11 and `tests/test_compare_hot_function.py` 14/14 pass (25 tests, OK).

The real keyvault workload was not run (pinned assets, wasmtime, wasm-tools and node are unavailable); that remains tracked on #798, whose harness this unblocks for manifests written next to the workload assets.