### PR TITLE
bench: correct CoreMark workload methodology

### DIFF
--- a/.github/workflows/coremark-aarch64.yml
+++ b/.github/workflows/coremark-aarch64.yml
@@ -127,6 +127,7 @@ jobs:
             --wasmtime-cache "$RUNNER_TEMP/coremark-wasmtime" \
             --require-native-arch aarch64 \
             --out      coremark-table.md \
+            --json-out coremark-report.json \
             --emit     github
 
       - name: Install matching perf for profiling
@@ -209,7 +210,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coremark-aarch64-${{ github.event_name }}-${{ github.sha }}
-          path: coremark-table.md
+          path: |
+            coremark-table.md
+            coremark-report.json
           if-no-files-found: error
           retention-days: 90
 

--- a/scripts/bench_coremark.py
+++ b/scripts/bench_coremark.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import os
 import platform
 import re
@@ -25,15 +26,28 @@ import statistics
 import subprocess
 import sys
 import tarfile
+import time
 import urllib.request
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 from bench_optimize import OPTIMIZE_CHOICES, fmt_ratio, optimize_slug, parse_optimize_modes
 
 ITER_PATTERN = re.compile(r"Iterations/Sec\s*:\s*([0-9]+(?:\.[0-9]+)?)")
 VALIDATION_TEXT = "Correct operation validated."
+PERFORMANCE_MARKER = "2K performance run parameters for coremark."
+ITERATIONS_PATTERN = re.compile(r"^\s*Iterations\s*:\s*(\d+)\s*$")
+THROUGHPUT_PATTERN = re.compile(
+    r"^\s*Iterations/Sec\s*:\s*([0-9]+(?:\.[0-9]+)?)\s*$"
+)
+COREMARK_GUEST_ARGS = ("0", "0", "0", "400000", "0")
+EXPECTED_ITERATIONS = 400000
+PROFILE_ITERATIONS = {
+    "authoritative": EXPECTED_ITERATIONS,
+    "ci": 200000,
+}
 DEFAULT_FIXTURE = Path("tests/benchmarks/coremark/coremark_wasi.wasm")
 DEFAULT_FIXTURE_SHA256 = "f4b7591296ead10264e0f101f355bdf848865c31329325594e66fbabefec235b"
 PINNED_WASMTIME_VERSION = "44.0.1"
@@ -68,6 +82,47 @@ class EngineResult:
     version: str
     optimize: str
     values: list[float]
+    samples: list["SampleRecord"] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ParsedCoreMark:
+    throughput: float
+    iterations: int
+
+
+@dataclass(frozen=True)
+class SampleRecord:
+    engine_key: str
+    engine: str
+    phase: str
+    engine_ordinal: int
+    schedule_position: int
+    started_at: str
+    completed_at: str
+    elapsed_seconds: float
+    iterations_per_second: float
+    iterations: int
+
+
+@dataclass(frozen=True)
+class PreparedEngine:
+    key: str
+    engine: str
+    version: str
+    optimize: str
+    cmd: list[str]
+    cwd: Path
+    env: dict
+    expected_iterations: int
+    retry_wamr_flake: bool = False
+
+
+@dataclass(frozen=True)
+class AffinityInfo:
+    allowed_cpus: tuple[int, ...]
+    selected_cpu: int
+    taskset: str
 
 
 @dataclass(frozen=True)
@@ -144,18 +199,124 @@ def resolve_fixture(repo: Path, fixture_arg: Path) -> tuple[Path, str]:
     return fixture, digest
 
 
-def parse_coremark_output(output: str, engine: str) -> float:
-    if VALIDATION_TEXT not in output or re.search(r"(?m)^.*ERROR!", output):
+def parse_coremark_output(
+    output: str,
+    engine: str,
+    expected_iterations: int = EXPECTED_ITERATIONS,
+) -> ParsedCoreMark:
+    if (
+        output.count(VALIDATION_TEXT) != 1
+        or re.search(r"(?m)^.*ERROR!", output)
+    ):
         raise RuntimeError(
             f"{engine} did not produce a CRC-validated CoreMark result:\n{output}"
         )
-    matches = ITER_PATTERN.findall(output)
-    if len(matches) != 1:
+    if output.count(PERFORMANCE_MARKER) != 1:
         raise RuntimeError(
-            f"{engine} produced {len(matches)} Iterations/Sec values; expected one:\n"
-            f"{output}"
+            f"{engine} did not produce exactly one {PERFORMANCE_MARKER!r} marker"
         )
