### PR TITLE
wasi: fix Windows poll post-merge review findings

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1121,6 +1121,10 @@ pub fn build(b: *std.Build) void {
         .root_module = test_module,
         .filters = &.{
             "Windows poll_oneoff:",
+            "Windows poll review:",
+            "Windows cancellable read:",
+            "poll_oneoff review:",
+            "ThreadManager: Windows cancel event",
             "group termination: a blocking poll_oneoff",
             "group termination: poll_oneoff still honours",
             "group termination: a blocking Windows stdin",

--- a/docs/wasi.md
+++ b/docs/wasi.md
@@ -216,9 +216,15 @@ Windows supports relative and absolute realtime/monotonic clock
 subscriptions plus stdio and regular-file readiness. Console input is treated
 as readable only when a key is available (or a complete line in line-input
 mode); redirected pipes use `PeekNamedPipe` so buffered bytes and writer
-closure/EOF are distinguished. With Preview-1 threads enabled, every blocking
-Windows wait includes a `ThreadManager`-owned manual-reset cancellation event,
-so group termination wakes `poll_oneoff` and blocking stdin reads immediately.
+closure/EOF are distinguished. Absolute deadlines are re-evaluated against
+their selected clock after every wake, including realtime clock adjustments.
+
+With Preview-1 threads enabled, binding the group lazily creates a
+`ThreadManager`-owned manual-reset cancellation event; allocation failure is
+reported as a setup error rather than panicking. Readiness waits include that
+event directly. Blocking stdin `ReadFile` calls run on a bounded helper thread:
+group cancellation waits for and cancels the actual syscall with
+`NtCancelSynchronousIoFile`, rather than relying on an earlier readiness probe.
 
 Preview-1 socket subscriptions on Windows currently produce a per-event
 `notsup` error; Windows socket I/O itself remains supported. POSIX

--- a/src/main.zig
+++ b/src/main.zig
@@ -1529,7 +1529,13 @@ fn runInterpreterCore(
             return 1;
         };
         module_inst.thread_manager = &manager;
-        manager.bindTermination(&wasi_ctx.termination);
+        manager.bindTermination(&wasi_ctx.termination) catch |err| {
+            std.debug.print(
+                "Error: failed to initialize WASI thread cancellation: {s}\n",
+                .{@errorName(err)},
+            );
+            return 1;
+        };
     }
 
     wamr.instance.runStartFunction(module_inst) catch |err| {
@@ -1754,7 +1760,13 @@ fn runAotReal(
             );
             return 1;
         };
-        manager.bindTermination(&ctx.termination);
+        manager.bindTermination(&ctx.termination) catch |err| {
+            std.debug.print(
+                "Error: failed to initialize AOT WASI thread cancellation: {s}\n",
+                .{@errorName(err)},
+            );
+            return 1;
+        };
     }
 
     const func_idx = aot_runtime.findExportFunc(aot_inst, "_start") orelse

--- a/src/platform/windows_poll.zig
+++ b/src/platform/windows_poll.zig
@@ -1,10 +1,4 @@
-//! Windows readiness support for WASI Preview-1 polling.
-//!
-//! Console handles are waitable, but anonymous/named pipe handles do not
-//! report byte readiness through `WaitForMultipleObjects`. Pipes are therefore
-//! probed with `PeekNamedPipe` between short waits on the thread group's
-//! manual-reset cancellation event. Disk/character files are always readable
-//! in the same sense as POSIX regular files.
+//! Windows readiness and cancellable stdin I/O for WASI Preview-1.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -62,6 +56,14 @@ const api = if (is_windows) struct {
     ) callconv(.winapi) windows.BOOL;
 
     extern "kernel32" fn GetFileType(hFile: Handle) callconv(.winapi) windows.DWORD;
+
+    extern "kernel32" fn ReadFile(
+        hFile: Handle,
+        lpBuffer: *anyopaque,
+        nNumberOfBytesToRead: windows.DWORD,
+        lpNumberOfBytesRead: ?*windows.DWORD,
+        lpOverlapped: ?*anyopaque,
+    ) callconv(.winapi) windows.BOOL;
 } else struct {};
 
 const wait_object_0: windows.DWORD = 0;
@@ -69,7 +71,7 @@ const wait_timeout: windows.DWORD = 258;
 const wait_failed: windows.DWORD = std.math.maxInt(windows.DWORD);
 const infinite: windows.DWORD = std.math.maxInt(windows.DWORD);
 const max_wait_handles = 64;
-const pipe_probe_slice_ms: windows.DWORD = 10;
+const polling_slice_ms: windows.DWORD = 10;
 
 const file_type_unknown: windows.DWORD = 0;
 const file_type_disk: windows.DWORD = 1;
@@ -109,23 +111,31 @@ comptime {
     std.debug.assert(@sizeOf(InputRecord) == 20);
 }
 
