### PR TITLE
bench: add authoritative AArch64 CoreMark flow

### DIFF
--- a/.github/workflows/coremark-aarch64.yml
+++ b/.github/workflows/coremark-aarch64.yml
@@ -1,7 +1,7 @@
 name: CoreMark (aarch64)
 
-# Per-PR CoreMark comparison on a hosted aarch64 runner.
-# Runs `scripts/bench_coremark.py` against the PR base, posts a delta table.
+# Per-PR CoreMark comparison plus an authoritative on-demand same-host
+# WAMR/Wasmtime measurement on a hosted native aarch64 runner.
 
 on:
   workflow_dispatch:
@@ -14,10 +14,6 @@ on:
         description: "Target git ref"
         required: false
         default: "HEAD"
-      runs:
-        description: "Runs per ref"
-        required: false
-        default: "3"
   pull_request:
     paths:
       - src/compiler/**
@@ -28,8 +24,9 @@ on:
       - .github/workflows/coremark-aarch64.yml
 
 concurrency:
-  # Keep one canonical ARM64 comparison active at a time.
-  group: coremark-aarch64
+  # Keep PR gates and the authoritative manual measurement from cancelling
+  # each other while still replacing superseded runs of the same kind.
+  group: coremark-aarch64-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:
@@ -75,20 +72,37 @@ jobs:
             echo "target=${INPUT_TARGET:-HEAD}"            >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run CoreMark comparison
-        id: bench
+      - name: Run CoreMark PR comparison
+        if: github.event_name == 'pull_request'
+        id: bench_pr
         continue-on-error: true
         env:
           BASELINE: ${{ steps.refs.outputs.baseline }}
           TARGET: ${{ steps.refs.outputs.target }}
-          RUNS: ${{ github.event.inputs.runs || '3' }}
         run: |
           python3 scripts/bench_coremark.py \
             --baseline "$BASELINE" \
             --target   "$TARGET" \
             --profile  ci \
-            --runs     "$RUNS" \
             --min-delta-pct=-5.0 \
+            --out      coremark-table.md \
+            --emit     github
+
+      - name: Run authoritative same-host CoreMark comparison
+        if: github.event_name == 'workflow_dispatch'
+        id: bench_authoritative
+        continue-on-error: true
+        env:
+          BASELINE: ${{ steps.refs.outputs.baseline }}
+          TARGET: ${{ steps.refs.outputs.target }}
+        run: |
+          python3 scripts/bench_coremark.py \
+            --baseline "$BASELINE" \
+            --target   "$TARGET" \
+            --profile  authoritative \
+            --wasmtime-baseline auto \
+            --wasmtime-cache "$RUNNER_TEMP/coremark-wasmtime" \
+            --require-native-arch aarch64 \
             --out      coremark-table.md \
             --emit     github
 
@@ -96,9 +110,9 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: coremark-aarch64-${{ github.sha }}
+          name: coremark-aarch64-${{ github.event_name }}-${{ github.sha }}
           path: coremark-table.md
-          if-no-files-found: ignore
+          if-no-files-found: error
           retention-days: 90
 
       - name: Comment on PR
@@ -119,6 +133,8 @@ jobs:
               body,
             });
 
-      - name: Fail on CoreMark regression
-        if: steps.bench.outcome == 'failure'
+      - name: Fail on benchmark error
+        if: >-
+          steps.bench_pr.outcome == 'failure' ||
+          steps.bench_authoritative.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/coremark-aarch64.yml
+++ b/.github/workflows/coremark-aarch64.yml
@@ -135,6 +135,7 @@ jobs:
 
       - name: Fail on benchmark error
         if: >-
-          steps.bench_pr.outcome == 'failure' ||
-          steps.bench_authoritative.outcome == 'failure'
+          always() &&
+          (steps.bench_pr.outcome == 'failure' ||
+          steps.bench_authoritative.outcome == 'failure')
         run: exit 1

--- a/scripts/bench_coremark.py
+++ b/scripts/bench_coremark.py
@@ -33,7 +33,9 @@ from pathlib import Path
 from bench_optimize import OPTIMIZE_CHOICES, fmt_ratio, optimize_slug, parse_optimize_modes
 
 ITER_PATTERN = re.compile(r"Iterations/Sec\s*:\s*([0-9]+(?:\.[0-9]+)?)")
+CRC_PATTERN = re.compile(r"(?mi)^\[\d+\]crcfinal\s*:\s*0x([0-9a-f]+)\s*$")
 VALIDATION_TEXT = "Correct operation validated."
+EXPECTED_CRC = "33ff"
 DEFAULT_FIXTURE = Path("tests/benchmarks/coremark/coremark_wasi.wasm")
 DEFAULT_FIXTURE_SHA256 = "f4b7591296ead10264e0f101f355bdf848865c31329325594e66fbabefec235b"
 PINNED_WASMTIME_VERSION = "44.0.1"
@@ -68,6 +70,27 @@ class EngineResult:
     version: str
     optimize: str
     values: list[float]
+
+
+@dataclass(frozen=True)
+class HostIdentity:
+    arch: str
+    cpu_count: int
+    cpu_model: str
+    runner_name: str
+    boot_id: str
+
+    def fingerprint(self) -> str:
+        encoded = "\0".join(
+            (
+                self.arch,
+                str(self.cpu_count),
+                self.cpu_model,
+                self.runner_name,
+                self.boot_id,
+            )
+        ).encode()
+        return hashlib.sha256(encoded).hexdigest()[:16]
 
 
 def run(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> str:
@@ -128,6 +151,12 @@ def parse_coremark_output(output: str, engine: str) -> float:
         raise RuntimeError(
             f"{engine} did not produce a CRC-validated CoreMark result:\n{output}"
         )
+    crc_matches = CRC_PATTERN.findall(output)
+    if len(crc_matches) != 1 or crc_matches[0].lower() != EXPECTED_CRC:
+        actual = ", ".join(f"0x{crc}" for crc in crc_matches) or "missing"
+        raise RuntimeError(
+            f"{engine} produced crcfinal {actual}; expected exactly 0x{EXPECTED_CRC}"
+        )
     matches = ITER_PATTERN.findall(output)
     if len(matches) != 1:
         raise RuntimeError(
@@ -137,8 +166,12 @@ def parse_coremark_output(output: str, engine: str) -> float:
     return float(matches[0])
 
 
+def resolve_ref_sha(repo: Path, ref: str) -> str:
+    return run(["git", "rev-parse", ref], cwd=repo).strip()
+
+
 def make_worktree(repo: Path, ref: str, root: Path, label: str) -> tuple[Path, str]:
-    sha = run(["git", "rev-parse", ref], cwd=repo).strip()
+    sha = resolve_ref_sha(repo, ref)
     wt = root / f"{label}-{sha[:12]}"
     run(["git", "worktree", "add", "--detach", str(wt), sha], cwd=repo)
     return wt, sha
@@ -247,16 +280,20 @@ def build_and_run_wamr(
         runs=runs,
         retry_wamr_flake=True,
     )
-    return EngineResult("WAMR", f"{ref} ({sha[:12]})", optimize, values)
+    return EngineResult("WAMR", f"{ref} ({sha})", optimize, values)
 
 
-def normalize_arch() -> str:
-    arch = platform.machine().lower()
+def normalize_arch_name(arch: str) -> str:
+    arch = arch.lower()
     return {
         "amd64": "x86_64",
         "x64": "x86_64",
         "arm64": "aarch64",
     }.get(arch, arch)
+
+
+def normalize_arch() -> str:
+    return normalize_arch_name(platform.machine())
 
 
 def wasmtime_version(path: Path) -> str:
@@ -357,6 +394,7 @@ def measure_wasmtime(
     warmups: int,
     runs: int,
 ) -> EngineResult:
+    binary_sha = sha256_file(path)
     values = measure_command(
         engine=label,
         cmd=[str(path), "run", str(fixture)],
@@ -365,7 +403,12 @@ def measure_wasmtime(
         warmups=warmups,
         runs=runs,
     )
-    return EngineResult(label, f"{version} ({path})", "default JIT", values)
+    return EngineResult(
+        label,
+        f"{version} (sha256:{binary_sha}; {path})",
+        "default JIT",
+        values,
+    )
 
 
 def fmt_stats(values: list[float]) -> tuple[float, float, float, float]:
@@ -406,13 +449,95 @@ def host_cpu_model() -> str:
     return platform.processor() or "unknown CPU"
 
 
-def host_info() -> str:
-    arch = platform.machine() or "unknown-arch"
-    ncpu = os.cpu_count()
-    parts = [f"arch `{arch}`", f"{ncpu or '?'} vCPU", f"`{host_cpu_model()}`"]
-    runner = os.environ.get("RUNNER_NAME")
-    if runner:
-        parts.append(f"runner `{runner}`")
+def read_optional_text(path: Path) -> str:
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return ""
+
+
+def capture_host_identity(*, require_boot_id: bool = False) -> HostIdentity:
+    arch = normalize_arch()
+    cpu_count = os.cpu_count() or 0
+    cpu_model = host_cpu_model()
+    runner_name = os.environ.get("RUNNER_NAME", "")
+    boot_id = read_optional_text(Path("/proc/sys/kernel/random/boot_id"))
+    if require_boot_id and not boot_id:
+        raise RuntimeError("cannot establish host identity: Linux boot ID is unavailable")
+    return HostIdentity(arch, cpu_count, cpu_model, runner_name, boot_id)
+
+
+def host_emulation_evidence() -> str:
+    evidence = [
+        platform.platform(),
+        os.environ.get("QEMU_CPU", ""),
+        os.environ.get("QEMU_LD_PREFIX", ""),
+        read_optional_text(Path("/proc/cpuinfo")),
+        read_optional_text(Path("/sys/class/dmi/id/product_name")),
+        read_optional_text(Path("/sys/class/dmi/id/sys_vendor")),
+    ]
+    try:
+        evidence.append(
+            subprocess.run(
+                ["lscpu"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            ).stdout
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return "\n".join(evidence)
+
+
+def validate_native_host(expected_arch: str) -> HostIdentity:
+    expected = normalize_arch_name(expected_arch)
+    identity = capture_host_identity(require_boot_id=True)
+    if identity.arch != expected:
+        raise RuntimeError(
+            f"authoritative host architecture must be {expected}; got {identity.arch}"
+        )
+    runner_arch = os.environ.get("RUNNER_ARCH")
+    if runner_arch and normalize_arch_name(runner_arch) != expected:
+        raise RuntimeError(
+            f"RUNNER_ARCH must be {expected}; got {runner_arch}"
+        )
+    if identity.cpu_count <= 0:
+        raise RuntimeError("authoritative host CPU count is unavailable")
+    if not identity.cpu_model or identity.cpu_model == "unknown CPU":
+        raise RuntimeError("authoritative host CPU model is unavailable")
+
+    evidence = host_emulation_evidence()
+    if re.search(r"\b(qemu|tcg|emulat(?:e|ed|ion|or))\b", evidence, re.IGNORECASE):
+        raise RuntimeError("authoritative measurements cannot run under emulation")
+    if expected == "aarch64" and re.search(
+        r"\b(Intel|AMD|Xeon|EPYC)\b", identity.cpu_model, re.IGNORECASE
+    ):
+        raise RuntimeError(
+            "AArch64 process reports an x86 CPU model, indicating user-mode emulation"
+        )
+    return identity
+
+
+def validate_same_host(expected: HostIdentity) -> None:
+    actual = capture_host_identity(require_boot_id=bool(expected.boot_id))
+    if actual != expected:
+        raise RuntimeError(
+            "host identity changed during measurement: "
+            f"started {expected.fingerprint()}, ended {actual.fingerprint()}"
+        )
+
+
+def host_info(identity: HostIdentity) -> str:
+    parts = [
+        f"arch `{identity.arch}`",
+        f"{identity.cpu_count or '?'} vCPU",
+        f"`{identity.cpu_model}`",
+    ]
+    if identity.runner_name:
+        parts.append(f"runner `{identity.runner_name}`")
+    parts.append(f"host fingerprint `{identity.fingerprint()}`")
     return "_Host: " + " · ".join(parts) + "_"
 
 
@@ -428,7 +553,14 @@ def render_table(
     runs: int,
     fixture: Path,
     fixture_sha: str,
+    host: HostIdentity,
 ) -> str:
+    for result in results:
+        if len(result.values) != runs:
+            raise RuntimeError(
+                f"{result.engine} produced {len(result.values)} measured samples; "
+                f"expected {runs}"
+            )
     baseline, target = results[0], results[1]
     delta_pct = compute_delta_pct(baseline.values, target.values)
     sign = "+" if delta_pct >= 0 else ""
@@ -439,6 +571,9 @@ def render_table(
         f"{runs} measured runs per engine)",
         f"- Fixture: `{fixture}` (`sha256:{fixture_sha}`)",
         f"- WAMR optimize mode: `{target.optimize}`; Wasmtime mode: `default JIT`",
+        f"- CRC validation: all {warmups + runs} invocations per measured engine "
+        f"produced `crcfinal 0x{EXPECTED_CRC}` and `{VALIDATION_TEXT}`; "
+        f"warmups were discarded",
         "",
         "| Engine | Version / ref | Optimize mode | Mean iter/s | Median | Range | Samples (iter/s) |",
         "|---|---|---|---:|---:|---:|---|",
@@ -461,15 +596,20 @@ def render_table(
         lines.extend(
             [
                 "",
-                "| Same-host ratio | Mean iter/s ratio |",
-                "|---|---:|",
+                "| Same-host ratio | Median iter/s ratio | Mean iter/s ratio |",
+                "|---|---:|---:|",
             ]
         )
         target_mean = statistics.fmean(target.values)
+        target_median = statistics.median(target.values)
         for result in wasmtime_results:
-            ratio = target_mean / statistics.fmean(result.values)
-            lines.append(f"| WAMR target / {result.engine} `{result.version}` | {ratio:.3f}× |")
-    lines.extend(["", host_info()])
+            median_ratio = target_median / statistics.median(result.values)
+            mean_ratio = target_mean / statistics.fmean(result.values)
+            lines.append(
+                f"| WAMR target / {result.engine} `{result.version}` | "
+                f"{median_ratio:.3f}× | {mean_ratio:.3f}× |"
+            )
+    lines.extend(["", host_info(host)])
     return "\n".join(lines)
 
 
@@ -482,6 +622,7 @@ def render_optimize_table(
     runs: int,
     fixture: Path,
     fixture_sha: str,
+    host: HostIdentity,
 ) -> str:
     lines = [
         "### CoreMark AOT optimize-mode comparison",
@@ -520,7 +661,7 @@ def render_optimize_table(
                 "At least one optimize mode failed before producing complete timings.",
             ]
         )
-    lines.extend(["", host_info()])
+    lines.extend(["", host_info(host)])
     return "\n".join(lines)
 
 
@@ -604,6 +745,12 @@ def main() -> int:
         help="cache for --wasmtime-baseline auto (default: .bench-coremark/tools)",
     )
     p.add_argument(
+        "--require-native-arch",
+        choices=("aarch64", "x86_64"),
+        default=None,
+        help="fail unless the run is on a native, non-emulated host of this architecture",
+    )
+    p.add_argument(
         "--min-delta-pct",
         type=float,
         default=None,
@@ -621,6 +768,11 @@ def main() -> int:
 
     repo = args.repo.resolve()
     fixture, fixture_sha = resolve_fixture(repo, args.fixture)
+    host = (
+        validate_native_host(args.require_native_arch)
+        if args.require_native_arch
+        else capture_host_identity()
+    )
     work_root = repo / ".bench-coremark" / f"run-{uuid.uuid4().hex}"
     work_root.mkdir(parents=True)
     optimize_modes = parse_optimize_modes(args.optimize)
@@ -656,32 +808,62 @@ def main() -> int:
                 runs=runs,
                 fixture=fixture,
                 fixture_sha=fixture_sha,
+                host=host,
             )
             target_vals = mode_results["ReleaseFast"] or []
         else:
             optimize = optimize_modes[0]
-            baseline_wt, baseline_sha = make_worktree(
-                repo, args.baseline, work_root, "baseline"
-            )
-            target_wt, target_sha = make_worktree(repo, args.target, work_root, "target")
-            baseline_result = build_and_run_wamr(
-                baseline_wt,
-                args.baseline,
-                baseline_sha,
-                fixture,
-                optimize,
-                warmups,
-                runs,
-            )
-            target_result = build_and_run_wamr(
-                target_wt,
-                args.target,
-                target_sha,
-                fixture,
-                optimize,
-                warmups,
-                runs,
-            )
+            baseline_sha = resolve_ref_sha(repo, args.baseline)
+            target_sha = resolve_ref_sha(repo, args.target)
+            if baseline_sha == target_sha:
+                target_wt, target_sha = make_worktree(
+                    repo, args.target, work_root, "target"
+                )
+                target_result = build_and_run_wamr(
+                    target_wt,
+                    args.target,
+                    target_sha,
+                    fixture,
+                    optimize,
+                    warmups,
+                    runs,
+                )
+                baseline_result = EngineResult(
+                    "WAMR",
+                    f"{args.baseline} ({baseline_sha})",
+                    optimize,
+                    target_result.values.copy(),
+                )
+                print(
+                    "[harness] WAMR baseline and target resolve to the same commit; "
+                    "reusing the target samples",
+                    file=sys.stderr,
+                )
+            else:
+                baseline_wt, baseline_sha = make_worktree(
+                    repo, args.baseline, work_root, "baseline"
+                )
+                target_wt, target_sha = make_worktree(
+                    repo, args.target, work_root, "target"
+                )
+                baseline_result = build_and_run_wamr(
+                    baseline_wt,
+                    args.baseline,
+                    baseline_sha,
+                    fixture,
+                    optimize,
+                    warmups,
+                    runs,
+                )
+                target_result = build_and_run_wamr(
+                    target_wt,
+                    args.target,
+                    target_sha,
+                    fixture,
+                    optimize,
+                    warmups,
+                    runs,
+                )
             results = [baseline_result, target_result]
             baseline_vals = baseline_result.values
             target_vals = target_result.values
@@ -742,11 +924,13 @@ def main() -> int:
                 runs=runs,
                 fixture=fixture,
                 fixture_sha=fixture_sha,
+                host=host,
             )
     finally:
         shutil.rmtree(work_root, ignore_errors=True)
         run(["git", "worktree", "prune"], cwd=repo)
 
+    validate_same_host(host)
     print(table)
     if args.out:
         args.out.write_text(table + "\n")

--- a/scripts/bench_coremark.py
+++ b/scripts/bench_coremark.py
@@ -33,9 +33,7 @@ from pathlib import Path
 from bench_optimize import OPTIMIZE_CHOICES, fmt_ratio, optimize_slug, parse_optimize_modes
 
 ITER_PATTERN = re.compile(r"Iterations/Sec\s*:\s*([0-9]+(?:\.[0-9]+)?)")
-CRC_PATTERN = re.compile(r"(?mi)^\[\d+\]crcfinal\s*:\s*0x([0-9a-f]+)\s*$")
 VALIDATION_TEXT = "Correct operation validated."
-EXPECTED_CRC = "33ff"
 DEFAULT_FIXTURE = Path("tests/benchmarks/coremark/coremark_wasi.wasm")
 DEFAULT_FIXTURE_SHA256 = "f4b7591296ead10264e0f101f355bdf848865c31329325594e66fbabefec235b"
 PINNED_WASMTIME_VERSION = "44.0.1"
@@ -150,12 +148,6 @@ def parse_coremark_output(output: str, engine: str) -> float:
     if VALIDATION_TEXT not in output or re.search(r"(?m)^.*ERROR!", output):
         raise RuntimeError(
             f"{engine} did not produce a CRC-validated CoreMark result:\n{output}"
-        )
-    crc_matches = CRC_PATTERN.findall(output)
-    if len(crc_matches) != 1 or crc_matches[0].lower() != EXPECTED_CRC:
-        actual = ", ".join(f"0x{crc}" for crc in crc_matches) or "missing"
-        raise RuntimeError(
-            f"{engine} produced crcfinal {actual}; expected exactly 0x{EXPECTED_CRC}"
         )
     matches = ITER_PATTERN.findall(output)
     if len(matches) != 1:
@@ -572,8 +564,8 @@ def render_table(
         f"- Fixture: `{fixture}` (`sha256:{fixture_sha}`)",
         f"- WAMR optimize mode: `{target.optimize}`; Wasmtime mode: `default JIT`",
         f"- CRC validation: all {warmups + runs} invocations per measured engine "
-        f"produced `crcfinal 0x{EXPECTED_CRC}` and `{VALIDATION_TEXT}`; "
-        f"warmups were discarded",
+        f"produced `{VALIDATION_TEXT}` with no CoreMark CRC error; warmups "
+        f"were discarded",
         "",
         "| Engine | Version / ref | Optimize mode | Mean iter/s | Median | Range | Samples (iter/s) |",
         "|---|---|---|---:|---:|---:|---|",

--- a/scripts/test_bench_coremark.py
+++ b/scripts/test_bench_coremark.py
@@ -9,6 +9,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import bench_coremark
 
 
+REPO = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO / ".github/workflows/coremark-aarch64.yml"
 VALID_OUTPUT = """\
 Iterations/Sec   : 12345.5
 [0]crcfinal      : 0x33ff
@@ -18,12 +20,11 @@ Correct operation validated. See README.md for run and reporting rules.
 
 class BenchCoremarkTests(unittest.TestCase):
     def test_tracked_fixture_checksum_is_pinned(self):
-        repo = Path(__file__).resolve().parents[1]
         fixture, digest = bench_coremark.resolve_fixture(
-            repo, bench_coremark.DEFAULT_FIXTURE
+            REPO, bench_coremark.DEFAULT_FIXTURE
         )
         self.assertEqual(
-            fixture, (repo / bench_coremark.DEFAULT_FIXTURE).resolve()
+            fixture, (REPO / bench_coremark.DEFAULT_FIXTURE).resolve()
         )
         self.assertEqual(digest, bench_coremark.DEFAULT_FIXTURE_SHA256)
 
@@ -38,6 +39,10 @@ class BenchCoremarkTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "CRC-validated"):
             bench_coremark.parse_coremark_output(
                 "Iterations/Sec : 12345.5\n", "test"
+            )
+        with self.assertRaisesRegex(RuntimeError, "expected exactly 0x33ff"):
+            bench_coremark.parse_coremark_output(
+                VALID_OUTPUT.replace("0x33ff", "0x1234"), "test"
             )
 
     def test_parse_rejects_ambiguous_throughput(self):
@@ -67,8 +72,7 @@ class BenchCoremarkTests(unittest.TestCase):
             "authoritative (overridden)",
         )
 
-    @mock.patch.object(bench_coremark, "host_info", return_value="_Host: test_")
-    def test_report_distinguishes_wasmtime_versions_and_lists_samples(self, _):
+    def test_report_distinguishes_wasmtime_versions_and_lists_samples(self):
         results = [
             bench_coremark.EngineResult(
                 "WAMR", "origin/main (aaaa)", "ReleaseFast", [50.0, 52.0]
@@ -78,13 +82,13 @@ class BenchCoremarkTests(unittest.TestCase):
             ),
             bench_coremark.EngineResult(
                 "Wasmtime historical pin",
-                "44.0.1 (/pinned/wasmtime)",
+                "44.0.1 (sha256:abc; /pinned/wasmtime)",
                 "default JIT",
                 [100.0, 102.0],
             ),
             bench_coremark.EngineResult(
                 "Wasmtime caller-selected",
-                "48.0.1 (/current/wasmtime)",
+                "48.0.1 (sha256:def; /current/wasmtime)",
                 "default JIT",
                 [120.0, 122.0],
             ),
@@ -96,13 +100,43 @@ class BenchCoremarkTests(unittest.TestCase):
             runs=2,
             fixture=Path("coremark.wasm"),
             fixture_sha="abc",
+            host=bench_coremark.HostIdentity(
+                "aarch64", 4, "Neoverse-N2", "runner", "boot-id"
+            ),
         )
         self.assertIn("Median", report)
         self.assertIn("50.0, 52.0", report)
-        self.assertIn("44.0.1 (/pinned/wasmtime)", report)
-        self.assertIn("48.0.1 (/current/wasmtime)", report)
+        self.assertIn("44.0.1 (sha256:abc; /pinned/wasmtime)", report)
+        self.assertIn("48.0.1 (sha256:def; /current/wasmtime)", report)
         self.assertIn("WAMR target / Wasmtime historical pin", report)
         self.assertIn("WAMR target / Wasmtime caller-selected", report)
+        self.assertIn("Median iter/s ratio", report)
+        self.assertIn("0.604×", report)
+        self.assertIn("CRC validation", report)
+        self.assertIn("Neoverse-N2", report)
+        self.assertIn("host fingerprint", report)
+
+    def test_report_rejects_missing_samples(self):
+        results = [
+            bench_coremark.EngineResult(
+                "WAMR", "origin/main (aaaa)", "ReleaseFast", [50.0]
+            ),
+            bench_coremark.EngineResult(
+                "WAMR", "HEAD (bbbb)", "ReleaseFast", [60.0, 62.0]
+            ),
+        ]
+        with self.assertRaisesRegex(RuntimeError, "produced 1 measured samples"):
+            bench_coremark.render_table(
+                results,
+                profile="authoritative",
+                warmups=2,
+                runs=2,
+                fixture=Path("coremark.wasm"),
+                fixture_sha="abc",
+                host=bench_coremark.HostIdentity(
+                    "aarch64", 4, "Neoverse-N2", "runner", "boot-id"
+                ),
+            )
 
     @mock.patch.object(
         bench_coremark, "run", return_value="wasmtime 44.0.1 (abcdef)"
@@ -117,6 +151,80 @@ class BenchCoremarkTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(RuntimeError, "must be 44.0.1"):
                 bench_coremark.validate_pinned_wasmtime(Path("/bin/wasmtime"))
+
+    @mock.patch.object(bench_coremark, "host_emulation_evidence", return_value="")
+    @mock.patch.dict(
+        bench_coremark.os.environ,
+        {"RUNNER_ARCH": "ARM64"},
+        clear=True,
+    )
+    @mock.patch.object(
+        bench_coremark,
+        "capture_host_identity",
+        return_value=bench_coremark.HostIdentity(
+            "aarch64", 4, "Neoverse-N2", "runner", "boot-id"
+        ),
+    )
+    def test_native_aarch64_host_validation(self, _, __):
+        identity = bench_coremark.validate_native_host("aarch64")
+        self.assertEqual(identity.cpu_model, "Neoverse-N2")
+
+    @mock.patch.object(
+        bench_coremark,
+        "capture_host_identity",
+        return_value=bench_coremark.HostIdentity(
+            "aarch64", 4, "Neoverse-N2", "runner", "boot-id"
+        ),
+    )
+    @mock.patch.object(
+        bench_coremark,
+        "host_emulation_evidence",
+        return_value="Hypervisor vendor: QEMU",
+    )
+    def test_native_host_rejects_emulation(self, _, __):
+        with self.assertRaisesRegex(RuntimeError, "under emulation"):
+            bench_coremark.validate_native_host("aarch64")
+
+    @mock.patch.object(
+        bench_coremark,
+        "capture_host_identity",
+        return_value=bench_coremark.HostIdentity(
+            "aarch64", 8, "Neoverse-N2", "runner", "other-boot"
+        ),
+    )
+    def test_host_consistency_rejects_mixed_host(self, _):
+        with self.assertRaisesRegex(RuntimeError, "host identity changed"):
+            bench_coremark.validate_same_host(
+                bench_coremark.HostIdentity(
+                    "aarch64", 4, "Neoverse-N2", "runner", "boot-id"
+                )
+            )
+
+    def test_aarch64_workflow_contract(self):
+        workflow = WORKFLOW.read_text()
+        self.assertIn("runs-on: ubuntu-24.04-arm", workflow)
+        dispatch = workflow.split(
+            "- name: Run authoritative same-host CoreMark comparison", 1
+        )[1].split("\n      - name:", 1)[0]
+        self.assertIn("github.event_name == 'workflow_dispatch'", dispatch)
+        self.assertIn("--profile  authoritative", dispatch)
+        self.assertIn("--wasmtime-baseline auto", dispatch)
+        self.assertIn("--require-native-arch aarch64", dispatch)
+        self.assertNotIn("--runs", dispatch)
+
+        pr = workflow.split("- name: Run CoreMark PR comparison", 1)[1].split(
+            "\n      - name:", 1
+        )[0]
+        self.assertIn("github.event_name == 'pull_request'", pr)
+        self.assertIn("--profile  ci", pr)
+        self.assertNotIn("--wasmtime-baseline", pr)
+
+        for line in workflow.splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("uses:") or "uses: ./" in stripped:
+                continue
+            action = stripped.split("#", 1)[0].strip()
+            self.assertRegex(action, r"@[0-9a-f]{40}$")
 
 
 if __name__ == "__main__":

--- a/scripts/test_bench_coremark.py
+++ b/scripts/test_bench_coremark.py
@@ -40,10 +40,6 @@ class BenchCoremarkTests(unittest.TestCase):
             bench_coremark.parse_coremark_output(
                 "Iterations/Sec : 12345.5\n", "test"
             )
-        with self.assertRaisesRegex(RuntimeError, "expected exactly 0x33ff"):
-            bench_coremark.parse_coremark_output(
-                VALID_OUTPUT.replace("0x33ff", "0x1234"), "test"
-            )
 
     def test_parse_rejects_ambiguous_throughput(self):
         with self.assertRaisesRegex(RuntimeError, "2 Iterations/Sec"):
@@ -180,6 +176,11 @@ class BenchCoremarkTests(unittest.TestCase):
         bench_coremark,
         "host_emulation_evidence",
         return_value="Hypervisor vendor: QEMU",
+    )
+    @mock.patch.dict(
+        bench_coremark.os.environ,
+        {"RUNNER_ARCH": "ARM64"},
+        clear=True,
     )
     def test_native_host_rejects_emulation(self, _, __):
         with self.assertRaisesRegex(RuntimeError, "under emulation"):


### PR DESCRIPTION
## Summary

- make manual AArch64 CoreMark runs authoritative (2 warmups, 10 samples) against checksum-pinned Wasmtime 44.0.1
- publish full WAMR commit and Wasmtime binary identity, raw samples, CRC validation, median/mean ratios, and a stable same-host fingerprint
- fail closed on wrong architecture, emulation, mixed hosts, invalid CRC, wrong Wasmtime version, or missing samples while leaving the normal PR gate at 0 warmups/3 runs

## Validation

- `python3 -m unittest scripts/test_bench_coremark.py`
- `python3 -m py_compile scripts/bench_coremark.py scripts/test_bench_coremark.py`
- workflow YAML parse and `bash -n` for every shell block
- `git diff --check`

Refs #949
Refs #940
Refs #393