### PR TITLE
wasi:http: stop leaking the first P3 trailer snapshot (#969 review)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1058,6 +1058,7 @@ pub fn build(b: *std.Build) void {
             "wasi:http #954 review:",
             "wasi:http #962 regression:",
             "wasi:http #967 review",
+            "wasi:http #969 review:",
         },
     });
     const run_http_streaming_unit_tests = b.addRunArtifact(

--- a/src/component/wasi_cli_adapter.zig
+++ b/src/component/wasi_cli_adapter.zig
@@ -5496,7 +5496,11 @@ const InboundHttpResponseSession = struct {
         self.head_ready = true;
         self.use_chunked = use_chunked;
         self.expected_content_length = expected_content_length;
-        if (trailers.state == .ready) {
+        // `pollP3Trailers` may already have snapshotted and stored the same
+        // trailers future (a guest can close the body stream before
+        // `task.return`). Only store when nothing is stored yet, otherwise the
+        // previously stored block would be clobbered and leaked.
+        if (trailers.state == .ready and self.trailer_state == .pending) {
             self.trailer_bytes = owned_trailers;
             self.trailer_state = .ready;
         } else if (owned_trailers) |bytes| {
@@ -49976,6 +49980,100 @@ test "wasi:http #967 review issue 4: check-write on an outbound request body rep
         try liveHttpCheckWritePermit(&adapter, &ci, inbound_stream.handle),
     );
     session.waitAndJoin();
+}
+
+test "wasi:http #969 review: P3 trailers snapshotted twice keep one owned block" {
+    const testing = std.testing;
+    var watchdog = LiveHttpWatchdog{
+        .label = "P3 trailers snapshotted twice keep one owned block",
+        .limit_ms = 60_000,
+    };
+    try watchdog.start();
+    defer watchdog.stop();
+
+    // The guest may close the body stream before `task.return`. That path
+    // snapshots the trailers future in `pollP3Trailers`, and `task.return`
+    // then snapshots the same future again in `prepareP3Head`. The second
+    // snapshot must not clobber (and leak) the first owned block, and the
+    // trailers must still reach the wire exactly once. Run both orderings
+    // under the testing allocator so a leak fails the test.
+    inline for (.{ true, false }) |close_body_first| {
+        var adapter = WasiCliAdapter.init(testing.allocator);
+        defer adapter.deinit();
+        var ci = p3HttpTestCi(testing.allocator);
+        defer p3HttpTestCiDeinit(&ci);
+        var output: streams.OutputStream = .{ .sink = .closed };
+
+        const fixture = try makeLiveHttpResponseFixture(
+            &adapter,
+            &ci,
+            null,
+            true,
+            .{ .name = "x-final", .value = "done" },
+        );
+
+        var sink = LiveHttpTestSink{};
+        const session = try InboundHttpResponseSession.create(
+            testing.allocator,
+            &adapter,
+            &ci,
+            &output,
+            false,
+            .{
+                .context = &sink,
+                .callback = &LiveHttpTestSink.interrupt,
+            },
+            .{
+                .context = &sink,
+                .write = &LiveHttpTestSink.write,
+            },
+        );
+        defer session.destroy();
+        try session.start();
+        // Attach without selecting: the head stays unframed until
+        // `handlerReturned`, so the body-close path reaches the trailers
+        // future first.
+        try testing.expect(session.attachP3Response(
+            fixture.response_handle,
+            fixture.body_handle,
+            fixture.trailers_handle,
+            fixture.transmission_handle,
+        ));
+
+        try testing.expect(InboundHttpResponseSession.onBodyWrite(
+            session,
+            "abc",
+        ));
+        if (close_body_first) {
+            InboundHttpResponseSession.onBodyClosed(session);
+            session.handlerReturned(fixture.response_handle);
+        } else {
+            session.handlerReturned(fixture.response_handle);
+            InboundHttpResponseSession.onBodyClosed(session);
+        }
+        session.waitAndJoin();
+        session.propagateTerminalToGuest();
+
+        try testing.expectEqual(
+            HttpLiveTerminal.succeeded,
+            session.currentTerminal(),
+        );
+        const wire = sink.contents();
+        try testing.expect(std.mem.indexOf(
+            u8,
+            wire,
+            "Trailer: x-final\r\n",
+        ) != null);
+        try testing.expect(std.mem.endsWith(
+            u8,
+            wire,
+            "0\r\nx-final: done\r\n\r\n",
+        ));
+        try testing.expectEqual(
+            @as(usize, 1),
+            std.mem.count(u8, wire, "x-final: done\r\n"),
+        );
+    }
 }
 
 test "wasi:http #954 review: P3 trailer error and dropped writer fail response" {


### PR DESCRIPTION
## The leak

A verification review of merged PR #969 (`8fea5383`) found a confirmed memory leak on the **success** path of live P3 inbound HTTP responses.

`prepareP3Head` stored a freshly snapshotted trailer block without checking whether one was already stored:

```zig
if (trailers.state == .ready) {
    self.trailer_bytes = owned_trailers;   // clobbers a non-null trailer_bytes
    self.trailer_state = .ready;
} else if (owned_trailers) |bytes| {
    self.allocator.free(bytes);
}
```

`pollP3Trailers` already guards its own store with `if (self.trailer_state == .pending)` and frees the block otherwise. `prepareP3Head` was the odd one out.

### Trigger ordering

A P3 guest closes the body stream **before** `task.return`, and the response has not yet been selected, so the head is still unframed:

1. `onBodyClosed` -> `markBodyClosed` -> `pollP3Trailers` snapshots the trailers future and stores the owned block in `self.trailer_bytes`.
2. `task.return` -> `handlerReturned` -> `prepareP3Head` (head not yet framed) snapshots the **same** future again and overwrites the pointer without freeing the previous one.
3. `destroy()` frees only the survivor.

Impact: on a keep-alive server this repeats per request; for a proxying or echoing guest the leaked block's size derives from upstream- or client-supplied trailers, so the growth rate is remotely influenced. Pre-existing (identical at `324a4fc4`), fixed here as part of this cleanup pass.

## The fix

Mirror the guard `pollP3Trailers` uses: store only while `self.trailer_state == .pending`, and free the redundant block otherwise. `snapshotTrailers` reads the future non-destructively, so both snapshots carry identical content — keeping the first one is correct and the trailers are still emitted exactly once.

## Before/after allocator evidence

Test binary built with Zig's `DebugAllocator` (`std.testing.allocator`), so a leak fails the test.

**Before** (fix reverted, new regression test in place) — `zig build test-http-streaming`:

```
Build Summary: 2/4 steps succeeded (1 failed); 38/38 tests passed
test-http-streaming transitive failure
+- run test 38 pass (38 total); 1 leaks

[DebugAllocator] (err): memory address 0x7b70e9820000 leaked:
    wasi_cli_adapter.zig:5352 in snapshotTrailers
    wasi_cli_adapter.zig:5670 in pollP3Trailers
    wasi_cli_adapter.zig:6064 in markBodyClosed
    wasi_cli_adapter.zig:6058 in onBodyClosed
    ... in test.wasi:http #969 review: P3 trailers snapshotted twice keep one owned block
```

Exactly one leaked allocation, only in the `close_body_first = true` ordering, with the response still reporting `terminal = succeeded`.

**After** (fix applied):

```
Build Summary: 4/4 steps succeeded; 38/38 tests passed
test-http-streaming success
+- run test 38 pass (38 total) 3s MaxRSS:11M
```

## Regression test

`wasi:http #969 review: P3 trailers snapshotted twice keep one owned block` runs **both** orderings (`close_body_first = true` and `false`) and asserts:

- terminal is `.succeeded`;
- `Trailer: x-final` is declared;
- the wire ends with `0\r\nx-final: done\r\n\r\n`;
- `x-final: done\r\n` appears **exactly once** on the wire.

It attaches the P3 response without selecting it, so the body-close path reaches the trailers future before the head is framed — that is the ordering that reproduces the double snapshot. A `LiveHttpWatchdog` bounds it at 60s so a hang fails rather than stalls CI. The test is wired into the `test-http-streaming` step filter.

## Audit of other owned-buffer stores

Every assignment to `self.trailer_bytes` and `self.head_bytes` in this file was reviewed for the same clobber-without-free pattern:

- `prepareP3Head` trailer store — **the bug, fixed here**.
- `pollP3Trailers` trailer store — already guarded by `trailer_state == .pending`, frees otherwise. Correct.
- `prepareP3Head` / `prepareP2Head` head stores — both sit behind an `if (self.head_ready) { free; return; }` check taken under the same mutex acquisition, so `head_bytes` can only be assigned once. Correct.
- `trailer_bytes` at emission time is borrowed under the lock, not transferred; ownership stays with `destroy()`. Correct.

No further genuine instances found.

## Validation

- `zig build test-http-streaming` — 38/38, no leaks (fails with 1 leak before the fix).
- `zig build test` — pass.
- `zig build test -Dlib_wasi_threads=true` — pass.
- `zig build test-adapter-resources test-stable-resources test-component-resources test-core-resources` (each covers both `lib_wasi_threads` modes) — pass.
- `zig build wasi-p2-testsuite -Daot-broken-components=false` — pass.

Positive controls that still pass inside `test-http-streaming`: no wire bytes before response selection; a slow-but-progressing client is not truncated; late-resolving P3 trailers still emit; over-declared Content-Length is still rejected with `HTTP-response-body-size` and zero wire bytes for both P2 and P3 (the #969 response-splitting fix remains intact).

Refs #969, #616. Out of scope: #970 (HEAD/204/304 body framing).