-/// Manual-reset event owned by a WASI thread manager. Once group termination
-/// starts it remains signalled for the rest of that manager's lifetime.
+pub const CancelEventError = error{SystemResources};
+
+/// Lazily-created manual-reset event owned by a WASI thread manager.
 pub const CancelEvent = if (is_windows) struct {
-    handle: Handle,
+    handle: ?Handle = null,
 
     pub fn init() @This() {
-        const handle = api.CreateEventW(null, .TRUE, .FALSE, null) orelse
-            @panic("failed to create WASI thread cancellation event");
-        return .{ .handle = handle };
+        return .{};
+    }
+
+    pub fn ensureInitialized(self: *@This(), fail_for_test: bool) CancelEventError!void {
+        if (self.handle != null) return;
+        if (fail_for_test) return error.SystemResources;
+        self.handle = api.CreateEventW(null, .TRUE, .FALSE, null) orelse
+            return error.SystemResources;
     }
 
     pub fn deinit(self: *@This()) void {
-        windows.CloseHandle(self.handle);
+        if (self.handle) |handle| windows.CloseHandle(handle);
+        self.handle = null;
     }
 
-    pub fn signal(self: *@This()) void {
-        _ = api.SetEvent(self.handle);
+    pub fn signal(self: *@This()) bool {
+        const handle = self.handle orelse return true;
+        return api.SetEvent(handle).toBool();
     }
 
     pub fn opaqueHandle(self: *const @This()) ?*anyopaque {
@@ -136,12 +146,18 @@ pub const CancelEvent = if (is_windows) struct {
         return .{};
     }
 
+    pub fn ensureInitialized(self: *@This(), fail_for_test: bool) CancelEventError!void {
+        _ = self;
+        _ = fail_for_test;
+    }
+
     pub fn deinit(self: *@This()) void {
         _ = self;
     }
 
-    pub fn signal(self: *@This()) void {
+    pub fn signal(self: *@This()) bool {
         _ = self;
+        return true;
     }
 
     pub fn opaqueHandle(self: *const @This()) ?*anyopaque {
@@ -163,6 +179,10 @@ pub const ReadInput = struct {
     status: InputStatus = .pending,
     nbytes: u64 = 0,
     console: bool = false,
+    /// The handle is currently signalled by low-level events, but a blocking
+    /// cooked read would not complete. Poll it in bounded slices rather than
+    /// waiting directly on the perpetually-signalled console handle.
+    poll_only: bool = false,
 };
 
 pub const WaitResult = enum {
@@ -172,37 +192,54 @@ pub const WaitResult = enum {
     failed,
 };
 
-fn consoleReady(handle: Handle, mode: windows.DWORD) InputStatus {
-    var event_count: windows.DWORD = 0;
-    if (!api.GetNumberOfConsoleInputEvents(handle, &event_count).toBool())
-        return .io_error;
-    if (event_count == 0) return .pending;
+const ConsoleStatus = struct {
+    status: InputStatus,
+    poll_only: bool,
+};
 
-    // Keep canonical console reads from being reported ready before Enter is
-    // present. This covers long pasted lines without consuming console events.
-    var records: [256]InputRecord = undefined;
-    var records_read: windows.DWORD = 0;
-    const count: windows.DWORD = @min(event_count, records.len);
-    if (!api.PeekConsoleInputW(handle, &records, count, &records_read).toBool())
-        return .io_error;
-
+fn inspectConsoleRecords(mode: windows.DWORD, records: []const InputRecord) ConsoleStatus {
     const line_mode = (mode & enable_line_input) != 0;
-    for (records[0..records_read]) |record| {
+    for (records) |record| {
         if (record.EventType != key_event) continue;
         const key = record.Event.KeyEvent;
         if (!key.bKeyDown.toBool()) continue;
         const char = key.uChar.UnicodeChar;
         if (char == 0) continue;
-        if (!line_mode or char == '\r' or char == '\n' or char == 0x1a)
-            return .ready;
+        if (!line_mode or char == '\r' or char == '\n')
+            return .{ .status = .ready, .poll_only = false };
     }
-    return .pending;
+    return .{
+        .status = .pending,
+        .poll_only = records.len != 0,
+    };
 }
 
-fn probeInput(input: *ReadInput) void {
+fn consoleReady(
+    allocator: std.mem.Allocator,
+    handle: Handle,
+    mode: windows.DWORD,
+) ConsoleStatus {
+    var event_count: windows.DWORD = 0;
+    if (!api.GetNumberOfConsoleInputEvents(handle, &event_count).toBool())
+        return .{ .status = .io_error, .poll_only = false };
+    if (event_count == 0)
+        return .{ .status = .pending, .poll_only = false };
+
+    const records = allocator.alloc(InputRecord, event_count) catch
+        return .{ .status = .io_error, .poll_only = false };
+    defer allocator.free(records);
+
+    var records_read: windows.DWORD = 0;
+    if (!api.PeekConsoleInputW(handle, records.ptr, event_count, &records_read).toBool())
+        return .{ .status = .io_error, .poll_only = false };
+    return inspectConsoleRecords(mode, records[0..records_read]);
+}
+
+fn probeInput(allocator: std.mem.Allocator, input: *ReadInput) void {
     input.status = .pending;
     input.nbytes = 0;
     input.console = false;
+    input.poll_only = false;
 
     if (input.handle == windows.INVALID_HANDLE_VALUE) {
         input.status = .bad_handle;
@@ -212,7 +249,9 @@ fn probeInput(input: *ReadInput) void {
     var console_mode: windows.DWORD = 0;
     if (api.GetConsoleMode(input.handle, &console_mode).toBool()) {
         input.console = true;
-        input.status = consoleReady(input.handle, console_mode);
+        const result = consoleReady(allocator, input.handle, console_mode);
+        input.status = result.status;
+        input.poll_only = result.poll_only;
         if (input.status == .ready) input.nbytes = 1;
         return;
     }
@@ -222,12 +261,14 @@ fn probeInput(input: *ReadInput) void {
         if (available != 0) {
             input.status = .ready;
             input.nbytes = available;
+        } else {
+            input.poll_only = true;
         }
         return;
     }
 
     switch (windows.GetLastError()) {
-        .BROKEN_PIPE, .PIPE_NOT_CONNECTED, .NO_DATA => {
+        .BROKEN_PIPE, .PIPE_NOT_CONNECTED, .NO_DATA, .HANDLE_EOF => {
             input.status = .hangup;
             return;
         },
@@ -256,22 +297,72 @@ fn appendUniqueHandle(handles: *[max_wait_handles]Handle, count: *usize, handle:
     return true;
 }
 
-fn remainingTimeout(start_ms: u64, timeout_ms: i32) ?windows.DWORD {
+const WaitHooks = struct {
+    ctx: *anyopaque,
+    now_ms: *const fn (*anyopaque) u64,
+    sleep: *const fn (*anyopaque, windows.DWORD) void,
+    wait: *const fn (*anyopaque, []const Handle, windows.DWORD) windows.DWORD,
+    probe: *const fn (*anyopaque, *ReadInput) void,
+};
+
+fn currentMs(hooks: ?WaitHooks) u64 {
+    if (hooks) |installed| return installed.now_ms(installed.ctx);
+    return api.GetTickCount64();
+}
+
+fn sleepMs(hooks: ?WaitHooks, timeout_ms: windows.DWORD) void {
+    if (hooks) |installed| {
+        installed.sleep(installed.ctx, timeout_ms);
+        return;
+    }
+    api.Sleep(timeout_ms);
+}
+
+fn waitHandles(
+    hooks: ?WaitHooks,
+    handles: []const Handle,
+    timeout_ms: windows.DWORD,
+) windows.DWORD {
+    if (hooks) |installed| return installed.wait(installed.ctx, handles, timeout_ms);
+    return api.WaitForMultipleObjects(
+        @intCast(handles.len),
+        handles.ptr,
+        .FALSE,
+        timeout_ms,
+    );
+}
+
+fn remainingTimeout(start_ms: u64, now_ms: u64, timeout_ms: i32) ?windows.DWORD {
     if (timeout_ms < 0) return infinite;
-    const elapsed = api.GetTickCount64() -% start_ms;
+    const elapsed = now_ms -% start_ms;
     const total: u64 = @intCast(timeout_ms);
     if (elapsed >= total) return null;
     return @intCast(total - elapsed);
 }
 
 /// Wait until one input is readable/closed, the timeout expires, or the
-/// manager cancellation event is signalled. The cancellation handle occupies
-/// slot zero whenever present. Pipe readiness and wait sets larger than the
-/// Win32 64-handle limit fall back to bounded cancellation-event waits.
+/// manager cancellation event is signalled.
 pub fn waitForReadiness(
+    allocator: std.mem.Allocator,
     cancel_handle_opaque: ?*anyopaque,
     inputs: []ReadInput,
     timeout_ms: i32,
+) WaitResult {
+    return waitForReadinessWithHooks(
+        allocator,
+        cancel_handle_opaque,
+        inputs,
+        timeout_ms,
+        null,
+    );
+}
+
+fn waitForReadinessWithHooks(
+    allocator: std.mem.Allocator,
+    cancel_handle_opaque: ?*anyopaque,
+    inputs: []ReadInput,
+    timeout_ms: i32,
+    hooks: ?WaitHooks,
 ) WaitResult {
     if (!is_windows) unreachable;
 
@@ -279,12 +370,12 @@ pub fn waitForReadiness(
         @ptrCast(handle)
     else
         null;
-    const start_ms = api.GetTickCount64();
+    const start_ms = currentMs(hooks);
 
     while (true) {
         var handles: [max_wait_handles]Handle = undefined;
         var handle_count: usize = 0;
-        var has_polled_input = false;
+        var needs_bounded_poll = false;
         var overflow = false;
 
         if (cancel_handle) |handle| {
@@ -294,15 +385,18 @@ pub fn waitForReadiness(
 
         var any_ready = false;
         for (inputs) |*input| {
-            probeInput(input);
+            if (hooks) |installed|
+                installed.probe(installed.ctx, input)
+            else
+                probeInput(allocator, input);
             switch (input.status) {
                 .ready, .hangup, .bad_handle, .io_error => any_ready = true,
                 .pending => {
-                    if (input.console) {
+                    if (input.console and !input.poll_only) {
                         if (!appendUniqueHandle(&handles, &handle_count, input.handle))
                             overflow = true;
                     } else {
-                        has_polled_input = true;
+                        needs_bounded_poll = true;
                     }
                 },
             }
@@ -310,30 +404,274 @@ pub fn waitForReadiness(
         if (any_ready) return .ready;
         if (timeout_ms == 0) return .timed_out;
 
-        var wait_ms = remainingTimeout(start_ms, timeout_ms) orelse
+        var wait_ms = remainingTimeout(start_ms, currentMs(hooks), timeout_ms) orelse
             return .timed_out;
-        if (has_polled_input or overflow)
-            wait_ms = @min(wait_ms, pipe_probe_slice_ms);
+        if (needs_bounded_poll or overflow)
+            wait_ms = @min(wait_ms, polling_slice_ms);
 
         if (handle_count == 0) {
-            api.Sleep(wait_ms);
             if (wait_ms == infinite) return .failed;
+            sleepMs(hooks, wait_ms);
             continue;
         }
 
-        const result = api.WaitForMultipleObjects(
-            @intCast(handle_count),
-            &handles,
-            .FALSE,
-            wait_ms,
-        );
+        const result = waitHandles(hooks, handles[0..handle_count], wait_ms);
         if (result == wait_failed) return .failed;
         if (result == wait_timeout) continue;
-        if (result < wait_object_0 or result >= wait_object_0 + handle_count)
-            return .failed;
+        if (result >= wait_object_0 + handle_count) return .failed;
         const index: usize = @intCast(result - wait_object_0);
         if (cancel_handle != null and index == 0) return .cancelled;
-        // A console handle fired. Re-probe to filter non-key events and, in
-        // canonical line mode, incomplete input that would still block ReadFile.
     }
+}
+
+pub const ReadError = error{
+    Cancelled,
+    BadHandle,
+    IoError,
+    ThreadSpawnFailed,
+    WaitFailed,
+};
+
+const ReadOutcome = enum {
+    pending,
+    success,
+    eof,
+    cancelled,
+    bad_handle,
+    io_error,
+};
+
+const ReadJob = struct {
+    handle: Handle,
+    buffer: []u8,
+    outcome: ReadOutcome = .pending,
+    nread: usize = 0,
+
+    fn run(self: *ReadJob) void {
+        var nread: windows.DWORD = 0;
+        if (api.ReadFile(
+            self.handle,
+            self.buffer.ptr,
+            @intCast(self.buffer.len),
+            &nread,
+            null,
+        ).toBool()) {
+            self.outcome = .success;
+            self.nread = nread;
+            return;
+        }
+        self.outcome = switch (windows.GetLastError()) {
+            .BROKEN_PIPE, .PIPE_NOT_CONNECTED, .NO_DATA, .HANDLE_EOF => .eof,
+            .OPERATION_ABORTED => .cancelled,
+            .INVALID_HANDLE => .bad_handle,
+            else => .io_error,
+        };
+    }
+};
+
+fn finishRead(thread: std.Thread, job: *const ReadJob) ReadError!usize {
+    thread.join();
+    return switch (job.outcome) {
+        .success => job.nread,
+        .eof => 0,
+        .cancelled => error.Cancelled,
+        .bad_handle => error.BadHandle,
+        .pending, .io_error => error.IoError,
+    };
+}
+
+fn cancelRead(thread: std.Thread) void {
+    const thread_handle: Handle = thread.getHandle();
+    var wait_handles = [_]Handle{thread_handle};
+    while (true) {
+        var iosb: windows.IO_STATUS_BLOCK = undefined;
+        _ = windows.ntdll.NtCancelSynchronousIoFile(thread_handle, null, &iosb);
+        const result = api.WaitForMultipleObjects(1, &wait_handles, .FALSE, polling_slice_ms);
+        if (result == wait_object_0 or result == wait_failed) break;
+    }
+    thread.join();
+}
+
+/// Perform the actual synchronous `ReadFile` on a helper thread, then wait on
+/// both that thread and the manager cancellation event. On cancellation the
+/// blocked syscall itself is stopped with `NtCancelSynchronousIoFile`.
+pub fn readCancellable(
+    cancel_handle_opaque: *anyopaque,
+    handle: Handle,
+    buffer: []u8,
+) ReadError!usize {
+    if (!is_windows) unreachable;
+    if (buffer.len == 0) return 0;
+    if (buffer.len > std.math.maxInt(windows.DWORD)) return error.IoError;
+
+    var job = ReadJob{ .handle = handle, .buffer = buffer };
+    var thread = std.Thread.spawn(.{}, ReadJob.run, .{&job}) catch
+        return error.ThreadSpawnFailed;
+    const thread_handle: Handle = thread.getHandle();
+    const cancel_handle: Handle = @ptrCast(cancel_handle_opaque);
+    var handles = [_]Handle{ cancel_handle, thread_handle };
+
+    const result = api.WaitForMultipleObjects(handles.len, &handles, .FALSE, infinite);
+    if (result == wait_object_0 + 1)
+        return finishRead(thread, &job);
+    if (result == wait_object_0) {
+        cancelRead(thread);
+        return error.Cancelled;
+    }
+
+    cancelRead(thread);
+    return error.WaitFailed;
+}
+
+fn testKeyRecord(char: windows.WCHAR) InputRecord {
+    return .{
+        .EventType = key_event,
+        .padding = 0,
+        .Event = .{ .KeyEvent = .{
+            .bKeyDown = .TRUE,
+            .wRepeatCount = 1,
+            .wVirtualKeyCode = 0,
+            .wVirtualScanCode = 0,
+            .uChar = .{ .UnicodeChar = char },
+            .dwControlKeyState = 0,
+        } },
+    };
+}
+
+test "Windows poll review: cooked console requires Enter and scans the complete queue" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var ctrl_z = [_]InputRecord{testKeyRecord(0x1a)};
+    const incomplete = inspectConsoleRecords(enable_line_input, &ctrl_z);
+    try std.testing.expectEqual(InputStatus.pending, incomplete.status);
+    try std.testing.expect(incomplete.poll_only);
+
+    var records: [300]InputRecord = undefined;
+    for (&records) |*record| record.* = testKeyRecord('x');
+    records[299] = testKeyRecord('\r');
+    const complete = inspectConsoleRecords(enable_line_input, &records);
+    try std.testing.expectEqual(InputStatus.ready, complete.status);
+    try std.testing.expect(!complete.poll_only);
+}
+
+test "Windows poll review: non-key records do not spin and raw Unicode is ready" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var non_key = [_]InputRecord{.{
+        .EventType = 0x0002,
+        .padding = 0,
+        .Event = .{ .padding = @splat(0) },
+    }};
+    const ignored = inspectConsoleRecords(enable_line_input, &non_key);
+    try std.testing.expectEqual(InputStatus.pending, ignored.status);
+    try std.testing.expect(ignored.poll_only);
+
+    var unicode = [_]InputRecord{testKeyRecord(0x03bb)};
+    const raw = inspectConsoleRecords(0, &unicode);
+    try std.testing.expectEqual(InputStatus.ready, raw.status);
+}
+
+const FakeWait = struct {
+    now_ms: u64 = 0,
+    probe_count: usize = 0,
+    sleep_count: usize = 0,
+    wait_count: usize = 0,
+    max_wait_handles: usize = 0,
+    max_wait_ms: windows.DWORD = 0,
+    poll_only: bool = true,
+    ready_handle: ?Handle = null,
+    ready_after_probe: usize = std.math.maxInt(usize),
+
+    fn now(raw: *anyopaque) u64 {
+        const self: *FakeWait = @ptrCast(@alignCast(raw));
+        return self.now_ms;
+    }
+
+    fn sleep(raw: *anyopaque, timeout_ms: windows.DWORD) void {
+        const self: *FakeWait = @ptrCast(@alignCast(raw));
+        self.sleep_count += 1;
+        self.max_wait_ms = @max(self.max_wait_ms, timeout_ms);
+        self.now_ms += timeout_ms;
+    }
+
+    fn wait(
+        raw: *anyopaque,
+        handles: []const Handle,
+        timeout_ms: windows.DWORD,
+    ) windows.DWORD {
+        const self: *FakeWait = @ptrCast(@alignCast(raw));
+        self.wait_count += 1;
+        self.max_wait_handles = @max(self.max_wait_handles, handles.len);
+        self.max_wait_ms = @max(self.max_wait_ms, timeout_ms);
+        self.now_ms += timeout_ms;
+        return wait_timeout;
+    }
+
+    fn probe(raw: *anyopaque, input: *ReadInput) void {
+        const self: *FakeWait = @ptrCast(@alignCast(raw));
+        self.probe_count += 1;
+        input.status = if (self.ready_handle == input.handle and
+            self.probe_count >= self.ready_after_probe)
+            .ready
+        else
+            .pending;
+        input.console = true;
+        input.poll_only = self.poll_only;
+        input.nbytes = if (input.status == .ready) 1 else 0;
+    }
+
+    fn hooks(self: *FakeWait) WaitHooks {
+        return .{
+            .ctx = @ptrCast(self),
+            .now_ms = now,
+            .sleep = sleep,
+            .wait = wait,
+            .probe = probe,
+        };
+    }
+};
+
+test "Windows poll review: incomplete cooked input is probed at a bounded rate" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    var fake = FakeWait{};
+    var inputs = [_]ReadInput{.{ .handle = @ptrFromInt(1) }};
+    try std.testing.expectEqual(
+        WaitResult.timed_out,
+        waitForReadinessWithHooks(
+            std.testing.allocator,
+            null,
+            &inputs,
+            35,
+            fake.hooks(),
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 5), fake.probe_count);
+    try std.testing.expectEqual(@as(usize, 4), fake.sleep_count);
+    try std.testing.expectEqual(@as(windows.DWORD, polling_slice_ms), fake.max_wait_ms);
+}
+
+test "Windows poll review: more than 64 console handles stay bounded and complete" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    var inputs: [70]ReadInput = undefined;
+    for (&inputs, 0..) |*input, index| {
+        input.* = .{ .handle = @ptrFromInt(index + 1) };
+    }
+    var fake = FakeWait{
+        .poll_only = false,
+        .ready_handle = inputs[69].handle,
+        .ready_after_probe = inputs.len + 1,
+    };
+    try std.testing.expectEqual(
+        WaitResult.ready,
+        waitForReadinessWithHooks(
+            std.testing.allocator,
+            null,
+            &inputs,
+            100,
+            fake.hooks(),
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, max_wait_handles), fake.max_wait_handles);
+    try std.testing.expectEqual(@as(windows.DWORD, polling_slice_ms), fake.max_wait_ms);
+    try std.testing.expectEqual(InputStatus.ready, inputs[69].status);
 }

--- a/src/wasi/host_functions.zig
+++ b/src/wasi/host_functions.zig
@@ -81,6 +81,7 @@ fn waitForWindowsReadiness(
     if (comptime builtin.os.tag != .windows) unreachable;
     if (ctx.isTerminating()) return .terminated;
     return switch (windows_poll.waitForReadiness(
+        ctx.allocator,
         ctx.termination.windowsCancelHandle(),
         inputs,
         timeout_ms,
@@ -1362,24 +1363,24 @@ fn doRead(ctx: *wasi.WasiCtx, lease: *wasi.FdTable.Lease, data: []u8) !usize {
     const entry = lease.snapshot();
     switch (entry.kind) {
         .stdin => {
-            // Park on readiness first so a sibling's terminal outcome can
-            // interrupt what would otherwise be an indefinite blocking read.
-            if (comptime config.lib_wasi_threads) {
-                if (comptime builtin.os.tag == .windows) {
-                    var inputs = [_]windows_poll.ReadInput{.{
-                        .handle = entry.host_fd orelse std.Io.File.stdin().handle,
-                    }};
-                    switch (waitForWindowsReadiness(ctx, &inputs, -1)) {
-                        .terminated => return error.Terminated,
-                        .failed => return error.IoError,
-                        .ready => switch (inputs[0].status) {
-                            .ready, .hangup => {},
-                            .bad_handle, .io_error => return error.IoError,
-                            .pending => unreachable,
-                        },
-                        .timed_out => unreachable,
-                    }
-                } else {
+            const file = if (entry.host_fd) |host_fd|
+                std.Io.File{ .handle = host_fd, .flags = .{ .nonblocking = false } }
+            else
+                std.Io.File.stdin();
+            if (comptime builtin.os.tag == .windows and config.lib_wasi_threads) {
+                if (ctx.termination.windowsCancelHandle()) |cancel_handle| {
+                    return windows_poll.readCancellable(
+                        cancel_handle,
+                        file.handle,
+                        data,
+                    ) catch |err| switch (err) {
+                        error.Cancelled => error.Terminated,
+                        error.BadHandle => error.BadFd,
+                        else => error.IoError,
+                    };
+                }
+            } else if (comptime config.lib_wasi_threads) {
+                {
                     var fds = [_]std.posix.pollfd{.{
                         .fd = entry.host_fd orelse std.posix.STDIN_FILENO,
                         .events = std.posix.POLL.IN,
@@ -1389,10 +1390,6 @@ fn doRead(ctx: *wasi.WasiCtx, lease: *wasi.FdTable.Lease, data: []u8) !usize {
                         return error.Terminated;
                 }
             }
-            const file = if (entry.host_fd) |host_fd|
-                std.Io.File{ .handle = host_fd, .flags = .{ .nonblocking = false } }
-            else
-                std.Io.File.stdin();
             var buf: [4096]u8 = undefined;
             var r = file.reader(ctx.io, &buf);
             const n = r.interface.readSliceShort(data) catch return error.IoError;
@@ -2653,9 +2650,31 @@ fn hostRealtimeNs(ctx: *const wasi.WasiCtx) u64 {
 /// saturating at i32 max. `0` ns stays `0` (poll returns immediately).
 fn nsToTimeoutMs(ns: u64) i32 {
     if (ns == 0) return 0;
-    const ms_u: u64 = (ns + 999_999) / 1_000_000;
+    const ms_u = (ns - 1) / std.time.ns_per_ms + 1;
     if (ms_u > @as(u64, @intCast(std.math.maxInt(i32)))) return std.math.maxInt(i32);
     return @intCast(ms_u);
+}
+
+const PollOneoffHooks = struct {
+    ctx: *anyopaque,
+    clock_now: ?*const fn (*anyopaque, u32) u64 = null,
+    clock_wait: ?*const fn (*anyopaque, i32) BlockingWait = null,
+    windows_wait: ?*const fn (*anyopaque, []windows_poll.ReadInput, i32) BlockingWait = null,
+};
+
+fn pollClockNow(
+    ctx: *const wasi.WasiCtx,
+    hooks: ?PollOneoffHooks,
+    clock_id: u32,
+) u64 {
+    if (hooks) |installed| {
+        if (installed.clock_now) |clock_now|
+            return clock_now(installed.ctx, clock_id);
+    }
+    return if (clock_id == wasi.CLOCKID_REALTIME)
+        hostRealtimeNs(ctx)
+    else
+        hostMonotonicNs(ctx);
 }
 
 /// Write a 32-byte preview1 `event` record at `off` in linear memory.
@@ -2680,14 +2699,30 @@ fn writeEvent(
 
 const PendingClock = struct {
     userdata: u64,
-    /// duration in nanoseconds from the start of the call until this
-    /// clock fires; `0` means "already expired at classification time".
-    duration_ns: u64,
+    clock_id: u32,
+    timeout_ns: u64,
+    relative_start_ns: u64,
+    absolute: bool,
     /// `false` if the subscription was malformed (unknown clock id);
     /// in that case `errno` is emitted as a synthetic event.
     valid: bool,
     errno: u16,
 };
+
+fn pendingClockRemainingNs(
+    ctx: *const wasi.WasiCtx,
+    hooks: ?PollOneoffHooks,
+    clock: PendingClock,
+) u64 {
+    const now = pollClockNow(ctx, hooks, clock.clock_id);
+    if (clock.absolute)
+        return if (now >= clock.timeout_ns) 0 else clock.timeout_ns - now;
+    const elapsed = if (now >= clock.relative_start_ns)
+        now - clock.relative_start_ns
+    else
+        0;
+    return if (elapsed >= clock.timeout_ns) 0 else clock.timeout_ns - elapsed;
+}
 
 const PendingFd = struct {
     userdata: u64,
@@ -2708,6 +2743,59 @@ const PendingFd = struct {
     lease: ?wasi.FdTable.Lease = null,
 };
 
+fn applyWindowsInputResults(
+    fd_subs: []PendingFd,
+    windows_inputs: []const windows_poll.ReadInput,
+) void {
+    for (fd_subs) |*sub| {
+        const input_index = sub.windows_input_index orelse continue;
+        const input = windows_inputs[input_index];
+        switch (input.status) {
+            .pending => {},
+            .ready => {
+                sub.ready = true;
+                sub.nbytes = input.nbytes;
+            },
+            .hangup => {
+                sub.ready = true;
+                sub.hangup = true;
+            },
+            .bad_handle => sub.errno = @intFromEnum(wasi.Errno.badf),
+            .io_error => sub.errno = @intFromEnum(wasi.Errno.io),
+        }
+    }
+}
+
+fn runWindowsPollWait(
+    ctx: *wasi.WasiCtx,
+    hooks: ?PollOneoffHooks,
+    inputs: []windows_poll.ReadInput,
+    timeout_ms: i32,
+) BlockingWait {
+    if (hooks) |installed| {
+        if (installed.windows_wait) |wait|
+            return wait(installed.ctx, inputs, timeout_ms);
+    }
+    return waitForWindowsReadiness(ctx, inputs, timeout_ms);
+}
+
+fn runClockOnlyWait(
+    ctx: *wasi.WasiCtx,
+    hooks: ?PollOneoffHooks,
+    timeout_ms: i32,
+) BlockingWait {
+    if (hooks) |installed| {
+        if (installed.clock_wait) |wait|
+            return wait(installed.ctx, timeout_ms);
+    }
+    if (comptime builtin.os.tag == .windows) {
+        var inputs: [0]windows_poll.ReadInput = .{};
+        return waitForWindowsReadiness(ctx, &inputs, timeout_ms);
+    }
+    var pollfds: [0]PosixPollFd = .{};
+    return waitForReadiness(ctx, &pollfds, timeout_ms);
+}
+
 pub fn ctxPollOneoffCore(
     ctx: *wasi.WasiCtx,
     mem: []u8,
@@ -2715,6 +2803,26 @@ pub fn ctxPollOneoffCore(
     out_ptr: i32,
     nsubs: i32,
     ret_ptr: i32,
+) i32 {
+    return ctxPollOneoffCoreWithHooks(
+        ctx,
+        mem,
+        in_ptr,
+        out_ptr,
+        nsubs,
+        ret_ptr,
+        null,
+    );
+}
+
+fn ctxPollOneoffCoreWithHooks(
+    ctx: *wasi.WasiCtx,
+    mem: []u8,
+    in_ptr: i32,
+    out_ptr: i32,
+    nsubs: i32,
+    ret_ptr: i32,
+    hooks: ?PollOneoffHooks,
 ) i32 {
     if (nsubs <= 0) return wasi_core.WASI_EINVAL;
     if (in_ptr < 0 or out_ptr < 0 or ret_ptr < 0) return wasi_core.WASI_EINVAL;
@@ -2730,8 +2838,6 @@ pub fn ctxPollOneoffCore(
     if (@as(u64, u_out) + evts_bytes > mem.len) return wasi_core.WASI_EINVAL;
     if (@as(u64, u_ret) + 4 > mem.len) return wasi_core.WASI_EINVAL;
 
-    const start = hostMonotonicNs(ctx);
-
     var clocks: std.ArrayListUnmanaged(PendingClock) = .empty;
     defer clocks.deinit(ctx.allocator);
     var fd_subs: std.ArrayListUnmanaged(PendingFd) = .empty;
@@ -2745,8 +2851,6 @@ pub fn ctxPollOneoffCore(
     defer pollfds.deinit(ctx.allocator);
     var windows_inputs: std.ArrayListUnmanaged(windows_poll.ReadInput) = .empty;
     defer windows_inputs.deinit(ctx.allocator);
-
-    var any_immediate: bool = false;
 
     // ── Pass 1: classify each subscription ─────────────────────────
     var i: usize = 0;
@@ -2765,40 +2869,39 @@ pub fn ctxPollOneoffCore(
                 if (clock_id > wasi.CLOCKID_THREAD_CPUTIME_ID) {
                     clocks.append(ctx.allocator, .{
                         .userdata = userdata,
-                        .duration_ns = 0,
+                        .clock_id = clock_id,
+                        .timeout_ns = timeout_ns,
+                        .relative_start_ns = 0,
+                        .absolute = abstime,
                         .valid = false,
                         .errno = @intFromEnum(wasi.Errno.inval),
                     }) catch return wasi_core.WASI_EINVAL;
-                    any_immediate = true;
                     continue;
                 }
                 if (comptime builtin.os.tag == .windows) {
                     if (clock_id > wasi.CLOCKID_MONOTONIC) {
                         clocks.append(ctx.allocator, .{
                             .userdata = userdata,
-                            .duration_ns = 0,
+                            .clock_id = clock_id,
+                            .timeout_ns = timeout_ns,
+                            .relative_start_ns = 0,
+                            .absolute = abstime,
                             .valid = false,
                             .errno = @intFromEnum(wasi.Errno.notsup),
                         }) catch return wasi_core.WASI_EINVAL;
-                        any_immediate = true;
                         continue;
                     }
                 }
 
-                const duration_ns: u64 = blk: {
-                    if (!abstime) break :blk timeout_ns;
-                    const now_clock_ns: u64 = if (clock_id == wasi.CLOCKID_REALTIME)
-                        hostRealtimeNs(ctx)
-                    else
-                        hostMonotonicNs(ctx);
-                    if (timeout_ns <= now_clock_ns) break :blk 0;
-                    break :blk timeout_ns - now_clock_ns;
-                };
-
-                if (duration_ns == 0) any_immediate = true;
                 clocks.append(ctx.allocator, .{
                     .userdata = userdata,
-                    .duration_ns = duration_ns,
+                    .clock_id = clock_id,
+                    .timeout_ns = timeout_ns,
+                    .relative_start_ns = if (abstime)
+                        0
+                    else
+                        pollClockNow(ctx, hooks, clock_id),
+                    .absolute = abstime,
                     .valid = true,
                     .errno = 0,
                 }) catch return wasi_core.WASI_EINVAL;
@@ -2820,7 +2923,6 @@ pub fn ctxPollOneoffCore(
 
                 var lease = ctx.fd_table.acquire(fd_raw) orelse {
                     pending.errno = @intFromEnum(wasi.Errno.badf);
-                    any_immediate = true;
                     fd_subs.append(ctx.allocator, pending) catch return wasi_core.WASI_EINVAL;
                     continue;
                 };
@@ -2831,7 +2933,6 @@ pub fn ctxPollOneoffCore(
                 if ((entry.rights_base & need_right) == 0) {
                     lease.release();
                     pending.errno = @intFromEnum(wasi.Errno.notcapable);
-                    any_immediate = true;
                     fd_subs.append(ctx.allocator, pending) catch return wasi_core.WASI_EINVAL;
                     continue;
                 }
@@ -2840,17 +2941,14 @@ pub fn ctxPollOneoffCore(
                     .stdout, .stderr => {
                         if (want_write) {
                             pending.ready = true;
-                            any_immediate = true;
                         } else {
                             // Reading from stdout/stderr: Linux returns EBADF.
                             pending.errno = @intFromEnum(wasi.Errno.badf);
-                            any_immediate = true;
                         }
                     },
                     .stdin => {
                         if (want_write) {
                             pending.errno = @intFromEnum(wasi.Errno.badf);
-                            any_immediate = true;
                         } else if (comptime builtin.os.tag == .windows) {
                             const input_index = windows_inputs.items.len;
                             windows_inputs.append(ctx.allocator, .{
@@ -2880,16 +2978,13 @@ pub fn ctxPollOneoffCore(
                         // We emit ready immediately to avoid the syscall and
                         // to stay platform-uniform.
                         pending.ready = true;
-                        any_immediate = true;
                     },
                     .directory => {
                         pending.errno = @intFromEnum(wasi.Errno.badf);
-                        any_immediate = true;
                     },
                     .socket => {
                         if (comptime builtin.os.tag == .windows) {
                             pending.errno = @intFromEnum(wasi.Errno.notsup);
-                            any_immediate = true;
                         } else if (entry.host_fd) |host_fd| {
                             const events: i16 = if (want_write) std.posix.POLL.OUT else std.posix.POLL.IN;
                             const pfd_index = pollfds.items.len;
@@ -2906,7 +3001,6 @@ pub fn ctxPollOneoffCore(
                             keep_lease = true;
                         } else {
                             pending.errno = @intFromEnum(wasi.Errno.badf);
-                            any_immediate = true;
                         }
                     },
                 }
@@ -2928,169 +3022,164 @@ pub fn ctxPollOneoffCore(
                     .windows_input_index = null,
                     .lease = null,
                 }) catch return wasi_core.WASI_EINVAL;
-                any_immediate = true;
             },
         }
     }
 
-    // ── Pass 2: optionally run poll(2) or sleep ─────────────────────
-    var did_poll = false;
-    if (!any_immediate) {
-        var earliest_ns: ?u64 = null;
-        for (clocks.items) |c| {
-            if (!c.valid) continue;
-            if (earliest_ns == null or c.duration_ns < earliest_ns.?) {
-                earliest_ns = c.duration_ns;
-            }
-        }
-        if (comptime builtin.os.tag == .windows) {
-            const timeout_ms: i32 = if (earliest_ns) |dur| nsToTimeoutMs(dur) else -1;
-            switch (waitForWindowsReadiness(ctx, windows_inputs.items, timeout_ms)) {
-                .terminated => return terminated_result,
-                .failed => return @intCast(@intFromEnum(wasi.Errno.io)),
-                .ready, .timed_out => {},
-            }
-            did_poll = true;
-            for (fd_subs.items) |*sub| {
-                const input_index = sub.windows_input_index orelse continue;
-                const input = windows_inputs.items[input_index];
-                switch (input.status) {
-                    .pending => {},
-                    .ready => {
-                        sub.ready = true;
-                        sub.nbytes = input.nbytes;
-                    },
-                    .hangup => {
-                        sub.ready = true;
-                        sub.hangup = true;
-                    },
-                    .bad_handle => sub.errno = @intFromEnum(wasi.Errno.badf),
-                    .io_error => sub.errno = @intFromEnum(wasi.Errno.io),
+    // ── Pass 2/3: probe complete readiness sets, wait, then emit ─────
+    var probe_inputs = true;
+    while (true) {
+        if (probe_inputs) {
+            if (comptime builtin.os.tag == .windows) {
+                if (windows_inputs.items.len != 0) {
+                    switch (runWindowsPollWait(ctx, hooks, windows_inputs.items, 0)) {
+                        .terminated => return terminated_result,
+                        .failed => return @intCast(@intFromEnum(wasi.Errno.io)),
+                        .ready, .timed_out => {},
+                    }
+                    applyWindowsInputResults(fd_subs.items, windows_inputs.items);
+                }
+            } else if (pollfds.items.len != 0) {
+                switch (waitForReadiness(ctx, pollfds.items, 0)) {
+                    .terminated => return terminated_result,
+                    .ready, .timed_out => {},
+                    .failed => unreachable,
                 }
             }
-        } else if (pollfds.items.len > 0) {
-            const timeout_ms: i32 = if (earliest_ns) |dur| nsToTimeoutMs(dur) else -1;
-            switch (waitForReadiness(ctx, pollfds.items, timeout_ms)) {
-                .terminated => return terminated_result,
-                .ready, .timed_out => {},
-                .failed => unreachable,
-            }
-            did_poll = true;
-        } else if (earliest_ns) |dur| {
-            // Only clocks: use poll(2) with an empty fd set as a portable
-            // sleep primitive that respects EINTR / cancellation the same
-            // way the fd-readiness path does.
-            var empty_fds: [0]PosixPollFd = .{};
-            switch (waitForReadiness(ctx, &empty_fds, nsToTimeoutMs(dur))) {
-                .terminated => return terminated_result,
-                .ready, .timed_out => {},
-                .failed => unreachable,
+        }
+        probe_inputs = true;
+
+        var has_ready = false;
+        for (clocks.items) |clock| {
+            if (!clock.valid or pendingClockRemainingNs(ctx, hooks, clock) == 0) {
+                has_ready = true;
+                break;
             }
         }
-    }
-
-    // ── Pass 3: emit events ─────────────────────────────────────────
-    const elapsed_ns: u64 = blk: {
-        const now = hostMonotonicNs(ctx);
-        if (now <= start) break :blk 0;
-        break :blk now - start;
-    };
-
-    var event_count: u32 = 0;
-
-    for (clocks.items) |c| {
-        if (!c.valid) {
-            writeEvent(
-                mem,
-                u_out + event_count * @as(u32, @intCast(wasi.EVENT_SIZE)),
-                c.userdata,
-                c.errno,
-                wasi.EVENTTYPE_CLOCK,
-                0,
-                0,
-            );
-            event_count += 1;
-            continue;
+        if (!has_ready) {
+            for (fd_subs.items) |sub| {
+                if (sub.errno != 0 or sub.ready) {
+                    has_ready = true;
+                    break;
+                }
+                if (sub.pollfd_index) |pollfd_index| {
+                    if (comptime builtin.os.tag == .windows) unreachable;
+                    const revents = pollfds.items[pollfd_index].revents;
+                    const wanted: i16 = if (sub.type_ == wasi.EVENTTYPE_FD_WRITE)
+                        std.posix.POLL.OUT
+                    else
+                        std.posix.POLL.IN;
+                    if ((revents & (wanted | std.posix.POLL.HUP | std.posix.POLL.ERR)) != 0) {
+                        has_ready = true;
+                        break;
+                    }
+                }
+            }
         }
-        const fired = c.duration_ns == 0 or elapsed_ns >= c.duration_ns;
-        if (fired) {
-            writeEvent(
-                mem,
-                u_out + event_count * @as(u32, @intCast(wasi.EVENT_SIZE)),
-                c.userdata,
-                0,
-                wasi.EVENTTYPE_CLOCK,
-                0,
-                0,
-            );
-            event_count += 1;
-        }
-    }
 
-    for (fd_subs.items) |s| {
-        if (s.errno != 0) {
-            writeEvent(
-                mem,
-                u_out + event_count * @as(u32, @intCast(wasi.EVENT_SIZE)),
-                s.userdata,
-                s.errno,
-                s.type_,
-                0,
-                0,
-            );
-            event_count += 1;
-        } else if (s.ready) {
-            const flags: u16 = if (s.hangup) wasi.EVENT_FD_READWRITE_HANGUP else 0;
-            writeEvent(
-                mem,
-                u_out + event_count * @as(u32, @intCast(wasi.EVENT_SIZE)),
-                s.userdata,
-                0,
-                s.type_,
-                s.nbytes,
-                flags,
-            );
-            event_count += 1;
-        } else if (s.pollfd_index) |pi| {
-            if (comptime builtin.os.tag == .windows) unreachable;
-            if (!did_poll) continue;
-            const r = pollfds.items[pi].revents;
-            const ready_for: i16 = if (s.type_ == wasi.EVENTTYPE_FD_WRITE)
-                std.posix.POLL.OUT
-            else
-                std.posix.POLL.IN;
-            const hangup = (r & (std.posix.POLL.HUP | std.posix.POLL.ERR)) != 0;
-            if ((r & ready_for) != 0 or hangup) {
-                const flags: u16 = if (hangup) wasi.EVENT_FD_READWRITE_HANGUP else 0;
+        if (has_ready) {
+            var event_count: u32 = 0;
+            for (clocks.items) |clock| {
+                if (clock.valid and pendingClockRemainingNs(ctx, hooks, clock) != 0)
+                    continue;
                 writeEvent(
                     mem,
                     u_out + event_count * @as(u32, @intCast(wasi.EVENT_SIZE)),
-                    s.userdata,
+                    clock.userdata,
+                    if (clock.valid) 0 else clock.errno,
+                    wasi.EVENTTYPE_CLOCK,
                     0,
-                    s.type_,
                     0,
-                    flags,
                 );
                 event_count += 1;
             }
-        }
-    }
 
-    // Safety net: callers (e.g. the wasi-testsuite poll_oneoff_stdio
-    // test) panic if zero events come back. If the poll timed out
-    // without any fd readiness AND no clock fired, treat the earliest
-    // valid clock as fired.
-    if (event_count == 0) {
-        for (clocks.items) |c| {
-            if (!c.valid) continue;
-            writeEvent(mem, u_out, c.userdata, 0, wasi.EVENTTYPE_CLOCK, 0, 0);
-            event_count = 1;
-            break;
-        }
-    }
+            for (fd_subs.items) |sub| {
+                if (sub.errno != 0) {
+                    writeEvent(
+                        mem,
+                        u_out + event_count * @as(u32, @intCast(wasi.EVENT_SIZE)),
+                        sub.userdata,
+                        sub.errno,
+                        sub.type_,
+                        0,
+                        0,
+                    );
+                    event_count += 1;
+                } else if (sub.ready) {
+                    writeEvent(
+                        mem,
+                        u_out + event_count * @as(u32, @intCast(wasi.EVENT_SIZE)),
+                        sub.userdata,
+                        0,
+                        sub.type_,
+                        sub.nbytes,
+                        if (sub.hangup) wasi.EVENT_FD_READWRITE_HANGUP else 0,
+                    );
+                    event_count += 1;
+                } else if (sub.pollfd_index) |pollfd_index| {
+                    if (comptime builtin.os.tag == .windows) unreachable;
+                    const revents = pollfds.items[pollfd_index].revents;
+                    const wanted: i16 = if (sub.type_ == wasi.EVENTTYPE_FD_WRITE)
+                        std.posix.POLL.OUT
+                    else
+                        std.posix.POLL.IN;
+                    const hangup =
+                        (revents & (std.posix.POLL.HUP | std.posix.POLL.ERR)) != 0;
+                    if ((revents & wanted) == 0 and !hangup) continue;
+                    writeEvent(
+                        mem,
+                        u_out + event_count * @as(u32, @intCast(wasi.EVENT_SIZE)),
+                        sub.userdata,
+                        0,
+                        sub.type_,
+                        0,
+                        if (hangup) wasi.EVENT_FD_READWRITE_HANGUP else 0,
+                    );
+                    event_count += 1;
+                }
+            }
 
-    if (!wasi_core.memWriteU32(mem, u_ret, event_count)) return wasi_core.WASI_EINVAL;
-    return wasi_core.WASI_ESUCCESS;
+            // A realtime clock can move backwards between the readiness check
+            // and emission. Re-enter the wait loop rather than returning an
+            // empty event set or fabricating an early clock event.
+            if (event_count != 0) {
+                if (!wasi_core.memWriteU32(mem, u_ret, event_count))
+                    return wasi_core.WASI_EINVAL;
+                return wasi_core.WASI_ESUCCESS;
+            }
+        }
+
+        var earliest_ns: ?u64 = null;
+        for (clocks.items) |clock| {
+            if (!clock.valid) continue;
+            const remaining_ns = pendingClockRemainingNs(ctx, hooks, clock);
+            if (remaining_ns == 0) continue;
+            if (earliest_ns == null or remaining_ns < earliest_ns.?)
+                earliest_ns = remaining_ns;
+        }
+        const timeout_ms: i32 = if (earliest_ns) |remaining_ns|
+            nsToTimeoutMs(remaining_ns)
+        else
+            -1;
+
+        const wait_result: BlockingWait = if (pollfds.items.len == 0 and
+            windows_inputs.items.len == 0)
+            runClockOnlyWait(ctx, hooks, timeout_ms)
+        else if (comptime builtin.os.tag == .windows)
+            runWindowsPollWait(ctx, hooks, windows_inputs.items, timeout_ms)
+        else
+            waitForReadiness(ctx, pollfds.items, timeout_ms);
+
+        switch (wait_result) {
+            .terminated => return terminated_result,
+            .failed => return @intCast(@intFromEnum(wasi.Errno.io)),
+            .ready => probe_inputs = false,
+            .timed_out => {},
+        }
+        if (comptime builtin.os.tag == .windows)
+            applyWindowsInputResults(fd_subs.items, windows_inputs.items);
+    }
 }
 
 // ── sock_shutdown (#420 phase 8) ───────────────────────────────────────
@@ -5268,6 +5357,71 @@ const WindowsPollTestPipe = if (builtin.os.tag == .windows) struct {
     }
 } else struct {};
 
+const FakePollTime = struct {
+    const Step = struct {
+        realtime_ns: ?u64 = null,
+        monotonic_ns: ?u64 = null,
+    };
+
+    realtime_ns: u64 = 0,
+    monotonic_ns: u64 = 0,
+    steps: []const Step = &.{},
+    advance_by_timeout: bool = false,
+    waits: [16]i32 = @splat(0),
+    wait_count: usize = 0,
+
+    fn now(raw: *anyopaque, clock_id: u32) u64 {
+        const self: *FakePollTime = @ptrCast(@alignCast(raw));
+        return if (clock_id == wasi.CLOCKID_REALTIME)
+            self.realtime_ns
+        else
+            self.monotonic_ns;
+    }
+
+    fn wait(raw: *anyopaque, timeout_ms: i32) BlockingWait {
+        const self: *FakePollTime = @ptrCast(@alignCast(raw));
+        if (self.wait_count < self.waits.len)
+            self.waits[self.wait_count] = timeout_ms;
+        if (self.wait_count < self.steps.len) {
+            const step = self.steps[self.wait_count];
+            if (step.realtime_ns) |value| self.realtime_ns = value;
+            if (step.monotonic_ns) |value| self.monotonic_ns = value;
+        } else if (self.advance_by_timeout and timeout_ms >= 0) {
+            const advance = @as(u64, @intCast(timeout_ms)) * std.time.ns_per_ms;
+            self.realtime_ns +|= advance;
+            self.monotonic_ns +|= advance;
+        }
+        self.wait_count += 1;
+        return .timed_out;
+    }
+
+    fn windowsReady(
+        raw: *anyopaque,
+        inputs: []windows_poll.ReadInput,
+        timeout_ms: i32,
+    ) BlockingWait {
+        const self: *FakePollTime = @ptrCast(@alignCast(raw));
+        if (self.wait_count < self.waits.len)
+            self.waits[self.wait_count] = timeout_ms;
+        self.wait_count += 1;
+        for (inputs) |*input| {
+            input.status = .ready;
+            input.nbytes = 1;
+            input.console = true;
+            input.poll_only = false;
+        }
+        return .ready;
+    }
+
+    fn hooks(self: *FakePollTime) PollOneoffHooks {
+        return .{
+            .ctx = @ptrCast(self),
+            .clock_now = now,
+            .clock_wait = wait,
+        };
+    }
+};
+
 test "ctxPollOneoffCore: nsubs <= 0 → einval" {
     if (builtin.os.tag != .linux and builtin.os.tag != .windows) return error.SkipZigTest;
     const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
@@ -5510,6 +5664,189 @@ test "ctxPollOneoffCore: rights deficit → notcapable event" {
     );
 }
 
+test "poll_oneoff review: timeout conversion is overflow-free and rounds up" {
+    try std.testing.expectEqual(@as(i32, 0), nsToTimeoutMs(0));
+    try std.testing.expectEqual(@as(i32, 1), nsToTimeoutMs(1));
+    try std.testing.expectEqual(@as(i32, 1), nsToTimeoutMs(std.time.ns_per_ms - 1));
+    try std.testing.expectEqual(@as(i32, 1), nsToTimeoutMs(std.time.ns_per_ms));
+    try std.testing.expectEqual(@as(i32, 2), nsToTimeoutMs(std.time.ns_per_ms + 1));
+    try std.testing.expectEqual(std.math.maxInt(i32), nsToTimeoutMs(std.math.maxInt(u64)));
+}
+
+test "poll_oneoff review: a 30-day clock uses repeated bounded wait chunks" {
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    var fake = FakePollTime{ .advance_by_timeout = true };
+    var mem: [256]u8 = @splat(0);
+    const thirty_days_ns: u64 = 30 * std.time.ns_per_day;
+    pollTestWriteClockSub(&mem, 0, 30, wasi.CLOCKID_MONOTONIC, thirty_days_ns, 0);
+
+    try std.testing.expectEqual(
+        wasi_core.WASI_ESUCCESS,
+        ctxPollOneoffCoreWithHooks(ctx, &mem, 0, 64, 1, 200, fake.hooks()),
+    );
+    try std.testing.expectEqual(@as(usize, 2), fake.wait_count);
+    try std.testing.expectEqual(std.math.maxInt(i32), fake.waits[0]);
+    try std.testing.expectEqual(@as(i32, 444_516_353), fake.waits[1]);
+    try std.testing.expectEqual(@as(u64, 30), pollTestEventUserdata(&mem, 64, 0));
+}
+
+test "poll_oneoff review: max u64 timeout neither overflows nor expires after one chunk" {
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    const steps = [_]FakePollTime.Step{.{ .monotonic_ns = std.math.maxInt(u64) }};
+    var fake = FakePollTime{ .steps = &steps };
+    var mem: [256]u8 = @splat(0);
+    pollTestWriteClockSub(
+        &mem,
+        0,
+        64,
+        wasi.CLOCKID_MONOTONIC,
+        std.math.maxInt(u64),
+        0,
+    );
+
+    try std.testing.expectEqual(
+        wasi_core.WASI_ESUCCESS,
+        ctxPollOneoffCoreWithHooks(ctx, &mem, 0, 64, 1, 200, fake.hooks()),
+    );
+    try std.testing.expectEqual(@as(usize, 1), fake.wait_count);
+    try std.testing.expectEqual(std.math.maxInt(i32), fake.waits[0]);
+    try std.testing.expectEqual(@as(u64, 64), pollTestEventUserdata(&mem, 64, 0));
+}
+
+test "poll_oneoff review: absolute clocks follow selected-clock jumps" {
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+
+    const forward_steps = [_]FakePollTime.Step{.{ .realtime_ns = 120 * std.time.ns_per_ms }};
+    var forward = FakePollTime{
+        .realtime_ns = 50 * std.time.ns_per_ms,
+        .steps = &forward_steps,
+    };
+    var forward_mem: [256]u8 = @splat(0);
+    pollTestWriteClockSub(
+        &forward_mem,
+        0,
+        1,
+        wasi.CLOCKID_REALTIME,
+        100 * std.time.ns_per_ms,
+        wasi.SUBSCRIPTION_CLOCK_ABSTIME,
+    );
+    try std.testing.expectEqual(
+        wasi_core.WASI_ESUCCESS,
+        ctxPollOneoffCoreWithHooks(
+            ctx,
+            &forward_mem,
+            0,
+            64,
+            1,
+            200,
+            forward.hooks(),
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), forward.wait_count);
+
+    const backward_steps = [_]FakePollTime.Step{
+        .{ .realtime_ns = 40 * std.time.ns_per_ms },
+        .{ .realtime_ns = 110 * std.time.ns_per_ms },
+    };
+    var backward = FakePollTime{
+        .realtime_ns = 50 * std.time.ns_per_ms,
+        .steps = &backward_steps,
+    };
+    var backward_mem: [256]u8 = @splat(0);
+    pollTestWriteClockSub(
+        &backward_mem,
+        0,
+        2,
+        wasi.CLOCKID_REALTIME,
+        100 * std.time.ns_per_ms,
+        wasi.SUBSCRIPTION_CLOCK_ABSTIME,
+    );
+    try std.testing.expectEqual(
+        wasi_core.WASI_ESUCCESS,
+        ctxPollOneoffCoreWithHooks(
+            ctx,
+            &backward_mem,
+            0,
+            64,
+            1,
+            200,
+            backward.hooks(),
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 2), backward.wait_count);
+    try std.testing.expectEqual(@as(i32, 50), backward.waits[0]);
+    try std.testing.expectEqual(@as(i32, 60), backward.waits[1]);
+}
+
+test "poll_oneoff review: immediate fd does not emit a future absolute clock" {
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    var fake = FakePollTime{ .monotonic_ns = 100 };
+    var mem: [256]u8 = @splat(0);
+    pollTestWriteClockSub(
+        &mem,
+        0,
+        1,
+        wasi.CLOCKID_MONOTONIC,
+        1_000,
+        wasi.SUBSCRIPTION_CLOCK_ABSTIME,
+    );
+    pollTestWriteFdSub(&mem, 1, 2, wasi.EVENTTYPE_FD_WRITE, 1);
+
+    try std.testing.expectEqual(
+        wasi_core.WASI_ESUCCESS,
+        ctxPollOneoffCoreWithHooks(ctx, &mem, 0, 128, 2, 248, fake.hooks()),
+    );
+    try std.testing.expectEqual(@as(u32, 1), wasi_core.memReadU32(&mem, 248).?);
+    try std.testing.expectEqual(@as(u64, 2), pollTestEventUserdata(&mem, 128, 0));
+    try std.testing.expectEqual(@as(usize, 0), fake.wait_count);
+}
+
+test "poll_oneoff review: multiple clocks emit the earliest complete ready set" {
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    const steps = [_]FakePollTime.Step{.{ .monotonic_ns = 100 * std.time.ns_per_ms }};
+    var fake = FakePollTime{ .steps = &steps };
+    var mem: [256]u8 = @splat(0);
+    pollTestWriteClockSub(
+        &mem,
+        0,
+        1,
+        wasi.CLOCKID_MONOTONIC,
+        100 * std.time.ns_per_ms,
+        wasi.SUBSCRIPTION_CLOCK_ABSTIME,
+    );
+    pollTestWriteClockSub(
+        &mem,
+        1,
+        2,
+        wasi.CLOCKID_MONOTONIC,
+        200 * std.time.ns_per_ms,
+        wasi.SUBSCRIPTION_CLOCK_ABSTIME,
+    );
+
+    try std.testing.expectEqual(
+        wasi_core.WASI_ESUCCESS,
+        ctxPollOneoffCoreWithHooks(ctx, &mem, 0, 128, 2, 248, fake.hooks()),
+    );
+    try std.testing.expectEqual(@as(i32, 100), fake.waits[0]);
+    try std.testing.expectEqual(@as(u32, 1), wasi_core.memReadU32(&mem, 248).?);
+    try std.testing.expectEqual(@as(u64, 1), pollTestEventUserdata(&mem, 128, 0));
+
+    fake.monotonic_ns = 250 * std.time.ns_per_ms;
+    fake.wait_count = 0;
+    @memset(mem[128..], 0);
+    try std.testing.expectEqual(
+        wasi_core.WASI_ESUCCESS,
+        ctxPollOneoffCoreWithHooks(ctx, &mem, 0, 128, 2, 248, fake.hooks()),
+    );
+    try std.testing.expectEqual(@as(u32, 2), wasi_core.memReadU32(&mem, 248).?);
+    try std.testing.expectEqual(@as(usize, 0), fake.wait_count);
+}
+
 test "Windows poll_oneoff: relative and absolute clocks have bounded deadlines" {
     if (builtin.os.tag != .windows) return error.SkipZigTest;
     const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
@@ -5626,6 +5963,84 @@ test "Windows poll_oneoff: redirected stdin pipe EOF reports hangup" {
         wasi.EVENT_FD_READWRITE_HANGUP,
         pollTestEventFlags(&mem, 128, 0),
     );
+}
+
+test "Windows poll review: ready pipe and unsupported socket both emit" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    var pipe = try WindowsPollTestPipe.init();
+    defer pipe.deinit();
+    try pipe.writeBytes("x");
+
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try ctx.fd_table.insert(110, .{ .kind = .stdin, .host_fd = pipe.read });
+    try ctx.fd_table.insert(111, .{ .kind = .socket });
+
+    var mem: [256]u8 = @splat(0);
+    pollTestWriteFdSub(&mem, 0, 10, wasi.EVENTTYPE_FD_READ, 110);
+    pollTestWriteFdSub(&mem, 1, 11, wasi.EVENTTYPE_FD_READ, 111);
+    try std.testing.expectEqual(
+        wasi_core.WASI_ESUCCESS,
+        ctxPollOneoffCore(ctx, &mem, 0, 128, 2, 248),
+    );
+
+    try std.testing.expectEqual(@as(u32, 2), wasi_core.memReadU32(&mem, 248).?);
+    try std.testing.expectEqual(@as(u64, 10), pollTestEventUserdata(&mem, 128, 0));
+    try std.testing.expectEqual(@as(u16, 0), pollTestEventErrno(&mem, 128, 0));
+    try std.testing.expectEqual(@as(u64, 11), pollTestEventUserdata(&mem, 128, 1));
+    try std.testing.expectEqual(
+        @intFromEnum(wasi.Errno.notsup),
+        pollTestEventErrno(&mem, 128, 1),
+    );
+}
+
+test "Windows poll review: ready console and expired clock both emit" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    var pipe = try WindowsPollTestPipe.init();
+    defer pipe.deinit();
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try ctx.fd_table.insert(112, .{ .kind = .stdin, .host_fd = pipe.read });
+
+    var fake = FakePollTime{};
+    var hooks = fake.hooks();
+    hooks.windows_wait = FakePollTime.windowsReady;
+    var mem: [256]u8 = @splat(0);
+    pollTestWriteClockSub(&mem, 0, 12, wasi.CLOCKID_MONOTONIC, 0, 0);
+    pollTestWriteFdSub(&mem, 1, 13, wasi.EVENTTYPE_FD_READ, 112);
+    try std.testing.expectEqual(
+        wasi_core.WASI_ESUCCESS,
+        ctxPollOneoffCoreWithHooks(ctx, &mem, 0, 128, 2, 248, hooks),
+    );
+
+    try std.testing.expectEqual(@as(u32, 2), wasi_core.memReadU32(&mem, 248).?);
+    try std.testing.expectEqual(@as(u64, 12), pollTestEventUserdata(&mem, 128, 0));
+    try std.testing.expectEqual(@as(u64, 13), pollTestEventUserdata(&mem, 128, 1));
+}
+
+test "poll_oneoff review: POSIX immediate and pipe readiness both emit" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const linux = std.os.linux;
+    var fds: [2]i32 = undefined;
+    if (linux.errno(linux.pipe2(&fds, .{})) != .SUCCESS) return error.SkipZigTest;
+    defer _ = linux.close(fds[0]);
+    defer _ = linux.close(fds[1]);
+    try std.testing.expectEqual(linux.E.SUCCESS, linux.errno(linux.write(fds[1], "x", 1)));
+
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try ctx.fd_table.insert(113, .{ .kind = .stdin, .host_fd = fds[0] });
+
+    var mem: [256]u8 = @splat(0);
+    pollTestWriteFdSub(&mem, 0, 14, wasi.EVENTTYPE_FD_WRITE, 1);
+    pollTestWriteFdSub(&mem, 1, 15, wasi.EVENTTYPE_FD_READ, 113);
+    try std.testing.expectEqual(
+        wasi_core.WASI_ESUCCESS,
+        ctxPollOneoffCore(ctx, &mem, 0, 128, 2, 248),
+    );
+    try std.testing.expectEqual(@as(u32, 2), wasi_core.memReadU32(&mem, 248).?);
+    try std.testing.expectEqual(@as(u64, 14), pollTestEventUserdata(&mem, 128, 0));
+    try std.testing.expectEqual(@as(u64, 15), pollTestEventUserdata(&mem, 128, 1));
 }
 
 // ── sock_shutdown tests (#420 phase 8) ──────────────────────────────
@@ -6041,7 +6456,7 @@ test "group termination: a blocking poll_oneoff is interrupted instead of waitin
     defer ctx.deinit();
     var manager = thread_manager.ThreadManager.init(std.testing.allocator);
     defer manager.deinit();
-    manager.bindTermination(&ctx.termination);
+    try manager.bindTermination(&ctx.termination);
 
     var mem: [256]u8 = @splat(0);
     // A two-second sleep is the hard test backstop; group cancellation must
@@ -6085,6 +6500,8 @@ const BlockingReadProbe = struct {
     ctx: *wasi.WasiCtx,
     fd: u32,
     outcome: Outcome = .pending,
+    nread: usize = 0,
+    byte: u8 = 0,
     finished: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     fn run(self: *BlockingReadProbe) void {
@@ -6095,11 +6512,13 @@ const BlockingReadProbe = struct {
         };
         defer lease.release();
         var byte: [1]u8 = undefined;
-        _ = doRead(self.ctx, &lease, &byte) catch |err| {
+        const nread = doRead(self.ctx, &lease, &byte) catch |err| {
             self.outcome = if (err == error.Terminated) .terminated else .failed;
             self.finished.store(true, .release);
             return;
         };
+        self.nread = nread;
+        if (nread != 0) self.byte = byte[0];
         self.outcome = .read;
         self.finished.store(true, .release);
     }
@@ -6121,7 +6540,7 @@ test "group termination: a blocking Windows stdin pipe read is interrupted" {
 
     var manager = thread_manager.ThreadManager.init(std.testing.allocator);
     defer manager.deinit();
-    manager.bindTermination(&ctx.termination);
+    try manager.bindTermination(&ctx.termination);
 
     const FallbackWriter = struct {
         fn run(target: *WindowsPollTestPipe) void {
@@ -6145,4 +6564,108 @@ test "group termination: a blocking Windows stdin pipe read is interrupted" {
     try std.testing.expectEqual(BlockingReadProbe.Outcome.terminated, probe.outcome);
     try std.testing.expect(interrupt_elapsed < 500 * std.time.ns_per_ms);
     try std.testing.expectEqual(@as(?u32, 5), ctx.getExitCode());
+}
+
+test "Windows cancellable read: two readers sharing one byte leave the loser interruptible" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    if (!config.lib_wasi_threads or is_single_threaded) return error.SkipZigTest;
+
+    var pipe = try WindowsPollTestPipe.init();
+    defer pipe.deinit();
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    const guest_fd: u32 = 103;
+    try ctx.fd_table.insert(guest_fd, .{ .kind = .stdin, .host_fd = pipe.read });
+
+    var manager = thread_manager.ThreadManager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.bindTermination(&ctx.termination);
+
+    const FallbackWriter = struct {
+        fn run(target: *WindowsPollTestPipe) void {
+            platform.usleep(std.time.us_per_s);
+            target.writeBytes("b") catch {};
+        }
+    };
+    const fallback = try std.Thread.spawn(.{}, FallbackWriter.run, .{&pipe});
+
+    var first = BlockingReadProbe{ .ctx = ctx, .fd = guest_fd };
+    var second = BlockingReadProbe{ .ctx = ctx, .fd = guest_fd };
+    const first_thread = try std.Thread.spawn(.{}, BlockingReadProbe.run, .{&first});
+    const second_thread = try std.Thread.spawn(.{}, BlockingReadProbe.run, .{&second});
+    platform.usleep(20 * std.time.us_per_ms);
+    try pipe.writeBytes("a");
+
+    const ready_deadline = hostMonotonicNs(ctx) + 500 * std.time.ns_per_ms;
+    while (!first.finished.load(.acquire) and
+        !second.finished.load(.acquire) and
+        hostMonotonicNs(ctx) < ready_deadline)
+    {
+        platform.usleep(std.time.us_per_ms);
+    }
+    const finished_before_cancel =
+        @as(usize, @intFromBool(first.finished.load(.acquire))) +
+        @as(usize, @intFromBool(second.finished.load(.acquire)));
+
+    const interrupted_at = hostMonotonicNs(ctx);
+    ctx.proc_exit(7);
+    first_thread.join();
+    second_thread.join();
+    const interrupt_elapsed = hostMonotonicNs(ctx) - interrupted_at;
+    fallback.join();
+
+    const first_read = first.outcome == .read and first.nread == 1 and first.byte == 'a';
+    const second_read = second.outcome == .read and second.nread == 1 and second.byte == 'a';
+    try std.testing.expectEqual(@as(usize, 1), finished_before_cancel);
+    try std.testing.expect(first_read != second_read);
+    try std.testing.expect(
+        first.outcome == .terminated or second.outcome == .terminated,
+    );
+    try std.testing.expect(interrupt_elapsed < 500 * std.time.ns_per_ms);
+    try std.testing.expectEqual(@as(?u32, 7), ctx.getExitCode());
+}
+
+test "Windows cancellable read: redirected pipe EOF returns zero" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    if (!config.lib_wasi_threads or is_single_threaded) return error.SkipZigTest;
+
+    var pipe = try WindowsPollTestPipe.init();
+    defer pipe.deinit();
+    pipe.closeWrite();
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try ctx.fd_table.insert(104, .{ .kind = .stdin, .host_fd = pipe.read });
+    var manager = thread_manager.ThreadManager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.bindTermination(&ctx.termination);
+
+    var lease = ctx.fd_table.acquire(104).?;
+    defer lease.release();
+    var byte: [1]u8 = undefined;
+    try std.testing.expectEqual(@as(usize, 0), try doRead(ctx, &lease, &byte));
+}
+
+test "Windows cancellable read: redirected file returns data then EOF" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    if (!config.lib_wasi_threads or is_single_threaded) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file = try tmp.dir.createFile(testing_io, "redirected-stdin.txt", .{ .read = true });
+    defer file.close(testing_io);
+    try file.writePositionalAll(testing_io, "file", 0);
+
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try ctx.fd_table.insert(105, .{ .kind = .stdin, .host_fd = file.handle });
+    var manager = thread_manager.ThreadManager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.bindTermination(&ctx.termination);
+
+    var lease = ctx.fd_table.acquire(105).?;
+    defer lease.release();
+    var buffer: [8]u8 = undefined;
+    const first_read = try doRead(ctx, &lease, &buffer);
+    try std.testing.expectEqualStrings("file", buffer[0..first_read]);
+    try std.testing.expectEqual(@as(usize, 0), try doRead(ctx, &lease, &buffer));
 }

--- a/src/wasi/host_functions.zig
+++ b/src/wasi/host_functions.zig
@@ -6654,6 +6654,7 @@ test "Windows cancellable read: redirected file returns data then EOF" {
     const file = try tmp.dir.createFile(testing_io, "redirected-stdin.txt", .{ .read = true });
     defer file.close(testing_io);
     try file.writePositionalAll(testing_io, "file", 0);
+    _ = try wasi.seekHostFile(testing_io, file, 0, .set);
 
     const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
     defer ctx.deinit();

--- a/src/wasi/thread_manager.zig
+++ b/src/wasi/thread_manager.zig
@@ -247,6 +247,10 @@ pub const PrepareError = error{
     OutOfMemory,
 };
 
+pub const BindError = error{
+    WindowsCancelEventUnavailable,
+};
+
 pub const JoinError = error{
     InvalidThreadId,
     UnknownThread,
@@ -299,6 +303,7 @@ const TestHooks = struct {
     fail_child_initialization: bool = false,
     fail_native_spawn: bool = false,
     fail_start_gate: bool = false,
+    fail_windows_cancel_event: bool = false,
     native_threads_started: ?*std.atomic.Value(usize) = null,
     native_threads_joined: ?*std.atomic.Value(usize) = null,
     records_destroyed: ?*std.atomic.Value(usize) = null,
@@ -498,8 +503,8 @@ pub const ThreadManager = struct {
     /// still reaches an interruption point; the interpreter needs none
     /// because its dispatch loop polls the manager directly.
     cancel_broadcast: ?CancelBroadcast = null,
-    /// Manual-reset event included in every Windows host wait set. The event
-    /// stays signalled after the first group interruption.
+    /// Lazily-created manual-reset event included in every Windows host wait
+    /// set. It stays signalled after the first group interruption.
     windows_cancel: windows_poll.CancelEvent,
 
     pub fn init(allocator: std.mem.Allocator) ThreadManager {
@@ -612,7 +617,15 @@ pub const ThreadManager = struct {
     /// Termination claimed anywhere — including `proc_exit` reached through
     /// the process state without ever touching this manager — then wakes
     /// every sibling through `interrupt`.
-    pub fn bindTermination(self: *ThreadManager, state: *termination.State) void {
+    pub fn bindTermination(self: *ThreadManager, state: *termination.State) BindError!void {
+        if (comptime config.lib_wasi_threads) {
+            const fail_for_test = if (self.test_hooks) |hooks|
+                hooks.fail_windows_cancel_event
+            else
+                false;
+            self.windows_cancel.ensureInitialized(fail_for_test) catch
+                return error.WindowsCancelEventUnavailable;
+        }
         self.termination = state;
         state.bindWindowsCancelHandle(self.windows_cancel.opaqueHandle());
         state.bindWake(.{ .ctx = @ptrCast(self), .wake = wakeFromTermination });
@@ -655,7 +668,7 @@ pub const ThreadManager = struct {
     /// threads unwind instead of hanging. Idempotent, safe from any thread.
     pub fn interrupt(self: *ThreadManager) void {
         self.trap_flag.store(true, .release);
-        self.windows_cancel.signal();
+        _ = self.windows_cancel.signal();
         if (self.cancel_broadcast) |hook| hook.broadcast(hook.ctx);
         if (self.shared_memory) |memory| _ = memory.cancelWaiters() catch {};
     }
@@ -2032,7 +2045,7 @@ test "group termination: the winning proc_exit is not masked by later terminatio
     var state = termination.State{};
     var manager = ThreadManager.init(allocator);
     defer manager.deinit();
-    manager.bindTermination(&state);
+    try manager.bindTermination(&state);
     try manager.prepareSharedMemory(ctx.mem_inst, null);
     ctx.inst.thread_manager = &manager;
 
@@ -2067,7 +2080,7 @@ test "group termination: a winning trap is never overwritten by a later proc_exi
     var state = termination.State{};
     var manager = ThreadManager.init(allocator);
     defer manager.deinit();
-    manager.bindTermination(&state);
+    try manager.bindTermination(&state);
     ctx.inst.thread_manager = &manager;
 
     const tid = try manager.spawnThread(ctx.inst, 0);
@@ -2097,7 +2110,7 @@ test "group termination: futex waiters wake and join within the teardown bound" 
     var state = termination.State{};
     var manager = ThreadManager.initWithTestHooks(allocator, &hooks);
     defer manager.deinit();
-    manager.bindTermination(&state);
+    try manager.bindTermination(&state);
     try manager.prepareSharedMemory(ctx.mem_inst, null);
     ctx.inst.thread_manager = &manager;
 
@@ -2136,7 +2149,7 @@ test "group termination: a spinning sibling is interrupted by the interpreter po
     var state = termination.State{};
     var manager = ThreadManager.init(allocator);
     defer manager.deinit();
-    manager.bindTermination(&state);
+    try manager.bindTermination(&state);
     ctx.inst.thread_manager = &manager;
 
     const child_count = 3;
@@ -2163,7 +2176,7 @@ test "group termination: joining a terminated sibling reports its trap" {
     var state = termination.State{};
     var manager = ThreadManager.init(allocator);
     defer manager.deinit();
-    manager.bindTermination(&state);
+    try manager.bindTermination(&state);
     try manager.prepareSharedMemory(ctx.mem_inst, null);
     ctx.inst.thread_manager = &manager;
 
@@ -2224,7 +2237,7 @@ test "group termination: an uncooperative sibling bounds teardown instead of dea
     var manager = ThreadManager.initWithTestHooks(allocator, &hooks);
     var manager_live = true;
     defer if (manager_live) manager.deinit();
-    manager.bindTermination(&state);
+    try manager.bindTermination(&state);
 
     _ = try manager.spawnWithBackend(
         @ptrCast(&backend),
@@ -2269,7 +2282,7 @@ test "group termination: a late binder still wakes an already terminated group" 
     try waitForReady(ctx, 1);
     // Claimed before the manager is bound: binding must replay the wakeup.
     _ = state.claimExit(4);
-    manager.bindTermination(&state);
+    try manager.bindTermination(&state);
 
     const summary = manager.terminateAndJoin(default_termination_timeout_ns);
     try std.testing.expect(!summary.timed_out);
@@ -2294,7 +2307,7 @@ test "group termination: the cancel broadcast reaches compiled code on every int
     var state = termination.State{};
     var manager = ThreadManager.init(std.testing.allocator);
     defer manager.deinit();
-    manager.bindTermination(&state);
+    try manager.bindTermination(&state);
     manager.bindCancelBroadcast(.{
         .ctx = @ptrCast(&probe),
         .broadcast = Probe.broadcast,
@@ -2313,13 +2326,37 @@ test "group termination: the cancel broadcast reaches compiled code on every int
     var terminated_state = termination.State{};
     var late_manager = ThreadManager.init(std.testing.allocator);
     defer late_manager.deinit();
-    late_manager.bindTermination(&terminated_state);
+    try late_manager.bindTermination(&terminated_state);
     _ = terminated_state.claimExit(1);
     late_manager.bindCancelBroadcast(.{
         .ctx = @ptrCast(&late),
         .broadcast = Probe.broadcast,
     });
     try std.testing.expect(late.calls >= 1);
+}
+
+test "ThreadManager: Windows cancel event is lazy for unused managers" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    const hooks = TestHooks{ .fail_windows_cancel_event = true };
+    var manager = ThreadManager.initWithTestHooks(std.testing.allocator, &hooks);
+    defer manager.deinit();
+    try std.testing.expect(manager.windows_cancel.opaqueHandle() == null);
+}
+
+test "ThreadManager: Windows cancel event creation failure is explicit" {
+    if (builtin.os.tag != .windows or !config.lib_wasi_threads)
+        return error.SkipZigTest;
+
+    const hooks = TestHooks{ .fail_windows_cancel_event = true };
+    var manager = ThreadManager.initWithTestHooks(std.testing.allocator, &hooks);
+    defer manager.deinit();
+    var state = termination.State{};
+    try std.testing.expectError(
+        error.WindowsCancelEventUnavailable,
+        manager.bindTermination(&state),
+    );
+    try std.testing.expect(manager.termination == null);
+    try std.testing.expect(state.windowsCancelHandle() == null);
 }
 
 /// Parks the calling thread on the group's shared memory with an infinite
@@ -2359,7 +2396,7 @@ test "group termination: the embedder parking after the last sweep is still canc
     var state = termination.State{};
     var manager = ThreadManager.init(allocator);
     defer manager.deinit();
-    manager.bindTermination(&state);
+    try manager.bindTermination(&state);
     try manager.prepareSharedMemory(ctx.mem_inst, null);
     ctx.inst.thread_manager = &manager;
 
@@ -2397,7 +2434,7 @@ test "group termination: an interpreter child that parks after termination traps
     var state = termination.State{};
     var manager = ThreadManager.init(allocator);
     defer manager.deinit();
-    manager.bindTermination(&state);
+    try manager.bindTermination(&state);
     try manager.prepareSharedMemory(ctx.mem_inst, null);
     ctx.inst.thread_manager = &manager;
 


### PR DESCRIPTION
Follow-up to #974. Refs #965 and #616; #965 intentionally remains open pending independent post-merge re-review.

## Confirmed findings fixed
1. **High — large clocks:** overflow-free ns→ms ceiling, repeated bounded wait chunks, and selected-clock rechecks before emission.
2. **High — actual stdin read:** synchronous `ReadFile` runs on a helper thread waited beside the manager event; cancellation invokes `NtCancelSynchronousIoFile` on the blocked syscall.
3. **Medium — incomplete ready sets:** Windows and POSIX descriptors receive a zero-time probe even when another subscription is synthetic-ready.
4. **Medium — console starvation:** all queued records are inspected; incomplete cooked/non-key input switches to bounded cancellation-aware polling; >64 handle sets remain bounded.
5. **Medium — absolute clocks:** retain clock ID/absolute deadline and re-evaluate realtime/monotonic clocks after every wake and before emission.
6. **Medium — cancel-event allocation:** creation is lazy/fallible at thread-group binding; unused managers allocate nothing and setup reports an explicit error.

## Regressions
- max-u64, 30-day/chunked, rounding-boundary, realtime jump, monotonic absolute, multi-clock tests with injected clocks/waits
- ready pipe + socket NOTSUP, simulated ready console + expired clock, and POSIX complete-ready-set coverage
- two-reader/one-byte race, writer-open cancellation watchdog, redirected pipe/file EOF/data
- cooked Ctrl-Z/Enter, Unicode/non-key, >256 records, bounded probe count, >64 handles
- injected CreateEvent failure and unused-manager success

## Validation
- `zig build test-windows-poll -Dlib_wasi_threads=true -Daot=false`
- `zig build test-thread-lifecycle -Dlib_wasi_threads=true -Daot=false`
- full `zig build test` with threads disabled and enabled
- interpreter/AOT WASI thread fixtures and threaded native/Windows cross-builds
