### PR TITLE
wasi: close Windows poll re-review gaps

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1123,9 +1123,12 @@ pub fn build(b: *std.Build) void {
         .filters = &.{
             "Windows poll_oneoff:",
             "Windows poll review:",
+            "Windows poll rereview:",
             "Windows cancellable read:",
             "poll_oneoff review:",
             "ThreadManager: Windows cancel event",
+            "ThreadManager: Windows interrupt",
+            "ThreadManager: pre-bind interrupt",
             "group termination: a blocking poll_oneoff",
             "group termination: poll_oneoff still honours",
             "group termination: a blocking Windows stdin",

--- a/docs/wasi.md
+++ b/docs/wasi.md
@@ -215,9 +215,12 @@ A2, A5, and C1.
 Windows supports relative and absolute realtime/monotonic clock
 subscriptions plus stdio and regular-file readiness. Console input is treated
 as readable only when a key is available (or a complete line in line-input
-mode); redirected pipes use `PeekNamedPipe` so buffered bytes and writer
-closure/EOF are distinguished. Absolute deadlines are re-evaluated against
-their selected clock after every wake, including realtime clock adjustments.
+mode). Redirected-pipe readiness runs `PeekNamedPipe` on a cancellable helper
+thread so a synchronous pipe probe cannot trap the guest thread inside an
+uncancellable kernel wait; buffered bytes and writer closure/EOF remain
+distinct. Message-pipe `ERROR_MORE_DATA` reads return the consumed prefix.
+Absolute deadlines are re-evaluated against their selected clock after every
+wake, and Windows bounds absolute-realtime waits to observe wall-clock jumps.
 
 With Preview-1 threads enabled, binding the group lazily creates a
 `ThreadManager`-owned manual-reset cancellation event; allocation failure is

--- a/src/platform/windows_poll.zig
+++ b/src/platform/windows_poll.zig
@@ -64,6 +64,21 @@ const api = if (is_windows) struct {
         lpNumberOfBytesRead: ?*windows.DWORD,
         lpOverlapped: ?*anyopaque,
     ) callconv(.winapi) windows.BOOL;
+
+    extern "kernel32" fn CreatePipe(
+        hReadPipe: *Handle,
+        hWritePipe: *Handle,
+        lpPipeAttributes: ?*windows.SECURITY_ATTRIBUTES,
+        nSize: windows.DWORD,
+    ) callconv(.winapi) windows.BOOL;
+
+    extern "kernel32" fn WriteFile(
+        hFile: Handle,
+        lpBuffer: *const anyopaque,
+        nNumberOfBytesToWrite: windows.DWORD,
+        lpNumberOfBytesWritten: ?*windows.DWORD,
+        lpOverlapped: ?*anyopaque,
+    ) callconv(.winapi) windows.BOOL;
 } else struct {};
 
 const wait_object_0: windows.DWORD = 0;
@@ -235,7 +250,117 @@ fn consoleReady(
     return inspectConsoleRecords(mode, records[0..records_read]);
 }
 
