### PR TITLE
bench: require canonical calibration platforms

### DIFF
--- a/scripts/bench_wasi_threads.py
+++ b/scripts/bench_wasi_threads.py
@@ -36,6 +36,11 @@ from benchmark_schema import (
     validate_common_report,
 )
 
+CANONICAL_PLATFORMS = {
+    "ubuntu-22.04-x86_64": ("Linux", "x86_64"),
+    "ubuntu-24.04-aarch64": ("Linux", "aarch64"),
+}
+
 
 KIND = "wasi-thread-benchmark"
 PROFILE_COUNTS = {
@@ -1111,11 +1116,13 @@ def load_budget(path: Path, report: dict[str, Any]) -> dict[str, Any]:
         raise HarnessError("budget required_profile must be authoritative")
     if (
         not isinstance(required_platforms, list)
-        or not required_platforms
+        or len(required_platforms) != len(CANONICAL_PLATFORMS)
         or len(set(required_platforms)) != len(required_platforms)
-        or not all(isinstance(item, str) and item for item in required_platforms)
+        or set(required_platforms) != set(CANONICAL_PLATFORMS)
     ):
-        raise HarnessError("budget required_platforms must be unique strings")
+        raise HarnessError(
+            "budget required_platforms must be exactly the canonical hosted platforms"
+        )
     _require_exact_keys(
         cohort,
         {
@@ -1152,6 +1159,8 @@ def load_budget(path: Path, report: dict[str, Any]) -> dict[str, Any]:
 
     metadata = report["metadata"]
     identity_checks = {
+        "baseline_commit": metadata["commit"],
+        "baseline_build_source_sha256": metadata["build_source_sha256"],
         "fixture_set_sha256": metadata["fixture_set_sha256"],
         "plan_sha256": metadata["plan_sha256"],
         "profile": report["plan"]["profile"],
@@ -1174,6 +1183,9 @@ def load_budget(path: Path, report: dict[str, Any]) -> dict[str, Any]:
         f"platforms.{platform_id}",
     )
     host = metadata["host"]
+    expected_host = CANONICAL_PLATFORMS[platform_id]
+    if (host["system"], host["machine"]) != expected_host:
+        raise HarnessError("report platform ID does not match its canonical host identity")
     if platform_budget["host_system"] != host["system"] or platform_budget["host_machine"] != host["machine"]:
         raise HarnessError("budget/report host platform mismatch")
 

--- a/scripts/test_bench_wasi_threads.py
+++ b/scripts/test_bench_wasi_threads.py
@@ -174,6 +174,34 @@ def make_report(
 
 def complete_budget(report: dict) -> dict:
     platform_id = report["metadata"]["platform_id"]
+    other_platform_id = (
+        "ubuntu-24.04-aarch64"
+        if platform_id == "ubuntu-22.04-x86_64"
+        else "ubuntu-22.04-x86_64"
+    )
+    other_system, other_machine = bench.CANONICAL_PLATFORMS[other_platform_id]
+    platform_budget = {
+        "host_system": report["metadata"]["host"]["system"],
+        "host_machine": report["metadata"]["host"]["machine"],
+        "pairs": [
+            {
+                "pair_key": item["pair_key"],
+                "left": item["left"],
+                "right": item["right"],
+                "max_median_elapsed_delta_pct": 100.0,
+            }
+            for item in report["plan"]["pairs"]
+        ],
+        "scenarios": [
+            {
+                "pair_key": item["pair_key"],
+                "condition": item["condition"],
+                "metric_kind": item["metric_kind"],
+                "min_median_ops_per_second": 0.1,
+            }
+            for item in report["summaries"]
+        ],
+    }
     return {
         "schema_version": SCHEMA_VERSION,
         "kind": "wasi-thread-benchmark-budget",
@@ -181,7 +209,7 @@ def complete_budget(report: dict) -> dict:
         "calibration_requirements": {
             "minimum_reports_per_platform": 20,
             "required_profile": "authoritative",
-            "required_platforms": [platform_id],
+            "required_platforms": list(bench.CANONICAL_PLATFORMS),
         },
         "cohort": {
             "baseline_commit": report["metadata"]["commit"],
@@ -189,31 +217,17 @@ def complete_budget(report: dict) -> dict:
             "fixture_set_sha256": report["metadata"]["fixture_set_sha256"],
             "plan_sha256": report["metadata"]["plan_sha256"],
             "profile": report["plan"]["profile"],
-            "report_count_by_platform": {platform_id: 20},
+            "report_count_by_platform": {
+                item: 20 for item in bench.CANONICAL_PLATFORMS
+            },
         },
         "platforms": {
-            platform_id: {
-                "host_system": report["metadata"]["host"]["system"],
-                "host_machine": report["metadata"]["host"]["machine"],
-                "pairs": [
-                    {
-                        "pair_key": item["pair_key"],
-                        "left": item["left"],
-                        "right": item["right"],
-                        "max_median_elapsed_delta_pct": 100.0,
-                    }
-                    for item in report["plan"]["pairs"]
-                ],
-                "scenarios": [
-                    {
-                        "pair_key": item["pair_key"],
-                        "condition": item["condition"],
-                        "metric_kind": item["metric_kind"],
-                        "min_median_ops_per_second": 0.1,
-                    }
-                    for item in report["summaries"]
-                ],
-            }
+            platform_id: platform_budget,
+            other_platform_id: {
+                **copy.deepcopy(platform_budget),
+                "host_system": other_system,
+                "host_machine": other_machine,
+            },
         },
     }
 
@@ -491,8 +505,8 @@ class ThreadBenchmarkTests(unittest.TestCase):
         report = make_report()
         budget = complete_budget(report)
         mutations = (
-            ("commit", lambda value: value["cohort"].__setitem__("baseline_commit", "bad")),
-            ("source", lambda value: value["cohort"].__setitem__("baseline_build_source_sha256", "bad")),
+            ("commit", lambda value: value["cohort"].__setitem__("baseline_commit", "e" * 40)),
+            ("source", lambda value: value["cohort"].__setitem__("baseline_build_source_sha256", "e" * 64)),
             ("fixture", lambda value: value["cohort"].__setitem__("fixture_set_sha256", "f" * 64)),
             ("plan", lambda value: value["cohort"].__setitem__("plan_sha256", "f" * 64)),
             ("profile", lambda value: value["cohort"].__setitem__("profile", "smoke")),
@@ -512,6 +526,35 @@ class ThreadBenchmarkTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(bench.HarnessError, "duplicate"):
             bench.load_budget(self.write_budget(duplicate_json), report)
+
+    def test_budget_requires_exact_canonical_platform_set_in_either_order(self) -> None:
+        report = make_report()
+        budget = complete_budget(report)
+        reversed_budget = copy.deepcopy(budget)
+        reversed_budget["calibration_requirements"]["required_platforms"].reverse()
+        bench.load_budget(self.write_budget(reversed_budget), report)
+
+        invalid_sets = (
+            ["ubuntu-22.04-x86_64"],
+            ["ubuntu-24.04-aarch64"],
+            ["arbitrary-platform"],
+            [
+                "ubuntu-22.04-x86_64",
+                "ubuntu-24.04-aarch64",
+                "third-platform",
+            ],
+            ["ubuntu-22.04-x86_64", "ubuntu-22.04-x86_64"],
+        )
+        for required_platforms in invalid_sets:
+            corrupt = copy.deepcopy(budget)
+            corrupt["calibration_requirements"][
+                "required_platforms"
+            ] = required_platforms
+            with self.subTest(required_platforms=required_platforms):
+                with self.assertRaisesRegex(
+                    bench.HarnessError, "canonical hosted platforms"
+                ):
+                    bench.load_budget(self.write_budget(corrupt), report)
 
     def test_cohort_rejects_mixed_identity_and_duplicate_run_ids(self) -> None:
         x86 = make_report(run_id="100")
@@ -539,6 +582,69 @@ class ThreadBenchmarkTests(unittest.TestCase):
         with self.assertRaisesRegex(bench.HarnessError, "duplicate"):
             cohort.validate_documents(
                 [(Path("x1"), x86), (Path("x2"), duplicate), (Path("arm"), arm)],
+                cohort.DEFAULT_PLATFORMS,
+                1,
+            )
+
+    def test_cohort_requires_canonical_paired_platform_reports(self) -> None:
+        x86 = make_report(run_id="100")
+        arm = make_report(
+            platform_id="ubuntu-24.04-aarch64",
+            machine="aarch64",
+            run_id="100",
+        )
+        for platforms in (
+            ("ubuntu-22.04-x86_64",),
+            ("ubuntu-24.04-aarch64",),
+            ("arbitrary-platform",),
+            (
+                "ubuntu-22.04-x86_64",
+                "ubuntu-24.04-aarch64",
+                "third-platform",
+            ),
+            ("ubuntu-22.04-x86_64", "ubuntu-22.04-x86_64"),
+        ):
+            with self.subTest(platforms=platforms), self.assertRaisesRegex(
+                bench.HarnessError, "canonical hosted set"
+            ):
+                cohort.validate_documents(
+                    [(Path("x86"), x86), (Path("arm"), arm)],
+                    platforms,
+                    1,
+                )
+
+        masquerading_arm = make_report(
+            platform_id="ubuntu-24.04-aarch64",
+            machine="x86_64",
+            run_id="100",
+        )
+        with self.assertRaisesRegex(bench.HarnessError, "canonical host identity"):
+            cohort.validate_documents(
+                [(Path("x86"), x86), (Path("arm"), masquerading_arm)],
+                cohort.DEFAULT_PLATFORMS,
+                1,
+            )
+
+        other_run_arm = make_report(
+            platform_id="ubuntu-24.04-aarch64",
+            machine="aarch64",
+            run_id="101",
+        )
+        with self.assertRaisesRegex(bench.HarnessError, "same workflow runs"):
+            cohort.validate_documents(
+                [(Path("x86"), x86), (Path("arm"), other_run_arm)],
+                cohort.DEFAULT_PLATFORMS,
+                1,
+            )
+
+        second_x86 = make_report(run_id="101")
+        with self.assertRaisesRegex(bench.HarnessError, "different report counts"):
+            cohort.validate_documents(
+                [
+                    (Path("x86-100"), x86),
+                    (Path("x86-101"), second_x86),
+                    (Path("arm-100"), arm),
+                ],
                 cohort.DEFAULT_PLATFORMS,
                 1,
             )

--- a/scripts/wasi_thread_cohort.py
+++ b/scripts/wasi_thread_cohort.py
@@ -19,14 +19,11 @@ from benchmark_schema import (
     atomic_write_json,
     collected_at,
 )
-from bench_wasi_threads import HarnessError, validate_report
+from bench_wasi_threads import CANONICAL_PLATFORMS, HarnessError, validate_report
 
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-DEFAULT_PLATFORMS = (
-    "ubuntu-22.04-x86_64",
-    "ubuntu-24.04-aarch64",
-)
+DEFAULT_PLATFORMS = tuple(CANONICAL_PLATFORMS)
 
 
 def require_sha(value: str) -> str:
@@ -168,6 +165,12 @@ def validate_documents(
 ) -> dict[str, Any]:
     if minimum_reports < 1:
         raise HarnessError("minimum report count must be positive")
+    if (
+        len(required_platforms) != len(DEFAULT_PLATFORMS)
+        or len(set(required_platforms)) != len(required_platforms)
+        or set(required_platforms) != set(DEFAULT_PLATFORMS)
+    ):
+        raise HarnessError("cohort platforms must be exactly the canonical hosted set")
     grouped: dict[str, list[tuple[Path, dict[str, Any]]]] = defaultdict(list)
     identities: set[tuple[str, str, str, str, str]] = set()
     for path, document in documents:
@@ -176,6 +179,12 @@ def validate_documents(
         platform_id = metadata["platform_id"]
         if platform_id not in required_platforms:
             raise HarnessError(f"{path}: unknown platform {platform_id!r}")
+        expected_host = CANONICAL_PLATFORMS[platform_id]
+        host = metadata["host"]
+        if (host["system"], host["machine"]) != expected_host:
+            raise HarnessError(
+                f"{path}: platform ID does not match canonical host identity"
+            )
         if document["plan"]["profile"] != "authoritative":
             raise HarnessError(f"{path}: cohort report is not authoritative")
         identities.add(
@@ -192,6 +201,7 @@ def validate_documents(
         raise HarnessError("cohort reports have mixed commit/source/fixture/plan identity")
     if set(grouped) != set(required_platforms):
         raise HarnessError("cohort platform set is incomplete")
+    run_ids_by_platform: dict[str, set[str]] = {}
     for platform_id in required_platforms:
         selected = grouped[platform_id]
         if len(selected) < minimum_reports:
@@ -204,6 +214,11 @@ def validate_documents(
         ]
         if any(not run_id for run_id in run_ids) or len(set(run_ids)) != len(run_ids):
             raise HarnessError(f"{platform_id}: workflow run IDs are missing or duplicate")
+        run_ids_by_platform[platform_id] = set(run_ids)
+    if len({len(items) for items in grouped.values()}) != 1:
+        raise HarnessError("cohort platforms have different report counts")
+    if len({frozenset(items) for items in run_ids_by_platform.values()}) != 1:
+        raise HarnessError("cohort platforms do not contain the same workflow runs")
     identity = next(iter(identities))
     return {
         "schema_version": SCHEMA_VERSION,
@@ -238,7 +253,7 @@ def validate_cohort(args: argparse.Namespace) -> int:
         raise HarnessError(f"no report.json files under {args.input_dir}")
     result = validate_documents(
         documents,
-        tuple(args.platform or DEFAULT_PLATFORMS),
+        DEFAULT_PLATFORMS,
         args.minimum_reports,
     )
     atomic_write_json(args.output, result)
@@ -266,11 +281,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     validate_parser = sub.add_parser("validate")
     validate_parser.add_argument("--input-dir", type=Path, required=True)
     validate_parser.add_argument("--minimum-reports", type=int, default=20)
-    validate_parser.add_argument(
-        "--platform",
-        action="append",
-        default=None,
-    )
     validate_parser.add_argument(
         "--output", type=Path, default=Path("wasi-thread-cohort.json")
     )

--- a/tests/benchmarks/wasi-threads/budget.schema.json
+++ b/tests/benchmarks/wasi-threads/budget.schema.json
@@ -32,9 +32,19 @@
         "required_profile": { "const": "authoritative" },
         "required_platforms": {
           "type": "array",
-          "minItems": 1,
+          "minItems": 2,
+          "maxItems": 2,
           "uniqueItems": true,
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "enum": [
+              "ubuntu-22.04-x86_64",
+              "ubuntu-24.04-aarch64"
+            ]
+          },
+          "allOf": [
+            { "contains": { "const": "ubuntu-22.04-x86_64" } },
+            { "contains": { "const": "ubuntu-24.04-aarch64" } }
+          ]
         }
       }
     },
@@ -63,9 +73,20 @@
             "profile": { "const": "authoritative" },
             "report_count_by_platform": {
               "type": "object",
-              "additionalProperties": {
-                "type": "integer",
-                "minimum": 20
+              "additionalProperties": false,
+              "required": [
+                "ubuntu-22.04-x86_64",
+                "ubuntu-24.04-aarch64"
+              ],
+              "properties": {
+                "ubuntu-22.04-x86_64": {
+                  "type": "integer",
+                  "minimum": 20
+                },
+                "ubuntu-24.04-aarch64": {
+                  "type": "integer",
+                  "minimum": 20
+                }
               }
             }
           }
@@ -74,7 +95,15 @@
     },
     "platforms": {
       "type": "object",
-      "additionalProperties": { "$ref": "#/$defs/platform" }
+      "additionalProperties": false,
+      "required": [
+        "ubuntu-22.04-x86_64",
+        "ubuntu-24.04-aarch64"
+      ],
+      "properties": {
+        "ubuntu-22.04-x86_64": { "$ref": "#/$defs/platform" },
+        "ubuntu-24.04-aarch64": { "$ref": "#/$defs/platform" }
+      }
     }
   },
   "$defs": {


### PR DESCRIPTION
Fixes the remaining Medium review issue from #988 before continuing #966 calibration.

- makes the exact hosted x86_64/AArch64 set immutable and order-insensitive
- constrains schema platform keys and report counts to that set
- requires canonical host identity and matching workflow-run sets/counts across platforms
- verifies budget commit/source/fixture/plan/profile identity
- adds negative coverage for one-platform, arbitrary, extra, duplicate, masquerading, and unpaired cohorts

Validation: `python3 -m unittest scripts/test_bench_wasi_threads.py`; `python3 -m py_compile scripts/bench_wasi_threads.py scripts/wasi_thread_cohort.py scripts/test_bench_wasi_threads.py`.

Refs #988, #966, #963.