-    return float(matches[0])
+
+    throughput_lines = [
+        line for line in output.splitlines() if "Iterations/Sec" in line
+    ]
+    if len(throughput_lines) != 1:
+        raise RuntimeError(
+            f"{engine} produced {len(throughput_lines)} Iterations/Sec fields; "
+            f"expected exactly one"
+        )
+    throughput_match = THROUGHPUT_PATTERN.fullmatch(throughput_lines[0])
+    if throughput_match is None:
+        raise RuntimeError(
+            f"{engine} produced malformed Iterations/Sec output: "
+            f"{throughput_lines[0]!r}"
+        )
+
+    iteration_lines = [
+        line
+        for line in output.splitlines()
+        if re.match(r"^\s*Iterations\s*:", line)
+    ]
+    if len(iteration_lines) != 1:
+        raise RuntimeError(
+            f"{engine} produced {len(iteration_lines)} Iterations fields; "
+            f"expected exactly one"
+        )
+    iteration_match = ITERATIONS_PATTERN.fullmatch(iteration_lines[0])
+    if iteration_match is None:
+        raise RuntimeError(
+            f"{engine} produced malformed Iterations output: "
+            f"{iteration_lines[0]!r}"
+        )
+    iterations = int(iteration_match.group(1))
+    if iterations != expected_iterations:
+        raise RuntimeError(
+            f"{engine} ran {iterations} iterations; expected fixed "
+            f"{expected_iterations} (self-calibration is forbidden)"
+        )
+    return ParsedCoreMark(float(throughput_match.group(1)), iterations)
+
+
+def select_cpu_affinity() -> AffinityInfo:
+    if not hasattr(os, "sched_getaffinity"):
+        raise RuntimeError("authoritative CPU affinity requires sched_getaffinity")
+    allowed = tuple(sorted(os.sched_getaffinity(0)))
+    if not allowed:
+        raise RuntimeError("authoritative CPU affinity set is empty")
+    taskset = shutil.which("taskset")
+    if taskset is None:
+        raise RuntimeError("authoritative CPU affinity requires taskset")
+    selected = allowed[0]
+    verify_script = (
+        "import os,sys; "
+        f"expected={selected}; actual=sorted(os.sched_getaffinity(0)); "
+        "print(','.join(str(cpu) for cpu in actual)); "
+        "sys.exit(0 if actual == [expected] else 1)"
+    )
+    output = run(
+        [
+            taskset,
+            "--cpu-list",
+            str(selected),
+            sys.executable,
+            "-c",
+            verify_script,
+        ]
+    ).strip()
+    if output != str(selected):
+        raise RuntimeError(
+            f"taskset affinity verification returned {output!r}; "
+            f"expected {selected}"
+        )
+    return AffinityInfo(allowed, selected, taskset)
+
+
+def apply_affinity(cmd: list[str], affinity: AffinityInfo | None) -> list[str]:
+    if affinity is None:
+        return cmd
+    return [
+        affinity.taskset,
+        "--cpu-list",
+        str(affinity.selected_cpu),
+        *cmd,
+    ]
+
+
+def counterbalanced_order(keys: list[str], count_per_engine: int) -> list[str]:
+    if count_per_engine < 0:
+        raise ValueError("count_per_engine must be non-negative")
+    if not keys and count_per_engine:
+        raise ValueError("cannot schedule samples without engines")
+    order: list[str] = []
+    for repetition in range(count_per_engine):
+        sequence = keys if repetition % 2 == 0 else list(reversed(keys))
+        order.extend(sequence)
+    return order
+
+
+def coremark_guest_args(iterations: int) -> tuple[str, ...]:
+    if iterations <= 0:
+        raise ValueError("fixed CoreMark iterations must be positive")
+    return ("0", "0", "0", str(iterations), "0")
 
 
 def resolve_ref_sha(repo: Path, ref: str) -> str:
@@ -215,15 +376,19 @@ def measure_command(
     warmups: int,
     runs: int,
     retry_wamr_flake: bool = False,
+    affinity: AffinityInfo | None = None,
+    expected_iterations: int = EXPECTED_ITERATIONS,
 ) -> list[float]:
     values: list[float] = []
     total = warmups + runs
+    cmd = apply_affinity(cmd, affinity)
     for i in range(total):
         if retry_wamr_flake:
             output = _run_wamr_with_retry(cmd, cwd, env, i, total)
         else:
             output = run(cmd, cwd=cwd, env=env)