-fn probeInput(allocator: std.mem.Allocator, input: *ReadInput) void {
+const PipeProbeResult = union(enum) {
+    pending,
+    ready: u64,
+    hangup,
+    bad_handle,
+    io_error,
+    cancelled,
+};
+
+const PipeProbeOperation = enum {
+    peek,
+    blocking_read_for_test,
+};
+
+const PipeProbeJob = struct {
+    handle: Handle,
+    operation: PipeProbeOperation,
+    result: PipeProbeResult = .pending,
+
+    fn run(self: *PipeProbeJob) void {
+        if (self.operation == .blocking_read_for_test) {
+            var byte: [1]u8 = undefined;
+            var nread: windows.DWORD = 0;
+            if (api.ReadFile(self.handle, &byte, 1, &nread, null).toBool()) {
+                self.result = if (nread == 0) .hangup else .{ .ready = nread };
+                return;
+            }
+            self.result = switch (windows.GetLastError()) {
+                .BROKEN_PIPE, .PIPE_NOT_CONNECTED, .NO_DATA, .HANDLE_EOF => .hangup,
+                .INVALID_HANDLE => .bad_handle,
+                .OPERATION_ABORTED => .cancelled,
+                else => .io_error,
+            };
+            return;
+        }
+
+        var available: windows.DWORD = 0;
+        if (api.PeekNamedPipe(self.handle, null, 0, null, &available, null).toBool()) {
+            self.result = if (available == 0)
+                .pending
+            else
+                .{ .ready = available };
+            return;
+        }
+        self.result = switch (windows.GetLastError()) {
+            .BROKEN_PIPE, .PIPE_NOT_CONNECTED, .NO_DATA, .HANDLE_EOF => .hangup,
+            .INVALID_HANDLE => .bad_handle,
+            .OPERATION_ABORTED => .cancelled,
+            else => .io_error,
+        };
+    }
+};
+
+fn cancelSynchronousWorker(thread: std.Thread) void {
+    const thread_handle: Handle = thread.getHandle();
+    var wait_handles = [_]Handle{thread_handle};
+    while (true) {
+        var iosb: windows.IO_STATUS_BLOCK = undefined;
+        _ = windows.ntdll.NtCancelSynchronousIoFile(thread_handle, null, &iosb);
+        const result = api.WaitForMultipleObjects(1, &wait_handles, .FALSE, polling_slice_ms);
+        if (result == wait_object_0 or result == wait_failed) break;
+    }
+    thread.join();
+}
+
+fn probePipeOperation(
+    cancel_handle: ?Handle,
+    handle: Handle,
+    operation: PipeProbeOperation,
+) PipeProbeResult {
+    var job = PipeProbeJob{ .handle = handle, .operation = operation };
+    var thread = std.Thread.spawn(.{}, PipeProbeJob.run, .{&job}) catch
+        return .io_error;
+    const thread_handle: Handle = thread.getHandle();
+    var handles: [2]Handle = undefined;
+    var handle_count: usize = 0;
+    if (cancel_handle) |cancel| {
+        handles[0] = cancel;
+        handle_count = 1;
+    }
+    handles[handle_count] = thread_handle;
+    handle_count += 1;
+
+    const result = api.WaitForMultipleObjects(
+        @intCast(handle_count),
+        &handles,
+        .FALSE,
+        polling_slice_ms,
+    );
+    if (cancel_handle != null and result == wait_object_0) {
+        cancelSynchronousWorker(thread);
+        return .cancelled;
+    }
+    const thread_index: windows.DWORD = if (cancel_handle == null) 0 else 1;
+    if (result == wait_object_0 + thread_index) {
+        thread.join();
+        return job.result;
+    }
+    cancelSynchronousWorker(thread);
+    return if (result == wait_timeout) .pending else .io_error;
+}
+
+fn probePipe(cancel_handle: ?Handle, handle: Handle) PipeProbeResult {
+    return probePipeOperation(cancel_handle, handle, .peek);
+}
+
+fn probeInput(
+    allocator: std.mem.Allocator,
+    cancel_handle: ?Handle,
+    input: *ReadInput,
+) bool {
     input.status = .pending;
     input.nbytes = 0;
     input.console = false;
@@ -243,7 +368,7 @@ fn probeInput(allocator: std.mem.Allocator, input: *ReadInput) void {
 
     if (input.handle == windows.INVALID_HANDLE_VALUE) {
         input.status = .bad_handle;
-        return;
+        return false;
     }
 
     var console_mode: windows.DWORD = 0;
@@ -253,38 +378,26 @@ fn probeInput(allocator: std.mem.Allocator, input: *ReadInput) void {
         input.status = result.status;
         input.poll_only = result.poll_only;
         if (input.status == .ready) input.nbytes = 1;
-        return;
-    }
-
-    var available: windows.DWORD = 0;
-    if (api.PeekNamedPipe(input.handle, null, 0, null, &available, null).toBool()) {
-        if (available != 0) {
-            input.status = .ready;
-            input.nbytes = available;
-        } else {
-            input.poll_only = true;
-        }
-        return;
-    }
-
-    switch (windows.GetLastError()) {
-        .BROKEN_PIPE, .PIPE_NOT_CONNECTED, .NO_DATA, .HANDLE_EOF => {
-            input.status = .hangup;
-            return;
-        },
-        .INVALID_HANDLE => {
-            input.status = .bad_handle;
-            return;
-        },
-        else => {},
+        return false;
     }
 
     switch (api.GetFileType(input.handle)) {
         file_type_disk, file_type_char => input.status = .ready,
-        file_type_pipe => input.status = .io_error,
+        file_type_pipe => switch (probePipe(cancel_handle, input.handle)) {
+            .pending => input.poll_only = true,
+            .ready => |nbytes| {
+                input.status = .ready;
+                input.nbytes = nbytes;
+            },
+            .hangup => input.status = .hangup,
+            .bad_handle => input.status = .bad_handle,
+            .io_error => input.status = .io_error,
+            .cancelled => return true,
+        },
         file_type_unknown => input.status = .bad_handle,
         else => input.status = .ready,
     }
+    return false;
 }
 
 fn appendUniqueHandle(handles: *[max_wait_handles]Handle, count: *usize, handle: Handle) bool {
@@ -373,6 +486,13 @@ fn waitForReadinessWithHooks(
     const start_ms = currentMs(hooks);
 
     while (true) {
+        if (cancel_handle) |cancel| {
+            var cancel_only = [_]Handle{cancel};
+            const cancel_result = waitHandles(hooks, &cancel_only, 0);
+            if (cancel_result == wait_object_0) return .cancelled;
+            if (cancel_result == wait_failed) return .failed;
+        }
+
         var handles: [max_wait_handles]Handle = undefined;
         var handle_count: usize = 0;
         var needs_bounded_poll = false;
@@ -387,8 +507,8 @@ fn waitForReadinessWithHooks(
         for (inputs) |*input| {
             if (hooks) |installed|
                 installed.probe(installed.ctx, input)
-            else
-                probeInput(allocator, input);
+            else if (probeInput(allocator, cancel_handle, input))
+                return .cancelled;
             switch (input.status) {
                 .ready, .hangup, .bad_handle, .io_error => any_ready = true,
                 .pending => {
@@ -460,7 +580,13 @@ const ReadJob = struct {
             self.nread = nread;
             return;
         }
-        self.outcome = switch (windows.GetLastError()) {
+        const err = windows.GetLastError();
+        if (err == .MORE_DATA and nread != 0) {
+            self.outcome = .success;
+            self.nread = nread;
+            return;
+        }
+        self.outcome = switch (err) {
             .BROKEN_PIPE, .PIPE_NOT_CONNECTED, .NO_DATA, .HANDLE_EOF => .eof,
             .OPERATION_ABORTED => .cancelled,
             .INVALID_HANDLE => .bad_handle,
@@ -478,18 +604,6 @@ fn finishRead(thread: std.Thread, job: *const ReadJob) ReadError!usize {
         .bad_handle => error.BadHandle,
         .pending, .io_error => error.IoError,
     };
-}
-
-fn cancelRead(thread: std.Thread) void {
-    const thread_handle: Handle = thread.getHandle();
-    var wait_handles = [_]Handle{thread_handle};
-    while (true) {
-        var iosb: windows.IO_STATUS_BLOCK = undefined;
-        _ = windows.ntdll.NtCancelSynchronousIoFile(thread_handle, null, &iosb);
-        const result = api.WaitForMultipleObjects(1, &wait_handles, .FALSE, polling_slice_ms);
-        if (result == wait_object_0 or result == wait_failed) break;
-    }
-    thread.join();
 }
 
 /// Perform the actual synchronous `ReadFile` on a helper thread, then wait on
@@ -515,11 +629,11 @@ pub fn readCancellable(
     if (result == wait_object_0 + 1)
         return finishRead(thread, &job);
     if (result == wait_object_0) {
-        cancelRead(thread);
+        cancelSynchronousWorker(thread);
         return error.Cancelled;
     }
 
-    cancelRead(thread);
+    cancelSynchronousWorker(thread);
     return error.WaitFailed;
 }
 
@@ -674,4 +788,42 @@ test "Windows poll review: more than 64 console handles stay bounded and complet
     try std.testing.expectEqual(@as(usize, max_wait_handles), fake.max_wait_handles);
     try std.testing.expectEqual(@as(windows.DWORD, polling_slice_ms), fake.max_wait_ms);
     try std.testing.expectEqual(InputStatus.ready, inputs[69].status);
+}
+
+test "Windows poll rereview: a blocked pipe probe is cancelled on its worker" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var read = windows.INVALID_HANDLE_VALUE;
+    var write = windows.INVALID_HANDLE_VALUE;
+    if (!api.CreatePipe(&read, &write, null, 0).toBool())
+        return error.TestUnexpectedResult;
+    defer windows.CloseHandle(read);
+    defer windows.CloseHandle(write);
+
+    var cancel = CancelEvent.init();
+    defer cancel.deinit();
+    try cancel.ensureInitialized(false);
+    _ = cancel.signal();
+
+    const Fallback = struct {
+        fn run(handle: Handle) void {
+            api.Sleep(1000);
+            var written: windows.DWORD = 0;
+            const byte = "x";
+            _ = api.WriteFile(handle, byte.ptr, 1, &written, null);
+        }
+    };
+    const fallback = try std.Thread.spawn(.{}, Fallback.run, .{write});
+
+    const started = api.GetTickCount64();
+    const result = probePipeOperation(
+        cancel.handle,
+        read,
+        .blocking_read_for_test,
+    );
+    const elapsed = api.GetTickCount64() - started;
+    fallback.join();
+
+    try std.testing.expectEqual(PipeProbeResult.cancelled, result);
+    try std.testing.expect(elapsed < 500);
 }

--- a/src/wasi/host_functions.zig
+++ b/src/wasi/host_functions.zig
@@ -3151,17 +3151,24 @@ fn ctxPollOneoffCoreWithHooks(
         }
 
         var earliest_ns: ?u64 = null;
+        var recheck_realtime = false;
         for (clocks.items) |clock| {
             if (!clock.valid) continue;
             const remaining_ns = pendingClockRemainingNs(ctx, hooks, clock);
             if (remaining_ns == 0) continue;
+            if (comptime builtin.os.tag == .windows) {
+                if (clock.absolute and clock.clock_id == wasi.CLOCKID_REALTIME)
+                    recheck_realtime = true;
+            }
             if (earliest_ns == null or remaining_ns < earliest_ns.?)
                 earliest_ns = remaining_ns;
         }
-        const timeout_ms: i32 = if (earliest_ns) |remaining_ns|
+        var timeout_ms: i32 = if (earliest_ns) |remaining_ns|
             nsToTimeoutMs(remaining_ns)
         else
             -1;
+        if (recheck_realtime)
+            timeout_ms = @min(timeout_ms, blocking_slice_ms);
 
         const wait_result: BlockingWait = if (pollfds.items.len == 0 and
             windows_inputs.items.len == 0)
@@ -5317,6 +5324,32 @@ const WindowsPollTestApi = if (builtin.os.tag == .windows) struct {
         lpNumberOfBytesWritten: ?*std.os.windows.DWORD,
         lpOverlapped: ?*anyopaque,
     ) callconv(.winapi) std.os.windows.BOOL;
+
+    extern "kernel32" fn CreateNamedPipeW(
+        lpName: std.os.windows.LPCWSTR,
+        dwOpenMode: std.os.windows.DWORD,
+        dwPipeMode: std.os.windows.DWORD,
+        nMaxInstances: std.os.windows.DWORD,
+        nOutBufferSize: std.os.windows.DWORD,
+        nInBufferSize: std.os.windows.DWORD,
+        nDefaultTimeOut: std.os.windows.DWORD,
+        lpSecurityAttributes: ?*std.os.windows.SECURITY_ATTRIBUTES,
+    ) callconv(.winapi) windows_poll.Handle;
+
+    extern "kernel32" fn CreateFileW(
+        lpFileName: std.os.windows.LPCWSTR,
+        dwDesiredAccess: std.os.windows.DWORD,
+        dwShareMode: std.os.windows.DWORD,
+        lpSecurityAttributes: ?*std.os.windows.SECURITY_ATTRIBUTES,
+        dwCreationDisposition: std.os.windows.DWORD,
+        dwFlagsAndAttributes: std.os.windows.DWORD,
+        hTemplateFile: ?windows_poll.Handle,
+    ) callconv(.winapi) windows_poll.Handle;
+
+    extern "kernel32" fn ConnectNamedPipe(
+        hNamedPipe: windows_poll.Handle,
+        lpOverlapped: ?*anyopaque,
+    ) callconv(.winapi) std.os.windows.BOOL;
 } else struct {};
 
 const WindowsPollTestPipe = if (builtin.os.tag == .windows) struct {
@@ -5354,6 +5387,72 @@ const WindowsPollTestPipe = if (builtin.os.tag == .windows) struct {
         const handle = self.write orelse return;
         std.os.windows.CloseHandle(handle);
         self.write = null;
+    }
+} else struct {};
+
+const WindowsMessagePipe = if (builtin.os.tag == .windows) struct {
+    const name = std.unicode.utf8ToUtf16LeStringLiteral(
+        "\\\\.\\pipe\\wamr-978-more-data",
+    );
+    const pipe_access_inbound: u32 = 0x0000_0001;
+    const pipe_type_message: u32 = 0x0000_0004;
+    const pipe_readmode_message: u32 = 0x0000_0002;
+    const generic_write: u32 = 0x4000_0000;
+    const open_existing: u32 = 3;
+    const file_attribute_normal: u32 = 0x0000_0080;
+
+    read: windows_poll.Handle,
+    write: windows_poll.Handle,
+
+    fn init() !@This() {
+        const read = WindowsPollTestApi.CreateNamedPipeW(
+            name,
+            pipe_access_inbound,
+            pipe_type_message | pipe_readmode_message,
+            1,
+            4096,
+            4096,
+            0,
+            null,
+        );
+        if (read == std.os.windows.INVALID_HANDLE_VALUE)
+            return error.TestUnexpectedResult;
+        errdefer std.os.windows.CloseHandle(read);
+
+        const write = WindowsPollTestApi.CreateFileW(
+            name,
+            generic_write,
+            0,
+            null,
+            open_existing,
+            file_attribute_normal,
+            null,
+        );
+        if (write == std.os.windows.INVALID_HANDLE_VALUE)
+            return error.TestUnexpectedResult;
+        errdefer std.os.windows.CloseHandle(write);
+
+        if (!WindowsPollTestApi.ConnectNamedPipe(read, null).toBool() and
+            std.os.windows.GetLastError() != .PIPE_CONNECTED)
+            return error.TestUnexpectedResult;
+        return .{ .read = read, .write = write };
+    }
+
+    fn deinit(self: *@This()) void {
+        std.os.windows.CloseHandle(self.read);
+        std.os.windows.CloseHandle(self.write);
+    }
+
+    fn writeBytes(self: *@This(), bytes: []const u8) !void {
+        var written: std.os.windows.DWORD = 0;
+        if (!WindowsPollTestApi.WriteFile(
+            self.write,
+            bytes.ptr,
+            @intCast(bytes.len),
+            &written,
+            null,
+        ).toBool()) return error.TestUnexpectedResult;
+        if (written != bytes.len) return error.TestUnexpectedResult;
     }
 } else struct {};
 
@@ -5746,6 +5845,10 @@ test "poll_oneoff review: absolute clocks follow selected-clock jumps" {
         ),
     );
     try std.testing.expectEqual(@as(usize, 1), forward.wait_count);
+    try std.testing.expectEqual(
+        @as(i32, if (builtin.os.tag == .windows) blocking_slice_ms else 50),
+        forward.waits[0],
+    );
 
     const backward_steps = [_]FakePollTime.Step{
         .{ .realtime_ns = 40 * std.time.ns_per_ms },
@@ -5777,8 +5880,14 @@ test "poll_oneoff review: absolute clocks follow selected-clock jumps" {
         ),
     );
     try std.testing.expectEqual(@as(usize, 2), backward.wait_count);
-    try std.testing.expectEqual(@as(i32, 50), backward.waits[0]);
-    try std.testing.expectEqual(@as(i32, 60), backward.waits[1]);
+    try std.testing.expectEqual(
+        @as(i32, if (builtin.os.tag == .windows) blocking_slice_ms else 50),
+        backward.waits[0],
+    );
+    try std.testing.expectEqual(
+        @as(i32, if (builtin.os.tag == .windows) blocking_slice_ms else 60),
+        backward.waits[1],
+    );
 }
 
 test "poll_oneoff review: immediate fd does not emit a future absolute clock" {
@@ -6669,4 +6778,30 @@ test "Windows cancellable read: redirected file returns data then EOF" {
     const first_read = try doRead(ctx, &lease, &buffer);
     try std.testing.expectEqualStrings("file", buffer[0..first_read]);
     try std.testing.expectEqual(@as(usize, 0), try doRead(ctx, &lease, &buffer));
+}
+
+test "Windows cancellable read: message pipe preserves ERROR_MORE_DATA prefix" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    if (!config.lib_wasi_threads or is_single_threaded) return error.SkipZigTest;
+
+    var pipe = try WindowsMessagePipe.init();
+    defer pipe.deinit();
+    try pipe.writeBytes("message");
+
+    const ctx = try wasi.WasiCtx.init(std.testing.allocator, testing_io);
+    defer ctx.deinit();
+    try ctx.fd_table.insert(106, .{ .kind = .stdin, .host_fd = pipe.read });
+    var manager = thread_manager.ThreadManager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.bindTermination(&ctx.termination);
+
+    var lease = ctx.fd_table.acquire(106).?;
+    defer lease.release();
+    var first: [3]u8 = undefined;
+    const first_read = try doRead(ctx, &lease, &first);
+    try std.testing.expectEqualStrings("mes", first[0..first_read]);
+
+    var second: [8]u8 = undefined;
+    const second_read = try doRead(ctx, &lease, &second);
+    try std.testing.expectEqualStrings("sage", second[0..second_read]);
 }

--- a/src/wasi/thread_manager.zig
+++ b/src/wasi/thread_manager.zig
@@ -628,6 +628,8 @@ pub const ThreadManager = struct {
         }
         self.termination = state;
         state.bindWindowsCancelHandle(self.windows_cancel.opaqueHandle());
+        if (self.trap_flag.load(.acquire))
+            _ = state.claimTrap(termination.generic_trap_code);
         state.bindWake(.{ .ctx = @ptrCast(self), .wake = wakeFromTermination });
     }
 
@@ -2357,6 +2359,45 @@ test "ThreadManager: Windows cancel event creation failure is explicit" {
     );
     try std.testing.expect(manager.termination == null);
     try std.testing.expect(state.windowsCancelHandle() == null);
+}
+
+test "ThreadManager: Windows interrupt before bind is replayed" {
+    if (builtin.os.tag != .windows or !config.lib_wasi_threads)
+        return error.SkipZigTest;
+
+    var manager = ThreadManager.init(std.testing.allocator);
+    defer manager.deinit();
+    manager.interrupt();
+
+    var state = termination.State{};
+    try manager.bindTermination(&state);
+    try std.testing.expectEqual(termination.Kind.trap, state.outcome().?.kind);
+
+    var inputs: [0]windows_poll.ReadInput = .{};
+    try std.testing.expectEqual(
+        windows_poll.WaitResult.cancelled,
+        windows_poll.waitForReadiness(
+            std.testing.allocator,
+            state.windowsCancelHandle(),
+            &inputs,
+            1,
+        ),
+    );
+}
+
+test "ThreadManager: pre-bind interrupt preserves an earlier exit outcome" {
+    if (builtin.os.tag != .windows or !config.lib_wasi_threads)
+        return error.SkipZigTest;
+
+    var manager = ThreadManager.init(std.testing.allocator);
+    defer manager.deinit();
+    manager.interrupt();
+
+    var state = termination.State{};
+    try std.testing.expect(state.claimExit(9));
+    try manager.bindTermination(&state);
+    try std.testing.expectEqual(termination.Kind.exit, state.outcome().?.kind);
+    try std.testing.expectEqual(@as(?u32, 9), state.exitCode());
 }
 
 /// Parks the calling thread on the group's shared memory with an infinite


### PR DESCRIPTION
Follow-up to #978 and #974. Refs #965 and #616; #965 remains open pending another independent post-merge review.

## Re-review findings
1. **Blocking `PeekNamedPipe`:** pipe probes now execute on a helper thread and are waited/cancelled with the manager event plus `NtCancelSynchronousIoFile`; no synchronous pipe probe runs on the guest thread.
2. **Realtime forward jumps:** Windows absolute-realtime waits are bounded by the host interruption slice, forcing selected-clock re-evaluation instead of sleeping until the old relative deadline.
3. **Message-mode partial reads:** `ERROR_MORE_DATA` with a nonzero byte count is returned as a successful consumed prefix.
4. **Pre-bind interruption:** binding replays `trap_flag`, claims a trap only if no earlier process outcome won, and signals the newly-created event.

## Regressions
- cancellation of a deliberately blocked probe worker with a hard fallback
- bounded fake realtime wait assertions for forward/backward jumps
- real Windows message-mode named pipe short-buffer prefix + remainder
- pre-bind interrupt event replay and first-wins exit preservation

The dedicated hosted Windows gate runs these alongside the prior clock/read/readiness/console/lifecycle suite.