-        value = parse_coremark_output(output, engine)
+        parsed = parse_coremark_output(output, engine, expected_iterations)
+        value = parsed.throughput
         if i < warmups:
             print(
                 f"[harness]   {engine} warmup {i + 1}/{warmups}: "
@@ -241,15 +406,104 @@ def measure_command(
     return values
 
 
-def build_and_run_wamr(
+def measure_prepared_engines(
+    engines: list[PreparedEngine],
+    *,
+    warmups: int,
+    runs: int,
+    affinity: AffinityInfo | None,
+) -> tuple[dict[str, EngineResult], list[SampleRecord]]:
+    if len({engine.key for engine in engines}) != len(engines):
+        raise RuntimeError("prepared engine keys must be unique")
+    by_key = {engine.key: engine for engine in engines}
+    records: list[SampleRecord] = []
+    engine_records: dict[str, list[SampleRecord]] = {
+        engine.key: [] for engine in engines
+    }
+    ordinals = {
+        phase: {engine.key: 0 for engine in engines}
+        for phase in ("warmup", "measured")
+    }
+    schedule_position = 0
+    keys = [engine.key for engine in engines]
+
+    for phase, count in (("warmup", warmups), ("measured", runs)):
+        for key in counterbalanced_order(keys, count):
+            engine = by_key[key]
+            schedule_position += 1
+            ordinals[phase][key] += 1
+            ordinal = ordinals[phase][key]
+            cmd = apply_affinity(engine.cmd, affinity)
+            started_at = datetime.now(timezone.utc).isoformat()
+            started = time.monotonic()
+            if engine.retry_wamr_flake:
+                output = _run_wamr_with_retry(
+                    cmd,
+                    engine.cwd,
+                    engine.env,
+                    ordinal - 1,
+                    count,
+                )
+            else:
+                output = run(cmd, cwd=engine.cwd, env=engine.env)
+            elapsed = time.monotonic() - started
+            completed_at = datetime.now(timezone.utc).isoformat()
+            parsed = parse_coremark_output(
+                output, engine.engine, engine.expected_iterations
+            )
+            record = SampleRecord(
+                engine_key=engine.key,
+                engine=engine.engine,
+                phase=phase,
+                engine_ordinal=ordinal,
+                schedule_position=schedule_position,
+                started_at=started_at,
+                completed_at=completed_at,
+                elapsed_seconds=elapsed,
+                iterations_per_second=parsed.throughput,
+                iterations=parsed.iterations,
+            )
+            records.append(record)
+            engine_records[key].append(record)
+            suffix = " (discarded)" if phase == "warmup" else ""
+            print(
+                f"[harness]   schedule {schedule_position}: {engine.engine} "
+                f"{phase} {ordinal}/{count}: {parsed.throughput:.1f} iter/s"
+                f"{suffix}",
+                file=sys.stderr,
+            )
+
+    results = {}
+    for engine in engines:
+        measured = [
+            record
+            for record in engine_records[engine.key]
+            if record.phase == "measured"
+        ]
+        if len(measured) != runs:
+            raise RuntimeError(
+                f"{engine.engine} produced {len(measured)} measured records; "
+                f"expected {runs}"
+            )
+        results[engine.key] = EngineResult(
+            engine.engine,
+            engine.version,
+            engine.optimize,
+            [record.iterations_per_second for record in measured],
+            engine_records[engine.key],
+        )
+    return results, records
+
+
+def prepare_wamr(
     wt: Path,
     ref: str,
     sha: str,
     fixture: Path,
     optimize: str,
-    warmups: int,
-    runs: int,
-) -> EngineResult:
+    guest_args: tuple[str, ...] = COREMARK_GUEST_ARGS,
+    expected_iterations: int = EXPECTED_ITERATIONS,
+) -> PreparedEngine:
     env = worktree_env(wt)
     print(f"[harness] building WAMR {ref} ({sha[:12]}, {optimize})", file=sys.stderr)
     run(["zig", "build", f"-Doptimize={optimize}"], cwd=wt, env=env)
@@ -263,14 +517,55 @@ def build_and_run_wamr(
         cwd=wt,
         env=env,
     )
-    values = measure_command(
+    return PreparedEngine(
+        key=f"wamr:{sha}:{optimize}",
         engine=f"WAMR {ref}",
-        cmd=[str(wamr), "run", str(cwasm)],
+        version=f"{ref} ({sha})",
+        optimize=optimize,
+        cmd=[
+            str(wamr),
+            "run",
+            str(cwasm),
+            *guest_args,
+        ],
         cwd=wt,
         env=env,
+        expected_iterations=expected_iterations,
+        retry_wamr_flake=True,
+    )
+
+
+def build_and_run_wamr(
+    wt: Path,
+    ref: str,
+    sha: str,
+    fixture: Path,
+    optimize: str,
+    warmups: int,
+    runs: int,
+    affinity: AffinityInfo | None = None,
+    guest_args: tuple[str, ...] = COREMARK_GUEST_ARGS,
+    expected_iterations: int = EXPECTED_ITERATIONS,
+) -> EngineResult:
+    prepared = prepare_wamr(
+        wt,
+        ref,
+        sha,
+        fixture,
+        optimize,
+        guest_args,
+        expected_iterations,
+    )
+    values = measure_command(
+        engine=f"WAMR {ref}",
+        cmd=prepared.cmd,
+        cwd=wt,
+        env=prepared.env,
         warmups=warmups,
         runs=runs,
         retry_wamr_flake=True,
+        affinity=affinity,
+        expected_iterations=expected_iterations,
     )
     return EngineResult("WAMR", f"{ref} ({sha})", optimize, values)
 
@@ -385,21 +680,57 @@ def measure_wasmtime(
     fixture: Path,
     warmups: int,
     runs: int,
+    affinity: AffinityInfo | None = None,
+    guest_args: tuple[str, ...] = COREMARK_GUEST_ARGS,
+    expected_iterations: int = EXPECTED_ITERATIONS,
 ) -> EngineResult:
     binary_sha = sha256_file(path)
     values = measure_command(
         engine=label,
-        cmd=[str(path), "run", str(fixture)],
+        cmd=[
+            str(path),
+            "run",
+            str(fixture),
+            *guest_args,
+        ],
         cwd=fixture.parent,
         env=os.environ.copy(),
         warmups=warmups,
         runs=runs,
+        affinity=affinity,
+        expected_iterations=expected_iterations,
     )
     return EngineResult(
         label,
         f"{version} (sha256:{binary_sha}; {path})",
         "default JIT",
         values,
+    )
+
+
+def prepare_wasmtime(
+    path: Path,
+    label: str,
+    version: str,
+    fixture: Path,
+    guest_args: tuple[str, ...] = COREMARK_GUEST_ARGS,
+    expected_iterations: int = EXPECTED_ITERATIONS,
+) -> PreparedEngine:
+    binary_sha = sha256_file(path)
+    return PreparedEngine(
+        key=f"wasmtime:{path.resolve()}",
+        engine=label,
+        version=f"{version} (sha256:{binary_sha}; {path})",
+        optimize="default JIT",
+        cmd=[
+            str(path),
+            "run",
+            str(fixture),
+            *guest_args,
+        ],
+        cwd=fixture.parent,
+        env=os.environ.copy(),
+        expected_iterations=expected_iterations,
     )
 
 
@@ -537,6 +868,20 @@ def format_samples(values: list[float]) -> str:
     return ", ".join(f"{value:.1f}" for value in values)
 
 
+def schedule_label(records: list[SampleRecord]) -> str:
+    names: dict[str, str] = {}
+    labels = []
+    for record in records:
+        if record.engine_key not in names:
+            names[record.engine_key] = chr(ord("A") + len(names))
+        labels.append(names[record.engine_key])
+    legend = ", ".join(
+        f"{label}={next(r.engine for r in records if r.engine_key == key)}"
+        for key, label in names.items()
+    )
+    return "".join(labels) + (f" ({legend})" if legend else "")
+
+
 def render_table(
     results: list[EngineResult],
     *,
@@ -546,6 +891,10 @@ def render_table(
     fixture: Path,
     fixture_sha: str,
     host: HostIdentity,
+    schedule_records: list[SampleRecord] | None = None,
+    affinity: AffinityInfo | None = None,
+    guest_args: tuple[str, ...] = COREMARK_GUEST_ARGS,
+    expected_iterations: int = EXPECTED_ITERATIONS,
 ) -> str:
     for result in results:
         if len(result.values) != runs:
@@ -562,10 +911,15 @@ def render_table(
         f"- Measurement profile: `{profile}` ({warmups} warmups discarded, "
         f"{runs} measured runs per engine)",
         f"- Fixture: `{fixture}` (`sha256:{fixture_sha}`)",
+        f"- Fixed guest args: `{' '.join(guest_args)}`; required "
+        f"`Iterations: {expected_iterations}` and `{PERFORMANCE_MARKER}`",
         f"- WAMR optimize mode: `{target.optimize}`; Wasmtime mode: `default JIT`",
         f"- CRC validation: all {warmups + runs} invocations per measured engine "
-        f"produced `{VALIDATION_TEXT}` with no CoreMark CRC error; warmups "
-        f"were discarded",
+        f"produced exactly one `{VALIDATION_TEXT}`, the fixed iteration count, "
+        f"and no CoreMark CRC error; warmups were discarded",
+        "- Methodology correction: supersedes non-authoritative run "
+        "`33576430466`, which allowed independent self-calibration and "
+        "separate unpinned engine blocks",
         "",
         "| Engine | Version / ref | Optimize mode | Mean iter/s | Median | Range | Samples (iter/s) |",
         "|---|---|---|---:|---:|---:|---|",
@@ -601,8 +955,115 @@ def render_table(
                 f"| WAMR target / {result.engine} `{result.version}` | "
                 f"{median_ratio:.3f}× | {mean_ratio:.3f}× |"
             )
+    if affinity is not None:
+        lines.extend(
+            [
+                "",
+                f"- CPU affinity: allowed `{','.join(map(str, affinity.allowed_cpus))}`; "
+                f"selected and verified CPU `{affinity.selected_cpu}` via "
+                f"`{affinity.taskset}`",
+            ]
+        )
+    if schedule_records:
+        lines.extend(
+            [
+                f"- Counterbalanced order: `{schedule_label(schedule_records)}`",
+                "",
+                "| Position | Phase | Engine | Engine sample | Started (UTC) | "
+                "Completed (UTC) | Iterations | Iter/s |",
+                "|---:|---|---|---:|---|---|---:|---:|",
+            ]
+        )
+        for record in schedule_records:
+            lines.append(
+                f"| {record.schedule_position} | {record.phase} | "
+                f"{record.engine} | {record.engine_ordinal} | "
+                f"`{record.started_at}` | `{record.completed_at}` | "
+                f"{record.iterations} | {record.iterations_per_second:.1f} |"
+            )
     lines.extend(["", host_info(host)])
     return "\n".join(lines)
+
+
+def build_json_report(
+    results: list[EngineResult],
+    *,
+    profile: str,
+    warmups: int,
+    runs: int,
+    fixture: Path,
+    fixture_sha: str,
+    host: HostIdentity,
+    schedule_records: list[SampleRecord],
+    affinity: AffinityInfo | None,
+    guest_args: tuple[str, ...] = COREMARK_GUEST_ARGS,
+    expected_iterations: int = EXPECTED_ITERATIONS,
+) -> dict:
+    engines = []
+    for result in results:
+        mean, median, minimum, maximum = fmt_stats(result.values)
+        engines.append(
+            {
+                "engine": result.engine,
+                "version": result.version,
+                "optimize": result.optimize,
+                "mean_iterations_per_second": mean,
+                "median_iterations_per_second": median,
+                "minimum_iterations_per_second": minimum,
+                "maximum_iterations_per_second": maximum,
+                "values": result.values,
+            }
+        )
+    ratios = []
+    target = results[1]
+    for result in results[2:]:
+        ratios.append(
+            {
+                "numerator": target.engine,
+                "denominator": result.engine,
+                "median_ratio": (
+                    statistics.median(target.values)
+                    / statistics.median(result.values)
+                ),
+                "mean_ratio": (
+                    statistics.fmean(target.values)
+                    / statistics.fmean(result.values)
+                ),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "kind": "coremark-authoritative-comparison",
+        "profile": profile,
+        "warmups_per_engine": warmups,
+        "measured_samples_per_engine": runs,
+        "fixture": {"path": str(fixture), "sha256": fixture_sha},
+        "guest_args": list(guest_args),
+        "expected_iterations": expected_iterations,
+        "required_performance_marker": PERFORMANCE_MARKER,
+        "required_crc_marker": VALIDATION_TEXT,
+        "invalidated_run": 33576430466,
+        "host": {
+            "arch": host.arch,
+            "cpu_count": host.cpu_count,
+            "cpu_model": host.cpu_model,
+            "runner_name": host.runner_name,
+            "fingerprint": host.fingerprint(),
+        },
+        "affinity": (
+            {
+                "allowed_cpus": list(affinity.allowed_cpus),
+                "selected_cpu": affinity.selected_cpu,
+                "taskset": affinity.taskset,
+                "verified": True,
+            }
+            if affinity is not None
+            else None
+        ),
+        "schedule": [asdict(record) for record in schedule_records],
+        "engines": engines,
+        "ratios": ratios,
+    }
 
 
 def render_optimize_table(
@@ -707,6 +1168,12 @@ def main() -> int:
     )
     p.add_argument("--out", type=Path, default=None, help="write markdown report here")
     p.add_argument(
+        "--json-out",
+        type=Path,
+        default=None,
+        help="write machine-readable comparison report here",
+    )
+    p.add_argument(
         "--emit",
         choices=["markdown", "github"],
         default="markdown",
@@ -755,8 +1222,12 @@ def main() -> int:
     except ValueError as exc:
         p.error(str(exc))
     effective_profile = profile_label(args.profile, args.warmups, args.runs)
+    expected_iterations = PROFILE_ITERATIONS[args.profile]
+    guest_args = coremark_guest_args(expected_iterations)
     if args.optimize == "both" and (args.wasmtime_baseline or args.wasmtime):
         p.error("Wasmtime comparisons require a single --optimize mode")
+    if args.optimize == "both" and args.json_out:
+        p.error("--json-out is not supported with --optimize both")
 
     repo = args.repo.resolve()
     fixture, fixture_sha = resolve_fixture(repo, args.fixture)
@@ -771,6 +1242,11 @@ def main() -> int:
     baseline_vals: list[float] | None = None
     target_vals: list[float] = []
     optimize_failed = False
+    schedule_records: list[SampleRecord] = []
+    affinity = (
+        select_cpu_affinity() if args.profile == "authoritative" else None
+    )
+    report_results: list[EngineResult] | None = None
 
     try:
         if args.optimize == "both":
@@ -781,7 +1257,16 @@ def main() -> int:
                 )
                 try:
                     result = build_and_run_wamr(
-                        wt, args.target, sha, fixture, optimize, warmups, runs
+                        wt,
+                        args.target,
+                        sha,
+                        fixture,
+                        optimize,
+                        warmups,
+                        runs,
+                        affinity,
+                        guest_args,
+                        expected_iterations,
                     )
                     mode_results[optimize] = result.values
                 except Exception as exc:
@@ -807,116 +1292,218 @@ def main() -> int:
             optimize = optimize_modes[0]
             baseline_sha = resolve_ref_sha(repo, args.baseline)
             target_sha = resolve_ref_sha(repo, args.target)
-            if baseline_sha == target_sha:
-                target_wt, target_sha = make_worktree(
-                    repo, args.target, work_root, "target"
-                )
-                target_result = build_and_run_wamr(
-                    target_wt,
-                    args.target,
-                    target_sha,
-                    fixture,
-                    optimize,
-                    warmups,
-                    runs,
-                )
-                baseline_result = EngineResult(
-                    "WAMR",
-                    f"{args.baseline} ({baseline_sha})",
-                    optimize,
-                    target_result.values.copy(),
-                )
-                print(
-                    "[harness] WAMR baseline and target resolve to the same commit; "
-                    "reusing the target samples",
-                    file=sys.stderr,
-                )
-            else:
-                baseline_wt, baseline_sha = make_worktree(
-                    repo, args.baseline, work_root, "baseline"
-                )
-                target_wt, target_sha = make_worktree(
-                    repo, args.target, work_root, "target"
-                )
-                baseline_result = build_and_run_wamr(
-                    baseline_wt,
-                    args.baseline,
-                    baseline_sha,
-                    fixture,
-                    optimize,
-                    warmups,
-                    runs,
-                )
-                target_result = build_and_run_wamr(
-                    target_wt,
-                    args.target,
-                    target_sha,
-                    fixture,
-                    optimize,
-                    warmups,
-                    runs,
-                )
-            results = [baseline_result, target_result]
-            baseline_vals = baseline_result.values
-            target_vals = target_result.values
-
-            measured_paths: dict[Path, EngineResult] = {}
-            if args.wasmtime_baseline:
-                baseline_path = (
-                    install_pinned_wasmtime(repo, args.wasmtime_cache)
-                    if args.wasmtime_baseline == "auto"
-                    else Path(args.wasmtime_baseline).expanduser().resolve()
-                )
-                if not baseline_path.is_file():
-                    raise FileNotFoundError(
-                        f"historical Wasmtime binary not found: {baseline_path}"
+            if args.wasmtime_baseline or args.wasmtime:
+                prepared: list[PreparedEngine] = []
+                if baseline_sha == target_sha:
+                    target_wt, target_sha = make_worktree(
+                        repo, args.target, work_root, "target"
                     )
-                version = validate_pinned_wasmtime(baseline_path)
-                result = measure_wasmtime(
-                    baseline_path,
-                    "Wasmtime historical pin",
-                    version,
-                    fixture,
-                    warmups,
-                    runs,
-                )
-                results.append(result)
-                measured_paths[baseline_path.resolve()] = result
-
-            if args.wasmtime:
-                current_path = args.wasmtime.expanduser().resolve()
-                if not current_path.is_file():
-                    raise FileNotFoundError(
-                        f"caller-selected Wasmtime binary not found: {current_path}"
-                    )
-                version = wasmtime_version(current_path)
-                cached = measured_paths.get(current_path)
-                if cached is None:
-                    current_result = measure_wasmtime(
-                        current_path,
-                        "Wasmtime caller-selected",
-                        version,
+                    target_prepared = prepare_wamr(
+                        target_wt,
+                        args.target,
+                        target_sha,
                         fixture,
-                        warmups,
-                        runs,
+                        optimize,
+                        guest_args,
+                        expected_iterations,
+                    )
+                    prepared.append(target_prepared)
+                    baseline_prepared = target_prepared
+                else:
+                    baseline_wt, baseline_sha = make_worktree(
+                        repo, args.baseline, work_root, "baseline"
+                    )
+                    target_wt, target_sha = make_worktree(
+                        repo, args.target, work_root, "target"
+                    )
+                    baseline_prepared = prepare_wamr(
+                        baseline_wt,
+                        args.baseline,
+                        baseline_sha,
+                        fixture,
+                        optimize,
+                        guest_args,
+                        expected_iterations,
+                    )
+                    target_prepared = prepare_wamr(
+                        target_wt,
+                        args.target,
+                        target_sha,
+                        fixture,
+                        optimize,
+                        guest_args,
+                        expected_iterations,
+                    )
+                    prepared.extend([baseline_prepared, target_prepared])
+
+                wasmtime_specs: list[tuple[Path, str, str]] = []
+                if args.wasmtime_baseline:
+                    pinned_path = (
+                        install_pinned_wasmtime(repo, args.wasmtime_cache)
+                        if args.wasmtime_baseline == "auto"
+                        else Path(args.wasmtime_baseline).expanduser().resolve()
+                    )
+                    if not pinned_path.is_file():
+                        raise FileNotFoundError(
+                            f"historical Wasmtime binary not found: {pinned_path}"
+                        )
+                    wasmtime_specs.append(
+                        (
+                            pinned_path,
+                            "Wasmtime historical pin",
+                            validate_pinned_wasmtime(pinned_path),
+                        )
+                    )
+                if args.wasmtime:
+                    current_path = args.wasmtime.expanduser().resolve()
+                    if not current_path.is_file():
+                        raise FileNotFoundError(
+                            f"caller-selected Wasmtime binary not found: {current_path}"
+                        )
+                    wasmtime_specs.append(
+                        (
+                            current_path,
+                            "Wasmtime caller-selected",
+                            wasmtime_version(current_path),
+                        )
+                    )
+
+                prepared_wasmtime: dict[Path, PreparedEngine] = {}
+                for path, label, version in wasmtime_specs:
+                    resolved = path.resolve()
+                    if resolved not in prepared_wasmtime:
+                        engine = prepare_wasmtime(
+                            path,
+                            label,
+                            version,
+                            fixture,
+                            guest_args,
+                            expected_iterations,
+                        )
+                        prepared_wasmtime[resolved] = engine
+                        prepared.append(engine)
+
+                measured, schedule_records = measure_prepared_engines(
+                    prepared,
+                    warmups=warmups,
+                    runs=runs,
+                    affinity=affinity,
+                )
+                target_measured = measured[target_prepared.key]
+                target_result = EngineResult(
+                    "WAMR",
+                    target_prepared.version,
+                    optimize,
+                    target_measured.values,
+                    target_measured.samples,
+                )
+                if baseline_sha == target_sha:
+                    baseline_result = EngineResult(
+                        "WAMR",
+                        f"{args.baseline} ({baseline_sha})",
+                        optimize,
+                        target_result.values.copy(),
+                        target_result.samples,
+                    )
+                    print(
+                        "[harness] WAMR baseline and target resolve to the same "
+                        "commit; reusing the target samples",
+                        file=sys.stderr,
                     )
                 else:
-                    current_result = EngineResult(
-                        "Wasmtime caller-selected",
-                        cached.version,
-                        cached.optimize,
-                        cached.values,
+                    baseline_measured = measured[baseline_prepared.key]
+                    baseline_result = EngineResult(
+                        "WAMR",
+                        baseline_prepared.version,
+                        optimize,
+                        baseline_measured.values,
+                        baseline_measured.samples,
                     )
-                results.append(current_result)
+                results = [baseline_result, target_result]
+                for path, label, version in wasmtime_specs:
+                    measured_result = measured[
+                        prepared_wasmtime[path.resolve()].key
+                    ]
+                    results.append(
+                        EngineResult(
+                            label,
+                            f"{version} (sha256:{sha256_file(path)}; {path})",
+                            "default JIT",
+                            measured_result.values,
+                            measured_result.samples,
+                        )
+                    )
+            else:
+                if baseline_sha == target_sha:
+                    target_wt, target_sha = make_worktree(
+                        repo, args.target, work_root, "target"
+                    )
+                    target_result = build_and_run_wamr(
+                        target_wt,
+                        args.target,
+                        target_sha,
+                        fixture,
+                        optimize,
+                        warmups,
+                        runs,
+                        affinity,
+                        guest_args,
+                        expected_iterations,
+                    )
+                    baseline_result = EngineResult(
+                        "WAMR",
+                        f"{args.baseline} ({baseline_sha})",
+                        optimize,
+                        target_result.values.copy(),
+                    )
+                else:
+                    baseline_wt, baseline_sha = make_worktree(
+                        repo, args.baseline, work_root, "baseline"
+                    )
+                    target_wt, target_sha = make_worktree(
+                        repo, args.target, work_root, "target"
+                    )
+                    baseline_result = build_and_run_wamr(
+                        baseline_wt,
+                        args.baseline,
+                        baseline_sha,
+                        fixture,
+                        optimize,
+                        warmups,
+                        runs,
+                        affinity,
+                        guest_args,
+                        expected_iterations,
+                    )
+                    target_result = build_and_run_wamr(
+                        target_wt,
+                        args.target,
+                        target_sha,
+                        fixture,
+                        optimize,
+                        warmups,
+                        runs,
+                        affinity,
+                        guest_args,
+                        expected_iterations,
+                    )
+                results = [baseline_result, target_result]
 
+            report_results = results
+            baseline_vals = baseline_result.values
+            target_vals = target_result.values
             table = render_table(
-                results,
+                report_results,
                 profile=effective_profile,
                 warmups=warmups,
                 runs=runs,
                 fixture=fixture,
                 fixture_sha=fixture_sha,
                 host=host,
+                schedule_records=schedule_records,
+                affinity=affinity,
+                guest_args=guest_args,
+                expected_iterations=expected_iterations,
             )
     finally:
         shutil.rmtree(work_root, ignore_errors=True)
@@ -926,6 +1513,24 @@ def main() -> int:
     print(table)
     if args.out:
         args.out.write_text(table + "\n")
+    if args.json_out:
+        assert report_results is not None
+        report = build_json_report(
+            report_results,
+            profile=effective_profile,
+            warmups=warmups,
+            runs=runs,
+            fixture=fixture,
+            fixture_sha=fixture_sha,
+            host=host,
+            schedule_records=schedule_records,
+            affinity=affinity,
+            guest_args=guest_args,
+            expected_iterations=expected_iterations,
+        )
+        args.json_out.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n"
+        )
     if args.emit == "github":
         summary = os.environ.get("GITHUB_STEP_SUMMARY")
         if summary:

--- a/scripts/test_bench_coremark.py
+++ b/scripts/test_bench_coremark.py
@@ -13,7 +13,9 @@ REPO = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO / ".github/workflows/coremark-aarch64.yml"
 PROFILE_SCRIPT = REPO / "scripts/profile_coremark_aarch64.py"
 VALID_OUTPUT = """\
+2K performance run parameters for coremark.
 Iterations/Sec   : 12345.5
+Iterations       : 400000
 [0]crcfinal      : 0x33ff
 Correct operation validated. See README.md for run and reporting rules.
 """
@@ -30,9 +32,9 @@ class BenchCoremarkTests(unittest.TestCase):
         self.assertEqual(digest, bench_coremark.DEFAULT_FIXTURE_SHA256)
 
     def test_parse_requires_crc_validation(self):
-        self.assertEqual(
-            bench_coremark.parse_coremark_output(VALID_OUTPUT, "test"), 12345.5
-        )
+        parsed = bench_coremark.parse_coremark_output(VALID_OUTPUT, "test")
+        self.assertEqual(parsed.throughput, 12345.5)
+        self.assertEqual(parsed.iterations, 400000)
         with self.assertRaisesRegex(RuntimeError, "CRC-validated"):
             bench_coremark.parse_coremark_output(
                 "Iterations/Sec : 12345.5\nERROR! bad crc\n", "test"
@@ -47,6 +49,163 @@ class BenchCoremarkTests(unittest.TestCase):
             bench_coremark.parse_coremark_output(
                 VALID_OUTPUT + "Iterations/Sec : 1\n", "test"
             )
+
+    def test_parse_rejects_invalid_fixed_workload(self):
+        with self.assertRaisesRegex(RuntimeError, "0 Iterations fields"):
+            bench_coremark.parse_coremark_output(
+                VALID_OUTPUT.replace("Iterations       : 400000\n", ""),
+                "test",
+            )
+        with self.assertRaisesRegex(RuntimeError, "2 Iterations fields"):
+            bench_coremark.parse_coremark_output(
+                VALID_OUTPUT + "Iterations : 400000\n", "test"
+            )
+        with self.assertRaisesRegex(RuntimeError, "malformed Iterations"):
+            bench_coremark.parse_coremark_output(
+                VALID_OUTPUT.replace("Iterations       : 400000", "Iterations : auto"),
+                "test",
+            )
+        with self.assertRaisesRegex(RuntimeError, "self-calibration is forbidden"):
+            bench_coremark.parse_coremark_output(
+                VALID_OUTPUT.replace("400000", "300000"), "test"
+            )
+        with self.assertRaisesRegex(RuntimeError, "2K performance"):
+            bench_coremark.parse_coremark_output(
+                VALID_OUTPUT.replace(
+                    "2K performance run parameters for coremark.\n", ""
+                ),
+                "test",
+            )
+        with self.assertRaisesRegex(RuntimeError, "CRC-validated"):
+            bench_coremark.parse_coremark_output(
+                VALID_OUTPUT + "Correct operation validated.\n", "test"
+            )
+
+    def test_fixed_guest_args_are_applied_to_both_engines(self):
+        self.assertEqual(
+            ("0", "0", "0", "200000", "0"),
+            bench_coremark.coremark_guest_args(
+                bench_coremark.PROFILE_ITERATIONS["ci"]
+            ),
+        )
+        with (
+            mock.patch.object(bench_coremark, "run", return_value=""),
+            mock.patch.object(bench_coremark, "worktree_env", return_value={}),
+            mock.patch.object(bench_coremark, "sha256_file", return_value="abc"),
+        ):
+            wamr = bench_coremark.prepare_wamr(
+                Path("/worktree"),
+                "HEAD",
+                "a" * 40,
+                Path("/fixture.wasm"),
+                "ReleaseFast",
+            )
+            wasmtime = bench_coremark.prepare_wasmtime(
+                Path("/wasmtime"),
+                "Wasmtime",
+                "44.0.1",
+                Path("/fixture.wasm"),
+            )
+        self.assertEqual(
+            list(bench_coremark.COREMARK_GUEST_ARGS),
+            wamr.cmd[-5:],
+        )
+        self.assertEqual(
+            list(bench_coremark.COREMARK_GUEST_ARGS),
+            wasmtime.cmd[-5:],
+        )
+
+    def test_authoritative_affinity_is_selected_and_verified(self):
+        with (
+            mock.patch.object(
+                bench_coremark.os,
+                "sched_getaffinity",
+                return_value={4, 7},
+            ),
+            mock.patch.object(
+                bench_coremark.shutil,
+                "which",
+                return_value="/usr/bin/taskset",
+            ),
+            mock.patch.object(bench_coremark, "run", return_value="4\n") as run,
+        ):
+            affinity = bench_coremark.select_cpu_affinity()
+        self.assertEqual((4, 7), affinity.allowed_cpus)
+        self.assertEqual(4, affinity.selected_cpu)
+        self.assertEqual("/usr/bin/taskset", run.call_args.args[0][0])
+        self.assertEqual(
+            ["/usr/bin/taskset", "--cpu-list", "4", "engine"],
+            bench_coremark.apply_affinity(["engine"], affinity),
+        )
+
+    def test_counterbalanced_order_is_abba(self):
+        self.assertEqual(
+            ["A", "B", "B", "A"],
+            bench_coremark.counterbalanced_order(["A", "B"], 2),
+        )
+        order = bench_coremark.counterbalanced_order(["A", "B"], 10)
+        self.assertEqual(10, order.count("A"))
+        self.assertEqual(10, order.count("B"))
+        self.assertEqual(["A", "B", "B", "A"], order[:4])
+
+    def test_schedule_groups_samples_and_recomputes_ratio(self):
+        def output(value):
+            return VALID_OUTPUT.replace("12345.5", str(value))
+
+        engines = [
+            bench_coremark.PreparedEngine(
+                "A",
+                "WAMR",
+                "commit",
+                "ReleaseFast",
+                ["wamr"],
+                Path("."),
+                {},
+                400000,
+            ),
+            bench_coremark.PreparedEngine(
+                "B",
+                "Wasmtime",
+                "44.0.1",
+                "default JIT",
+                ["wasmtime"],
+                Path("."),
+                {},
+                400000,
+            ),
+        ]
+        with mock.patch.object(
+            bench_coremark,
+            "run",
+            side_effect=[output(10), output(20), output(22), output(12)],
+        ):
+            results, records = bench_coremark.measure_prepared_engines(
+                engines,
+                warmups=0,
+                runs=2,
+                affinity=None,
+            )
+        self.assertEqual([10.0, 12.0], results["A"].values)
+        self.assertEqual([20.0, 22.0], results["B"].values)
+        self.assertEqual(["A", "B", "B", "A"], [r.engine_key for r in records])
+        report = bench_coremark.build_json_report(
+            [
+                results["A"],
+                results["A"],
+                results["B"],
+            ],
+            profile="authoritative",
+            warmups=0,
+            runs=2,
+            fixture=Path("fixture.wasm"),
+            fixture_sha="abc",
+            host=bench_coremark.HostIdentity(
+                "aarch64", 4, "Neoverse-N2", "runner", "boot"
+            ),
+            schedule_records=records,
+            affinity=None,
+        )
+        self.assertAlmostEqual(11 / 21, report["ratios"][0]["median_ratio"])
 
     def test_profile_defaults_and_overrides(self):
         self.assertEqual(
@@ -221,6 +380,7 @@ class BenchCoremarkTests(unittest.TestCase):
         self.assertIn("--profile  authoritative", dispatch)
         self.assertIn("--wasmtime-baseline auto", dispatch)
         self.assertIn("--require-native-arch aarch64", dispatch)
+        self.assertIn("--json-out coremark-report.json", dispatch)
         self.assertNotIn("--runs", dispatch)
 
         pr = workflow.split("- name: Run CoreMark PR comparison", 1)[1].split(

--- a/tests/benchmarks/coremark/README.md
+++ b/tests/benchmarks/coremark/README.md
@@ -57,6 +57,26 @@ mean/median/range, and same-host WAMR/Wasmtime ratios. Every sample must contain
 CoreMark's `Correct operation validated.` CRC result; command failures, CRC
 errors, missing results, and ambiguous output fail the run.
 
+Every authoritative invocation receives the fixed guest arguments
+`0 0 0 400000 0`: the three zero seeds select CoreMark's canonical 2K
+performance parameters, `400000` fixes the timed iteration count, and the zero
+execution mask selects all algorithms. The affordable PR profile uses the same
+explicit seed/mask contract with 200,000 fixed iterations. The harness requires
+exactly one `2K performance run parameters for coremark.` marker, the selected
+fixed `Iterations` value, and one CRC-success marker, so independent
+self-calibration cannot silently produce unequal workloads.
+
+Authoritative mode also reads the runner's allowed CPU set, selects one CPU,
+verifies `taskset` can restrict a child to that CPU, and pins every engine
+invocation to it. Engines are fully built/installed before timing and warmups
+and measured samples use a counterbalanced forward/reverse order (ABBA for two
+engines). The Markdown and JSON reports retain the exact order, per-sample UTC
+start/end timestamps, CPU selection, iterations, and raw throughput.
+
+Run 33576430466 predates these controls and is explicitly non-authoritative:
+it allowed each engine to self-calibrate a different iteration count and
+measured the engines in separate unpinned blocks.
+
 `--wasmtime-baseline auto` downloads Wasmtime 44.0.1 (the latest Wasmtime
 release line available before #393's 2026-05-07 reference measurement), the
 pinned historical baseline for future comparisons, and verifies the official


### PR DESCRIPTION
## Summary

- pass the verified canonical 2K performance arguments with fixed iterations to every engine (`0 0 0 400000 0` authoritative; fixed 200,000 for affordable PR gates)
- reject missing, duplicate, malformed, mismatched, or self-calibrated `Iterations` output and require exactly one 2K performance marker plus CRC success
- build/install every compared engine before timing, verify one allowed CPU with `taskset`, and pin every authoritative invocation to it
- use counterbalanced forward/reverse warmup and measured schedules, retaining exact order, UTC timestamps, iterations, raw samples, statistics, and ratios in Markdown/JSON

Run 33576430466 is explicitly non-authoritative and must not gate #949. This PR replaces its methodology; arithmetic from that run is unchanged but workload equivalence was not enforced.

## Validation

- `python3 -m unittest scripts/test_bench_coremark.py scripts/test_profile_coremark_aarch64.py tests/test_aot_jit_attr.py tests/test_compare_hot_function.py` (56 passed, 1 skipped)
- Python compilation checks
- workflow YAML parsing and `bash -n` for shell blocks
- local affinity/schedule dry-run
- `git diff --check`

Refs #973
Refs #949